### PR TITLE
fix(chat): preserve attachment lifecycle across reset

### DIFF
--- a/.changeset/reliable-chat-attachment-lifecycle.md
+++ b/.changeset/reliable-chat-attachment-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Chat now rechecks attachment compatibility after you change coach models. An unsent attachment draft stays visible until starting a new conversation has safely cleared it.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -521,6 +521,7 @@ export function bootRenderer(): Disposer {
   const providerModelSettingsController = createProviderModelSettingsController({
     load: () => window.enduragentAuth.llmConfiguration(),
     apply: (selection) => window.enduragentAuth.applyLlmSelection(selection),
+    onSaved: () => chatController.refreshAttachments(),
     openSetup: openSetupFromSettings,
     beginMutation: () => store.getState().beginSettingsMutation("provider-model"),
     codexAgentSupported: platform.capabilities.codexAgent,
@@ -577,9 +578,12 @@ export function bootRenderer(): Disposer {
       importDroppedFiles: (paths) => void rideImports.importPaths("resident", paths),
     },
   });
-  const disposeDroppedChatAttachments = window.enduragentAuth.onDroppedChatAttachments((results) =>
-    chatController.receiveAttachmentAdmissions(results),
-  );
+  const disposeDroppedChatAttachments = window.enduragentAuth.onDroppedChatAttachments((event) => {
+    if (event.phase === "started") {
+      return chatController.beginDroppedAttachmentAdmission(event.operationId);
+    }
+    chatController.settleDroppedAttachmentAdmission(event.operationId, event.results);
+  });
 
   void trainingContextController.start();
   void planController.start();

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -120,6 +120,12 @@ export interface ChatView {
 export interface ChatController {
   start(): Promise<void>;
   resume(): Promise<void>;
+  refreshAttachments(): Promise<void>;
+  beginDroppedAttachmentAdmission(operationId: string): boolean;
+  settleDroppedAttachmentAdmission(
+    operationId: string,
+    results: readonly AttachmentAdmissionReadModel[] | null,
+  ): void;
   submit(message: string, attachmentIds?: readonly string[]): Promise<boolean>;
   chooseAttachments(): Promise<void>;
   pasteAttachment(): Promise<void>;
@@ -245,10 +251,19 @@ export function createChatController(input: {
   let queueMutationError: string | null = null;
   let attachmentSurface: ChatAttachmentComposerReadModel | null = null;
   let attachmentAdmissions: readonly AttachmentAdmissionReadModel[] = [];
-  let attachmentBusy = false;
   let attachmentError: string | null = null;
   let attachmentTextRevision = 0;
   let attachmentTextSaveTask: Promise<void> = Promise.resolve();
+  let attachmentGeneration = 0;
+  let attachmentSurfaceRevision = 0;
+  let attachmentOperationSequence = 0;
+  const attachmentWriteTokens = new Set<number>();
+  const attachmentBusyTokens = new Set<number>();
+  const attachmentWriteWaiters = new Set<() => void>();
+  const droppedAttachmentAdmissions = new Map<
+    string,
+    { readonly token: number; readonly generation: number }
+  >();
   const attachmentSummaries = new Map<string, ChatSentAttachment>();
   let planningRequests: readonly PlanningRequestDelivery[] = [];
   let planningRequestsLoaded = false;
@@ -281,6 +296,7 @@ export function createChatController(input: {
     !decisionBlocksWork() &&
     activeTask === undefined &&
     outstandingChatTasks.size === 0 &&
+    attachmentWriteTokens.size === 0 &&
     queuedRetry === undefined &&
     resetTask === undefined;
   const render = (appendDelta?: ChatAppendDelta): void => {
@@ -303,7 +319,7 @@ export function createChatController(input: {
           attachments: {
             value: attachmentSurface,
             admissions: attachmentAdmissions,
-            busy: attachmentBusy,
+            busy: attachmentBusyTokens.size > 0,
             error: attachmentError,
           },
           planningRequests: {
@@ -331,6 +347,35 @@ export function createChatController(input: {
       );
     } catch {}
   };
+  const attachmentGenerationIsCurrent = (generation: number): boolean =>
+    !disposed && generation === attachmentGeneration;
+  const attachmentSurfaceIsCurrent = (generation: number, revision: number): boolean =>
+    attachmentGenerationIsCurrent(generation) && revision === attachmentSurfaceRevision;
+  const claimAttachmentSurface = (): number => ++attachmentSurfaceRevision;
+  const beginAttachmentWrite = (
+    busy: boolean,
+  ): { readonly token: number; readonly generation: number } | null => {
+    if (disposed || resetBlocksWork()) return null;
+    const token = ++attachmentOperationSequence;
+    claimAttachmentSurface();
+    attachmentWriteTokens.add(token);
+    if (busy) attachmentBusyTokens.add(token);
+    render();
+    return { token, generation: attachmentGeneration };
+  };
+  const finishAttachmentWrite = (token: number): void => {
+    attachmentWriteTokens.delete(token);
+    attachmentBusyTokens.delete(token);
+    if (attachmentWriteTokens.size === 0) {
+      for (const resolve of attachmentWriteWaiters) resolve();
+      attachmentWriteWaiters.clear();
+    }
+    render();
+  };
+  const waitForAttachmentWrites = (): Promise<void> =>
+    attachmentWriteTokens.size === 0
+      ? Promise.resolve()
+      : new Promise((resolve) => attachmentWriteWaiters.add(resolve));
   const reduce = (
     action: Parameters<typeof reduceChatState>[1],
     appendDelta?: ChatAppendDelta,
@@ -812,12 +857,38 @@ export function createChatController(input: {
     return snapshot;
   };
 
-  const refreshAttachments = async (client?: CoachClient): Promise<void> => {
-    const activeClient = client ?? (await input.clients.getClient());
-    const surface = await activeClient.call("getChatAttachmentComposer", {
-      chatId: DESKTOP_CHAT_ID,
-    });
-    if (disposed) return;
+  const refreshAttachments = async (
+    client?: CoachClient,
+    generation = attachmentGeneration,
+    reportError = true,
+  ): Promise<void> => {
+    const attemptRevision = attachmentSurfaceRevision;
+    let activeClient: CoachClient;
+    try {
+      activeClient = client ?? (await input.clients.getClient());
+    } catch {
+      if (reportError && attachmentSurfaceIsCurrent(generation, attemptRevision)) {
+        attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
+        render();
+      }
+      return;
+    }
+    if (attachmentWriteTokens.size > 0) await waitForAttachmentWrites();
+    if (!attachmentGenerationIsCurrent(generation)) return;
+    const revision = claimAttachmentSurface();
+    let surface: ChatAttachmentComposerReadModel;
+    try {
+      surface = await activeClient.call("getChatAttachmentComposer", {
+        chatId: DESKTOP_CHAT_ID,
+      });
+    } catch {
+      if (reportError && attachmentSurfaceIsCurrent(generation, revision)) {
+        attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
+        render();
+      }
+      return;
+    }
+    if (!attachmentSurfaceIsCurrent(generation, revision)) return;
     attachmentSurface = surface;
     attachmentError = null;
     render();
@@ -962,58 +1033,62 @@ export function createChatController(input: {
       });
   };
 
-  const receiveAdmissions = (results: readonly AttachmentAdmissionReadModel[]): void => {
-    if (disposed) return;
+  const receiveAdmissions = (
+    results: readonly AttachmentAdmissionReadModel[],
+    generation = attachmentGeneration,
+  ): void => {
+    if (!attachmentGenerationIsCurrent(generation)) return;
     attachmentAdmissions = results.filter((result) => result.status !== "accepted");
     attachmentError = null;
     render();
-    void refreshAttachments().catch(() => {
-      if (disposed) return;
-      attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
-      render();
-    });
+    void refreshAttachments(undefined, generation);
   };
 
   const runNativeAttachmentAction = async (
     operation: (() => Promise<readonly AttachmentAdmissionReadModel[]>) | undefined,
   ): Promise<void> => {
-    if (operation === undefined || disposed || attachmentBusy || resetBlocksWork()) return;
-    attachmentBusy = true;
+    if (operation === undefined || attachmentBusyTokens.size > 0) return;
+    const ownership = beginAttachmentWrite(true);
+    if (ownership === null) return;
     attachmentError = null;
     render();
     try {
-      receiveAdmissions(await operation());
-    } catch {
-      if (!disposed) attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
-    } finally {
-      if (!disposed) {
-        attachmentBusy = false;
-        render();
+      const results = await operation();
+      if (attachmentGenerationIsCurrent(ownership.generation)) {
+        receiveAdmissions(results, ownership.generation);
       }
+    } catch {
+      if (attachmentGenerationIsCurrent(ownership.generation)) {
+        attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
+      }
+    } finally {
+      finishAttachmentWrite(ownership.token);
     }
   };
 
   const mutateAttachment = async (
     operation: (client: CoachClient) => Promise<ChatAttachmentComposerReadModel>,
   ): Promise<void> => {
-    if (disposed || resetBlocksWork()) return;
-    attachmentBusy = true;
+    if (attachmentBusyTokens.size > 0) return;
+    const ownership = beginAttachmentWrite(true);
+    if (ownership === null) return;
+    let revision = attachmentSurfaceRevision;
     attachmentError = null;
     render();
     try {
       const client = await input.clients.getClient();
+      revision = claimAttachmentSurface();
       const surface = await operation(client);
-      if (!disposed) {
+      if (attachmentSurfaceIsCurrent(ownership.generation, revision)) {
         attachmentSurface = surface;
         attachmentError = null;
       }
     } catch {
-      if (!disposed) attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
-    } finally {
-      if (!disposed) {
-        attachmentBusy = false;
-        render();
+      if (attachmentSurfaceIsCurrent(ownership.generation, revision)) {
+        attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
       }
+    } finally {
+      finishAttachmentWrite(ownership.token);
     }
   };
 
@@ -1370,12 +1445,8 @@ export function createChatController(input: {
         render();
       }
     })();
-    const attachmentLoadTask = refreshAttachments().catch(() => {
-      if (!disposed) {
-        attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
-        render();
-      }
-    });
+    const attachmentLoadGeneration = attachmentGeneration;
+    const attachmentLoadTask = refreshAttachments(undefined, attachmentLoadGeneration);
     const planningRequestLoadTask = recoverPlanningRequests().catch(() => {
       if (!disposed) {
         planningRequestsLoaded = false;
@@ -1405,6 +1476,29 @@ export function createChatController(input: {
     resume() {
       return start().then(() => drain());
     },
+    async refreshAttachments() {
+      if (disposed || resetBlocksWork()) return;
+      const generation = attachmentGeneration;
+      await refreshAttachments(undefined, generation);
+    },
+    beginDroppedAttachmentAdmission(operationId) {
+      if (droppedAttachmentAdmissions.has(operationId) || attachmentBusyTokens.size > 0) {
+        return false;
+      }
+      const ownership = beginAttachmentWrite(true);
+      if (ownership === null) return false;
+      droppedAttachmentAdmissions.set(operationId, ownership);
+      return true;
+    },
+    settleDroppedAttachmentAdmission(operationId, results) {
+      const ownership = droppedAttachmentAdmissions.get(operationId);
+      if (ownership === undefined) return;
+      droppedAttachmentAdmissions.delete(operationId);
+      if (results !== null && attachmentGenerationIsCurrent(ownership.generation)) {
+        receiveAdmissions(results, ownership.generation);
+      }
+      finishAttachmentWrite(ownership.token);
+    },
     submit(message, attachmentIds = []) {
       if (
         !canChat() ||
@@ -1417,6 +1511,8 @@ export function createChatController(input: {
       ) {
         return Promise.resolve(false);
       }
+      const ownership = beginAttachmentWrite(false);
+      if (ownership === null) return Promise.resolve(false);
       const submissionId = globalThis.crypto.randomUUID();
       const submittedAttachments = (attachmentSurface?.draft?.attachments ?? [])
         .filter((attachment) => attachmentIds.includes(attachment.attachmentId))
@@ -1426,26 +1522,39 @@ export function createChatController(input: {
           kind,
           extension,
         }));
-      return input.clients.getClient().then(async (client) => {
-        await attachmentTextSaveTask;
-        const acknowledged = await client.call("enqueueChatMessage", {
-          chatId: DESKTOP_CHAT_ID,
-          submissionId,
-          text: message,
-          ...(attachmentIds.length === 0 ? {} : { attachmentIds: [...attachmentIds] }),
-        });
-        if (disposed) return false;
-        for (const attachment of submittedAttachments) {
-          attachmentSummaries.set(attachment.attachmentId, attachment);
-        }
-        attachmentAdmissions = [];
-        attachmentSurface =
-          attachmentSurface === null ? null : { ...attachmentSurface, draft: null };
-        applyQueueSnapshot(acknowledged);
-        void drain();
-        void refreshAttachments(client).catch(() => {});
-        return true;
-      });
+      return input.clients.getClient().then(
+        async (client) => {
+          try {
+            await attachmentTextSaveTask;
+            const revision = claimAttachmentSurface();
+            const acknowledged = await client.call("enqueueChatMessage", {
+              chatId: DESKTOP_CHAT_ID,
+              submissionId,
+              text: message,
+              ...(attachmentIds.length === 0 ? {} : { attachmentIds: [...attachmentIds] }),
+            });
+            if (!attachmentGenerationIsCurrent(ownership.generation)) return false;
+            for (const attachment of submittedAttachments) {
+              attachmentSummaries.set(attachment.attachmentId, attachment);
+            }
+            if (attachmentSurfaceIsCurrent(ownership.generation, revision)) {
+              attachmentAdmissions = [];
+              attachmentSurface =
+                attachmentSurface === null ? null : { ...attachmentSurface, draft: null };
+            }
+            applyQueueSnapshot(acknowledged);
+            void drain();
+            void refreshAttachments(client, ownership.generation, false);
+            return true;
+          } finally {
+            finishAttachmentWrite(ownership.token);
+          }
+        },
+        (error: unknown) => {
+          finishAttachmentWrite(ownership.token);
+          throw error;
+        },
+      );
     },
     chooseAttachments() {
       return runNativeAttachmentAction(input.nativeAttachments?.choose);
@@ -1454,28 +1563,46 @@ export function createChatController(input: {
       return runNativeAttachmentAction(input.nativeAttachments?.paste);
     },
     receiveAttachmentAdmissions(results) {
+      if (disposed || resetBlocksWork() || attachmentBusyTokens.size > 0) return;
       receiveAdmissions(results);
     },
     saveAttachmentDraftText(text) {
-      if (disposed || resetBlocksWork()) return;
-      const revision = ++attachmentTextRevision;
-      const task = attachmentTextSaveTask.then(async () => {
-        try {
-          const client = await input.clients.getClient();
-          const surface = await client.call("saveChatAttachmentDraftText", {
-            chatId: DESKTOP_CHAT_ID,
-            text,
-          });
-          if (disposed || revision !== attachmentTextRevision) return;
-          attachmentSurface = surface;
-          attachmentError = null;
-          render();
-        } catch {
-          if (disposed || revision !== attachmentTextRevision) return;
-          attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
-          render();
-        }
-      });
+      const ownership = beginAttachmentWrite(false);
+      if (ownership === null) return;
+      const textRevision = ++attachmentTextRevision;
+      let surfaceRevision = attachmentSurfaceRevision;
+      const task = attachmentTextSaveTask
+        .then(async () => {
+          try {
+            const client = await input.clients.getClient();
+            surfaceRevision = claimAttachmentSurface();
+            const surface = await client.call("saveChatAttachmentDraftText", {
+              chatId: DESKTOP_CHAT_ID,
+              text,
+            });
+            if (
+              !attachmentSurfaceIsCurrent(ownership.generation, surfaceRevision) ||
+              textRevision !== attachmentTextRevision
+            ) {
+              return;
+            }
+            attachmentSurface = surface;
+            attachmentError = null;
+            render();
+          } catch {
+            if (
+              !attachmentSurfaceIsCurrent(ownership.generation, surfaceRevision) ||
+              textRevision !== attachmentTextRevision
+            ) {
+              return;
+            }
+            attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
+            render();
+          }
+        })
+        .finally(() => {
+          finishAttachmentWrite(ownership.token);
+        });
       attachmentTextSaveTask = task;
     },
     removeAttachment(attachmentId) {
@@ -1792,6 +1919,7 @@ export function createChatController(input: {
       state = reduceChatState(state, {
         type: "open-new-conversation",
         hasHydratedHistory: hydration.turns.length > 0 || hydration.entries.length > 0,
+        hasAttachmentDraft: attachmentSurface?.draft != null,
       });
       render();
       return true;
@@ -1807,20 +1935,48 @@ export function createChatController(input: {
       }
       updateReset(() => hydrator.beginReset(), { type: "begin-reset" });
       const resetEpoch = ++epoch;
+      const resetAttachmentGeneration = ++attachmentGeneration;
+      claimAttachmentSurface();
       const task = (async () => {
         try {
+          if (attachmentWriteTokens.size > 0) await waitForAttachmentWrites();
+          if (
+            disposed ||
+            epoch !== resetEpoch ||
+            !attachmentGenerationIsCurrent(resetAttachmentGeneration)
+          ) {
+            return;
+          }
           const client = await input.clients.getClient();
           const result = await client.call("resetSession", { chatId: DESKTOP_CHAT_ID });
-          if (disposed || epoch !== resetEpoch) return;
-          try {
-            attachmentSurface = await client.call("clearChatAttachmentDraft", {
-              chatId: DESKTOP_CHAT_ID,
-            });
-            attachmentAdmissions = [];
-            attachmentError = null;
-          } catch {
-            attachmentError = CHAT_ATTACHMENT_FAILURE_COPY;
+          if (
+            disposed ||
+            epoch !== resetEpoch ||
+            !attachmentGenerationIsCurrent(resetAttachmentGeneration)
+          ) {
+            return;
           }
+          await attachmentTextSaveTask;
+          if (
+            disposed ||
+            epoch !== resetEpoch ||
+            !attachmentGenerationIsCurrent(resetAttachmentGeneration)
+          ) {
+            return;
+          }
+          const clearedAttachmentSurface = await client.call("clearChatAttachmentDraft", {
+            chatId: DESKTOP_CHAT_ID,
+          });
+          if (
+            disposed ||
+            epoch !== resetEpoch ||
+            !attachmentGenerationIsCurrent(resetAttachmentGeneration)
+          ) {
+            return;
+          }
+          attachmentSurface = clearedAttachmentSurface;
+          attachmentAdmissions = [];
+          attachmentError = null;
           sequence += 1;
           retryClient = undefined;
           queuedRetry = undefined;
@@ -1839,7 +1995,13 @@ export function createChatController(input: {
               : NEW_CONVERSATION_MEMORY_WARNING_COPY,
           });
         } catch {
-          if (disposed || epoch !== resetEpoch) return;
+          if (
+            disposed ||
+            epoch !== resetEpoch ||
+            !attachmentGenerationIsCurrent(resetAttachmentGeneration)
+          ) {
+            return;
+          }
           updateReset(() => hydrator.resetFailed(), {
             type: "reset-failed",
             announcement: NEW_CONVERSATION_UNCERTAIN_COPY,
@@ -1909,6 +2071,14 @@ export function createChatController(input: {
       hydrator.dispose();
       decision = null;
       epoch += 1;
+      attachmentGeneration += 1;
+      claimAttachmentSurface();
+      attachmentTextRevision += 1;
+      attachmentWriteTokens.clear();
+      attachmentBusyTokens.clear();
+      droppedAttachmentAdmissions.clear();
+      for (const resolve of attachmentWriteWaiters) resolve();
+      attachmentWriteWaiters.clear();
       sequence += 1;
     },
   };

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -65,7 +65,7 @@ interface EnduragentAuth {
   chooseChatAttachments(): Promise<readonly DesktopAttachmentAdmission[]>;
   pasteChatAttachment(): Promise<readonly DesktopAttachmentAdmission[]>;
   onDroppedChatAttachments(
-    listener: (results: readonly DesktopAttachmentAdmission[]) => void,
+    listener: (event: DesktopDroppedChatAttachmentEvent) => boolean | void,
   ): () => void;
   choosePlanRaceCourseFile(): Promise<string | null>;
   exportTrainingFile(input: DesktopTrainingExportRequest): Promise<DesktopTrainingExportResult>;
@@ -78,6 +78,13 @@ interface EnduragentAuth {
 
 type DesktopPlatformProjection = import("./platform-copy").DesktopPlatformProjection;
 type DesktopAttachmentAdmission = import("@enduragent/coach-contract").AttachmentAdmissionReadModel;
+type DesktopDroppedChatAttachmentEvent =
+  | { readonly phase: "started"; readonly operationId: string }
+  | {
+      readonly phase: "settled";
+      readonly operationId: string;
+      readonly results: readonly DesktopAttachmentAdmission[] | null;
+    };
 type DesktopAttachmentReference = import("@enduragent/coach-contract").ChatAttachmentReference;
 type DesktopPlanningReadModel = import("@enduragent/coach-contract").PlanningReadModel;
 type DesktopPlanStateResult = import("@enduragent/coach-contract").GetPlanStateRpcResult;

--- a/apps/desktop-renderer/src/settings/provider-model-controller.ts
+++ b/apps/desktop-renderer/src/settings/provider-model-controller.ts
@@ -144,6 +144,7 @@ function editableState(state: ProviderModelSettingsState): EditableState | null 
 export function createProviderModelSettingsController(input: {
   readonly load: () => Promise<OnboardingLlmConfiguration>;
   readonly apply: (selection: OnboardingLlmSelection) => Promise<OnboardingLlmSelectionResult>;
+  readonly onSaved?: (selection: OnboardingLlmSelection) => Promise<void> | void;
   readonly openSetup: () => void;
   readonly view: ProviderModelSettingsView;
   readonly beginMutation?: () => (() => void) | null;
@@ -293,7 +294,7 @@ export function createProviderModelSettingsController(input: {
     const pending = Promise.resolve()
       .then(() => input.apply(selection))
       .then(
-        (result) => {
+        async (result) => {
           if (disposed || generation !== operationGeneration) return;
           if (result.status === "refused") {
             render({
@@ -304,6 +305,8 @@ export function createProviderModelSettingsController(input: {
             });
             return;
           }
+          await input.onSaved?.(selection);
+          if (disposed || generation !== operationGeneration) return;
           const active = { provider: selection.provider, model: selection.model };
           render({
             status: "saved",

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -123,7 +123,11 @@ export type ChatAction =
   | { readonly type: "remove-queued"; readonly id: string }
   | { readonly type: "dequeue-group" }
   | { readonly type: "session-probe"; readonly hasSession: boolean }
-  | { readonly type: "open-new-conversation"; readonly hasHydratedHistory?: boolean }
+  | {
+      readonly type: "open-new-conversation";
+      readonly hasHydratedHistory?: boolean;
+      readonly hasAttachmentDraft?: boolean;
+    }
   | { readonly type: "cancel-new-conversation" }
   | { readonly type: "begin-reset" }
   | { readonly type: "reset-succeeded"; readonly announcement: string }
@@ -475,7 +479,9 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
       };
     }
     case "open-new-conversation":
-      return (!action.hasHydratedHistory && !hasClearableConversation(state)) ||
+      return (!action.hasHydratedHistory &&
+        !action.hasAttachmentDraft &&
+        !hasClearableConversation(state)) ||
         state.session.resetPhase !== "idle" ||
         state.status === "streaming" ||
         state.queued.length > 0

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -86,6 +86,7 @@ export function Composer(props: {
   useEffect(
     () => () => {
       if (saveTimer.current !== null) clearTimeout(saveTimer.current);
+      saveTimer.current = null;
     },
     [],
   );
@@ -97,6 +98,8 @@ export function Composer(props: {
         textarea.current?.focus();
       },
       reset() {
+        if (saveTimer.current !== null) clearTimeout(saveTimer.current);
+        saveTimer.current = null;
         const input = textarea.current;
         if (input !== null) {
           input.value = "";
@@ -201,7 +204,9 @@ export function Composer(props: {
     <form
       ref={form}
       className="composer relative"
-      data-chat-attachment-dropzone={props.surface === undefined ? "true" : undefined}
+      data-chat-attachment-dropzone={
+        props.surface === undefined && !inputDisabled && canChat ? "true" : undefined
+      }
       hidden={props.hidden}
       onSubmit={(event) => {
         event.preventDefault();
@@ -247,6 +252,7 @@ export function Composer(props: {
             setDismissed(false);
             if (saveTimer.current !== null) clearTimeout(saveTimer.current);
             saveTimer.current = setTimeout(() => {
+              saveTimer.current = null;
               if (props.surface === undefined) actions?.saveAttachmentDraftText(value);
             }, 300);
           }}
@@ -260,18 +266,20 @@ export function Composer(props: {
           className={`chat-composer__toolbar flex items-center ${props.leadingAction !== undefined || props.surface === undefined ? "justify-between" : "justify-end"}`}
         >
           {props.leadingAction ??
-          (props.surface === undefined ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label="Attach files"
-              disabled={actions === null || inputDisabled || !canChat || attachmentSurface === null}
-              onClick={() => void actions?.chooseAttachments()}
-            >
-              <Paperclip aria-hidden="true" />
-            </Button>
-          ) : null)}
+            (props.surface === undefined ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Attach files"
+                disabled={
+                  actions === null || inputDisabled || !canChat || attachmentSurface === null
+                }
+                onClick={() => void actions?.chooseAttachments()}
+              >
+                <Paperclip aria-hidden="true" />
+              </Button>
+            ) : null)}
           {status === "streaming" ? (
             <Button
               type="button"

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -65,6 +65,91 @@ function errorEvent(message = "Safe athlete message"): Extract<TurnEvent, { type
   };
 }
 
+function imageComposer(imagesEnabled: boolean): ChatAttachmentComposerReadModel {
+  const common = {
+    schemaVersion: 1 as const,
+    attachmentId: "attachment-image",
+    displayName: "recovery-note.jpg",
+    kind: "image" as const,
+    extension: "jpg" as const,
+    byteSize: 128,
+  };
+  const sharedCapabilities: Pick<
+    ChatAttachmentComposerReadModel["capabilities"],
+    "schemaVersion" | "documents" | "completedActivities" | "plannedWorkouts"
+  > = {
+    schemaVersion: 1,
+    documents: { enabled: true, extensions: ["pdf", "txt", "csv", "docx"] },
+    completedActivities: {
+      enabled: true,
+      extensions: ["fit", "tcx", "gpx"],
+    },
+    plannedWorkouts: {
+      enabled: true,
+      extensions: ["zwo", "erg", "mrc"],
+    },
+  };
+  const sharedDraft = {
+    schemaVersion: 1 as const,
+    chatId: "desktop",
+    text: "Keep this draft.",
+    state: "restored" as const,
+    updatedAt: "1998-08-24T08:00:00.000Z",
+  };
+  if (imagesEnabled) {
+    return {
+      schemaVersion: 1,
+      capabilities: {
+        ...sharedCapabilities,
+        active: {
+          provider: "anthropic",
+          model: "claude-sonnet-5",
+          transport: "ai-sdk",
+        },
+        images: {
+          enabled: true,
+          mediaTypes: ["image/png", "image/jpeg", "image/webp"],
+          reason: "supported",
+          source: "maintained_catalogue",
+          checkedAt: "1998-08-24T08:00:00.000Z",
+        },
+      },
+      draft: {
+        ...sharedDraft,
+        attachments: [
+          {
+            ...common,
+            status: "ready",
+            preview: { kind: "image", mediaType: "image/jpeg", width: 1, height: 1 },
+          },
+        ],
+      },
+    };
+  }
+  return {
+    schemaVersion: 1,
+    capabilities: {
+      ...sharedCapabilities,
+      active: {
+        provider: "deepseek",
+        model: "deepseek-chat",
+        transport: "ai-sdk",
+      },
+      images: {
+        enabled: false,
+        mediaTypes: [],
+        reason: "model_incompatible",
+        source: "maintained_catalogue",
+        checkedAt: "1998-08-24T08:05:00.000Z",
+      },
+    },
+    draft: {
+      ...sharedDraft,
+      attachments: [{ ...common, status: "blocked", reason: "model_incompatible" }],
+    },
+  };
+}
+
 function planningDelivery(
   state: PlanningRequestDelivery["state"] = "delivered",
 ): PlanningRequestDelivery {
@@ -146,6 +231,9 @@ function client(
     }) => Promise<{ stopped: boolean }>;
     readonly composer?: () => Promise<ChatAttachmentComposerReadModel>;
     readonly saveAttachmentDraftText?: (text: string) => Promise<ChatAttachmentComposerReadModel>;
+    readonly mutateAttachment?: (
+      method: "removeChatAttachment" | "retryChatAttachment" | "selectChatAttachmentWorkout",
+    ) => Promise<ChatAttachmentComposerReadModel>;
     readonly clearAttachmentDraft?: () => Promise<ChatAttachmentComposerReadModel>;
     readonly listPlanningRequests?: () => Promise<{
       readonly deliveries: readonly PlanningRequestDelivery[];
@@ -260,7 +348,9 @@ function client(
       return (
         method === "clearChatAttachmentDraft" && sessions.clearAttachmentDraft !== undefined
           ? sessions.clearAttachmentDraft()
-          : Promise.resolve(emptyComposer())
+          : method !== "clearChatAttachmentDraft" && sessions.mutateAttachment !== undefined
+            ? sessions.mutateAttachment(method)
+            : Promise.resolve(emptyComposer())
       ) as never;
     }
     if (method === "getChatQueue") {
@@ -1239,6 +1329,178 @@ describe("chat controller", () => {
     await expect(controller.submit("/status", ["attachment-1"])).resolves.toBe(false);
   });
 
+  it("refreshes the durable Composer after attachment capabilities change", async () => {
+    let imagesEnabled = true;
+    const fake = client(replies(), { composer: async () => imageComposer(imagesEnabled) });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    expect(controls.at(-1)?.attachments?.value).toEqual(imageComposer(true));
+
+    imagesEnabled = false;
+    await controller.refreshAttachments();
+
+    expect(controls.at(-1)?.attachments).toMatchObject({
+      error: null,
+      value: {
+        capabilities: {
+          active: { provider: "deepseek", model: "deepseek-chat" },
+          images: { enabled: false, reason: "model_incompatible" },
+        },
+        draft: {
+          text: "Keep this draft.",
+          attachments: [
+            {
+              attachmentId: "attachment-image",
+              status: "blocked",
+              reason: "model_incompatible",
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("opens reset confirmation for an attachment-only draft", async () => {
+    const fake = client(replies(), { composer: async () => imageComposer(true) });
+    const { controller, states } = subject(fake);
+    await controller.start();
+
+    expect(states.at(-1)?.messages).toEqual([]);
+    expect(controller.openNewConversation()).toBe(true);
+    expect(states.at(-1)?.session.resetPhase).toBe("confirming");
+  });
+
+  it("keeps reset behind an in-flight attachment mutation", async () => {
+    const surface = imageComposer(true);
+    const cleared = { ...surface, draft: null };
+    let resolveMutation!: (value: ChatAttachmentComposerReadModel) => void;
+    const mutation = new Promise<ChatAttachmentComposerReadModel>((resolve) => {
+      resolveMutation = resolve;
+    });
+    const fake = client(replies(), {
+      composer: async () => surface,
+      mutateAttachment: async () => mutation,
+      resetSession: async () => ({ memoryFlushed: true }),
+      clearAttachmentDraft: async () => cleared,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+
+    controller.removeAttachment("attachment-image");
+    await vi.waitFor(() => expect(controls.at(-1)?.attachments?.busy).toBe(true));
+    expect(controller.openNewConversation()).toBe(false);
+
+    resolveMutation(surface);
+    await vi.waitFor(() => expect(controls.at(-1)?.attachments?.busy).toBe(false));
+    expect(controller.openNewConversation()).toBe(true);
+    await controller.confirmNewConversation();
+
+    expect(controls.at(-1)?.attachments?.value).toEqual(cleared);
+  });
+
+  it("keeps a settled drop refresh from restoring the draft after reset", async () => {
+    const surface = imageComposer(true);
+    const cleared = { ...surface, draft: null };
+    let composerReads = 0;
+    let resolveStaleRefresh!: (value: ChatAttachmentComposerReadModel) => void;
+    const staleRefresh = new Promise<ChatAttachmentComposerReadModel>((resolve) => {
+      resolveStaleRefresh = resolve;
+    });
+    const fake = client(replies(), {
+      composer: () => {
+        composerReads += 1;
+        return composerReads === 1 ? Promise.resolve(surface) : staleRefresh;
+      },
+      resetSession: async () => ({ memoryFlushed: true }),
+      clearAttachmentDraft: async () => cleared,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+
+    expect(controller.beginDroppedAttachmentAdmission("drop-1")).toBe(true);
+    expect(controller.openNewConversation()).toBe(false);
+    controller.settleDroppedAttachmentAdmission("drop-1", [
+      {
+        selectionId: "selection-drop-1",
+        displayName: "recovery-note.jpg",
+        status: "accepted",
+        attachmentId: "attachment-image",
+      },
+    ]);
+    await vi.waitFor(() => expect(composerReads).toBe(2));
+    expect(controller.openNewConversation()).toBe(true);
+    expect(controller.beginDroppedAttachmentAdmission("drop-2")).toBe(false);
+
+    await controller.confirmNewConversation();
+    resolveStaleRefresh(surface);
+    await staleRefresh;
+    await Promise.resolve();
+
+    expect(controls.at(-1)?.attachments?.value).toEqual(cleared);
+  });
+
+  it("keeps an older composer read from replacing a newer one", async () => {
+    const initial = imageComposer(true);
+    const oldSurface = imageComposer(true);
+    const newSurface = imageComposer(false);
+    let composerReads = 0;
+    let resolveOldRead!: (value: ChatAttachmentComposerReadModel) => void;
+    let resolveNewRead!: (value: ChatAttachmentComposerReadModel) => void;
+    const oldRead = new Promise<ChatAttachmentComposerReadModel>((resolve) => {
+      resolveOldRead = resolve;
+    });
+    const newRead = new Promise<ChatAttachmentComposerReadModel>((resolve) => {
+      resolveNewRead = resolve;
+    });
+    const fake = client(replies(), {
+      composer: () => {
+        composerReads += 1;
+        if (composerReads === 1) return Promise.resolve(initial);
+        return composerReads === 2 ? oldRead : newRead;
+      },
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+
+    const firstRefresh = controller.refreshAttachments();
+    const secondRefresh = controller.refreshAttachments();
+    await vi.waitFor(() => expect(composerReads).toBe(3));
+    resolveNewRead(newSurface);
+    await secondRefresh;
+    resolveOldRead(oldSurface);
+    await firstRefresh;
+
+    expect(controls.at(-1)?.attachments?.value).toEqual(newSurface);
+  });
+
+  it("keeps an older composer read from replacing a later attachment mutation", async () => {
+    const oldSurface = imageComposer(true);
+    const mutatedSurface = imageComposer(false);
+    let composerReads = 0;
+    let resolveOldRead!: (value: ChatAttachmentComposerReadModel) => void;
+    const oldRead = new Promise<ChatAttachmentComposerReadModel>((resolve) => {
+      resolveOldRead = resolve;
+    });
+    const fake = client(replies(), {
+      composer: () => {
+        composerReads += 1;
+        return composerReads === 1 ? Promise.resolve(oldSurface) : oldRead;
+      },
+      mutateAttachment: async () => mutatedSurface,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+
+    const staleRefresh = controller.refreshAttachments();
+    await vi.waitFor(() => expect(composerReads).toBe(2));
+    controller.removeAttachment("attachment-image");
+    await vi.waitFor(() => expect(controls.at(-1)?.attachments?.value).toEqual(mutatedSurface));
+    resolveOldRead(oldSurface);
+    await staleRefresh;
+
+    expect(controls.at(-1)?.attachments?.value).toEqual(mutatedSurface);
+  });
+
   it("creates one trusted Workout handoff and opens the delivered request in Plan", async () => {
     const surface: ChatAttachmentComposerReadModel = {
       schemaVersion: 1,
@@ -1823,7 +2085,7 @@ describe("chat controller", () => {
     releaseRefresh();
     await chatA;
 
-    expect(controls.at(-1)?.newConversationDisabled).toBe(false);
+    await vi.waitFor(() => expect(controls.at(-1)?.newConversationDisabled).toBe(false));
     expect(controller.openNewConversation()).toBe(true);
     expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession")).toEqual(
       [],
@@ -1951,6 +2213,39 @@ describe("chat controller", () => {
     expect(
       vi.mocked(fake.call).mock.calls.filter(([method]) => method === "hasSession"),
     ).toHaveLength(0);
+  });
+
+  it("keeps the visible conversation and attachment draft when durable draft clearing fails", async () => {
+    const surface = imageComposer(true);
+    const clearAttachmentDraft = vi.fn(async () => {
+      throw new Error("private attachment clear failure");
+    });
+    const fake = client(replies(), {
+      composer: async () => surface,
+      resetSession: async () => ({ memoryFlushed: true }),
+      clearAttachmentDraft,
+    });
+    const { controller, states, controls } = subject(fake);
+    await controller.start();
+    await controller.submit("Original");
+    const beforeMessages = structuredClone(states.at(-1)?.messages);
+    expect(controller.openNewConversation()).toBe(true);
+
+    await controller.confirmNewConversation();
+
+    expect(states.at(-1)).toMatchObject({
+      messages: beforeMessages,
+      session: {
+        presence: "present",
+        resetPhase: "uncertain",
+        announcement: NEW_CONVERSATION_UNCERTAIN_COPY,
+      },
+    });
+    expect(controls.at(-1)?.attachments?.value).toEqual(surface);
+    expect(clearAttachmentDraft).toHaveBeenCalledOnce();
+    expect(
+      vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession"),
+    ).toHaveLength(1);
   });
 
   it("blocks reset while a durable retry is unresolved and preserves retry ownership", async () => {

--- a/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
@@ -83,6 +83,9 @@ function coachClient(input: {
       if (method === "getChatAttachmentComposer") {
         return Promise.resolve(emptyAttachmentComposer()) as never;
       }
+      if (method === "clearChatAttachmentDraft") {
+        return Promise.resolve(emptyAttachmentComposer()) as never;
+      }
       if (method === "getChatQueue") {
         return Promise.resolve({
           schemaVersion: 1,

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type {
   AttachmentCapabilitiesReadModel,
@@ -791,6 +791,15 @@ describe("chat surface", () => {
 
       expect(composer()).toBeEnabled();
       expect(composer()).toHaveFocus();
+    });
+
+    it("removes the file drop target while chat work is blocked", () => {
+      render(<Harness />);
+      const form = composer().closest("form");
+
+      expect(form).toHaveAttribute("data-chat-attachment-dropzone", "true");
+      setChat({ inputDisabled: true });
+      expect(form).not.toHaveAttribute("data-chat-attachment-dropzone");
     });
 
     it("leaves the composer unfocused when the app mounts on another destination", () => {
@@ -1623,6 +1632,25 @@ describe("chat surface", () => {
       await waitFor(() => {
         expect(dialog).not.toBeInTheDocument();
       });
+    });
+
+    it("cancels a pending draft save when reset succeeds", () => {
+      vi.useFakeTimers();
+      try {
+        render(<Harness />);
+        fireEvent.change(composer(), { target: { value: "pending reset draft" } });
+
+        setChat({ resetPhase: "confirming" });
+        setChat({ resetPhase: "resetting" });
+        setChat({ resetPhase: "idle", resetCount: 1 });
+        act(() => vi.advanceTimersByTime(300));
+
+        expect(composer()).toHaveValue("");
+        expect(actions.saveAttachmentDraftText).not.toHaveBeenCalled();
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
     });
 
     it("returns focus to the opener when the athlete cancels", async () => {

--- a/apps/desktop-renderer/tests/provider-model-settings.test.ts
+++ b/apps/desktop-renderer/tests/provider-model-settings.test.ts
@@ -93,6 +93,7 @@ function fakeView() {
 function createSubject(input: {
   readonly load?: () => Promise<OnboardingLlmConfiguration>;
   readonly apply?: () => Promise<OnboardingLlmSelectionResult>;
+  readonly onSaved?: () => Promise<void> | void;
   readonly openSetup?: () => void;
   readonly codexAgentSupported?: boolean;
 }) {
@@ -104,6 +105,7 @@ function createSubject(input: {
   const controller = createProviderModelSettingsController({
     load,
     apply,
+    ...(input.onSaved === undefined ? {} : { onSaved: input.onSaved }),
     openSetup: input.openSetup ?? vi.fn(),
     ...(input.codexAgentSupported === undefined
       ? {}
@@ -355,6 +357,33 @@ describe("provider and model settings controller", () => {
       active: { provider: "anthropic", model: "claude-private" },
       dirty: false,
     });
+  });
+
+  it("refreshes dependent surfaces after the new route is active", async () => {
+    const order: string[] = [];
+    const onSaved = vi.fn(async () => {
+      order.push("refresh");
+    });
+    const { controller, subject, apply } = createSubject({
+      apply: vi.fn(async () => {
+        order.push("apply");
+        return { status: "configured" as const, runtimeReady: true as const };
+      }),
+      onSaved,
+    });
+    await controller.activate();
+    subject.model("claude-opus");
+
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("saved"));
+
+    expect(apply).toHaveBeenCalledOnce();
+    expect(onSaved).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-opus",
+      endpoint: { mode: "automatic" },
+    });
+    expect(order).toEqual(["apply", "refresh"]);
   });
 
   it.each(["invalid-input", "credential-required", "runtime-unavailable"] as const)(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1345,6 +1345,7 @@ async function invokeTelegramSenders(): Promise<unknown> {
 
 let dropDisposer: (() => void) | undefined;
 let chatAttachmentDropDisposer: (() => void) | undefined;
+let chatAttachmentDropSequence = 0;
 const updateListeners = new Set<(state: PreloadUpdateState) => void>();
 const chatGptLoginProgressListeners = new Set<(progress: PreloadChatGptLoginProgress) => void>();
 const planProgressListeners = new Set<(progress: PlanProgressEvent) => void>();
@@ -1738,10 +1739,28 @@ contextBridge.exposeInMainWorld(
           .filter((path) => PlatformAbsolutePathSchema.safeParse(path).success)
           .slice(0, CHAT_ATTACHMENT_LIMITS.attachmentsPerMessage);
         if (paths.length === 0) return;
-        void ipcRenderer
-          .invoke(DESKTOP_CHAT_ATTACHMENT_DROP_CHANNEL, paths)
-          .then((value) => listener(parseAttachmentAdmissions(value)))
-          .catch(() => {});
+        const operationId = `drop-${++chatAttachmentDropSequence}`;
+        let accepted = false;
+        try {
+          accepted = listener({ phase: "started", operationId }) === true;
+        } catch {}
+        if (!accepted) return;
+        void ipcRenderer.invoke(DESKTOP_CHAT_ATTACHMENT_DROP_CHANNEL, paths).then(
+          (value) => {
+            let results: readonly AttachmentAdmissionReadModel[] | null = null;
+            try {
+              results = parseAttachmentAdmissions(value);
+            } catch {}
+            try {
+              listener({ phase: "settled", operationId, results });
+            } catch {}
+          },
+          () => {
+            try {
+              listener({ phase: "settled", operationId, results: null });
+            } catch {}
+          },
+        );
       };
       const onDragOver = (event: DragEvent): void => {
         const target = event.target;

--- a/apps/desktop/tests/chat-attachment-lifecycle.integration.test.ts
+++ b/apps/desktop/tests/chat-attachment-lifecycle.integration.test.ts
@@ -1,0 +1,1441 @@
+import { createServer } from "node:net";
+import { copyFile, mkdir, mkdtemp, readdir, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CHAT_ATTACHMENT_LIMITS,
+  type AttachmentCapabilitiesReadModel,
+  type ChatAttachmentReference,
+  type CoachEngine,
+  type TurnEvent,
+} from "@enduragent/coach-contract";
+import {
+  Memory,
+  classifyFailure,
+  createConversationStore,
+  createMissingPlatformCalendarMutations,
+  extractRetryAfterMs,
+  type ConversationStorePort,
+} from "@enduragent/core";
+import {
+  createAttachmentCapabilityResolver,
+  createCoachEngine,
+  transportForProvider,
+  type ChatAttachmentTurnPort,
+  type EngineHostPorts,
+  type ModelTransportRequest,
+} from "@enduragent/engine";
+import type { GenerateResult, Sport } from "@enduragent/engine/sport";
+import {
+  createChatAttachmentRepository,
+  runMigrations,
+  type ChatAttachmentRepository,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import {
+  createManagedActivityReader,
+  createManagedChatAttachmentStore,
+  createManagedDocumentReader,
+  createManagedMediaReader,
+} from "@enduragent/kernel-node/chat-attachments";
+import { createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createManagedWorkoutReader } from "@enduragent/sport-cycling/workout-import";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createActivityAttachmentOperations,
+  type ActivityAttachmentOperations,
+} from "../../../packages/coach/src/activity-attachment-operations.js";
+import {
+  createAttachmentComposerOperations,
+  type AttachmentComposerOperations,
+} from "../../../packages/coach/src/attachment-composer-operations.js";
+import {
+  createManagedChatAttachmentOperations,
+  type ManagedChatAttachmentOperations,
+} from "../../../packages/coach/src/attachment-operations.js";
+import { createDocumentMediaAttachmentOperations } from "../../../packages/coach/src/document-media-attachment-operations.js";
+import {
+  createWorkoutAttachmentOperations,
+  type WorkoutAttachmentOperations,
+} from "../../../packages/coach/src/workout-attachment-operations.js";
+import {
+  launchDesktopFixture,
+  type DesktopFixtureScript,
+  type RunningDesktopFixture,
+} from "./helpers/desktop-fixture.js";
+import { createPlanQaFixtureScript } from "./helpers/plan-qa-live.js";
+
+const hasLoopback = await new Promise<boolean>((resolveAvailability) => {
+  const server = createServer();
+  server.once("error", () => resolveAvailability(false));
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolveAvailability(true));
+  });
+});
+
+const token = "a".repeat(43);
+const chatId = "desktop";
+const activityName = "fallback-cycling.tcx";
+const imageName = "Synthetic recovery image.png";
+const imageDraftText = "Keep this recovery image for the next conversation.";
+const partialText = "I imported the synthetic ride and started reviewing";
+const completedText = "The synthetic ride is stored once in Training and ready for review.";
+const incompatibleModel = "synthetic-text-only";
+const activityFixturePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../packages/kernel-node/tests/fixtures/ingest/fallback-cycling.tcx",
+);
+const imageFixturePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../resources/app-icon.png",
+);
+const fixtures: RunningDesktopFixture[] = [];
+const backends: AttachmentLifecycleBackend[] = [];
+const scratchPaths: string[] = [];
+const configuredQaEvidenceDir = process.env.ENDURAGENT_VISIBLE_QA_EVIDENCE_DIR?.trim();
+const qaEvidenceDir =
+  configuredQaEvidenceDir === undefined || configuredQaEvidenceDir.length === 0
+    ? undefined
+    : resolve(configuredQaEvidenceDir);
+
+interface ScriptRequest {
+  readonly jsonrpc: "2.0";
+  readonly method: string;
+  readonly params: Record<string, unknown>;
+}
+
+function response(value: unknown): readonly string[] {
+  return [JSON.stringify(value)];
+}
+
+function generated(text: string): GenerateResult {
+  const usage = {
+    inputTokens: 1,
+    outputTokens: 1,
+    totalTokens: 2,
+    inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    outputTokenDetails: { textTokens: 1, reasoningTokens: 0 },
+  };
+  return { text, toolCalls: [], finishReason: "stop", usage, totalUsage: usage, steps: 1 };
+}
+
+const lifecycleSport = {
+  id: "cycling",
+  soul: "",
+  skills: {},
+  sessionClusterGapMinutes: 30,
+  memorySections: [],
+  mustPreserveTokens: [],
+  intervalsActivityTypes: [],
+  athleteProfileSchema: {},
+  tools: () => [],
+} as unknown as Sport;
+
+const workoutLimits = {
+  candidates: CHAT_ATTACHMENT_LIMITS.workoutCandidates,
+  segmentsPerWorkout: CHAT_ATTACHMENT_LIMITS.workoutSegments,
+  durationSeconds: CHAT_ATTACHMENT_LIMITS.workoutDurationSeconds,
+  diagnostics: CHAT_ATTACHMENT_LIMITS.workoutDiagnostics,
+  diagnosticChars: CHAT_ATTACHMENT_LIMITS.workoutDiagnosticChars,
+  titleChars: CHAT_ATTACHMENT_LIMITS.workoutTitleChars,
+  purposeChars: CHAT_ATTACHMENT_LIMITS.workoutPurposeChars,
+} as const;
+
+class AttachmentLifecycleBackend {
+  readonly calls: ScriptRequest[] = [];
+  readonly script: DesktopFixtureScript;
+  coachCalls = 0;
+  flushCalls = 0;
+  clearCalls = 0;
+  private store: (SqlStore & MigratorStore) | undefined;
+  private conversation: ConversationStorePort | undefined;
+  private repository: ChatAttachmentRepository | undefined;
+  private attachments: ManagedChatAttachmentOperations | undefined;
+  private activities: ActivityAttachmentOperations | undefined;
+  private workouts: WorkoutAttachmentOperations | undefined;
+  private composer: AttachmentComposerOperations | undefined;
+  private chatAttachments: ChatAttachmentTurnPort | undefined;
+  private capabilities: (() => Promise<AttachmentCapabilitiesReadModel>) | undefined;
+  private engine: CoachEngine | undefined;
+  private activeModel = "gpt-5.6-sol";
+  private runtimeProvider: "codex-agent" | "openai" = "codex-agent";
+  private failNextClear = false;
+  private instant = Date.UTC(1998, 7, 24, 8);
+  private engineIdSequence = 0;
+  private attachmentIdSequence = 0;
+  private lastEngineId: string | undefined;
+  private activityAttachmentId: string | undefined;
+
+  constructor(
+    private readonly databasePath: string,
+    private readonly conversationDir: string,
+    private readonly archiveDir: string,
+  ) {
+    const base = createPlanQaFixtureScript("PL-S004");
+    this.script = {
+      onRequest: async (value) => {
+        const request = value as ScriptRequest;
+        this.calls.push(request);
+        if (request.method === "enqueueChatMessage") {
+          const operation = this.requireEngine().enqueueChatMessage;
+          if (operation === undefined) throw new TypeError("queue admission is unavailable");
+          return response(
+            await operation({
+              chatId: String(request.params.chatId),
+              submissionId: String(request.params.submissionId),
+              text: String(request.params.text),
+              ...(Array.isArray(request.params.attachmentIds)
+                ? { attachmentIds: request.params.attachmentIds.map(String) }
+                : {}),
+            }),
+          );
+        }
+        if (request.method === "getChatQueue") {
+          const operation = this.requireEngine().getChatQueue;
+          if (operation === undefined) throw new TypeError("queue read is unavailable");
+          return response(await operation({ chatId: String(request.params.chatId) }));
+        }
+        if (request.method === "removeQueuedChatMessage") {
+          const operation = this.requireEngine().removeQueuedChatMessage;
+          if (operation === undefined) throw new TypeError("queue removal is unavailable");
+          return response(
+            await operation({
+              chatId: String(request.params.chatId),
+              queuedMessageId: String(request.params.queuedMessageId),
+            }),
+          );
+        }
+        if (request.method === "resumeChatQueue") {
+          const operation = this.requireEngine().resumeChatQueue;
+          if (operation === undefined) throw new TypeError("queue resume is unavailable");
+          return this.turnFrames((onEvent) =>
+            operation({ chatId: String(request.params.chatId) }, onEvent),
+          );
+        }
+        if (request.method === "retryQueuedTurn") {
+          const operation = this.requireEngine().retryQueuedTurn;
+          if (operation === undefined) throw new TypeError("queue retry is unavailable");
+          return this.turnFrames((onEvent) =>
+            operation(
+              {
+                chatId: String(request.params.chatId),
+                claimId: String(request.params.claimId),
+              },
+              onEvent,
+            ),
+          );
+        }
+        if (request.method === "stopChat") {
+          const operation = this.requireEngine().stopChat;
+          if (operation === undefined) throw new TypeError("chat stop is unavailable");
+          return response(
+            await operation({
+              chatId: String(request.params.chatId),
+              turnId: String(request.params.turnId),
+            }),
+          );
+        }
+        if (request.method === "hasSession") {
+          return response(await this.requireEngine().hasSession({ chatId }));
+        }
+        if (request.method === "resetSession") {
+          return response(
+            await this.requireEngine().resetSession({ chatId: String(request.params.chatId) }),
+          );
+        }
+        if (request.method === "getCoachDecision") {
+          return response(
+            await this.requireEngine().getCoachDecision({
+              chatId: String(request.params.chatId),
+            }),
+          );
+        }
+        if (request.method === "getTranscriptPage") {
+          const cursor = request.params.cursor;
+          const limit = request.params.limit;
+          if ((cursor !== null && typeof cursor !== "string") || typeof limit !== "number") {
+            throw new TypeError("invalid transcript page request");
+          }
+          return response(
+            this.requireConversation().readCurrentConversationPage(chatId, { cursor, limit }),
+          );
+        }
+        if (request.method === "getChatAttachmentComposer") {
+          return response(await this.requireComposer().read(String(request.params.chatId)));
+        }
+        if (request.method === "saveChatAttachmentDraftText") {
+          return response(
+            await this.requireComposer().saveText(
+              String(request.params.chatId),
+              String(request.params.text),
+            ),
+          );
+        }
+        if (request.method === "removeChatAttachment") {
+          return response(
+            await this.requireComposer().remove(
+              String(request.params.chatId),
+              String(request.params.attachmentId),
+            ),
+          );
+        }
+        if (request.method === "retryChatAttachment") {
+          return response(
+            await this.requireComposer().retry(
+              String(request.params.chatId),
+              String(request.params.attachmentId),
+            ),
+          );
+        }
+        if (request.method === "selectChatAttachmentWorkout") {
+          return response(
+            await this.requireComposer().selectWorkout(
+              String(request.params.chatId),
+              String(request.params.attachmentId),
+              String(request.params.workoutId),
+            ),
+          );
+        }
+        if (request.method === "clearChatAttachmentDraft") {
+          this.clearCalls += 1;
+          if (this.failNextClear) {
+            this.failNextClear = false;
+            throw new Error("synthetic draft clear uncertainty");
+          }
+          return response(await this.requireComposer().clear(String(request.params.chatId)));
+        }
+        if (request.method === "configureRuntime") {
+          const llm = request.params.llm;
+          if (llm === null || typeof llm !== "object" || Array.isArray(llm)) {
+            throw new TypeError("invalid runtime update");
+          }
+          const model = (llm as Record<string, unknown>).model;
+          if (typeof model === "string") this.activeModel = model;
+          this.engine = this.buildEngine();
+          return response({
+            schemaVersion: 3,
+            status: "applied",
+            applied: { llm: true, intervals: false, session: false },
+          });
+        }
+        if (request.method === "getRuntimeConfig") return response(this.runtimeConfig());
+        return base.onRequest(value);
+      },
+    };
+  }
+
+  async open(): Promise<void> {
+    await mkdir(this.archiveDir, { recursive: true, mode: 0o700 });
+    await mkdir(this.conversationDir, { recursive: true, mode: 0o700 });
+    const store = openSqliteStorage(this.databasePath);
+    await runMigrations(store, MIGRATIONS);
+    this.store = store;
+    const conversation = createConversationStore(this.conversationDir);
+    this.conversation = conversation;
+    const repository = createChatAttachmentRepository(store);
+    this.repository = repository;
+    const objects = createManagedChatAttachmentStore({
+      archiveDir: this.archiveDir,
+      kindByteLimits: {
+        document: CHAT_ATTACHMENT_LIMITS.documentBytes,
+        activity: CHAT_ATTACHMENT_LIMITS.activityBytes,
+        workout: CHAT_ATTACHMENT_LIMITS.workoutBytes,
+        image: CHAT_ATTACHMENT_LIMITS.imageBytes,
+      },
+      now: () => this.now(),
+    });
+    const activities = createActivityAttachmentOperations({
+      repository,
+      reader: createManagedActivityReader({
+        objects,
+        limits: {
+          activityBytes: CHAT_ATTACHMENT_LIMITS.activityBytes,
+          parserMs: CHAT_ATTACHMENT_LIMITS.parserMs,
+          parserOldGenerationMiB: CHAT_ATTACHMENT_LIMITS.parserOldGenerationMiB,
+          sessions: 256,
+        },
+      }),
+      importer: createNodeImportRuntime({ archiveDir: this.archiveDir, store }),
+      store,
+      runExclusive: (work) => work(),
+      now: () => this.now(),
+    });
+    this.activities = activities;
+    const workouts = createWorkoutAttachmentOperations({
+      repository,
+      reader: createManagedWorkoutReader({
+        objects,
+        limits: {
+          ...workoutLimits,
+          workoutBytes: CHAT_ATTACHMENT_LIMITS.workoutBytes,
+          parserMs: CHAT_ATTACHMENT_LIMITS.parserMs,
+          parserOldGenerationMiB: CHAT_ATTACHMENT_LIMITS.parserOldGenerationMiB,
+        },
+      }),
+      limits: workoutLimits,
+      runExclusive: (work) => work(),
+      now: () => this.now(),
+    });
+    this.workouts = workouts;
+    const documentMedia = createDocumentMediaAttachmentOperations({
+      repository,
+      documents: createManagedDocumentReader({
+        objects,
+        limits: {
+          documentBytes: CHAT_ATTACHMENT_LIMITS.documentBytes,
+          extractedTextChars: CHAT_ATTACHMENT_LIMITS.extractedTextChars,
+          pdfPages: CHAT_ATTACHMENT_LIMITS.pdfPages,
+          pdfVisualPages: CHAT_ATTACHMENT_LIMITS.pdfVisualPages,
+          pdfUsefulTextCharsPerPage: CHAT_ATTACHMENT_LIMITS.pdfUsefulTextCharsPerPage,
+          docxEntries: CHAT_ATTACHMENT_LIMITS.docxEntries,
+          docxExpandedBytes: CHAT_ATTACHMENT_LIMITS.docxExpandedBytes,
+          docxCompressionRatio: CHAT_ATTACHMENT_LIMITS.docxCompressionRatio,
+          csvRows: CHAT_ATTACHMENT_LIMITS.csvRows,
+          csvColumns: CHAT_ATTACHMENT_LIMITS.csvColumns,
+          csvRecordChars: CHAT_ATTACHMENT_LIMITS.csvRecordChars,
+          parserMs: CHAT_ATTACHMENT_LIMITS.parserMs,
+          parserOldGenerationMiB: CHAT_ATTACHMENT_LIMITS.parserOldGenerationMiB,
+        },
+      }),
+      media: createManagedMediaReader({
+        objects,
+        limits: {
+          imageBytes: CHAT_ATTACHMENT_LIMITS.imageBytes,
+          imageDimension: CHAT_ATTACHMENT_LIMITS.imageDimension,
+          imagePixels: CHAT_ATTACHMENT_LIMITS.imagePixels,
+          documentBytes: CHAT_ATTACHMENT_LIMITS.documentBytes,
+          pdfPages: CHAT_ATTACHMENT_LIMITS.pdfPages,
+          pdfVisualPages: CHAT_ATTACHMENT_LIMITS.pdfVisualPages,
+          pdfVisualPixels: CHAT_ATTACHMENT_LIMITS.pdfVisualPixels,
+          pdfPageDimension: CHAT_ATTACHMENT_LIMITS.pdfPageDimension,
+          parserMs: CHAT_ATTACHMENT_LIMITS.parserMs,
+          parserOldGenerationMiB: CHAT_ATTACHMENT_LIMITS.parserOldGenerationMiB,
+        },
+      }),
+      runExclusive: (work) => work(),
+      now: () => this.now(),
+    });
+    const attachments = createManagedChatAttachmentOperations({
+      repository,
+      objects,
+      runExclusive: (work) => work(),
+      now: () => this.now(),
+      randomId: () => `synthetic-attachment-${++this.attachmentIdSequence}`,
+      onAdmitted: async (admitted) => {
+        await documentMedia.preprocessAdmitted(admitted);
+        await activities.preprocessAdmitted(admitted);
+        await workouts.preprocessAdmitted(admitted);
+      },
+    });
+    this.attachments = attachments;
+    await attachments.reconcile();
+    const capabilityResolver = createAttachmentCapabilityResolver({
+      openRouterCache: { read: async () => undefined, write: async () => {} },
+      metadataMaxAgeMs: CHAT_ATTACHMENT_LIMITS.capabilityMetadataMaxAgeMs,
+      now: () => this.now(),
+    });
+    const capabilities = () =>
+      capabilityResolver.resolve({
+        provider: "openai",
+        model: this.activeModel,
+        transport: transportForProvider("openai"),
+        apiKey: "fixture",
+      });
+    this.capabilities = capabilities;
+    this.composer = createAttachmentComposerOperations({
+      repository,
+      attachments,
+      activities,
+      workouts,
+      capabilities,
+    });
+    const chatAttachments: ChatAttachmentTurnPort = {
+      acceptQueuedMessage: async (request) => {
+        await repository.linkMessage({
+          conversationId: request.chatId,
+          messageId: request.messageId,
+          attachmentIds: request.attachmentIds,
+          createdAtMs: this.now(),
+        });
+      },
+      prepareQueuedTurn: async (request) => {
+        const activity = await activities.turnPort.prepareQueuedTurn(request);
+        const document = await documentMedia.prepareLinkedTurn(request);
+        const workout = await workouts.prepareLinkedTurn(request);
+        const attachmentContext = [document.attachmentContext, workout.attachmentContext]
+          .filter((value): value is string => value !== undefined)
+          .join("\n");
+        const untrustedAttachmentText = [
+          document.untrustedAttachmentText,
+          workout.untrustedAttachmentText,
+        ]
+          .filter((value): value is string => value !== undefined)
+          .join("\n");
+        const references: ChatAttachmentReference[] = [];
+        for (const message of request.messages) {
+          for (const attachment of await repository.listMessageAttachments(message.messageId)) {
+            references.push({
+              attachmentId: attachment.id,
+              displayName: attachment.display_name,
+              kind: attachment.kind,
+              extension: attachment.extension as ChatAttachmentReference["extension"],
+            });
+          }
+        }
+        return {
+          ...activity,
+          attachments: references,
+          nativeMedia: document.nativeMedia,
+          ...(attachmentContext.length === 0 ? {} : { attachmentContext }),
+          ...(untrustedAttachmentText.length === 0 ? {} : { untrustedAttachmentText }),
+        };
+      },
+      completeQueuedTurn: async (request) => {
+        await activities.turnPort.completeQueuedTurn(request);
+        await documentMedia.completeLinkedTurn(request);
+        await workouts.completeLinkedTurn(request);
+      },
+    };
+    this.chatAttachments = chatAttachments;
+    this.engine = this.buildEngine();
+  }
+
+  async seedActivityDraft(): Promise<void> {
+    const admission = await this.requireAttachments().admit({
+      chatId,
+      selectionId: "synthetic-activity-selection",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath: activityFixturePath },
+    });
+    if (admission.status !== "accepted") throw new TypeError("activity admission failed");
+    this.activityAttachmentId = admission.attachmentId;
+  }
+
+  async seedImageDraft(): Promise<void> {
+    const sourcePath = join(dirname(this.databasePath), imageName);
+    await copyFile(imageFixturePath, sourcePath);
+    const admission = await this.requireAttachments().admit({
+      chatId,
+      selectionId: "synthetic-image-selection",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath },
+    });
+    if (admission.status !== "accepted") throw new TypeError("image admission failed");
+    await this.requireAttachments().saveDraftText(chatId, imageDraftText);
+  }
+
+  failDraftClearOnce(): void {
+    this.failNextClear = true;
+  }
+
+  exposeProviderSettings(): void {
+    this.runtimeProvider = "openai";
+  }
+
+  restoreKeylessStartup(): void {
+    this.runtimeProvider = "codex-agent";
+  }
+
+  async reopen(): Promise<void> {
+    await this.closeStore();
+    await this.open();
+  }
+
+  async close(): Promise<void> {
+    await this.closeStore();
+  }
+
+  async snapshot() {
+    const store = this.requireStore();
+    const training = await store.get(
+      "SELECT COUNT(*) AS count, MIN(sport) AS sport, MIN(local_date_key) AS local_date_key FROM session",
+    );
+    const activity =
+      this.activityAttachmentId === undefined
+        ? undefined
+        : await this.requireRepository().readAttachment(this.activityAttachmentId);
+    const draft = (await this.requireComposer().read(chatId)).draft;
+    const transcript = this.requireConversation().readCurrentConversationPage(chatId, {
+      cursor: null,
+      limit: 25,
+    });
+    const transcriptTurns =
+      "entries" in transcript
+        ? transcript.entries.filter((entry) => entry.kind === "turn")
+        : transcript.turns;
+    const queueOperation = this.requireEngine().getChatQueue;
+    if (queueOperation === undefined) throw new TypeError("queue read is unavailable");
+    const queue = await queueOperation({ chatId });
+    return {
+      training: {
+        count: Number(training?.count ?? 0),
+        sport:
+          training?.sport === null || training?.sport === undefined ? null : String(training.sport),
+        localDateKey: Number(training?.local_date_key ?? 0),
+      },
+      activityStatus: activity?.status ?? null,
+      draft:
+        draft === null
+          ? null
+          : {
+              text: draft.text,
+              attachments: draft.attachments.map((attachment) => ({
+                name: attachment.displayName,
+                status: attachment.status,
+              })),
+            },
+      transcript: transcriptTurns.map((entry) => ({
+        coachText: entry.coachText,
+        delivery: entry.delivery ?? "complete",
+        attachments: entry.attachments?.map((attachment) => attachment.displayName) ?? [],
+      })),
+      queue: { count: queue.items.length, retryRequired: queue.retryRequired !== undefined },
+      coachCalls: this.coachCalls,
+      flushCalls: this.flushCalls,
+      clearCalls: this.clearCalls,
+      activeModel: this.activeModel,
+    };
+  }
+
+  private buildEngine(): CoachEngine {
+    const conversation = this.requireConversation();
+    const capabilities = this.requireCapabilities();
+    const ports: EngineHostPorts = {
+      config: {
+        dataSource: "platform",
+        llm: { provider: "openai", model: this.activeModel, apiKey: "fixture" },
+        session: {
+          historyTokenBudgetRatio: 0.3,
+          idleMinutes: 0,
+          dailyResetHour: 4,
+          resetArchiveRetentionDays: 0,
+          timezone: "UTC",
+        },
+        contextWindowTokens: 272_000,
+        compactContextWindowTokens: 272_000,
+      },
+      memory: new Memory(this.conversationDir, "UTC"),
+      chatStore: conversation,
+      chatAttachments: this.requireChatAttachments(),
+      attachmentCapabilities: { resolve: () => capabilities() },
+      transcriptWriter: conversation,
+      coachDecisions: conversation,
+      secrets: { resolve: async () => "" },
+      platform: {
+        legacyClient: null,
+        athleteData: undefined,
+        calendarMutations: createMissingPlatformCalendarMutations(),
+      },
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      usage: { append: () => {} },
+      stateReader: {
+        getAthleteState: async () => {
+          throw new TypeError("athlete state is unavailable in this fixture");
+        },
+      },
+      readReferenceState: () => ({ errorState: null, latest: null }),
+      getAccessToken: async () => "token",
+      classifyFailure,
+      extractRetryAfterMs,
+      now: () => this.now(),
+      randomId: () => {
+        const id = `synthetic-engine-${++this.engineIdSequence}`;
+        this.lastEngineId = id;
+        return id;
+      },
+      modelTransportDecorator: () => ({ generate: (request) => this.generate(request) }),
+    };
+    return createCoachEngine({ sport: lifecycleSport, ports });
+  }
+
+  private async generate(request: ModelTransportRequest): Promise<GenerateResult> {
+    if (request.options.caller === "flush") {
+      this.flushCalls += 1;
+      return generated("Synthetic memory flush complete.");
+    }
+    if (request.options.caller !== "chat") return generated("Synthetic maintenance complete.");
+    this.coachCalls += 1;
+    if (this.coachCalls === 1) {
+      request.options.onTextDelta?.(partialText);
+      const turnId = this.lastEngineId;
+      const stop = this.requireEngine().stopChat;
+      if (turnId === undefined || stop === undefined) throw new TypeError("active turn is missing");
+      const result = await stop({ chatId, turnId });
+      if (!result.stopped) throw new TypeError("active turn did not stop");
+      request.options.signal?.throwIfAborted();
+      throw new TypeError("synthetic interrupted turn remained active");
+    }
+    if (this.coachCalls !== 2) throw new TypeError("unexpected Coach invocation");
+    request.options.onTextDelta?.(completedText);
+    return generated(completedText);
+  }
+
+  private async turnFrames(
+    run: (onEvent: (event: TurnEvent) => void) => Promise<unknown>,
+  ): Promise<readonly string[]> {
+    const events: TurnEvent[] = [];
+    const result = await run((event) => events.push(event));
+    return [...events.map((event) => JSON.stringify(event)), JSON.stringify(result)];
+  }
+
+  private runtimeConfig() {
+    return {
+      schemaVersion: 3,
+      llm: {
+        provider: this.runtimeProvider,
+        model: this.activeModel,
+        credential_configured: true,
+      },
+      intervals: {
+        athlete_id: "0",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+        resetArchiveRetentionDays: 0,
+        timezone: "UTC",
+        managedByEnvironment: {
+          historyTokenBudgetRatio: false,
+          idleMinutes: false,
+          dailyResetHour: false,
+          resetArchiveRetentionDays: false,
+          timezone: false,
+        },
+      },
+    } as const;
+  }
+
+  private now(): number {
+    return ++this.instant;
+  }
+
+  private requireStore(): SqlStore & MigratorStore {
+    if (this.store === undefined) throw new TypeError("store is closed");
+    return this.store;
+  }
+
+  private requireConversation(): ConversationStorePort {
+    if (this.conversation === undefined) throw new TypeError("conversation store is closed");
+    return this.conversation;
+  }
+
+  private requireRepository(): ChatAttachmentRepository {
+    if (this.repository === undefined) throw new TypeError("attachment repository is closed");
+    return this.repository;
+  }
+
+  private requireAttachments(): ManagedChatAttachmentOperations {
+    if (this.attachments === undefined) throw new TypeError("attachment operations are closed");
+    return this.attachments;
+  }
+
+  private requireComposer(): AttachmentComposerOperations {
+    if (this.composer === undefined) throw new TypeError("attachment composer is closed");
+    return this.composer;
+  }
+
+  private requireCapabilities(): () => Promise<AttachmentCapabilitiesReadModel> {
+    if (this.capabilities === undefined) throw new TypeError("capability resolver is closed");
+    return this.capabilities;
+  }
+
+  private requireChatAttachments(): ChatAttachmentTurnPort {
+    if (this.chatAttachments === undefined) throw new TypeError("attachment turn port is closed");
+    return this.chatAttachments;
+  }
+
+  private requireEngine(): CoachEngine {
+    if (this.engine === undefined) throw new TypeError("coach engine is closed");
+    return this.engine;
+  }
+
+  private async closeStore(): Promise<void> {
+    const store = this.store;
+    this.store = undefined;
+    this.conversation = undefined;
+    this.repository = undefined;
+    this.attachments = undefined;
+    this.activities = undefined;
+    this.workouts = undefined;
+    this.composer = undefined;
+    this.chatAttachments = undefined;
+    this.capabilities = undefined;
+    this.engine = undefined;
+    if (store !== undefined) await store.close();
+  }
+}
+
+async function waitForActivityDraft(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly draft: string;
+    readonly attachmentCount: number;
+    readonly sendDisabled: boolean;
+  }>(`
+    const name = ${JSON.stringify(activityName)};
+    const deadline = Date.now() + 10000;
+    let attachment;
+    let composer;
+    let send;
+    while (Date.now() < deadline) {
+      attachment = document.querySelector('section[aria-label="' + name + ' attachment"]');
+      composer = document.querySelector("textarea#message");
+      send = document.querySelector('button[aria-label="Send message"]');
+      if (
+        attachment instanceof HTMLElement &&
+        composer instanceof HTMLTextAreaElement &&
+        send instanceof HTMLButtonElement
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(attachment instanceof HTMLElement)) throw new Error("activity attachment missing");
+    if (!(composer instanceof HTMLTextAreaElement)) throw new Error("composer missing");
+    if (!(send instanceof HTMLButtonElement)) throw new Error("send action missing");
+    return {
+      draft: composer.value,
+      attachmentCount: document.querySelectorAll(
+        'section[aria-label="' + name + ' attachment"]',
+      ).length,
+      sendDisabled: send.disabled,
+    };
+  `);
+}
+
+async function captureQaEvidence(fixture: RunningDesktopFixture, name: string): Promise<void> {
+  if (qaEvidenceDir === undefined) return;
+  await fixture.setViewport(1180, 820);
+  await fixture.screenshot(join(qaEvidenceDir, `${name}.png`));
+}
+
+async function sendAndWaitForInterruption(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly retryCount: number;
+    readonly athleteAttachmentCount: number;
+    readonly partialCount: number;
+  }>(`
+    const name = ${JSON.stringify(activityName)};
+    const partial = ${JSON.stringify(partialText)};
+    const send = document.querySelector('button[aria-label="Send message"]');
+    if (!(send instanceof HTMLButtonElement)) throw new Error("send action missing");
+    send.click();
+    const deadline = Date.now() + 20000;
+    let retry;
+    while (Date.now() < deadline) {
+      retry = [...document.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Retry interrupted message",
+      );
+      const athleteReady = [...document.querySelectorAll("article.chat-message--athlete")].some(
+        (row) => row.textContent?.includes(name),
+      );
+      const partialReady = [...document.querySelectorAll("article.chat-message--coach")].some(
+        (row) => row.textContent?.includes(partial),
+      );
+      if (retry instanceof HTMLButtonElement && athleteReady && partialReady) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(retry instanceof HTMLButtonElement)) throw new Error("durable retry action missing");
+    const athleteRows = [...document.querySelectorAll("article.chat-message--athlete")].filter(
+      (row) => row.textContent?.includes(name),
+    );
+    const coachRows = [...document.querySelectorAll("article.chat-message--coach")].filter(
+      (row) => row.textContent?.includes(partial),
+    );
+    return {
+      retryCount: [...document.querySelectorAll("button")].filter(
+        (button) => button.textContent?.trim() === "Retry interrupted message",
+      ).length,
+      athleteAttachmentCount: athleteRows.length,
+      partialCount: coachRows.length,
+    };
+  `);
+}
+
+async function readRetrySurface(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly retryCount: number;
+    readonly athleteAttachmentCount: number;
+    readonly partialCount: number;
+  }>(`
+    const name = ${JSON.stringify(activityName)};
+    const partial = ${JSON.stringify(partialText)};
+    const deadline = Date.now() + 10000;
+    let retry;
+    while (Date.now() < deadline) {
+      retry = [...document.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Retry interrupted message",
+      );
+      const athleteReady = [...document.querySelectorAll("article.chat-message--athlete")].some(
+        (row) => row.textContent?.includes(name),
+      );
+      const partialReady = [...document.querySelectorAll("article.chat-message--coach")].some(
+        (row) => row.textContent?.includes(partial),
+      );
+      if (retry instanceof HTMLButtonElement && athleteReady && partialReady) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(retry instanceof HTMLButtonElement)) throw new Error("restored retry action missing");
+    return {
+      retryCount: [...document.querySelectorAll("button")].filter(
+        (button) => button.textContent?.trim() === "Retry interrupted message",
+      ).length,
+      athleteAttachmentCount: [...document.querySelectorAll("article.chat-message--athlete")].filter(
+        (row) => row.textContent?.includes(name),
+      ).length,
+      partialCount: [...document.querySelectorAll("article.chat-message--coach")].filter(
+        (row) => row.textContent?.includes(partial),
+      ).length,
+    };
+  `);
+}
+
+async function retryAndReadCompleted(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly retryCount: number;
+    readonly athleteAttachmentCount: number;
+    readonly completedCount: number;
+  }>(`
+    const name = ${JSON.stringify(activityName)};
+    const completed = ${JSON.stringify(completedText)};
+    const retry = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Retry interrupted message",
+    );
+    if (!(retry instanceof HTMLButtonElement)) throw new Error("retry action missing");
+    retry.click();
+    const deadline = Date.now() + 20000;
+    while (Date.now() < deadline) {
+      const completedRows = [...document.querySelectorAll("article.chat-message--coach")].filter(
+        (row) => row.textContent?.includes(completed),
+      );
+      const retryCount = [...document.querySelectorAll("button")].filter(
+        (button) => button.textContent?.trim() === "Retry interrupted message",
+      ).length;
+      if (completedRows.length === 1 && retryCount === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return {
+      retryCount: [...document.querySelectorAll("button")].filter(
+        (button) => button.textContent?.trim() === "Retry interrupted message",
+      ).length,
+      athleteAttachmentCount: [...document.querySelectorAll("article.chat-message--athlete")].filter(
+        (row) => row.textContent?.includes(name),
+      ).length,
+      completedCount: [...document.querySelectorAll("article.chat-message--coach")].filter(
+        (row) => row.textContent?.includes(completed),
+      ).length,
+    };
+  `);
+}
+
+async function readCompletedSurface(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly athleteAttachmentCount: number;
+    readonly partialCount: number;
+    readonly completedCount: number;
+  }>(`
+    const name = ${JSON.stringify(activityName)};
+    const partial = ${JSON.stringify(partialText)};
+    const completed = ${JSON.stringify(completedText)};
+    const deadline = Date.now() + 10000;
+    while (Date.now() < deadline) {
+      if (
+        [...document.querySelectorAll("article.chat-message--coach")].some(
+          (row) => row.textContent?.includes(completed),
+        )
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return {
+      athleteAttachmentCount: [...document.querySelectorAll("article.chat-message--athlete")].filter(
+        (row) => row.textContent?.includes(name),
+      ).length,
+      partialCount: [...document.querySelectorAll("article.chat-message--coach")].filter(
+        (row) => row.textContent?.includes(partial),
+      ).length,
+      completedCount: [...document.querySelectorAll("article.chat-message--coach")].filter(
+        (row) => row.textContent?.includes(completed),
+      ).length,
+    };
+  `);
+}
+
+async function readImageDraft(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly draft: string;
+    readonly imageCount: number;
+    readonly ready: boolean;
+    readonly activityTranscriptCount: number;
+  }>(`
+    const imageName = ${JSON.stringify(imageName)};
+    const activityName = ${JSON.stringify(activityName)};
+    const draftText = ${JSON.stringify(imageDraftText)};
+    const deadline = Date.now() + 10000;
+    let attachment;
+    let composer;
+    while (Date.now() < deadline) {
+      attachment = document.querySelector('section[aria-label="' + imageName + ' attachment"]');
+      composer = document.querySelector("textarea#message");
+      if (
+        attachment instanceof HTMLElement &&
+        composer instanceof HTMLTextAreaElement &&
+        composer.value === draftText &&
+        [...document.querySelectorAll("article.chat-message--athlete")].some(
+          (row) => row.textContent?.includes(activityName),
+        )
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(attachment instanceof HTMLElement)) throw new Error("image attachment missing");
+    if (!(composer instanceof HTMLTextAreaElement)) throw new Error("composer missing");
+    return {
+      draft: composer.value,
+      imageCount: document.querySelectorAll(
+        'section[aria-label="' + imageName + ' attachment"]',
+      ).length,
+      ready: attachment.textContent?.includes("Image input available") === true,
+      activityTranscriptCount: [...document.querySelectorAll("article.chat-message--athlete")].filter(
+        (row) => row.textContent?.includes(activityName),
+      ).length,
+    };
+  `);
+}
+
+async function switchModelAndReadBlockedDraft(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly blocked: boolean;
+    readonly settingsActionCount: number;
+    readonly draft: string;
+  }>(`
+    const imageName = ${JSON.stringify(imageName)};
+    const model = ${JSON.stringify(incompatibleModel)};
+    const nav = (label) => [...document.querySelectorAll('nav[aria-label="Main navigation"] button')]
+      .find((button) => button.textContent?.includes(label));
+    const settings = nav("Settings");
+    if (!(settings instanceof HTMLButtonElement)) throw new Error("Settings navigation missing");
+    settings.click();
+    const settingsDeadline = Date.now() + 10000;
+    while (document.querySelector("#coach-model") === null && Date.now() < settingsDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    const trigger = document.querySelector("#coach-model");
+    if (!(trigger instanceof HTMLButtonElement)) throw new Error("model control missing");
+    trigger.click();
+    const optionDeadline = Date.now() + 10000;
+    let option;
+    while (option === undefined && Date.now() < optionDeadline) {
+      option = [...document.querySelectorAll('[role="option"]')].find(
+        (entry) => entry.textContent?.trim() === "Other model…",
+      );
+      if (option === undefined) await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(option instanceof HTMLElement)) throw new Error("custom model option missing");
+    option.click();
+    const customDeadline = Date.now() + 10000;
+    while (document.querySelector("#coach-custom-model") === null && Date.now() < customDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    const custom = document.querySelector("#coach-custom-model");
+    if (!(custom instanceof HTMLInputElement)) throw new Error("custom model input missing");
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    setter?.call(custom, model);
+    custom.dispatchEvent(new Event("input", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const save = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Save coach route",
+    );
+    if (!(save instanceof HTMLButtonElement) || save.disabled) {
+      throw new Error("save coach route action unavailable");
+    }
+    save.click();
+    const savedDeadline = Date.now() + 10000;
+    while (
+      !document.body.textContent?.includes("Coach settings saved.") &&
+      Date.now() < savedDeadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!document.body.textContent?.includes("Coach settings saved.")) {
+      throw new Error("coach route did not save");
+    }
+    const chat = nav("Chat");
+    if (!(chat instanceof HTMLButtonElement)) throw new Error("Chat navigation missing");
+    chat.click();
+    const blockedDeadline = Date.now() + 10000;
+    let attachment;
+    while (Date.now() < blockedDeadline) {
+      attachment = document.querySelector('section[aria-label="' + imageName + ' attachment"]');
+      if (
+        attachment instanceof HTMLElement &&
+        attachment.textContent?.includes("This model can’t view this file")
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(attachment instanceof HTMLElement)) throw new Error("blocked image attachment missing");
+    const composer = document.querySelector("textarea#message");
+    if (!(composer instanceof HTMLTextAreaElement)) throw new Error("composer missing");
+    return {
+      blocked: attachment.textContent?.includes("This model can’t view this file") === true,
+      settingsActionCount: [...attachment.querySelectorAll("button")].filter(
+        (button) => button.textContent?.trim() === "Open Settings",
+      ).length,
+      draft: composer.value,
+    };
+  `);
+}
+
+async function resetAndReadUncertain(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly uncertaintyVisible: boolean;
+    readonly activityTranscriptCount: number;
+    readonly imageCount: number;
+    readonly draft: string;
+    readonly newChatAriaDisabled: string | null;
+  }>(`
+    const activityName = ${JSON.stringify(activityName)};
+    const imageName = ${JSON.stringify(imageName)};
+    const uncertainty = "We couldn’t confirm whether the new conversation started. Your visible conversation is preserved.";
+    const actionDeadline = Date.now() + 10000;
+    let newChat;
+    while (Date.now() < actionDeadline) {
+      newChat = [...document.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "New chat",
+      );
+      if (
+        newChat instanceof HTMLButtonElement &&
+        !newChat.disabled &&
+        newChat.getAttribute("aria-disabled") !== "true"
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (
+      !(newChat instanceof HTMLButtonElement) ||
+      newChat.disabled ||
+      newChat.getAttribute("aria-disabled") === "true"
+    ) throw new Error("New chat action unavailable");
+    newChat.click();
+    const dialogDeadline = Date.now() + 10000;
+    let confirm;
+    while (Date.now() < dialogDeadline) {
+      confirm = [...document.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Start new conversation",
+      );
+      if (confirm instanceof HTMLButtonElement) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(confirm instanceof HTMLButtonElement)) throw new Error("reset confirmation missing");
+    confirm.click();
+    const resetDeadline = Date.now() + 20000;
+    while (!document.body.textContent?.includes(uncertainty) && Date.now() < resetDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    const composer = document.querySelector("textarea#message");
+    const currentNewChat = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "New chat",
+    );
+    if (!(composer instanceof HTMLTextAreaElement)) throw new Error("composer missing");
+    if (!(currentNewChat instanceof HTMLButtonElement)) throw new Error("New chat action missing");
+    return {
+      uncertaintyVisible: document.body.textContent?.includes(uncertainty) === true,
+      activityTranscriptCount: [...document.querySelectorAll("article.chat-message--athlete")].filter(
+        (row) => row.textContent?.includes(activityName),
+      ).length,
+      imageCount: document.querySelectorAll(
+        'section[aria-label="' + imageName + ' attachment"]',
+      ).length,
+      draft: composer.value,
+      newChatAriaDisabled: currentNewChat.getAttribute("aria-disabled"),
+    };
+  `);
+}
+
+async function readDraftAfterUncertainRelaunch(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly activityTranscriptCount: number;
+    readonly imageCount: number;
+    readonly draft: string;
+  }>(`
+    const activityName = ${JSON.stringify(activityName)};
+    const imageName = ${JSON.stringify(imageName)};
+    const draftText = ${JSON.stringify(imageDraftText)};
+    const deadline = Date.now() + 10000;
+    let composer;
+    while (Date.now() < deadline) {
+      composer = document.querySelector("textarea#message");
+      if (composer instanceof HTMLTextAreaElement && composer.value === draftText) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(composer instanceof HTMLTextAreaElement)) throw new Error("composer missing");
+    return {
+      activityTranscriptCount: [...document.querySelectorAll("article.chat-message--athlete")].filter(
+        (row) => row.textContent?.includes(activityName),
+      ).length,
+      imageCount: document.querySelectorAll(
+        'section[aria-label="' + imageName + ' attachment"]',
+      ).length,
+      draft: composer.value,
+    };
+  `);
+}
+
+async function confirmResetSuccess(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly successVisible: boolean;
+    readonly imageCount: number;
+    readonly draft: string;
+  }>(`
+    const imageName = ${JSON.stringify(imageName)};
+    const success = "New conversation started.";
+    const actionDeadline = Date.now() + 10000;
+    let newChat;
+    while (Date.now() < actionDeadline) {
+      newChat = [...document.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "New chat",
+      );
+      if (
+        newChat instanceof HTMLButtonElement &&
+        !newChat.disabled &&
+        newChat.getAttribute("aria-disabled") !== "true"
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (
+      !(newChat instanceof HTMLButtonElement) ||
+      newChat.disabled ||
+      newChat.getAttribute("aria-disabled") === "true"
+    ) throw new Error("New chat action unavailable");
+    newChat.click();
+    const dialogDeadline = Date.now() + 10000;
+    let confirm;
+    while (Date.now() < dialogDeadline) {
+      confirm = [...document.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Start new conversation",
+      );
+      if (confirm instanceof HTMLButtonElement) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(confirm instanceof HTMLButtonElement)) throw new Error("reset confirmation missing");
+    confirm.click();
+    const resetDeadline = Date.now() + 20000;
+    while (Date.now() < resetDeadline) {
+      const composer = document.querySelector("textarea#message");
+      const image = document.querySelector('section[aria-label="' + imageName + ' attachment"]');
+      if (
+        composer instanceof HTMLTextAreaElement &&
+        composer.value === "" &&
+        image === null &&
+        document.body.textContent?.includes(success)
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    const composer = document.querySelector("textarea#message");
+    if (!(composer instanceof HTMLTextAreaElement)) throw new Error("composer missing");
+    return {
+      successVisible: document.body.textContent?.includes(success) === true,
+      imageCount: document.querySelectorAll(
+        'section[aria-label="' + imageName + ' attachment"]',
+      ).length,
+      draft: composer.value,
+    };
+  `);
+}
+
+afterEach(async () => {
+  const failures: unknown[] = [];
+  for (const results of [
+    await Promise.allSettled(fixtures.splice(0).map(async (fixture) => fixture.close())),
+    await Promise.allSettled(backends.splice(0).map(async (backend) => backend.close())),
+    await Promise.allSettled(
+      scratchPaths
+        .splice(0)
+        .map(async (path) =>
+          rm(path, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }),
+        ),
+    ),
+  ]) {
+    for (const result of results) {
+      if (result.status === "rejected") failures.push(result.reason);
+    }
+  }
+  if (failures.length > 0) throw new AggregateError(failures, "desktop fixture cleanup failed");
+});
+
+describe.skipIf(process.platform !== "darwin" || !hasLoopback)(
+  "Chat attachment production lifecycle",
+  () => {
+    it("preserves one canonical import, retry summaries, incompatible drafts, and reset certainty", async () => {
+      if (qaEvidenceDir !== undefined) {
+        await mkdir(qaEvidenceDir, { recursive: true, mode: 0o700 });
+        if ((await readdir(qaEvidenceDir)).length > 0) {
+          throw new Error("visible QA evidence directory must be empty");
+        }
+      }
+      const scratch = await mkdtemp(join(await realpath(tmpdir()), "chat-attachment-lifecycle-"));
+      scratchPaths.push(scratch);
+      const backend = new AttachmentLifecycleBackend(
+        join(scratch, "training.sqlite"),
+        join(scratch, "conversation"),
+        join(scratch, "attachments"),
+      );
+      backends.push(backend);
+      await backend.open();
+      await backend.seedActivityDraft();
+
+      expect(await backend.snapshot()).toMatchObject({
+        training: { count: 0, sport: null, localDateKey: 0 },
+        activityStatus: "ready",
+        draft: { text: "", attachments: [{ name: activityName, status: "ready" }] },
+        queue: { count: 0, retryRequired: false },
+        coachCalls: 0,
+      });
+
+      const fixture = await launchDesktopFixture({
+        script: backend.script,
+        token,
+        width: 1180,
+        height: 820,
+        colorScheme: "light",
+        reducedMotion: true,
+        hidden: qaEvidenceDir === undefined,
+        routeChatAttachmentComposer: true,
+      });
+      fixtures.push(fixture);
+
+      expect(await waitForActivityDraft(fixture)).toEqual({
+        draft: "",
+        attachmentCount: 1,
+        sendDisabled: false,
+      });
+      expect((await backend.snapshot()).training.count).toBe(0);
+      await captureQaEvidence(fixture, "01-pre-send-activity-draft");
+
+      expect(await sendAndWaitForInterruption(fixture)).toEqual({
+        retryCount: 1,
+        athleteAttachmentCount: 1,
+        partialCount: 1,
+      });
+      expect(await backend.snapshot()).toMatchObject({
+        training: { count: 1, sport: "cycling", localDateKey: 19980704 },
+        activityStatus: "imported",
+        draft: null,
+        transcript: [
+          { coachText: partialText, delivery: "interrupted", attachments: [activityName] },
+        ],
+        queue: { count: 1, retryRequired: true },
+        coachCalls: 1,
+      });
+
+      await fixture.relaunch(() => backend.reopen());
+      expect(await readRetrySurface(fixture)).toEqual({
+        retryCount: 1,
+        athleteAttachmentCount: 1,
+        partialCount: 1,
+      });
+      await captureQaEvidence(fixture, "02-restored-retry-required");
+      expect(await retryAndReadCompleted(fixture)).toEqual({
+        retryCount: 0,
+        athleteAttachmentCount: 1,
+        completedCount: 1,
+      });
+      expect(await backend.snapshot()).toMatchObject({
+        training: { count: 1, sport: "cycling", localDateKey: 19980704 },
+        activityStatus: "sent",
+        queue: { count: 0, retryRequired: false },
+        coachCalls: 2,
+      });
+      await captureQaEvidence(fixture, "03-completed-live");
+
+      await fixture.relaunch(() => backend.reopen());
+      expect(await readCompletedSurface(fixture)).toEqual({
+        athleteAttachmentCount: 1,
+        partialCount: 1,
+        completedCount: 1,
+      });
+      expect((await backend.snapshot()).coachCalls).toBe(2);
+      await captureQaEvidence(fixture, "04-completed-clean-relaunch");
+
+      await backend.seedImageDraft();
+      expect(await backend.snapshot()).toMatchObject({
+        draft: {
+          text: imageDraftText,
+          attachments: [{ name: imageName, status: "ready" }],
+        },
+      });
+      await fixture.relaunch(() => backend.reopen());
+      expect(await readImageDraft(fixture)).toEqual({
+        draft: imageDraftText,
+        imageCount: 1,
+        ready: true,
+        activityTranscriptCount: 1,
+      });
+      await captureQaEvidence(fixture, "05-restored-image-draft");
+
+      backend.exposeProviderSettings();
+      expect(await switchModelAndReadBlockedDraft(fixture)).toEqual({
+        blocked: true,
+        settingsActionCount: 1,
+        draft: imageDraftText,
+      });
+      expect(await backend.snapshot()).toMatchObject({
+        activeModel: incompatibleModel,
+        draft: {
+          text: imageDraftText,
+          attachments: [{ name: imageName, status: "blocked" }],
+        },
+        training: { count: 1, sport: "cycling", localDateKey: 19980704 },
+      });
+      await captureQaEvidence(fixture, "06-incompatible-model-blocked");
+
+      backend.failDraftClearOnce();
+      expect(await resetAndReadUncertain(fixture)).toEqual({
+        uncertaintyVisible: true,
+        activityTranscriptCount: 1,
+        imageCount: 1,
+        draft: imageDraftText,
+        newChatAriaDisabled: "true",
+      });
+      expect(await backend.snapshot()).toMatchObject({
+        draft: {
+          text: imageDraftText,
+          attachments: [{ name: imageName, status: "blocked" }],
+        },
+        transcript: [],
+        training: { count: 1, sport: "cycling", localDateKey: 19980704 },
+        activityStatus: "sent",
+        clearCalls: 1,
+      });
+      await captureQaEvidence(fixture, "07-reset-uncertainty-preserved");
+
+      backend.restoreKeylessStartup();
+      await fixture.relaunch(() => backend.reopen());
+      expect(await readDraftAfterUncertainRelaunch(fixture)).toEqual({
+        activityTranscriptCount: 0,
+        imageCount: 1,
+        draft: imageDraftText,
+      });
+      await captureQaEvidence(fixture, "08-post-uncertainty-relaunch");
+      expect(await confirmResetSuccess(fixture)).toEqual({
+        successVisible: true,
+        imageCount: 0,
+        draft: "",
+      });
+      expect(await backend.snapshot()).toMatchObject({
+        training: { count: 1, sport: "cycling", localDateKey: 19980704 },
+        activityStatus: "sent",
+        draft: null,
+        transcript: [],
+        queue: { count: 0, retryRequired: false },
+        coachCalls: 2,
+        clearCalls: 2,
+      });
+      await captureQaEvidence(fixture, "09-reset-success-cleared");
+
+      expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
+      fixtures.splice(fixtures.indexOf(fixture), 1);
+    }, 120_000);
+  },
+);

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -790,6 +790,7 @@ async function launch(input: {
     colorScheme: input.colorScheme ?? "light",
     reducedMotion: input.reducedMotion,
     hidden: input.hidden,
+    routeChatAttachmentComposer: true,
   });
   fixtures.push(fixture);
   await fixture.evaluate<void>(`
@@ -1890,7 +1891,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     expect(readingRoom.composerHeight).toBeGreaterThan(0);
     await fixture.setViewport(1180, 820);
     expect(await stackedProjectionGeometry(fixture)).toEqual({
-      attachmentIssue: true,
+      attachmentIssue: false,
       planningIssue: true,
       composerWithinViewport: true,
       disclaimerWithinViewport: true,
@@ -1901,7 +1902,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     });
     await fixture.setViewport(760, 820);
     expect(await stackedProjectionGeometry(fixture)).toEqual({
-      attachmentIssue: true,
+      attachmentIssue: false,
       planningIssue: true,
       composerWithinViewport: true,
       disclaimerWithinViewport: true,
@@ -2845,7 +2846,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       contextVisible: true,
     });
     expect(await stackedProjectionGeometry(fixture)).toEqual({
-      attachmentIssue: true,
+      attachmentIssue: false,
       planningIssue: true,
       composerWithinViewport: true,
       disclaimerWithinViewport: true,
@@ -2857,7 +2858,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
 
     await fixture.setViewport(760, 820);
     expect(await stackedProjectionGeometry(fixture)).toEqual({
-      attachmentIssue: true,
+      attachmentIssue: false,
       planningIssue: true,
       composerWithinViewport: true,
       disclaimerWithinViewport: true,

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -437,6 +437,31 @@ export async function launchDesktopFixture(input: {
               ReturnType<NonNullable<CoachOperations["getChatAttachmentComposer"]>>
             >;
           },
+          async saveChatAttachmentDraftText(request) {
+            return finalFrame(await invoke("saveChatAttachmentDraftText", request)) as Awaited<
+              ReturnType<NonNullable<CoachOperations["saveChatAttachmentDraftText"]>>
+            >;
+          },
+          async removeChatAttachment(request) {
+            return finalFrame(await invoke("removeChatAttachment", request)) as Awaited<
+              ReturnType<NonNullable<CoachOperations["removeChatAttachment"]>>
+            >;
+          },
+          async retryChatAttachment(request) {
+            return finalFrame(await invoke("retryChatAttachment", request)) as Awaited<
+              ReturnType<NonNullable<CoachOperations["retryChatAttachment"]>>
+            >;
+          },
+          async selectChatAttachmentWorkout(request) {
+            return finalFrame(await invoke("selectChatAttachmentWorkout", request)) as Awaited<
+              ReturnType<NonNullable<CoachOperations["selectChatAttachmentWorkout"]>>
+            >;
+          },
+          async clearChatAttachmentDraft(request) {
+            return finalFrame(await invoke("clearChatAttachmentDraft", request)) as Awaited<
+              ReturnType<NonNullable<CoachOperations["clearChatAttachmentDraft"]>>
+            >;
+          },
         }
       : {}),
     ...(input.routeChatAttachmentOperations === true

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -14,23 +14,39 @@ const mocks = vi.hoisted(() => {
       readonly target = "_blank",
     ) {}
   }
+  class FakeElement {
+    closest(selector: string): FakeElement | null {
+      return selector === "[data-chat-attachment-dropzone]" ? this : null;
+    }
+  }
   let clickListener: ((event: Record<string, unknown>) => void) | undefined;
+  let dropListener: ((event: Record<string, unknown>) => void) | undefined;
   const fakeWindow = {
     location: {
       href: `enduragent://app/index.html?navigationToken=${"n".repeat(43)}`,
     },
     addEventListener: vi.fn((name: string, listener: typeof clickListener) => {
       if (name === "click") clickListener = listener;
+      if (name === "drop") dropListener = listener;
+    }),
+    removeEventListener: vi.fn((name: string, listener: typeof clickListener) => {
+      if (name === "drop" && dropListener === listener) dropListener = undefined;
     }),
     dispatchEvent: vi.fn(),
   };
+  const getPathForFile = vi.fn();
   return {
     exposed,
     FakeAnchor,
+    FakeElement,
     fakeWindow,
     get clickListener() {
       return clickListener;
     },
+    get dropListener() {
+      return dropListener;
+    },
+    getPathForFile,
     exposeInMainWorld: vi.fn((name: string, value: unknown) => {
       exposed[name] = value;
     }),
@@ -49,7 +65,7 @@ vi.mock("electron", () => ({
     send: mocks.send,
     sendSync: mocks.sendSync,
   },
-  webUtils: { getPathForFile: vi.fn() },
+  webUtils: { getPathForFile: mocks.getPathForFile },
 }));
 
 interface AuthBridge {
@@ -97,7 +113,17 @@ interface AuthBridge {
   chooseImportFiles(): Promise<readonly string[]>;
   chooseChatAttachments(): Promise<readonly unknown[]>;
   pasteChatAttachment(): Promise<readonly unknown[]>;
-  onDroppedChatAttachments(listener: (results: readonly unknown[]) => void): () => void;
+  onDroppedChatAttachments(
+    listener: (
+      event:
+        | { readonly phase: "started"; readonly operationId: string }
+        | {
+            readonly phase: "settled";
+            readonly operationId: string;
+            readonly results: readonly unknown[] | null;
+          },
+    ) => boolean | void,
+  ): () => void;
   choosePlanRaceCourseFile(): Promise<string | null>;
   exportTrainingFile(input: unknown): Promise<unknown>;
   getUpdateState(): Promise<unknown>;
@@ -216,6 +242,7 @@ beforeAll(async () => {
   Object.assign(globalThis, {
     window: mocks.fakeWindow,
     HTMLAnchorElement: mocks.FakeAnchor,
+    Element: mocks.FakeElement,
   });
   await import("../src/preload/index.js");
   bridge = mocks.exposed.enduragentAuth as AuthBridge;
@@ -224,10 +251,12 @@ beforeAll(async () => {
 beforeEach(() => {
   mocks.invoke.mockReset();
   mocks.send.mockReset();
+  mocks.getPathForFile.mockReset();
   mocks.fakeWindow.dispatchEvent.mockReset();
   Object.assign(globalThis, {
     window: mocks.fakeWindow,
     HTMLAnchorElement: mocks.FakeAnchor,
+    Element: mocks.FakeElement,
   });
   mocks.fakeWindow.location.href = RENDERER_URL;
 });
@@ -386,6 +415,83 @@ describe("desktop preload ChatGPT auth", () => {
       ].sort(),
     );
     expect(bridge).not.toHaveProperty("openExternal");
+  });
+
+  it("hands dropped attachment work to the renderer before admission starts", async () => {
+    type DropEvent =
+      | { readonly phase: "started"; readonly operationId: string }
+      | {
+          readonly phase: "settled";
+          readonly operationId: string;
+          readonly results: readonly unknown[] | null;
+        };
+    const events: DropEvent[] = [];
+    const dispose = bridge.onDroppedChatAttachments((event) => {
+      events.push(event);
+      return event.phase === "started";
+    });
+    const drop = mocks.dropListener;
+    if (drop === undefined) throw new TypeError("drop listener missing");
+    mocks.getPathForFile.mockReturnValue("/tmp/synthetic-recovery.jpg");
+    let resolveAdmission!: (value: unknown) => void;
+    mocks.invoke.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAdmission = resolve;
+        }),
+    );
+    const event = {
+      target: new mocks.FakeElement(),
+      preventDefault: vi.fn(),
+      dataTransfer: { files: [{}] },
+    };
+
+    drop(event);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ phase: "started" });
+    expect(mocks.invoke).toHaveBeenCalledWith("desktop:chat-attachment:drop", [
+      "/tmp/synthetic-recovery.jpg",
+    ]);
+    resolveAdmission([
+      {
+        selectionId: "selection-drop-1",
+        displayName: "synthetic-recovery.jpg",
+        status: "accepted",
+        attachmentId: "attachment-drop-1",
+      },
+    ]);
+    await vi.waitFor(() => expect(events).toHaveLength(2));
+    expect(events[1]).toEqual({
+      phase: "settled",
+      operationId: events[0]!.operationId,
+      results: [
+        {
+          selectionId: "selection-drop-1",
+          displayName: "synthetic-recovery.jpg",
+          status: "accepted",
+          attachmentId: "attachment-drop-1",
+        },
+      ],
+    });
+
+    mocks.invoke.mockRejectedValueOnce(new Error("synthetic admission failure"));
+    drop(event);
+    await vi.waitFor(() => expect(events).toHaveLength(4));
+    expect(events[3]).toEqual({
+      phase: "settled",
+      operationId: events[2]!.operationId,
+      results: null,
+    });
+    dispose();
+
+    mocks.invoke.mockClear();
+    const disposeBlocked = bridge.onDroppedChatAttachments(() => false);
+    const blockedDrop = mocks.dropListener;
+    if (blockedDrop === undefined) throw new TypeError("blocked drop listener missing");
+    blockedDrop(event);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    disposeBlocked();
   });
 
   it("sends only the three supported appearances to the main process", () => {


### PR DESCRIPTION
## Summary\n\n- keep attachment admissions, draft saves, removals, retries, selections, and dropped files owned until they settle\n- prevent stale or out-of-order attachment reads from restoring cleared state\n- preserve the complete attachment draft after an uncertain reset and clear it only after confirmed success\n- make the nine-checkpoint production evidence run deterministic and cleanup-safe\n\n## Verification\n\n- focused renderer tests: 190 passed\n- preload tests: 83 passed\n- renderer and desktop typechecks passed\n- dependency, renderer, and desktop production builds passed\n- visible macOS Electron ATT-03 lifecycle: 1 passed with nine inspected checkpoints\n- fixture privacy, changeset, format, lint, and diff checks passed\n- final Codex autoreview: clean, no accepted or actionable findings