### PR TITLE
fix(kernel): restore legacy Planning backups

### DIFF
--- a/.changeset/fruity-files-smoke.md
+++ b/.changeset/fruity-files-smoke.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/kernel-node": patch
+"@enduragent/kernel": patch
+"cycling-coach": patch
+---
+
+User-facing: Backups made before the Planning storage update now restore successfully when they contain a replaced Plan. Current backups continue to restore the replacement history safely.

--- a/packages/kernel-node/src/store-export/index.ts
+++ b/packages/kernel-node/src/store-export/index.ts
@@ -1,1 +1,2 @@
 export { webCryptoExportCrypto, webCryptoTextCodec, webCryptoExportEnv } from "./web-crypto.js";
+export { createSqliteImportSink } from "./sqlite-import.js";

--- a/packages/kernel-node/src/store-export/sqlite-import.ts
+++ b/packages/kernel-node/src/store-export/sqlite-import.ts
@@ -1,0 +1,134 @@
+import { addCivilDays } from "@enduragent/kernel/planning";
+import type { AuthoredRow, ImportSink, RestoreTableResult } from "@enduragent/kernel/store/export";
+import type { MigratorStore, Row, SqlStore, SqlValue } from "@enduragent/kernel/store";
+
+type SqliteImportStore = SqlStore & Pick<MigratorStore, "transaction">;
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function toSqlValue(value: unknown): SqlValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  throw new TypeError("Export row contains a non-SQL value");
+}
+
+function text(row: AuthoredRow | Row, key: string): string {
+  const value = row[key];
+  if (typeof value !== "string") throw new TypeError("Export row is invalid");
+  return value;
+}
+
+function integer(row: AuthoredRow | Row, key: string): number {
+  const value = row[key];
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError("Export row is invalid");
+  }
+  return value;
+}
+
+async function requireCompatibleCleanupJob(
+  store: SqliteImportStore,
+  replacement: AuthoredRow,
+): Promise<void> {
+  const cleanupJobId = text(replacement, "cleanup_job_id");
+  const previousPlanId = text(replacement, "previous_plan_id");
+  const existing = await store.get("SELECT plan_id,kind FROM plan_reconciliation_job WHERE id=?", [
+    cleanupJobId,
+  ]);
+  if (existing !== undefined) {
+    if (text(existing, "plan_id") !== previousPlanId || text(existing, "kind") !== "cleanup") {
+      throw new TypeError("Export row is inconsistent");
+    }
+    return;
+  }
+  const plan = await store.get("SELECT start_date_key,total_weeks FROM plan WHERE id=?", [
+    previousPlanId,
+  ]);
+  if (plan === undefined) throw new TypeError("Export row is inconsistent");
+  const startDateKey = integer(plan, "start_date_key");
+  const totalWeeks = integer(plan, "total_weeks");
+  if (totalWeeks === 0) throw new TypeError("Export row is invalid");
+  const createdAtMs = integer(replacement, "created_at_ms");
+  const updatedAtMs = integer(replacement, "updated_at_ms");
+  await store.run(
+    `INSERT INTO plan_reconciliation_job (
+      id,plan_id,kind,status,window_start_date_key,window_end_date_key,
+      attempt_count,failure_count,resumed_count,last_resumed_attempt,last_error_code,
+      created_at_ms,updated_at_ms,completed_at_ms
+    ) VALUES (?,?,'cleanup','verified',?,?,0,0,0,NULL,NULL,?,?,?)
+    ON CONFLICT DO NOTHING`,
+    [
+      cleanupJobId,
+      previousPlanId,
+      startDateKey,
+      addCivilDays(startDateKey, totalWeeks * 7 - 1),
+      createdAtMs,
+      updatedAtMs,
+      updatedAtMs,
+    ],
+  );
+  const restored = await store.get("SELECT plan_id,kind FROM plan_reconciliation_job WHERE id=?", [
+    cleanupJobId,
+  ]);
+  if (
+    restored === undefined ||
+    text(restored, "plan_id") !== previousPlanId ||
+    text(restored, "kind") !== "cleanup"
+  ) {
+    throw new TypeError("Export row is inconsistent");
+  }
+}
+
+function normalizeRows(
+  table: string,
+  rows: readonly AuthoredRow[],
+  sourceUserVersion: number,
+): readonly AuthoredRow[] {
+  if (table !== "plan_adaptation_ledger" || sourceUserVersion < 19 || sourceUserVersion >= 28) {
+    return rows;
+  }
+  return rows.map((row) => ({ ...row, operation: "update" }));
+}
+
+async function restoreRows(
+  store: SqliteImportStore,
+  table: string,
+  rows: readonly AuthoredRow[],
+): Promise<RestoreTableResult> {
+  const tableName = quoteIdentifier(table);
+  const before = Number((await store.get(`SELECT COUNT(*) AS count FROM ${tableName}`))?.count);
+  for (const row of rows) {
+    const columns = Object.keys(row);
+    if (columns.length === 0) throw new TypeError("Export row is invalid");
+    await store.run(
+      `INSERT INTO ${tableName} (${columns.map(quoteIdentifier).join(", ")}) VALUES (${columns.map(() => "?").join(", ")}) ON CONFLICT DO NOTHING`,
+      columns.map((column) => toSqlValue(row[column])),
+    );
+  }
+  const after = Number((await store.get(`SELECT COUNT(*) AS count FROM ${tableName}`))?.count);
+  const inserted = after - before;
+  return { table, inserted, skipped: rows.length - inserted };
+}
+
+export function createSqliteImportSink(store: SqliteImportStore): ImportSink {
+  return {
+    restoreAuthoredTable(table, rows, { sourceUserVersion }) {
+      return store.transaction(async () => {
+        const normalized = normalizeRows(table, rows, sourceUserVersion);
+        if (table === "plan_replacement" && sourceUserVersion >= 21 && sourceUserVersion < 29) {
+          for (const row of normalized) await requireCompatibleCleanupJob(store, row);
+        }
+        return restoreRows(store, table, normalized);
+      });
+    },
+  };
+}

