### PR TITLE
test(desktop): add plan inspection fixture

### DIFF
--- a/apps/desktop/scripts/interactive-development.d.mts
+++ b/apps/desktop/scripts/interactive-development.d.mts
@@ -7,6 +7,9 @@ export interface InteractiveDevelopmentPlanInput {
   readonly environment: Readonly<Record<string, string | undefined>>;
 }
 
+export const DESKTOP_INSPECTION_FIXTURE_ENV: "ENDURAGENT_DESKTOP_INSPECTION_FIXTURE";
+export const PLAN_CURRENT_INSPECTION_FIXTURE: "plan-current";
+
 export interface InteractiveDevelopmentPlan {
   readonly command: "/usr/bin/caffeinate";
   readonly args: readonly string[];

--- a/apps/desktop/scripts/interactive-development.mjs
+++ b/apps/desktop/scripts/interactive-development.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const canonicalDesktopRoot = resolve(scriptDirectory, "..");
 const SCRATCH_PREFIX = "enduragent-desktop-development-";
+export const DESKTOP_INSPECTION_FIXTURE_ENV = "ENDURAGENT_DESKTOP_INSPECTION_FIXTURE";
+export const PLAN_CURRENT_INSPECTION_FIXTURE = "plan-current";
 
 export function selectInteractiveDevelopmentTemporaryRoot(platform, configuredRoot) {
   return configuredRoot ?? (platform === "darwin" ? "/tmp" : tmpdir());
@@ -33,6 +35,14 @@ export function createInteractiveDevelopmentPlan(input) {
   const athleteHome = join(scratchRoot, "athlete-home");
   const userData = join(scratchRoot, "electron-user-data");
   const environment = { ...input.environment };
+  const inspectionFixture = environment[DESKTOP_INSPECTION_FIXTURE_ENV];
+  if (inspectionFixture !== undefined && inspectionFixture !== PLAN_CURRENT_INSPECTION_FIXTURE) {
+    throw new TypeError("unknown desktop inspection fixture");
+  }
+  if (inspectionFixture === PLAN_CURRENT_INSPECTION_FIXTURE) {
+    delete environment.PLAN_QA_SCENARIO;
+    delete environment.PLAN_QA_OUTCOME;
+  }
   delete environment.ENDURAGENT_ACCEPTANCE_HIDDEN;
   delete environment.ELECTRON_CLI_ARGS;
   Object.assign(environment, {
@@ -48,8 +58,9 @@ export function createInteractiveDevelopmentPlan(input) {
       nodeExecutable,
       packageManagerScript,
       "exec",
-      "electron-vite",
-      "dev",
+      ...(inspectionFixture === PLAN_CURRENT_INSPECTION_FIXTURE
+        ? ["tsx", "tests/helpers/plan-inspection-live.ts"]
+        : ["electron-vite", "dev"]),
     ]),
     cwd: desktopRoot,
     environment: Object.freeze(environment),

--- a/apps/desktop/tests/helpers/plan-inspection-live.ts
+++ b/apps/desktop/tests/helpers/plan-inspection-live.ts
@@ -1,0 +1,98 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { DesktopFixtureScript, RunningDesktopFixture } from "./desktop-fixture.js";
+import { launchDesktopFixture } from "./desktop-fixture.js";
+import { createPlanQaFixtureScript } from "./plan-qa-live.js";
+
+export const PLAN_INSPECTION_SCENARIO_ID = "PL-S004";
+
+export const PLAN_INSPECTION_TURNS = Object.freeze([
+  Object.freeze({
+    turnId: "inspection-turn-week",
+    completedAt: "1998-08-22T07:40:00.000Z",
+    athleteText: "How does this week support the Gran Fondo?",
+    coachText:
+      "This week keeps one threshold session, one endurance ride, and recovery before the next build.",
+  }),
+  Object.freeze({
+    turnId: "inspection-turn-recovery",
+    completedAt: "1998-08-22T07:50:00.000Z",
+    athleteText: "Keep Sunday easy if recovery slips.",
+    coachText:
+      "Yes. The current Plan keeps Sunday controlled and leaves the final choice visible in Plan.",
+  }),
+]);
+
+export const PLAN_INSPECTION_ATTACHMENT_COMPOSER = Object.freeze({
+  schemaVersion: 1,
+  capabilities: {
+    schemaVersion: 1,
+    active: { provider: "codex-agent", model: "inspection-fixture", transport: "codex-agent" },
+    documents: { enabled: true, extensions: ["pdf", "txt", "csv", "docx"] },
+    completedActivities: { enabled: true, extensions: ["fit", "tcx", "gpx"] },
+    plannedWorkouts: { enabled: true, extensions: ["zwo", "erg", "mrc"] },
+    images: {
+      enabled: false,
+      mediaTypes: [],
+      reason: "transport_incompatible",
+      source: "transport_blocked",
+      checkedAt: "1998-08-22T08:00:00.000Z",
+    },
+  },
+  draft: null,
+});
+
+function response(value: unknown): readonly string[] {
+  return [JSON.stringify(value)];
+}
+
+export function createPlanInspectionFixtureScript(): DesktopFixtureScript {
+  const plan = createPlanQaFixtureScript(PLAN_INSPECTION_SCENARIO_ID);
+  return {
+    onRequest(value) {
+      const request = value as { readonly method: string };
+      if (request.method === "hasSession") return response({ hasSession: true });
+      if (request.method === "getTranscriptPage") {
+        return response({
+          schemaVersion: 1,
+          status: "page",
+          turns: PLAN_INSPECTION_TURNS,
+          nextCursor: null,
+        });
+      }
+      if (request.method === "getChatAttachmentComposer") {
+        return response(PLAN_INSPECTION_ATTACHMENT_COMPOSER);
+      }
+      if (request.method === "resumePlanningRequests") return response({ deliveries: [] });
+      if (request.method === "listPlanningRequests") return response({ deliveries: [] });
+      return plan.onRequest(value);
+    },
+  };
+}
+
+const token = "v".repeat(43);
+let fixture: RunningDesktopFixture | undefined;
+
+async function close(): Promise<void> {
+  await fixture?.close();
+  process.exit(0);
+}
+
+const directExecution =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (directExecution) {
+  fixture = await launchDesktopFixture({
+    script: createPlanInspectionFixtureScript(),
+    token,
+    width: 1180,
+    height: 820,
+    colorScheme: "light",
+    reducedMotion: true,
+    hidden: false,
+    routeChatAttachmentComposer: true,
+  });
+  process.on("SIGINT", () => void close());
+  process.on("SIGTERM", () => void close());
+  process.stdout.write(`PLAN_INSPECTION_READY ${PLAN_INSPECTION_SCENARIO_ID}\n`);
+}

--- a/apps/desktop/tests/interactive-development.test.ts
+++ b/apps/desktop/tests/interactive-development.test.ts
@@ -2,6 +2,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   createInteractiveDevelopmentPlan,
+  DESKTOP_INSPECTION_FIXTURE_ENV,
+  PLAN_CURRENT_INSPECTION_FIXTURE,
   selectInteractiveDevelopmentTemporaryRoot,
 } from "../scripts/interactive-development.mjs";
 
@@ -53,6 +55,34 @@ describe("interactive desktop development plan", () => {
       userData: join(scratchRoot, "electron-user-data"),
     });
     expect(value.athleteHome).not.toBe(value.userData);
+  });
+
+  it("launches the bounded Plan inspection fixture through the isolated command", () => {
+    const value = plan({
+      environment: {
+        [DESKTOP_INSPECTION_FIXTURE_ENV]: PLAN_CURRENT_INSPECTION_FIXTURE,
+        PLAN_QA_SCENARIO: "PL-S089",
+        PLAN_QA_OUTCOME: "failure",
+      },
+    });
+
+    expect(value.args).toEqual([
+      "-dimsu",
+      nodeExecutable,
+      packageManagerScript,
+      "exec",
+      "tsx",
+      "tests/helpers/plan-inspection-live.ts",
+    ]);
+    expect(value.environment[DESKTOP_INSPECTION_FIXTURE_ENV]).toBe(PLAN_CURRENT_INSPECTION_FIXTURE);
+    expect(value.environment.PLAN_QA_SCENARIO).toBeUndefined();
+    expect(value.environment.PLAN_QA_OUTCOME).toBeUndefined();
+  });
+
+  it("refuses an unknown inspection fixture", () => {
+    expect(() =>
+      plan({ environment: { [DESKTOP_INSPECTION_FIXTURE_ENV]: "arbitrary-script" } }),
+    ).toThrow("unknown desktop inspection fixture");
   });
 
   it.each([

--- a/apps/desktop/tests/plan-inspection-live.test.ts
+++ b/apps/desktop/tests/plan-inspection-live.test.ts
@@ -1,0 +1,92 @@
+import {
+  GetRuntimeConfigRpcResultSchema,
+  GetSetupStatusRpcResultSchema,
+  GetTranscriptPageRpcResultSchema,
+  ListPlanningRequestsRpcResultSchema,
+  PlanReadModelSchema,
+  ResumePlanningRequestsRpcResultSchema,
+  ChatAttachmentComposerReadModelSchema,
+} from "@enduragent/coach-contract";
+import { describe, expect, it } from "vitest";
+import {
+  createPlanInspectionFixtureScript,
+  PLAN_INSPECTION_SCENARIO_ID,
+  PLAN_INSPECTION_TURNS,
+} from "./helpers/plan-inspection-live.js";
+
+function request(method: string, params: Record<string, unknown> = {}) {
+  return { jsonrpc: "2.0", method, params };
+}
+
+async function result(
+  script: ReturnType<typeof createPlanInspectionFixtureScript>,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  const frames = await script.onRequest(request(method, params));
+  return JSON.parse(frames.at(-1) ?? "null") as unknown;
+}
+
+describe("Plan inspection live fixture", () => {
+  it("uses privacy-safe ordinary Main Chat turns", async () => {
+    const script = createPlanInspectionFixtureScript();
+    const transcript = GetTranscriptPageRpcResultSchema.parse(
+      await result(script, "getTranscriptPage"),
+    );
+
+    expect(transcript.status).toBe("page");
+    expect(transcript.turns).toEqual(PLAN_INSPECTION_TURNS);
+    expect(transcript.turns.every((turn) => turn.completedAt.startsWith("1998-"))).toBe(true);
+  });
+
+  it("provides completed setup and empty schema-valid Chat startup state", async () => {
+    const script = createPlanInspectionFixtureScript();
+    const setup = GetSetupStatusRpcResultSchema.parse(await result(script, "getSetupStatus"));
+    expect(setup.durableTrainingData).toBe(true);
+    expect(setup.intake).not.toBeNull();
+    expect(
+      GetRuntimeConfigRpcResultSchema.parse(await result(script, "getRuntimeConfig")),
+    ).toMatchObject({ llm: { provider: "codex-agent", credential_configured: true } });
+    expect(await result(script, "hasSession")).toEqual({ hasSession: true });
+    expect(
+      ChatAttachmentComposerReadModelSchema.parse(
+        await result(script, "getChatAttachmentComposer"),
+      ),
+    ).toMatchObject({ schemaVersion: 1, draft: null });
+    expect(
+      ResumePlanningRequestsRpcResultSchema.parse(await result(script, "resumePlanningRequests")),
+    ).toEqual({ deliveries: [] });
+    expect(
+      ListPlanningRequestsRpcResultSchema.parse(
+        await result(script, "listPlanningRequests", { chatId: "main" }),
+      ),
+    ).toEqual({ deliveries: [] });
+  });
+
+  it("starts on the active Plan and follows the existing next-Plan transition", async () => {
+    const script = createPlanInspectionFixtureScript();
+    const initial = (await result(script, "getPlanState")) as {
+      readonly status: string;
+      readonly state: unknown;
+    };
+    const initialPlan = PlanReadModelSchema.parse(initial.state);
+    expect(initial.status).toBe("ready");
+    expect(initialPlan.scenarioId).toBe(PLAN_INSPECTION_SCENARIO_ID);
+    expect(initialPlan.lifecycle).toBe("active");
+
+    const transitioned = (await result(script, "executePlanTransition", {
+      transitionId: "PL-T25",
+      commandId: "inspection-command-start-plan",
+      planId: initialPlan.planId,
+    })) as { readonly status: string; readonly state: unknown };
+    const next = PlanReadModelSchema.parse(transitioned.state);
+    expect(transitioned.status).toBe("completed");
+    expect(next.scenarioId).toBe("PL-S079");
+
+    const refreshed = (await result(script, "getPlanState")) as {
+      readonly status: string;
+      readonly state: unknown;
+    };
+    expect(PlanReadModelSchema.parse(refreshed.state).scenarioId).toBe("PL-S079");
+  });
+});


### PR DESCRIPTION
Summary:
- add an exact opt-in `plan-current` desktop inspection fixture
- seed privacy-safe Main Chat and Plan states through the production fixture path
- reject unsupported fixture values and cover the launcher contract

Tests:
- `pnpm --filter @enduragent/desktop... build`
- `pnpm exec vitest run apps/desktop/tests/interactive-development.test.ts apps/desktop/tests/plan-inspection-live.test.ts` (12 passed)
- `pnpm --filter @enduragent/desktop check`
- `pnpm check:types`
- `pnpm check:fixture-privacy`
- `pnpm exec oxlint` on all five changed files

Review:
- autoreview clean; no accepted or actionable findings