### PR TITLE
docs(skills): record mocked-engine proof deviation in verify-enduragent

### DIFF
--- a/.agents/skills/verify-enduragent/SKILL.md
+++ b/.agents/skills/verify-enduragent/SKILL.md
@@ -30,4 +30,6 @@ If a build fails, stop with the failed command. Do not drive stale `dist/` or `o
 
 Follow the exact commands and proof requirements on the selected feature page. For Playwright, retain its failure screenshot, trace, and log under `apps/desktop/test-results/e2e/`; a passing run is supported by its visible-state assertions and command result.
 
+Treat proofs from the `fresh` and `ready` profiles as renderer-only: both run against a scripted engine RPC backend and do not prove engine side effects. Cover engine side effects with a future `real` profile that boots the actual coach engine over a seeded athlete home, uses fakes only at the LLM-provider and intervals.icu boundaries, and reuses the `tools/s8a` provider machinery.
+
 Finish with `pnpm check:fixture-privacy`. Confirm the Electron fixture closed and report any retained evidence path. Do not upload evidence.


### PR DESCRIPTION
## Summary
Records in the verify-enduragent skill that the fresh/ready runner profiles drive a scripted engine RPC backend, so current proofs cover renderer behavior only — and names the future remedy (a real profile with fakes only at the LLM and intervals.icu boundaries).
Prose-only change; review skipped per ship-loop prose exemption (catalog structure tests ran green in QA).
Infra-only change: no changeset.

## Verified
- `pnpm install` in the worktree: completed (14.5s, pnpm 11.24.0). One expected warning: `.bin/enduragent` bin link not created because the coach dist is absent before `pnpm -r build`; pre-existing, not caused by this branch.
- `pnpm -C apps/desktop exec vitest run tests/verification-feature-selection.test.ts`: 5/5 passed standalone.
- `pnpm check:verification-catalog` (root script → desktop `vitest run --project workspace` over verification-feature-selection + windows-parity-scenarios tests): 2 files, 35/35 tests passed.
- Prose criteria confirmed against the branch's only change (SKILL.md line 33, commit f2944f48): the note states fresh/ready profiles run against a scripted engine RPC backend with renderer-only proofs, names the remedy in exactly one sentence (future `real` profile booting the actual coach engine over a seeded athlete home with fakes only at the LLM-provider and intervals.icu boundaries, reusing tools/s8a provider machinery), and no other sentence in the skill or its reference pages contradicts it.
- Pre-existing/stale suspects noted during QA, none caused by this branch: a spec citation references `apps/desktop/scripts/verification/controller.ts` which exists neither on this branch nor on origin/main; the note says `fresh` profile while the skill's feature pages name profiles `first-run` and `ready` (wording matches the spec's acceptance criterion verbatim, but the name may be stale relative to the tree).

https://claude.ai/code/session_01Spnd158f3F4tCuYf2BVpML