--- a/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
+++ b/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
@@ -1,22 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
   buildExport,
+  encodeContainer,
+  EXPORT_DOCUMENT_KIND,
+  EXPORT_FORMAT_VERSION,
   importExport,
+  MIXED_AUTHORED_TABLES,
+  PURE_AUTHORED_TABLES,
   type ArchiveManifestReader,
   type ArchivePresenceChecker,
+  type AuthoredRow,
   type ExportSource,
-  type ImportSink,
-  type RestoreTableResult,
 } from "@enduragent/kernel/store/export";
+import {
+  createPlanConversationRepository,
+  createPlanReplacementRepository,
+  createPlanRepository,
+} from "@enduragent/kernel/planning";
 import {
   dumpStore,
   runMigrations,
   type MigratorStore,
   type SqlStore,
-  type SqlValue,
 } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
-import { webCryptoExportEnv } from "@enduragent/kernel-node/store-export";
+import { createSqliteImportSink, webCryptoExportEnv } from "@enduragent/kernel-node/store-export";
 import { openSqliteStorage } from "../src/sqlite/index.js";
 
 const PLANNING_TABLES = [
@@ -43,22 +51,20 @@ const DRAFT_ID = id(6);
 const PREFERENCE_ID = id(7);
 const RESTRICTION_ID = id(8);
 const CHANGE_ID = id(9);
+const PREVIOUS_PLAN_ID = id(11);
+const REPLACEMENT_PLAN_ID = id(12);
+const CONVERSATION_ID = id(13);
+const LEGACY_DRAFT_ID = id(14);
+const REPLACEMENT_ID = id(15);
+const CLEANUP_JOB_ID = id(16);
+const LEDGER_PLAN_ID = id(17);
+const LEDGER_WORKOUT_ID = id(18);
+const LEDGER_ID = id(19);
+
+const POST_V28_TABLES = new Set<string>([...PLANNING_TABLES, "plan_reconciliation_job"]);
 
 function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
-}
-
-function toSqlValue(value: unknown): SqlValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "bigint" ||
-    value instanceof Uint8Array
-  ) {
-    return value;
-  }
-  throw new TypeError("Export row contains a non-SQL value");
 }
 
 function sqliteExportSource(store: SqlStore & MigratorStore): ExportSource {
@@ -71,23 +77,134 @@ function sqliteExportSource(store: SqlStore & MigratorStore): ExportSource {
   };
 }
 
