### PR TITLE
fix(desktop): preserve chat state during reset

### DIFF
--- a/.changeset/chat-reset-combined-state.md
+++ b/.changeset/chat-reset-combined-state.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: New chat remains available when messages are queued or the Coach is waiting for an answer, and an uncertain reset keeps the entire conversation intact.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -249,6 +249,7 @@ export function createChatController(input: {
   let queueLoaded = input.initialQueueSnapshot !== undefined;
   let queueLoadError: string | null = null;
   let queueMutationError: string | null = null;
+  let queueMutationCount = 0;
   let attachmentSurface: ChatAttachmentComposerReadModel | null = null;
   let attachmentAdmissions: readonly AttachmentAdmissionReadModel[] = [];
   let attachmentError: string | null = null;
@@ -282,6 +283,9 @@ export function createChatController(input: {
     !decisionLoaded ||
     decision?.status === "unanswered" ||
     (decision?.status === "answered" && decision.continuation.status === "pending");
+  const decisionBlocksReset = (): boolean =>
+    !decisionLoaded ||
+    (decision?.status === "answered" && decision.continuation.status === "pending");
   const canOpenNewConversation = (): boolean =>
     canChat() &&
     queueLoaded &&
@@ -292,11 +296,12 @@ export function createChatController(input: {
       attachmentSurface?.draft != null) &&
     state.session.resetPhase === "idle" &&
     state.status !== "streaming" &&
-    state.queued.length === 0 &&
-    !decisionBlocksWork() &&
+    !decisionBlocksReset() &&
     activeTask === undefined &&
     outstandingChatTasks.size === 0 &&
     attachmentWriteTokens.size === 0 &&
+    state.retryRequired == null &&
+    queueMutationCount === 0 &&
     queuedRetry === undefined &&
     resetTask === undefined;
   const render = (appendDelta?: ChatAppendDelta): void => {
@@ -1762,32 +1767,39 @@ export function createChatController(input: {
     removeQueued(id) {
       if (disposed || resetBlocksWork()) return;
       queueMutationError = null;
+      queueMutationCount += 1;
       render();
-      void input.clients.getClient().then(
-        async (client) => {
-          try {
-            const acknowledged = await client.call("removeQueuedChatMessage", {
-              chatId: DESKTOP_CHAT_ID,
-              queuedMessageId: id,
-            });
-            if (!disposed) {
-              queueMutationError = null;
-              applyQueueSnapshot(acknowledged);
+      void input.clients
+        .getClient()
+        .then(
+          async (client) => {
+            try {
+              const acknowledged = await client.call("removeQueuedChatMessage", {
+                chatId: DESKTOP_CHAT_ID,
+                queuedMessageId: id,
+              });
+              if (!disposed) {
+                queueMutationError = null;
+                applyQueueSnapshot(acknowledged);
+              }
+            } catch {
+              if (!disposed) {
+                queueMutationError = CHAT_QUEUE_REMOVE_FAILURE_COPY;
+                render();
+              }
             }
-          } catch {
+          },
+          () => {
             if (!disposed) {
               queueMutationError = CHAT_QUEUE_REMOVE_FAILURE_COPY;
               render();
             }
-          }
-        },
-        () => {
-          if (!disposed) {
-            queueMutationError = CHAT_QUEUE_REMOVE_FAILURE_COPY;
-            render();
-          }
-        },
-      );
+          },
+        )
+        .finally(() => {
+          queueMutationCount -= 1;
+          render();
+        });
     },
     runQueuedCommand(id) {
       if (

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -182,6 +182,7 @@ export function nextDrainGroup(state: ChatState): ChatDrainGroup | null {
 export function hasClearableConversation(state: ChatState): boolean {
   return (
     state.session.presence === "present" ||
+    state.queued.length > 0 ||
     state.messages.some((message) => message.role === "athlete" || /\S/u.test(message.text))
   );
 }
@@ -483,8 +484,7 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         !action.hasAttachmentDraft &&
         !hasClearableConversation(state)) ||
         state.session.resetPhase !== "idle" ||
-        state.status === "streaming" ||
-        state.queued.length > 0
+        state.status === "streaming"
         ? state
         : {
             ...state,

--- a/apps/desktop-renderer/tests/chat-decision-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-decision-controller.test.ts
@@ -222,6 +222,16 @@ describe("Coach decision controller", () => {
     ]);
   });
 
+  it("opens New chat while preserving an unanswered decision", async () => {
+    const { controller, states, controls } = subject();
+    await controller.submit("What should I do tomorrow?");
+    const decision = controls.at(-1)?.decision?.value;
+
+    expect(controller.openNewConversation()).toBe(true);
+    expect(states.at(-1)?.session.resetPhase).toBe("confirming");
+    expect(controls.at(-1)?.decision?.value).toEqual(decision);
+  });
+
   it("continues a selected answer without creating a second athlete message", async () => {
     const { controller, states, controls } = subject();
     await controller.submit("What should I do tomorrow?");
@@ -273,6 +283,43 @@ describe("Coach decision controller", () => {
         delivery: "complete",
       });
     });
+  });
+
+  it("keeps New chat blocked while a saved continuation is resuming", async () => {
+    const pending: Extract<CoachDecisionReadModel, { status: "answered" }> = {
+      ...unanswered(),
+      status: "answered",
+      answer: { kind: "option", optionId: "recovery" },
+      consequence: "Tomorrow becomes a recovery day.",
+      continuation: { continuationId: "continuation-1", status: "pending" },
+    };
+    const release = deferred<void>();
+    const { controller, call } = subject(pending, async (method, options) => {
+      emit(options, method, { type: "turn-start", turnId: "turn-2", chatId: "desktop" }, 2);
+      await release.promise;
+      const decision = completed();
+      if (decision.continuation.status !== "completed") {
+        throw new Error("completed fixture required");
+      }
+      emit(
+        options,
+        method,
+        { type: "final-text", turnId: "turn-2", text: decision.continuation.coachText },
+        2,
+      );
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { decision } });
+      return { decision };
+    });
+
+    const starting = controller.start();
+    await vi.waitFor(() => {
+      expect(call.mock.calls.filter(([method]) => method === "resumeCoachDecision")).toHaveLength(
+        1,
+      );
+    });
+    expect(controller.openNewConversation()).toBe(false);
+    release.resolve();
+    await starting;
   });
 
   it("stops a decision continuation and resumes it with the same client", async () => {

--- a/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
+++ b/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
@@ -324,6 +324,45 @@ describe("durable chat queue controller", () => {
     expect(states.at(-1)?.queued).toEqual([]);
   });
 
+  it("opens New chat for a restored queue-only command", async () => {
+    const queued: ChatQueueSnapshot = {
+      schemaVersion: 1,
+      revision: 1,
+      items: [
+        {
+          queuedMessageId: "command-1",
+          messageId: "message-command-1",
+          submissionId: "submission-1",
+          text: "/review",
+          kind: "slash-command",
+          attachmentIds: [],
+          position: 0,
+          restored: true,
+        },
+      ],
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method) => {
+        if (method === "getCoachDecision") return { decision: null } as never;
+        if (method === "hasSession") return { hasSession: false } as never;
+        if (method === "getChatQueue") return queued as never;
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+
+    await controller.start();
+
+    expect(states.at(-1)).toMatchObject({
+      messages: [],
+      queued: [{ id: "command-1" }],
+      session: { presence: "absent" },
+    });
+    expect(controller.openNewConversation()).toBe(true);
+  });
+
   it("auto-resumes restored ordinary work and discards a blocked no-response run", async () => {
     const queued: ChatQueueSnapshot = {
       schemaVersion: 1,
@@ -460,6 +499,46 @@ describe("durable chat queue controller", () => {
 
     removal.resolve({ schemaVersion: 1, revision: 2, items: [] });
     await vi.waitFor(() => expect(states.at(-1)?.queued).toEqual([]));
+  });
+
+  it("waits for durable queue removal before opening New chat", async () => {
+    const removal = deferred<ChatQueueSnapshot>();
+    const queued: ChatQueueSnapshot = {
+      schemaVersion: 1,
+      revision: 1,
+      items: [
+        {
+          queuedMessageId: "command-1",
+          messageId: "message-command-1",
+          submissionId: "submission-1",
+          text: "/review",
+          kind: "slash-command",
+          attachmentIds: [],
+          position: 0,
+          restored: true,
+        },
+      ],
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: true }) as never;
+        if (method === "getChatQueue") return Promise.resolve(queued) as never;
+        if (method === "removeQueuedChatMessage") return removal.promise as never;
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    await controller.start();
+
+    controller.removeQueued("command-1");
+    expect(controller.openNewConversation()).toBe(false);
+
+    removal.resolve({ schemaVersion: 1, revision: 2, items: [] });
+    await vi.waitFor(() => expect(states.at(-1)?.queued).toEqual([]));
+    expect(controller.openNewConversation()).toBe(true);
   });
 
   it("keeps a queued row and reports visible feedback when durable removal fails", async () => {

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -662,12 +662,16 @@ describe("desktop message queue", () => {
     expect(held.queued).toBe(state.queued);
   });
 
-  it("refuses to open a new conversation while messages are queued", () => {
-    const failed = reduceChatState(started(), { type: "fail", requestKey: 1, copy: "Failed" });
-    const state = queued(failed, "Queued");
+  it("opens a queue-only conversation without changing queued messages", () => {
+    const state = queued(
+      reduceChatState(EMPTY_CHAT_STATE, { type: "session-probe", hasSession: false }),
+      "Queued",
+    );
 
     expect(hasClearableConversation(state)).toBe(true);
-    expect(reduceChatState(state, { type: "open-new-conversation" })).toBe(state);
+    const confirming = reduceChatState(state, { type: "open-new-conversation" });
+    expect(confirming.session.resetPhase).toBe("confirming");
+    expect(confirming.queued).toBe(state.queued);
   });
 
   it("clears the queue when a reset succeeds", () => {

--- a/apps/desktop/tests/chat-recovery-relaunch.integration.test.ts
+++ b/apps/desktop/tests/chat-recovery-relaunch.integration.test.ts
@@ -46,6 +46,7 @@ import {
   launchDesktopFixture,
   type DesktopFixtureScript,
   type RunningDesktopFixture,
+  visibleQaCheckpoint,
 } from "./helpers/desktop-fixture.js";
 import { createPlanQaFixtureScript } from "./helpers/plan-qa-live.js";
 
@@ -70,6 +71,12 @@ const recoveredPartialText = "Partial recovery guidance.";
 const recoveredCoachText = "Recovered recovery guidance.";
 const laterAthleteText = "Later one\n\nLater two";
 const laterCoachText = "Later reply.";
+const historyAthleteText = "How should I pace the recovery block?";
+const historyCoachText = "Keep the opening rides conversational and controlled.";
+const interruptedAthleteText = "Compare the last two recovery rides.";
+const interruptedCoachText = "The first ride stayed controlled, while the second";
+const resetUncertaintyCopy =
+  "We couldn’t confirm whether the new conversation started. Your visible conversation is preserved.";
 const fixtures: RunningDesktopFixture[] = [];
 const backends: RecoveryBackend[] = [];
 const scratchPaths: string[] = [];
@@ -120,6 +127,16 @@ function response(value: unknown): readonly string[] {
   return [JSON.stringify(value)];
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function planningPayload(): CreatePlanningRequestPayload {
   return {
     requestId,
@@ -151,6 +168,14 @@ class RecoveryBackend {
   private idSequence = 0;
   private attachmentId: string | undefined;
   private workoutId: string | undefined;
+  private resetControl:
+    | {
+        readonly entered: ReturnType<typeof deferred<void>>;
+        readonly outcome: ReturnType<typeof deferred<readonly string[]>>;
+        requestEntered: boolean;
+        settled: boolean;
+      }
+    | undefined;
 
   constructor(
     private readonly databasePath: string,
@@ -176,8 +201,25 @@ class RecoveryBackend {
         if (request.method === "getCoachDecision") {
           return response({ decision: this.requireConversation().getDecision(chatId) });
         }
+        if (request.method === "getTranscriptPage") {
+          const cursor = request.params.cursor;
+          const limit = request.params.limit;
+          if ((cursor !== null && typeof cursor !== "string") || typeof limit !== "number") {
+            throw new TypeError("invalid transcript page request");
+          }
+          return response(
+            this.requireConversation().readCurrentConversationPage(chatId, { cursor, limit }),
+          );
+        }
         if (request.method === "getChatAttachmentComposer") {
           return response(await this.requireAttachmentComposer().read(chatId));
+        }
+        if (request.method === "resetSession") {
+          const control = this.resetControl;
+          if (control === undefined) throw new TypeError("reset control is not armed");
+          control.requestEntered = true;
+          control.entered.resolve(undefined);
+          return control.outcome.promise;
         }
         if (request.method === "resumePlanningRequests") {
           return response(await this.requirePlanning().resumePlanningRequests?.({}));
@@ -351,6 +393,45 @@ class RecoveryBackend {
     }
   }
 
+  async establishNavigationState(): Promise<void> {
+    const conversation = this.requireConversation();
+    conversation.appendCompletedTurn({
+      chatId,
+      turnId: "turn-history-recovery",
+      completedAt: "1998-08-24T07:55:00.000Z",
+      athleteText: historyAthleteText,
+      coachText: historyCoachText,
+    });
+    if (conversation.appendInterruptedTurn === undefined) {
+      throw new TypeError("interrupted transcript persistence is unavailable");
+    }
+    conversation.appendInterruptedTurn({
+      chatId,
+      turnId: "turn-interrupted-recovery",
+      completedAt: "1998-08-24T07:58:00.000Z",
+      athleteText: interruptedAthleteText,
+      coachText: interruptedCoachText,
+    });
+    await this.establishDurableState();
+  }
+
+  pauseReset(): { readonly entered: Promise<void>; fail(error: Error): void } {
+    if (this.resetControl !== undefined) throw new TypeError("reset control is already armed");
+    const entered = deferred<void>();
+    const outcome = deferred<readonly string[]>();
+    this.resetControl = { entered, outcome, requestEntered: false, settled: false };
+    return {
+      entered: entered.promise,
+      fail: (error) => this.failReset(error),
+    };
+  }
+
+  abortPendingReset(): void {
+    if (this.resetControl?.requestEntered === true) {
+      this.failReset(new Error("reset fixture closed"));
+    }
+  }
+
   async reopen(): Promise<void> {
     await this.closeStore();
     await this.open();
@@ -367,6 +448,7 @@ class RecoveryBackend {
     return {
       queue: this.requireConversation().getChatQueue(chatId),
       decision: this.requireConversation().getDecision(chatId),
+      transcript: this.requireConversation().readCurrentConversation(chatId),
       attachment,
       planningRequest,
       outbox,
@@ -385,6 +467,13 @@ class RecoveryBackend {
 
   private now(): number {
     return ++this.instant;
+  }
+
+  private failReset(error: Error): void {
+    const control = this.resetControl;
+    if (control === undefined || control.settled) return;
+    control.settled = true;
+    control.outcome.reject(error);
   }
 
   private requireConversation(): ConversationStorePort {
@@ -559,7 +648,48 @@ async function readRecoverySurface(fixture: RunningDesktopFixture) {
   `);
 }
 
+async function readNavigationResetSurface(fixture: RunningDesktopFixture) {
+  const recovery = await readRecoverySurface(fixture);
+  const navigation = await fixture.evaluate<{
+    readonly historyAthleteCount: number;
+    readonly historyCoachCount: number;
+    readonly interruptedAthleteCount: number;
+    readonly interruptedCoachCount: number;
+    readonly dialogOpen: boolean;
+    readonly dialogBusy: boolean;
+    readonly newChatDisabled: boolean;
+    readonly newChatAriaDisabled: boolean;
+    readonly announcement: string;
+  }>(`
+    const messages = [...document.querySelectorAll(".chat-message")];
+    const opener = document.querySelector(".new-conversation-button");
+    const dialog = document.querySelector(".new-conversation-dialog");
+    if (!(opener instanceof HTMLButtonElement)) throw new Error("New chat action missing");
+    return {
+      historyAthleteCount: messages.filter((message) =>
+        message.textContent?.includes(${JSON.stringify(historyAthleteText)}),
+      ).length,
+      historyCoachCount: messages.filter((message) =>
+        message.textContent?.includes(${JSON.stringify(historyCoachText)}),
+      ).length,
+      interruptedAthleteCount: messages.filter((message) =>
+        message.textContent?.includes(${JSON.stringify(interruptedAthleteText)}),
+      ).length,
+      interruptedCoachCount: messages.filter((message) =>
+        message.textContent?.includes(${JSON.stringify(interruptedCoachText)}),
+      ).length,
+      dialogOpen: dialog?.hasAttribute("data-open") === true,
+      dialogBusy: dialog?.getAttribute("aria-busy") === "true",
+      newChatDisabled: opener.disabled,
+      newChatAriaDisabled: opener.getAttribute("aria-disabled") === "true",
+      announcement: document.querySelector(".new-conversation-status")?.textContent?.trim() ?? "",
+    };
+  `);
+  return { ...recovery, ...navigation };
+}
+
 afterEach(async () => {
+  for (const backend of backends) backend.abortPendingReset();
   await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
   await Promise.all(backends.splice(0).map((backend) => backend.close()));
   await Promise.all(
@@ -709,5 +839,162 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)(
       expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
       fixtures.splice(fixtures.indexOf(fixture), 1);
     }, 120_000);
+
+    it("preserves the complete conversation after one paused ambiguous reset", async () => {
+      const scratch = await mkdtemp(join(await realpath(tmpdir()), "chat-reset-uncertain-"));
+      scratchPaths.push(scratch);
+      const backend = new RecoveryBackend(
+        join(scratch, "reset.sqlite"),
+        join(scratch, "conversation"),
+        join(scratch, "attachments"),
+      );
+      backends.push(backend);
+      await backend.open();
+      await backend.establishNavigationState();
+      const reset = backend.pauseReset();
+
+      const fixture = await launchDesktopFixture({
+        script: backend.script,
+        token,
+        width: 1180,
+        height: 820,
+        colorScheme: "light",
+        reducedMotion: true,
+        hidden: process.env.NAV_03_VISIBLE === "1" ? false : true,
+        routeChatAttachmentComposer: true,
+      });
+      fixtures.push(fixture);
+
+      const initial = await readNavigationResetSurface(fixture);
+      expect(initial).toMatchObject({
+        questionCount: 1,
+        attachmentCount: 1,
+        selectedWorkoutCount: 1,
+        queueCount: 1,
+        planRequestCount: 1,
+        draft: attachmentDraftText,
+        historyAthleteCount: 1,
+        historyCoachCount: 1,
+        interruptedAthleteCount: 1,
+        interruptedCoachCount: 1,
+        dialogOpen: false,
+        newChatDisabled: false,
+        newChatAriaDisabled: false,
+        announcement: "",
+      });
+      const storedBefore = await backend.snapshot();
+
+      const confirmed = fixture.evaluate<void>(`
+        const opener = document.querySelector(".new-conversation-button");
+        if (!(opener instanceof HTMLButtonElement) || opener.disabled) {
+          throw new Error("New chat is unavailable");
+        }
+        opener.click();
+        const dialogDeadline = Date.now() + 5000;
+        let dialog = document.querySelector(".new-conversation-dialog");
+        while (dialog === null && Date.now() < dialogDeadline) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          dialog = document.querySelector(".new-conversation-dialog");
+        }
+        const confirm = dialog?.querySelector(".new-conversation-dialog__confirm");
+        if (!(confirm instanceof HTMLButtonElement)) throw new Error("Reset confirmation missing");
+        confirm.click();
+        confirm.click();
+        const pendingDeadline = Date.now() + 5000;
+        while (
+          document.querySelector(".new-conversation-dialog")?.getAttribute("aria-busy") !== "true" &&
+          Date.now() < pendingDeadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        if (document.querySelector(".new-conversation-dialog")?.getAttribute("aria-busy") !== "true") {
+          throw new Error("Reset confirmation did not become busy");
+        }
+      `);
+      await Promise.all([confirmed, reset.entered]);
+
+      expect(backend.calls.filter((call) => call.method === "resetSession")).toEqual([
+        { jsonrpc: "2.0", method: "resetSession", params: { chatId } },
+      ]);
+      expect(await readNavigationResetSurface(fixture)).toMatchObject({
+        questionCount: 1,
+        attachmentCount: 1,
+        selectedWorkoutCount: 1,
+        queueCount: 1,
+        planRequestCount: 1,
+        draft: attachmentDraftText,
+        historyAthleteCount: 1,
+        historyCoachCount: 1,
+        interruptedAthleteCount: 1,
+        interruptedCoachCount: 1,
+        dialogOpen: true,
+        dialogBusy: true,
+        newChatDisabled: true,
+        announcement: "",
+      });
+      const evidenceDirectory = process.env.NAV_03_EVIDENCE_DIR;
+      if (evidenceDirectory !== undefined) {
+        await mkdir(evidenceDirectory, { recursive: true, mode: 0o700 });
+        await fixture.screenshot(join(evidenceDirectory, "nav-03-reset-pending.png"));
+      }
+      await visibleQaCheckpoint("nav-03-reset-pending");
+
+      reset.fail(new Error("private ambiguous reset detail"));
+      await fixture.evaluate<void>(`
+        const expected = ${JSON.stringify(resetUncertaintyCopy)};
+        const deadline = Date.now() + 5000;
+        while (
+          (document.querySelector(".new-conversation-status")?.textContent?.trim() !== expected ||
+            document.querySelector(".new-conversation-dialog[data-open]") !== null) &&
+          Date.now() < deadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        if (document.querySelector(".new-conversation-status")?.textContent?.trim() !== expected) {
+          throw new Error("Reset uncertainty did not render");
+        }
+        if (document.querySelector(".new-conversation-dialog[data-open]") !== null) {
+          throw new Error("Reset confirmation did not close");
+        }
+      `);
+
+      expect(await readNavigationResetSurface(fixture)).toMatchObject({
+        questionCount: 1,
+        attachmentCount: 1,
+        selectedWorkoutCount: 1,
+        queueCount: 1,
+        planRequestCount: 1,
+        draft: attachmentDraftText,
+        historyAthleteCount: 1,
+        historyCoachCount: 1,
+        interruptedAthleteCount: 1,
+        interruptedCoachCount: 1,
+        dialogOpen: false,
+        dialogBusy: false,
+        newChatDisabled: false,
+        newChatAriaDisabled: true,
+        announcement: resetUncertaintyCopy,
+      });
+      expect(await backend.snapshot()).toEqual(storedBefore);
+      if (evidenceDirectory !== undefined) {
+        await fixture.screenshot(join(evidenceDirectory, "nav-03-reset-uncertain.png"));
+      }
+      await visibleQaCheckpoint("nav-03-reset-uncertain");
+
+      expect(
+        await fixture.evaluate(`
+          const opener = document.querySelector(".new-conversation-button");
+          if (!(opener instanceof HTMLButtonElement)) throw new Error("New chat action missing");
+          opener.click();
+          await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+          return document.querySelector(".new-conversation-dialog[data-open]") === null;
+        `),
+      ).toBe(true);
+      expect(backend.calls.filter((call) => call.method === "resetSession")).toHaveLength(1);
+      expect(await backend.snapshot()).toEqual(storedBefore);
+
+      expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
+      fixtures.splice(fixtures.indexOf(fixture), 1);
+    }, 150_000);
   },
 );


### PR DESCRIPTION
## Summary

- Preserve queued messages and pending Coach decisions while New chat confirmation is open.
- Keep reset uncertainty recoverable without silently discarding active Chat state.

## Proof

- Focused renderer reset, queue, and turn-state tests passed.
- Desktop recovery/relaunch integration passed twice after the latest-main rebase.
- Visible macOS QA passed for pending and uncertain reset states at 1180×820.
- Final isolated Codex autoreview reported no actionable findings.