-function sqliteImportSink(store: SqlStore): ImportSink {
-  return {
-    async restoreAuthoredTable(table, rows): Promise<RestoreTableResult> {
-      const tableName = quoteIdentifier(table);
-      const before = Number((await store.get(`SELECT COUNT(*) AS count FROM ${tableName}`))?.count);
-      for (const row of rows) {
-        const columns = Object.keys(row);
-        await store.run(
-          `INSERT OR IGNORE INTO ${tableName} (${columns.map(quoteIdentifier).join(", ")}) VALUES (${columns.map(() => "?").join(", ")})`,
-          columns.map((column) => toSqlValue(row[column])),
-        );
-      }
-      const after = Number((await store.get(`SELECT COUNT(*) AS count FROM ${tableName}`))?.count);
-      const inserted = after - before;
-      return { table, inserted, skipped: rows.length - inserted };
+async function buildPre29Container(store: SqlStore & MigratorStore): Promise<Uint8Array> {
+  const source = sqliteExportSource(store);
+  const authored: Record<string, readonly AuthoredRow[]> = {};
+  for (const table of PURE_AUTHORED_TABLES) {
+    const exists = await store.get(
+      "SELECT 1 AS present FROM sqlite_master WHERE type='table' AND name=?",
+      [table],
+    );
+    if (exists !== undefined && !POST_V28_TABLES.has(table)) {
+      authored[table] = await source.readAuthoredTable(table, { manualOnly: false });
+    }
+  }
+  for (const table of MIXED_AUTHORED_TABLES) {
+    authored[table] = await source.readAuthoredTable(table, { manualOnly: true });
+  }
+  return encodeContainer(
+    {
+      kind: EXPORT_DOCUMENT_KIND,
+      formatVersion: EXPORT_FORMAT_VERSION,
+      store: { userVersion: await store.getUserVersion(), authored },
+      archiveManifest: [],
     },
+    webCryptoExportEnv,
+    {},
+  );
+}
+
+function legacyPlan(idValue: string, name: string, status: "draft" | "active" | "ended") {
+  return {
+    id: idValue,
+    originId: null,
+    name,
+    primaryGoal: "Complete a synthetic endurance event",
+    startDateKey: 19980824,
+    targetDateKey: 19981115,
+    status,
+    kind: "full_plan" as const,
+    totalWeeks: 12,
+    weekStartDay: 1,
+    structureJson: '{"phases":[]}',
+    createdAtMs: BASE_MS,
+    updatedAtMs: BASE_MS + 1,
+    deviceId: DEVICE_ID,
+    hlcPhysicalMs: BASE_MS + 1,
+    hlcCounter: 0,
   };
+}
+
+async function populateV28Replacement(store: SqlStore & MigratorStore): Promise<void> {
+  const plans = createPlanRepository(store);
+  const conversations = createPlanConversationRepository(store);
+  await plans.replace(legacyPlan(PREVIOUS_PLAN_ID, "Previous synthetic Plan", "active"), []);
+  await plans.replace(legacyPlan(REPLACEMENT_PLAN_ID, "Replacement synthetic Plan", "draft"), []);
+  await conversations.saveConversation({
+    id: CONVERSATION_ID,
+    planId: REPLACEMENT_PLAN_ID,
+    replacesPlanId: PREVIOUS_PLAN_ID,
+    courseChoiceStatus: "omitted",
+    raceCourseJson: null,
+    status: "open",
+    endedAtMs: null,
+    createdAtMs: BASE_MS + 2,
+    updatedAtMs: BASE_MS + 2,
+    deviceId: DEVICE_ID,
+    hlcPhysicalMs: BASE_MS + 2,
+    hlcCounter: 0,
+  });
+  await conversations.saveDraftRevision({
+    id: LEGACY_DRAFT_ID,
+    conversationId: CONVERSATION_ID,
+    planId: REPLACEMENT_PLAN_ID,
+    revision: 1,
+    parentRevisionId: null,
+    status: "ready",
+    snapshotJson: '{"weeks":12}',
+    raceCourseJson: null,
+    createdAtMs: BASE_MS + 3,
+    updatedAtMs: BASE_MS + 3,
+    deviceId: DEVICE_ID,
+    hlcPhysicalMs: BASE_MS + 3,
+    hlcCounter: 0,
+  });
+  await createPlanReplacementRepository(store).approve({
+    id: REPLACEMENT_ID,
+    previousPlanId: PREVIOUS_PLAN_ID,
+    replacementPlanId: REPLACEMENT_PLAN_ID,
+    draftRevisionId: LEGACY_DRAFT_ID,
+    expectedRevision: 1,
+    cleanupJobId: CLEANUP_JOB_ID,
+    windowStartDateKey: 19980824,
+    windowEndDateKey: 19980830,
+    updatedAtMs: BASE_MS + 4,
+    deviceId: DEVICE_ID,
+    hlcPhysicalMs: BASE_MS + 4,
+    hlcCounter: 0,
+  });
+  await store.run(
+    `UPDATE plan_settings
+     SET updated_at_ms=?,hlc_physical_ms=?
+     WHERE plan_id IN (?,?)`,
+    [BASE_MS + 4, BASE_MS + 4, PREVIOUS_PLAN_ID, REPLACEMENT_PLAN_ID],
+  );
+}
+
+async function populateLegacyAdaptation(store: SqlStore & MigratorStore): Promise<void> {
+  await createPlanRepository(store).replace(legacyPlan(LEDGER_PLAN_ID, "Ledger Plan", "active"), [
+    {
+      id: LEDGER_WORKOUT_ID,
+      planId: LEDGER_PLAN_ID,
+      dateKey: 19980825,
+      sport: "cycling",
+      name: "Synthetic endurance ride",
+      durationS: 3_600,
+      structureJson: '{"steps":[]}',
+      origin: "coach",
+      deviceId: DEVICE_ID,
+      hlcPhysicalMs: BASE_MS + 2,
+      hlcCounter: 0,
+    },
+  ]);
+  await store.run(
+    `INSERT INTO plan_adaptation_ledger (
+      id,plan_id,target_workout_id,kind,source_id,reversal_of_id,label,before_json,after_json,
+      week_load_before,week_load_after,occurred_at_ms,device_id,hlc_physical_ms,hlc_counter
+    ) VALUES (?, ?, ?, 'proposal-applied', 'synthetic-source', NULL, 'Synthetic update',
+      '{"durationS":3600}', '{"durationS":4200}', 100, 110, ?, ?, ?, 0)`,
+    [LEDGER_ID, LEDGER_PLAN_ID, LEDGER_WORKOUT_ID, BASE_MS + 3, DEVICE_ID, BASE_MS + 3],
+  );
 }
 
 async function populatePlanningDomain(store: SqlStore): Promise<void> {
@@ -253,6 +370,86 @@ const completePresence: ArchivePresenceChecker = {
 };
 
 describe("planning-domain SQLite export round-trip", () => {
+  it("restores a v28 replacement lineage without its derived cleanup table", async () => {
+    const source = openSqliteStorage(":memory:");
+    const destination = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(source, MIGRATIONS.slice(0, 28));
+      await runMigrations(destination, MIGRATIONS);
+      await populateV28Replacement(source);
+      const container = await buildPre29Container(source);
+
+      await expect(
+        importExport(
+          {
+            sink: createSqliteImportSink(destination),
+            presence: completePresence,
+            targetUserVersion: 29,
+            ...webCryptoExportEnv,
+          },
+          { container },
+        ),
+      ).resolves.toBeDefined();
+      await expect(
+        destination.get(
+          "SELECT previous_plan_id,replacement_plan_id,cleanup_job_id FROM plan_replacement WHERE id=?",
+          [REPLACEMENT_ID],
+        ),
+      ).resolves.toEqual({
+        previous_plan_id: PREVIOUS_PLAN_ID,
+        replacement_plan_id: REPLACEMENT_PLAN_ID,
+        cleanup_job_id: CLEANUP_JOB_ID,
+      });
+      await expect(
+        destination.get(
+          "SELECT plan_id,kind,status,window_start_date_key,window_end_date_key,completed_at_ms FROM plan_reconciliation_job WHERE id=?",
+          [CLEANUP_JOB_ID],
+        ),
+      ).resolves.toEqual({
+        plan_id: PREVIOUS_PLAN_ID,
+        kind: "cleanup",
+        status: "verified",
+        window_start_date_key: 19980824,
+        window_end_date_key: 19981115,
+        completed_at_ms: BASE_MS + 4,
+      });
+      await expect(destination.all("PRAGMA foreign_key_check")).resolves.toEqual([]);
+    } finally {
+      await source.close();
+      await destination.close();
+    }
+  });
+
+  it.each([21, 27])("restores migration-028 adaptation rows from v%i", async (sourceVersion) => {
+    const source = openSqliteStorage(":memory:");
+    const destination = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(source, MIGRATIONS.slice(0, sourceVersion));
+      await runMigrations(destination, MIGRATIONS);
+      await populateLegacyAdaptation(source);
+      const container = await buildPre29Container(source);
+
+      await expect(
+        importExport(
+          {
+            sink: createSqliteImportSink(destination),
+            presence: completePresence,
+            targetUserVersion: 29,
+            ...webCryptoExportEnv,
+          },
+          { container },
+        ),
+      ).resolves.toBeDefined();
+      await expect(
+        destination.get("SELECT operation FROM plan_adaptation_ledger WHERE id=?", [LEDGER_ID]),
+      ).resolves.toEqual({ operation: "update" });
+      await expect(destination.all("PRAGMA foreign_key_check")).resolves.toEqual([]);
+    } finally {
+      await source.close();
+      await destination.close();
+    }
+  });
+
   it("restores all nine tables with valid links and is idempotent", async () => {
     const source = openSqliteStorage(":memory:");
     const destination = openSqliteStorage(":memory:");
@@ -260,6 +457,7 @@ describe("planning-domain SQLite export round-trip", () => {
       await runMigrations(source, MIGRATIONS);
       await runMigrations(destination, MIGRATIONS);
       await populatePlanningDomain(source);
+      await populateV28Replacement(source);
       const sourceDump = await dumpStore(source);
       const built = await buildExport(
         {
@@ -273,10 +471,13 @@ describe("planning-domain SQLite export round-trip", () => {
       for (const table of PLANNING_TABLES) {
         expect(built.tables.find((entry) => entry.table === table)?.count).toBeGreaterThan(0);
       }
+      expect(
+        built.tables.find((entry) => entry.table === "plan_reconciliation_job")?.count,
+      ).toBeGreaterThan(0);
 
       const first = await importExport(
         {
-          sink: sqliteImportSink(destination),
+          sink: createSqliteImportSink(destination),
           presence: completePresence,
           targetUserVersion: 29,
           ...webCryptoExportEnv,
@@ -292,7 +493,7 @@ describe("planning-domain SQLite export round-trip", () => {
 
       const second = await importExport(
         {
-          sink: sqliteImportSink(destination),
+          sink: createSqliteImportSink(destination),
           presence: completePresence,
           targetUserVersion: 29,
           ...webCryptoExportEnv,
@@ -306,6 +507,37 @@ describe("planning-domain SQLite export round-trip", () => {
       }
       expect(await dumpStore(destination)).toBe(sourceDump);
       expect(await destination.all("PRAGMA foreign_key_check")).toEqual([]);
+    } finally {
+      await source.close();
+      await destination.close();
+    }
+  });
+
+  it("rejects a current replacement archive when its cleanup parent is missing", async () => {
+    const source = openSqliteStorage(":memory:");
+    const destination = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(source, MIGRATIONS.slice(0, 28));
+      await runMigrations(destination, MIGRATIONS);
+      await populateV28Replacement(source);
+      await source.setUserVersion(29);
+      const container = await buildPre29Container(source);
+
+      await expect(
+        importExport(
+          {
+            sink: createSqliteImportSink(destination),
+            presence: completePresence,
+            targetUserVersion: 29,
+            ...webCryptoExportEnv,
+          },
+          { container },
+        ),
+      ).rejects.toThrow(/FOREIGN KEY/u);
+      await expect(destination.get("SELECT id FROM plan_replacement")).resolves.toBeUndefined();
+      await expect(
+        destination.get("SELECT id FROM plan_reconciliation_job"),
+      ).resolves.toBeUndefined();
     } finally {
       await source.close();
       await destination.close();

--- a/packages/kernel/src/store/export/export-op.ts
+++ b/packages/kernel/src/store/export/export-op.ts
@@ -158,8 +158,15 @@ export async function importExport(
   ) {
     throw new ExportFormatError("The export file is not a recognized enduragent export document.");
   }
-  const storeUserVersion = storeRecord.userVersion as number;
+  const storeUserVersion = storeRecord.userVersion;
   const authored = storeRecord.authored as Record<string, readonly AuthoredRow[]>;
+  if (
+    typeof storeUserVersion !== "number" ||
+    !Number.isSafeInteger(storeUserVersion) ||
+    storeUserVersion < 0
+  ) {
+    throw new ExportFormatError("The export file is not a recognized enduragent export document.");
+  }
   if (storeUserVersion > deps.targetUserVersion) {
     throw new ExportSchemaMismatchError(
       "This backup was created by a newer version of the app; update before restoring.",
@@ -168,7 +175,11 @@ export async function importExport(
   const restored: RestoreTableResult[] = [];
   for (const t of ALL_AUTHORED_TABLES) {
     const rows = authored[t] ?? [];
-    restored.push(await deps.sink.restoreAuthoredTable(t, rows));
+    restored.push(
+      await deps.sink.restoreAuthoredTable(t, rows, {
+        sourceUserVersion: storeUserVersion,
+      }),
+    );
   }
   const manifestArtifacts = archiveManifest as readonly ArchiveArtifact[];
   const missing: ArchiveArtifact[] = [];

--- a/packages/kernel/src/store/export/index.ts
+++ b/packages/kernel/src/store/export/index.ts
@@ -1,17 +1,48 @@
-export { buildExport, importExport, EXPORT_WARNING, EXPORT_DOCUMENT_KIND, ExportSchemaMismatchError } from "./export-op.js";
+export {
+  buildExport,
+  importExport,
+  EXPORT_WARNING,
+  EXPORT_DOCUMENT_KIND,
+  ExportSchemaMismatchError,
+} from "./export-op.js";
 export type {
-  BuildExportDeps, BuildExportResult, ImportExportDeps, ImportResult, ManifestVerification,
+  BuildExportDeps,
+  BuildExportResult,
+  ImportExportDeps,
+  ImportResult,
+  ManifestVerification,
 } from "./export-op.js";
 export {
-  encodeContainer, decodeContainer, canonicalJson, stableSerialize,
-  CONTAINER_MAGIC, EXPORT_FORMAT_VERSION, MODE_PLAINTEXT, MODE_PASSPHRASE,
-  ExportFormatError, ExportPassphraseRequiredError, ExportDecryptionError,
+  encodeContainer,
+  decodeContainer,
+  canonicalJson,
+  stableSerialize,
+  CONTAINER_MAGIC,
+  EXPORT_FORMAT_VERSION,
+  MODE_PLAINTEXT,
+  MODE_PASSPHRASE,
+  ExportFormatError,
+  ExportPassphraseRequiredError,
+  ExportDecryptionError,
 } from "./container.js";
 export {
-  PURE_AUTHORED_TABLES, MIXED_AUTHORED_TABLES,
-  PBKDF2_ITERATIONS, PBKDF2_HASH, SALT_BYTES, NONCE_BYTES, AES_KEY_BITS,
+  PURE_AUTHORED_TABLES,
+  MIXED_AUTHORED_TABLES,
+  PBKDF2_ITERATIONS,
+  PBKDF2_HASH,
+  SALT_BYTES,
+  NONCE_BYTES,
+  AES_KEY_BITS,
 } from "./ports.js";
 export type {
-  ExportCryptoPort, TextCodec, ArchiveArtifact, AuthoredRow,
-  ExportSource, ArchiveManifestReader, ImportSink, RestoreTableResult, ArchivePresenceChecker,
+  ExportCryptoPort,
+  TextCodec,
+  ArchiveArtifact,
+  AuthoredRow,
+  ExportSource,
+  ArchiveManifestReader,
+  ImportSink,
+  RestoreTableOptions,
+  RestoreTableResult,
+  ArchivePresenceChecker,
 } from "./ports.js";

--- a/packages/kernel/src/store/export/ports.ts
+++ b/packages/kernel/src/store/export/ports.ts
@@ -65,10 +65,18 @@ export interface RestoreTableResult {
   readonly skipped: number;
 }
 
+export interface RestoreTableOptions {
+  readonly sourceUserVersion: number;
+}
+
 export interface ImportSink {
   /** Idempotent insert-if-absent by the table's primary key. Re-importing
    *  the same container inserts zero duplicate rows (skipped counts them). */
-  restoreAuthoredTable(table: string, rows: readonly AuthoredRow[]): Promise<RestoreTableResult>;
+  restoreAuthoredTable(
+    table: string,
+    rows: readonly AuthoredRow[],
+    options: RestoreTableOptions,
+  ): Promise<RestoreTableResult>;
 }
 
 export interface ArchivePresenceChecker {
@@ -87,6 +95,7 @@ export const PURE_AUTHORED_TABLES = [
   "dedup_confirmation",
   "chat_plan_outbox",
   "plan",
+  "plan_reconciliation_job",
   "planning_plan",
   "plan_revision",
   "plan_creation",

--- a/packages/kernel/tests/store-export.test.ts
+++ b/packages/kernel/tests/store-export.test.ts
@@ -124,11 +124,20 @@ function makeManifest(data: Populated): ArchiveManifestReader {
   };
 }
 
-function makeSink(): ImportSink & { stored: Map<string, Set<string>> } {
+function makeSink(): ImportSink & {
+  stored: Map<string, Set<string>>;
+  sourceUserVersions: number[];
+} {
   const stored = new Map<string, Set<string>>();
-  const sink: ImportSink & { stored: Map<string, Set<string>> } = {
+  const sourceUserVersions: number[] = [];
+  const sink: ImportSink & {
+    stored: Map<string, Set<string>>;
+    sourceUserVersions: number[];
+  } = {
     stored,
-    async restoreAuthoredTable(table, rows): Promise<RestoreTableResult> {
+    sourceUserVersions,
+    async restoreAuthoredTable(table, rows, options): Promise<RestoreTableResult> {
+      sourceUserVersions.push(options.sourceUserVersion);
       let set = stored.get(table);
       if (!set) {
         set = new Set<string>();
@@ -166,7 +175,7 @@ function makePresence(
 }
 
 describe("store export op", () => {
-  it("(enumerate) exports every authored key with correct manualOnly flags and no source/derived tables", async () => {
+  it("(enumerate) exports every portable key with correct manualOnly flags", async () => {
     const data = populated();
     const { source, calls } = makeSource(data);
     const crypto = new FakeCrypto();
@@ -184,6 +193,9 @@ describe("store export op", () => {
     for (const t of MIXED_AUTHORED_TABLES) {
       expect(calls.find((c) => c.table === t)?.manualOnly).toBe(true);
     }
+    expect(PURE_AUTHORED_TABLES.indexOf("plan_reconciliation_job")).toBeLessThan(
+      PURE_AUTHORED_TABLES.indexOf("plan_replacement"),
+    );
     for (const forbidden of [
       "workout",
       "session",
@@ -238,6 +250,12 @@ describe("store export op", () => {
     for (const t of MIXED_AUTHORED_TABLES) {
       expect(imported.restored.find((r) => r.table === t)?.inserted).toBe(1);
     }
+    expect(sink.sourceUserVersions).toEqual(
+      Array.from(
+        { length: PURE_AUTHORED_TABLES.length + MIXED_AUTHORED_TABLES.length },
+        () => data.userVersion,
+      ),
+    );
     expect(imported.manifest.total).toBe(data.artifacts.length);
   });
 


### PR DESCRIPTION
## Summary
- preserve replacement cleanup-job lineage in current backups
- restore v21-v28 Planning rows through a version-aware SQLite compatibility adapter without changing migration 029
- reject current-schema or inconsistent archives transactionally

## Testing
- affected kernel and kernel-node typechecks
- affected kernel and kernel-node builds
- 24 focused store-export tests
- changed-file oxfmt and oxlint checks
- fixture privacy, changeset wording, package dependency, and kernel discipline checks
- autoreview clean with no accepted or actionable findings