### PR TITLE
feat: training-history contract, reader, coverage, projection, and calendar threading (PR1)

### DIFF
--- a/.changeset/thread-training-history-contract.md
+++ b/.changeset/thread-training-history-contract.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/kernel": patch
+"@enduragent/engine": patch
+"@enduragent/sync-intervals-icu": patch
+"@enduragent/core": patch
+"@enduragent/coach": patch
+---
+
+Add the internal training-history contract, persisted coverage evidence, calendar-aware capture plan, and state composition wiring.

--- a/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
@@ -115,6 +115,7 @@ describe("resident ride import glue", () => {
               },
             ],
           },
+          trainingHistory: { kind: "unavailable", reason: "not-synced" },
           anchorZones: { kind: "unknown", reason: "not-synced" },
           cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
           plan: { kind: "unknown", reason: "no-plan" },

--- a/apps/desktop-renderer/tests/training-context.test.ts
+++ b/apps/desktop-renderer/tests/training-context.test.ts
@@ -17,6 +17,7 @@ import {
 const context: CyclingTrainingContext = {
   performanceProgress: { kind: "unavailable", reason: "not-synced" },
   recentRides: { kind: "unknown", reason: "no-recent-rides" },
+  trainingHistory: { kind: "unavailable", reason: "not-synced" },
   anchorZones: { kind: "unknown", reason: "missing-anchor" },
   cyclingLoad: {
     kind: "computed",

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -135,6 +135,7 @@ const context: CyclingTrainingContext = {
       },
     ],
   },
+  trainingHistory: { kind: "unavailable", reason: "not-synced" },
   anchorZones: {
     kind: "computed",
     asOf: "1998-07-19T08:00:00.000Z",
@@ -196,6 +197,7 @@ const context: CyclingTrainingContext = {
 const unknownContext: CyclingTrainingContext = {
   performanceProgress: { kind: "unavailable", reason: "not-synced" },
   recentRides: { kind: "unknown", reason: "not-synced" },
+  trainingHistory: { kind: "unavailable", reason: "not-synced" },
   anchorZones: { kind: "unknown", reason: "missing-anchor" },
   cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
   plan: { kind: "unknown", reason: "no-plan" },

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -85,6 +85,7 @@ const trainingContext = {
       },
     ],
   },
+  trainingHistory: { kind: "unavailable", reason: "not-synced" },
   anchorZones: {
     kind: "computed",
     asOf: "2026-07-19T08:00:00.000Z",

--- a/apps/desktop/tests/helpers/plan-qa-live.ts
+++ b/apps/desktop/tests/helpers/plan-qa-live.ts
@@ -1560,6 +1560,7 @@ export function createPlanQaFixtureScript(
               windowDays: 28,
               items: [],
             },
+            trainingHistory: { kind: "unavailable", reason: "not-synced" },
             anchorZones: { kind: "unavailable", reason: "not-synced" },
             cyclingLoad: { kind: "unavailable", reason: "not-synced" },
             plan: { kind: "computed", asOf: "1998-08-22T08:00:00.000Z", items: [] },

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -154,6 +154,7 @@ function makeScript(): DesktopFixtureScript {
                 },
               ],
             },
+            trainingHistory: { kind: "unavailable", reason: "not-synced" },
             anchorZones: { kind: "unknown", reason: "not-synced" },
             cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
             plan: { kind: "unknown", reason: "no-plan" },

--- a/packages/coach-contract/src/athlete-state.ts
+++ b/packages/coach-contract/src/athlete-state.ts
@@ -53,7 +53,7 @@ function utf8LenAtMost(maximumBytes: number): (value: string) => boolean {
 
 function isMondayWeek(value: { readonly start: string; readonly end: string }): boolean {
   return (
-    civilEpochDay(value.start) % 7 === 4 &&
+    ((civilEpochDay(value.start) % 7) + 7) % 7 === 4 &&
     civilEpochDay(value.end) - civilEpochDay(value.start) === 6
   );
 }

--- a/packages/coach-contract/src/athlete-state.ts
+++ b/packages/coach-contract/src/athlete-state.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import { CanonicalActivityIdSchema } from "./activity-analysis.js";
+import { CivilDateSchema } from "./training-export.js";
+
+export { CivilDateSchema } from "./training-export.js";
 
 export const FreshnessSchema = z.enum(["fresh", "flag", "stale", "critical"]);
 export type Freshness = z.infer<typeof FreshnessSchema>;
@@ -6,30 +10,80 @@ export type Freshness = z.infer<typeof FreshnessSchema>;
 const POWER_PROGRESS_DURATIONS = [5, 60, 300, 1_200, 3_600] as const;
 const POWER_PROGRESS_HR_DURATIONS = [60, 300, 1_200, 3_600] as const;
 
-function isCivilDate(value: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
-  const parsed = new Date(Date.UTC(year, month - 1, day));
-  return (
-    parsed.getUTCFullYear() === year &&
-    parsed.getUTCMonth() === month - 1 &&
-    parsed.getUTCDate() === day
-  );
-}
-
 function civilEpochDay(value: string): number {
   return Date.parse(`${value}T00:00:00.000Z`) / 86_400_000;
 }
 
-const PowerProgressDateSchema = z.string().length(10).refine(isCivilDate, "invalid civil date");
+const ISO_INSTANT_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|([+-])(\d{2}):(\d{2}))$/u;
 
-const CivilDateWindowSchema = z
+function isFiniteIsoInstant(value: string): boolean {
+  const match = ISO_INSTANT_PATTERN.exec(value);
+  if (match === null) return false;
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) return false;
+  const offsetHours = Number(match[9] ?? 0);
+  const offsetMinutes = Number(match[10] ?? 0);
+  if (offsetHours > 23 || offsetMinutes > 59) return false;
+  const offsetSign = match[8] === "-" ? -1 : 1;
+  const local = new Date(milliseconds + offsetSign * (offsetHours * 60 + offsetMinutes) * 60_000);
+  return (
+    local.getUTCFullYear() === Number(match[1]) &&
+    local.getUTCMonth() + 1 === Number(match[2]) &&
+    local.getUTCDate() === Number(match[3]) &&
+    local.getUTCHours() === Number(match[4]) &&
+    local.getUTCMinutes() === Number(match[5]) &&
+    local.getUTCSeconds() === Number(match[6])
+  );
+}
+
+function isActiveIanaZone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function utf8LenAtMost(maximumBytes: number): (value: string) => boolean {
+  const encoder = new TextEncoder();
+  return (value) => encoder.encode(value).byteLength <= maximumBytes;
+}
+
+function isMondayWeek(value: { readonly start: string; readonly end: string }): boolean {
+  return (
+    civilEpochDay(value.start) % 7 === 4 &&
+    civilEpochDay(value.end) - civilEpochDay(value.start) === 6
+  );
+}
+
+const PowerProgressDateSchema = z
+  .string()
+  .length(10)
+  .refine((value) => CivilDateSchema.safeParse(value).success, "invalid civil date");
+
+export const CivilDateWindowSchema = z
   .object({
     start: PowerProgressDateSchema,
     end: PowerProgressDateSchema,
   })
   .strict()
   .refine((value) => value.start <= value.end, "date window start must not follow its end");
+
+export const IsoInstantSchema = z
+  .string()
+  .max(64)
+  .datetime({ offset: true })
+  .refine(isFiniteIsoInstant);
+
+export const CanonicalSessionIdSchema = CanonicalActivityIdSchema;
+
+const CalendarTimeZoneSchema = z
+  .string()
+  .min(1)
+  .refine(isActiveIanaZone)
+  .refine(utf8LenAtMost(255));
 
 export const PowerProgressDateWindowSchema = CivilDateWindowSchema.refine(
   (value) => civilEpochDay(value.end) - civilEpochDay(value.start) === 27,
@@ -420,10 +474,431 @@ export const RecentRidesPanelSchema = z.discriminatedUnion("kind", [
     .strict(),
 ]);
 
+type MetricValueOutput =
+  | { kind: "computed"; value: number }
+  | { kind: "partial"; value: number; reason: "incomplete-coverage" }
+  | {
+      kind: "unavailable";
+      reason: "no-recorded-value" | "incomplete-coverage" | "invalid-recorded-value";
+    };
+
+type MissingRecordedMetricValueOutput = {
+  kind: "partial";
+  value: number;
+  reason: "missing-recorded-value";
+  knownRideMissingValueCount: number;
+};
+
+function metricValueSchema(
+  value: z.ZodNumber,
+  options: { readonly countsMissingRides: false },
+): z.ZodType<MetricValueOutput>;
+function metricValueSchema(
+  value: z.ZodNumber,
+  options: { readonly countsMissingRides: true },
+): z.ZodType<MetricValueOutput | MissingRecordedMetricValueOutput>;
+function metricValueSchema(
+  value: z.ZodNumber,
+  options: { readonly countsMissingRides: boolean },
+): z.ZodType<MetricValueOutput | MissingRecordedMetricValueOutput> {
+  const computed = z.object({ kind: z.literal("computed"), value }).strict();
+  const incomplete = z
+    .object({
+      kind: z.literal("partial"),
+      value,
+      reason: z.literal("incomplete-coverage"),
+    })
+    .strict();
+  const unavailable = z
+    .object({
+      kind: z.literal("unavailable"),
+      reason: z.enum([
+        "no-recorded-value",
+        "incomplete-coverage",
+        "invalid-recorded-value",
+      ]),
+    })
+    .strict();
+  if (!options.countsMissingRides) {
+    return z.union([computed, incomplete, unavailable]);
+  }
+  const missing = z
+    .object({
+      kind: z.literal("partial"),
+      value,
+      reason: z.literal("missing-recorded-value"),
+      knownRideMissingValueCount: z.number().int().min(1).max(1_000),
+    })
+    .strict();
+  return z.union([computed, missing, incomplete, unavailable]);
+}
+
+export const RideCountMetricValueSchema = metricValueSchema(
+  z.number().int().min(0).max(1_000),
+  { countsMissingRides: false },
+);
+export const DurationMetricValueSchema = metricValueSchema(
+  z.number().int().safe().nonnegative(),
+  { countsMissingRides: true },
+);
+export const DistanceMetricValueSchema = metricValueSchema(
+  z.number().finite().min(0).max(100_000_000),
+  { countsMissingRides: true },
+);
+export const LoadMetricValueSchema = metricValueSchema(
+  z.number().finite().min(0).max(Number.MAX_SAFE_INTEGER),
+  { countsMissingRides: true },
+);
+
+export const TrainingHistoryRideSchema = z
+  .object({
+    id: CanonicalSessionIdSchema,
+    title: z.string().refine(utf8LenAtMost(512)).nullable(),
+    subSport: z.string().min(1).max(128).nullable(),
+    startEpochSeconds: z.number().int().safe().nonnegative(),
+    timezoneOffsetSeconds: z.number().int().min(-86_400).max(86_400).nullable(),
+    localDate: CivilDateSchema,
+    ridingSeconds: z.number().int().safe().nonnegative().nullable(),
+    ridingTimeBasis: z.enum(["moving", "elapsed"]).nullable(),
+    elapsedSeconds: z.number().int().safe().nonnegative().nullable(),
+    distanceMeters: z.number().finite().min(0).max(100_000_000).nullable(),
+    load: z.number().finite().min(0).max(Number.MAX_SAFE_INTEGER).nullable(),
+    averagePowerWatts: z.number().finite().min(0).max(20_000).nullable(),
+    averageHeartRateBpm: z.number().finite().positive().max(500).nullable(),
+    perceivedExertion: z.number().finite().min(0).max(10).nullable(),
+    energyKilojoules: z.number().finite().min(0).max(Number.MAX_SAFE_INTEGER).nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.ridingSeconds === null) !== (value.ridingTimeBasis === null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["ridingTimeBasis"],
+        message: "riding seconds and riding time basis must be present together",
+      });
+    }
+  });
+
+export const WeekCoverageSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("complete") }).strict(),
+  z
+    .object({
+      kind: z.literal("incomplete"),
+      recordedThrough: CivilDateSchema.nullable(),
+      reason: z.enum([
+        "backfill-incomplete",
+        "source-degraded",
+        "sparse-imports",
+        "coverage-timezone-changed",
+        "coverage-lag",
+        "scan-limit",
+        "invalid-core-record",
+      ]),
+    })
+    .strict(),
+]);
+
+export const TrendBucketSchema = z
+  .object({
+    window: CivilDateWindowSchema,
+    rideCount: z.number().int().min(0).max(1_000),
+    ridingSeconds: z.number().int().safe().nonnegative(),
+  })
+  .strict();
+
+export const RidingTimeTrendSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      buckets: z.array(TrendBucketSchema).length(6),
+    })
+    .strict()
+    .superRefine((value, context) => {
+      for (let index = 0; index < value.buckets.length; index += 1) {
+        const bucket = value.buckets[index]!;
+        if (!isMondayWeek(bucket.window)) {
+          context.addIssue({
+            code: "custom",
+            path: ["buckets", index, "window"],
+            message: "trend buckets must be closed Monday weeks",
+          });
+        }
+        if (
+          index > 0 &&
+          civilEpochDay(bucket.window.start) -
+            civilEpochDay(value.buckets[index - 1]!.window.end) !==
+            1
+        ) {
+          context.addIssue({
+            code: "custom",
+            path: ["buckets", index, "window"],
+            message: "trend buckets must be contiguous and ascending",
+          });
+        }
+      }
+    }),
+  z
+    .object({
+      kind: z.literal("unavailable"),
+      reason: z.enum(["limited-history", "incomplete-source", "missing-duration"]),
+    })
+    .strict(),
+]);
+
+export const TrainingRideCalloutSchema = z
+  .object({
+    kind: z.literal("longest-ride-28d"),
+    rideId: CanonicalSessionIdSchema,
+    durationSeconds: z.number().int().safe().positive(),
+    window: CivilDateWindowSchema,
+    comparisonRideCount: z.number().int().min(4).max(1_000),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (civilEpochDay(value.window.end) - civilEpochDay(value.window.start) !== 27) {
+      context.addIssue({
+        code: "custom",
+        path: ["window"],
+        message: "callout window must contain 28 civil dates",
+      });
+    }
+  });
+
+export const CompletedActivityWeekSchema = z
+  .object({
+    id: z.enum(["anchor", "previous"]),
+    window: CivilDateWindowSchema,
+    calendarState: z.enum(["open", "closed"]),
+    coverage: WeekCoverageSchema,
+    totals: z
+      .object({
+        rideCount: RideCountMetricValueSchema,
+        ridingSeconds: DurationMetricValueSchema,
+        distanceMeters: DistanceMetricValueSchema,
+        load: LoadMetricValueSchema,
+      })
+      .strict(),
+    rides: z
+      .object({
+        count: z.union([
+          z
+            .object({
+              kind: z.literal("exact"),
+              value: z.number().int().min(0).max(1_000),
+            })
+            .strict(),
+          z
+            .object({
+              kind: z.literal("at-least"),
+              value: z.number().int().min(0).max(1_000),
+            })
+            .strict(),
+        ]),
+        items: z.array(TrainingHistoryRideSchema).max(50),
+        truncated: z.boolean(),
+      })
+      .strict(),
+    trend: RidingTimeTrendSchema,
+    callout: TrainingRideCalloutSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (!isMondayWeek(value.window)) {
+      context.addIssue({
+        code: "custom",
+        path: ["window"],
+        message: "completed activity week must run from Monday through Sunday",
+      });
+    }
+    const ids = new Set<string>();
+    for (let index = 0; index < value.rides.items.length; index += 1) {
+      const ride = value.rides.items[index]!;
+      if (ride.localDate < value.window.start || ride.localDate > value.window.end) {
+        context.addIssue({
+          code: "custom",
+          path: ["rides", "items", index, "localDate"],
+          message: "ride local date must fall inside the week",
+        });
+      }
+      if (ids.has(ride.id)) {
+        context.addIssue({
+          code: "custom",
+          path: ["rides", "items", index, "id"],
+          message: "ride ids must be unique within a week",
+        });
+      }
+      ids.add(ride.id);
+      if (index > 0) {
+        const previous = value.rides.items[index - 1]!;
+        if (
+          previous.startEpochSeconds < ride.startEpochSeconds ||
+          (previous.startEpochSeconds === ride.startEpochSeconds && previous.id > ride.id)
+        ) {
+          context.addIssue({
+            code: "custom",
+            path: ["rides", "items", index],
+            message: "rides must be sorted by start time descending and id ascending",
+          });
+        }
+      }
+    }
+    if (value.rides.count.value < value.rides.items.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["rides", "count", "value"],
+        message: "ride count must include every returned ride",
+      });
+    }
+    const shouldBeTruncated =
+      value.rides.count.kind === "at-least" ||
+      value.rides.count.value > value.rides.items.length;
+    if (value.rides.truncated !== shouldBeTruncated) {
+      context.addIssue({
+        code: "custom",
+        path: ["rides", "truncated"],
+        message: "ride truncation must match the count envelope",
+      });
+    }
+    if (value.callout !== null) {
+      const ride = value.rides.items.find((item) => item.id === value.callout?.rideId);
+      if (ride === undefined) {
+        context.addIssue({
+          code: "custom",
+          path: ["callout", "rideId"],
+          message: "callout ride must be returned in the week",
+        });
+      } else if (ride.ridingSeconds !== value.callout.durationSeconds) {
+        context.addIssue({
+          code: "custom",
+          path: ["callout", "durationSeconds"],
+          message: "callout duration must match the returned ride",
+        });
+      }
+    }
+  });
+
+export const TrainingHistoryCoverageSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("contiguous"),
+      start: CivilDateSchema,
+      through: CivilDateSchema,
+      committedAt: IsoInstantSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("incomplete"),
+      provenStart: CivilDateSchema.nullable(),
+      provenThrough: CivilDateSchema.nullable(),
+      observedThrough: CivilDateSchema.nullable(),
+      committedAt: IsoInstantSchema.nullable(),
+      reason: z.enum([
+        "backfill-incomplete",
+        "source-degraded",
+        "undated-dropped-rows",
+        "coverage-timezone-changed",
+      ]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("sparse"),
+      latestKnownRideDate: CivilDateSchema,
+      latestImportAt: IsoInstantSchema.nullable(),
+    })
+    .strict(),
+]);
+
+export const TrainingHistoryComputedSchema = z
+  .object({
+    kind: z.literal("computed"),
+    asOf: IsoInstantSchema,
+    calendarTimeZone: CalendarTimeZoneSchema,
+    displayMode: z.enum(["current", "last-recorded"]),
+    coverage: TrainingHistoryCoverageSchema,
+    anchorWeek: CompletedActivityWeekSchema,
+    previousWeek: CompletedActivityWeekSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.anchorWeek.id !== "anchor") {
+      context.addIssue({
+        code: "custom",
+        path: ["anchorWeek", "id"],
+        message: "anchor week must carry the anchor id",
+      });
+    }
+    if (value.previousWeek !== null) {
+      if (value.previousWeek.id !== "previous") {
+        context.addIssue({
+          code: "custom",
+          path: ["previousWeek", "id"],
+          message: "previous week must carry the previous id",
+        });
+      }
+      if (
+        civilEpochDay(value.anchorWeek.window.start) -
+          civilEpochDay(value.previousWeek.window.end) !==
+        1
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["previousWeek", "window"],
+          message: "previous week must end before the anchor week starts",
+        });
+      }
+    }
+  });
+
+const TrainingHistoryUnavailableSchema = z
+  .object({
+    kind: z.literal("unavailable"),
+    reason: z.enum([
+      "not-synced",
+      "coverage-unavailable",
+      "temporary-failure",
+      "invalid-data",
+    ]),
+  })
+  .strict();
+
+export const TrainingHistoryProjectionSchema = z.discriminatedUnion("kind", [
+  TrainingHistoryComputedSchema,
+  TrainingHistoryUnavailableSchema,
+]);
+
+const TrainingHistoryStaleSchema = z
+  .object({
+    kind: z.literal("stale"),
+    failedAt: IsoInstantSchema,
+    reason: z.literal("temporary-failure"),
+    lastGood: TrainingHistoryComputedSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (
+      value.lastGood.anchorWeek.callout !== null ||
+      (value.lastGood.previousWeek !== null && value.lastGood.previousWeek.callout !== null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["lastGood"],
+        message: "last-good training history cannot carry callouts",
+      });
+    }
+  });
+
+export const TrainingHistoryPanelSchema = z.discriminatedUnion("kind", [
+  ...TrainingHistoryProjectionSchema.options,
+  TrainingHistoryStaleSchema,
+]);
+
 export const CyclingTrainingContextSchema = z
   .object({
     performanceProgress: PowerProgressPanelSchema,
     recentRides: RecentRidesPanelSchema.default({ kind: "unknown", reason: "not-synced" }),
+    trainingHistory: TrainingHistoryPanelSchema,
     anchorZones: AnchorZonesPanelSchema,
     cyclingLoad: CyclingLoadPanelSchema,
     plan: PlanPanelSchema,
@@ -445,11 +920,30 @@ export type WellnessSeries = z.infer<typeof WellnessSeriesSchema>;
 export type WellnessTrendPanel = z.infer<typeof WellnessTrendPanelSchema>;
 export type RecentRide = z.infer<typeof RecentRideSchema>;
 export type RecentRidesPanel = z.infer<typeof RecentRidesPanelSchema>;
+export type IsoInstant = z.infer<typeof IsoInstantSchema>;
+export type CivilDate = z.infer<typeof CivilDateSchema>;
+export type CivilDateWindow = z.infer<typeof CivilDateWindowSchema>;
+export type CanonicalSessionId = z.infer<typeof CanonicalSessionIdSchema>;
+export type RideCountMetricValue = z.infer<typeof RideCountMetricValueSchema>;
+export type DurationMetricValue = z.infer<typeof DurationMetricValueSchema>;
+export type DistanceMetricValue = z.infer<typeof DistanceMetricValueSchema>;
+export type LoadMetricValue = z.infer<typeof LoadMetricValueSchema>;
+export type TrainingHistoryRide = z.infer<typeof TrainingHistoryRideSchema>;
+export type WeekCoverage = z.infer<typeof WeekCoverageSchema>;
+export type TrendBucket = z.infer<typeof TrendBucketSchema>;
+export type RidingTimeTrend = z.infer<typeof RidingTimeTrendSchema>;
+export type TrainingRideCallout = z.infer<typeof TrainingRideCalloutSchema>;
+export type CompletedActivityWeek = z.infer<typeof CompletedActivityWeekSchema>;
+export type TrainingHistoryCoverage = z.infer<typeof TrainingHistoryCoverageSchema>;
+export type TrainingHistoryComputed = z.infer<typeof TrainingHistoryComputedSchema>;
+export type TrainingHistoryProjection = z.infer<typeof TrainingHistoryProjectionSchema>;
+export type TrainingHistoryPanel = z.infer<typeof TrainingHistoryPanelSchema>;
 export type CyclingTrainingContext = z.infer<typeof CyclingTrainingContextSchema>;
 
 export const UNKNOWN_CYCLING_TRAINING_CONTEXT: CyclingTrainingContext = {
   performanceProgress: { kind: "unavailable", reason: "not-synced" },
   recentRides: { kind: "unknown", reason: "not-synced" },
+  trainingHistory: { kind: "unavailable", reason: "not-synced" },
   anchorZones: { kind: "unknown", reason: "not-synced" },
   cyclingLoad: { kind: "unknown", reason: "not-synced" },
   plan: { kind: "unknown", reason: "not-synced" },

--- a/packages/coach-contract/src/training-export.ts
+++ b/packages/coach-contract/src/training-export.ts
@@ -22,6 +22,7 @@ function isCivilDate(value: string): boolean {
 export const TrainingExportCivilDateSchema = z
   .string()
   .refine(isCivilDate, "invalid training export civil date");
+export const CivilDateSchema = TrainingExportCivilDateSchema;
 
 export const DesktopTrainingExportRequestSchema = z.discriminatedUnion("kind", [
   z

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 32;
+export const PROTOCOL_VERSION = 33;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 32 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("ships protocol 33 and rejects a blank enqueue without attachments", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -151,8 +151,8 @@ describe("coach decision wire contract", () => {
     expect(parsed.entries).toHaveLength(1);
   });
 
-  it("projects resume completion explicitly at protocol 32", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("projects resume completion explicitly at protocol 33", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -21,6 +21,7 @@ import {
   PowerProgressPanelSchema,
   RecentRidesPanelSchema,
   RideCountMetricValueSchema,
+  RidingTimeTrendSchema,
   TrainingHistoryPanelSchema,
   TrainingHistoryProjectionSchema,
   TrainingHistoryRideSchema,
@@ -516,6 +517,8 @@ describe("AthleteState", () => {
         adherence: { ...computed.adherence, ratio: 1.1 },
       }).success,
     ).toBe(false);
+    const { trainingHistory: _trainingHistory, ...withoutTrainingHistory } = computed;
+    expect(CyclingTrainingContextSchema.safeParse(withoutTrainingHistory).success).toBe(false);
   });
 
   it("round trips a computed training-history panel", () => {
@@ -540,6 +543,54 @@ describe("AthleteState", () => {
     } as const;
     expect(TrainingHistoryPanelSchema.parse(stale)).toEqual(stale);
     expect(TrainingHistoryProjectionSchema.safeParse(stale).success).toBe(false);
+  });
+
+  it("accepts pre-1970 Monday weeks and rejects pre-1970 non-Monday starts", () => {
+    const emptyWeek = computedTrainingHistory.previousWeek;
+    const preEpochMonday = {
+      ...emptyWeek,
+      window: { start: "1969-12-29", end: "1970-01-04" },
+    };
+    expect(CompletedActivityWeekSchema.safeParse(preEpochMonday).success).toBe(true);
+    const preEpochTuesday = {
+      ...emptyWeek,
+      window: { start: "1969-12-30", end: "1970-01-05" },
+    };
+    expect(CompletedActivityWeekSchema.safeParse(preEpochTuesday).success).toBe(false);
+  });
+
+  it("rejects non-adjacent previous weeks and non-contiguous trend buckets", () => {
+    const detachedPrevious = {
+      ...computedTrainingHistory,
+      previousWeek: {
+        ...computedTrainingHistory.previousWeek,
+        window: { start: "1998-06-22", end: "1998-06-28" },
+      },
+    };
+    expect(TrainingHistoryProjectionSchema.safeParse(detachedPrevious).success).toBe(false);
+    const buckets = computedTrainingHistory.anchorWeek.trend.buckets;
+    const gappedTrend = {
+      kind: "computed",
+      buckets: [
+        ...buckets.slice(0, 5),
+        { ...buckets[5], window: { start: "1998-07-06", end: "1998-07-12" } },
+      ],
+    };
+    expect(RidingTimeTrendSchema.safeParse(gappedTrend).success).toBe(false);
+    const descendingTrend = {
+      kind: "computed",
+      buckets: [...buckets].reverse(),
+    };
+    expect(RidingTimeTrendSchema.safeParse(descendingTrend).success).toBe(false);
+    const offMondayTrend = {
+      kind: "computed",
+      buckets: buckets.map((bucket, index) =>
+        index === 2
+          ? { ...bucket, window: { start: "1998-06-02", end: "1998-06-08" } }
+          : bucket,
+      ),
+    };
+    expect(RidingTimeTrendSchema.safeParse(offMondayTrend).success).toBe(false);
   });
 
   it("rejects invalid completed-week windows, rides, ordering, and truncation", () => {

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -14,8 +14,17 @@ import {
   AdherencePanelSchema,
   CyclingLoadPanelSchema,
   CyclingTrainingContextSchema,
+  CompletedActivityWeekSchema,
+  DistanceMetricValueSchema,
+  DurationMetricValueSchema,
+  LoadMetricValueSchema,
   PowerProgressPanelSchema,
   RecentRidesPanelSchema,
+  RideCountMetricValueSchema,
+  TrainingHistoryPanelSchema,
+  TrainingHistoryProjectionSchema,
+  TrainingHistoryRideSchema,
+  TrainingRideCalloutSchema,
   UNKNOWN_CYCLING_TRAINING_CONTEXT,
   ChatRequestSchema,
   ChatResponseSchema,
@@ -97,6 +106,118 @@ const computedPowerProgress = {
   asOf: "1998-07-06T09:00:00.000Z",
 } as const;
 
+const trainingHistoryRides = [
+  {
+    id: "a".repeat(64),
+    title: "Long endurance ride",
+    subSport: "road",
+    startEpochSeconds: 899_800_000,
+    timezoneOffsetSeconds: 21_600,
+    localDate: "1998-07-10",
+    ridingSeconds: 7_200,
+    ridingTimeBasis: "moving",
+    elapsedSeconds: 7_500,
+    distanceMeters: 60_000,
+    load: 110,
+    averagePowerWatts: 210,
+    averageHeartRateBpm: 145,
+    perceivedExertion: 6,
+    energyKilojoules: 1_500,
+  },
+  {
+    id: "b".repeat(64),
+    title: null,
+    subSport: null,
+    startEpochSeconds: 899_700_000,
+    timezoneOffsetSeconds: null,
+    localDate: "1998-07-08",
+    ridingSeconds: 3_600,
+    ridingTimeBasis: "elapsed",
+    elapsedSeconds: 3_600,
+    distanceMeters: null,
+    load: null,
+    averagePowerWatts: null,
+    averageHeartRateBpm: null,
+    perceivedExertion: null,
+    energyKilojoules: null,
+  },
+] as const;
+
+const trainingHistoryCallout = {
+  kind: "longest-ride-28d",
+  rideId: trainingHistoryRides[0].id,
+  durationSeconds: trainingHistoryRides[0].ridingSeconds,
+  window: { start: "1998-06-09", end: "1998-07-06" },
+  comparisonRideCount: 4,
+} as const;
+
+const computedTrainingHistory = {
+  kind: "computed",
+  asOf: "1998-07-12T23:59:59.000Z",
+  calendarTimeZone: "UTC",
+  displayMode: "current",
+  coverage: {
+    kind: "contiguous",
+    start: "1998-05-18",
+    through: "1998-07-12",
+    committedAt: "1998-07-12T22:00:00.000Z",
+  },
+  anchorWeek: {
+    id: "anchor",
+    window: { start: "1998-07-06", end: "1998-07-12" },
+    calendarState: "closed",
+    coverage: { kind: "complete" },
+    totals: {
+      rideCount: { kind: "computed", value: 2 },
+      ridingSeconds: { kind: "computed", value: 10_800 },
+      distanceMeters: {
+        kind: "partial",
+        value: 60_000,
+        reason: "missing-recorded-value",
+        knownRideMissingValueCount: 1,
+      },
+      load: {
+        kind: "partial",
+        value: 110,
+        reason: "missing-recorded-value",
+        knownRideMissingValueCount: 1,
+      },
+    },
+    rides: {
+      count: { kind: "exact", value: 2 },
+      items: trainingHistoryRides,
+      truncated: false,
+    },
+    trend: {
+      kind: "computed",
+      buckets: [
+        { window: { start: "1998-05-18", end: "1998-05-24" }, rideCount: 1, ridingSeconds: 3_600 },
+        { window: { start: "1998-05-25", end: "1998-05-31" }, rideCount: 2, ridingSeconds: 7_200 },
+        { window: { start: "1998-06-01", end: "1998-06-07" }, rideCount: 1, ridingSeconds: 4_000 },
+        { window: { start: "1998-06-08", end: "1998-06-14" }, rideCount: 3, ridingSeconds: 9_000 },
+        { window: { start: "1998-06-15", end: "1998-06-21" }, rideCount: 2, ridingSeconds: 6_000 },
+        { window: { start: "1998-06-22", end: "1998-06-28" }, rideCount: 1, ridingSeconds: 3_000 },
+      ],
+    },
+    callout: trainingHistoryCallout,
+  },
+  previousWeek: {
+    id: "previous",
+    window: { start: "1998-06-29", end: "1998-07-05" },
+    calendarState: "closed",
+    coverage: { kind: "complete" },
+    totals: {
+      rideCount: { kind: "computed", value: 0 },
+      ridingSeconds: { kind: "computed", value: 0 },
+      distanceMeters: { kind: "computed", value: 0 },
+      load: { kind: "computed", value: 0 },
+    },
+    rides: { count: { kind: "exact", value: 0 }, items: [], truncated: false },
+    trend: { kind: "unavailable", reason: "limited-history" },
+    callout: null,
+  },
+} as const;
+
 function cloneState(): Record<string, unknown> {
   return structuredClone(validState) as unknown as Record<string, unknown>;
 }
@@ -114,8 +235,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 32", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("is 33", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
   });
 
   it("requires Stop to name the exact active turn", () => {
@@ -375,6 +496,7 @@ describe("AthleteState", () => {
           { metric: "resting-hr", unit: "bpm", points: [] },
         ],
       },
+      trainingHistory: { kind: "unavailable", reason: "not-synced" },
     } as const;
     expect(CyclingTrainingContextSchema.parse(computed)).toEqual(computed);
     const { recentRides: _recentRides, ...olderContext } = computed;
@@ -394,6 +516,184 @@ describe("AthleteState", () => {
         adherence: { ...computed.adherence, ratio: 1.1 },
       }).success,
     ).toBe(false);
+  });
+
+  it("round trips a computed training-history panel", () => {
+    expect(TrainingHistoryProjectionSchema.parse(computedTrainingHistory)).toEqual(
+      computedTrainingHistory,
+    );
+    expect(TrainingHistoryPanelSchema.parse(computedTrainingHistory)).toEqual(
+      computedTrainingHistory,
+    );
+  });
+
+  it("keeps stale state out of the training-history projection", () => {
+    const lastGood = {
+      ...computedTrainingHistory,
+      anchorWeek: { ...computedTrainingHistory.anchorWeek, callout: null },
+    } as const;
+    const stale = {
+      kind: "stale",
+      failedAt: "1998-07-13T00:05:00.000Z",
+      reason: "temporary-failure",
+      lastGood,
+    } as const;
+    expect(TrainingHistoryPanelSchema.parse(stale)).toEqual(stale);
+    expect(TrainingHistoryProjectionSchema.safeParse(stale).success).toBe(false);
+  });
+
+  it("rejects invalid completed-week windows, rides, ordering, and truncation", () => {
+    const week = computedTrainingHistory.anchorWeek;
+    const invalidWeeks = [
+      { ...week, window: { start: "1998-07-07", end: "1998-07-13" } },
+      {
+        ...week,
+        rides: {
+          ...week.rides,
+          items: [week.rides.items[0], { ...week.rides.items[1], localDate: "1998-07-13" }],
+        },
+      },
+      {
+        ...week,
+        rides: {
+          ...week.rides,
+          items: [week.rides.items[0], { ...week.rides.items[1], id: week.rides.items[0].id }],
+        },
+      },
+      { ...week, rides: { ...week.rides, items: [...week.rides.items].reverse() } },
+      { ...week, rides: { ...week.rides, truncated: true } },
+      { ...week, rides: { ...week.rides, count: { kind: "exact", value: 1 } } },
+    ];
+    for (const invalidWeek of invalidWeeks) {
+      expect(CompletedActivityWeekSchema.safeParse(invalidWeek).success).toBe(false);
+    }
+  });
+
+  it("parses every metric envelope arm and rejects unknown keys", () => {
+    const metricCases = [
+      {
+        schema: RideCountMetricValueSchema,
+        accepted: [
+          { kind: "computed", value: 2 },
+          { kind: "partial", value: 2, reason: "incomplete-coverage" },
+          { kind: "unavailable", reason: "incomplete-coverage" },
+        ],
+      },
+      {
+        schema: DurationMetricValueSchema,
+        accepted: [
+          { kind: "computed", value: 3_600 },
+          {
+            kind: "partial",
+            value: 3_600,
+            reason: "missing-recorded-value",
+            knownRideMissingValueCount: 1,
+          },
+          { kind: "partial", value: 3_600, reason: "incomplete-coverage" },
+          { kind: "unavailable", reason: "no-recorded-value" },
+        ],
+      },
+      {
+        schema: DistanceMetricValueSchema,
+        accepted: [
+          { kind: "computed", value: 40_000 },
+          {
+            kind: "partial",
+            value: 40_000,
+            reason: "missing-recorded-value",
+            knownRideMissingValueCount: 1,
+          },
+          { kind: "partial", value: 40_000, reason: "incomplete-coverage" },
+          { kind: "unavailable", reason: "invalid-recorded-value" },
+        ],
+      },
+      {
+        schema: LoadMetricValueSchema,
+        accepted: [
+          { kind: "computed", value: 80 },
+          {
+            kind: "partial",
+            value: 80,
+            reason: "missing-recorded-value",
+            knownRideMissingValueCount: 1,
+          },
+          { kind: "partial", value: 80, reason: "incomplete-coverage" },
+          { kind: "unavailable", reason: "no-recorded-value" },
+        ],
+      },
+    ];
+    for (const { schema, accepted } of metricCases) {
+      for (const value of accepted) {
+        expect(schema.parse(value)).toEqual(value);
+        expect(schema.safeParse({ ...value, extra: true }).success).toBe(false);
+      }
+    }
+    expect(
+      RideCountMetricValueSchema.safeParse({
+        kind: "partial",
+        value: 2,
+        reason: "missing-recorded-value",
+        knownRideMissingValueCount: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires a riding-time basis whenever riding seconds are present", () => {
+    expect(
+      TrainingHistoryRideSchema.safeParse({
+        ...trainingHistoryRides[0],
+        ridingTimeBasis: null,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires callout windows to contain exactly 28 civil dates", () => {
+    expect(TrainingRideCalloutSchema.parse(trainingHistoryCallout)).toEqual(
+      trainingHistoryCallout,
+    );
+    expect(
+      TrainingRideCalloutSchema.safeParse({
+        ...trainingHistoryCallout,
+        window: { start: "1998-06-10", end: "1998-07-06" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires both last-good week callouts to be null", () => {
+    const lastGood = {
+      ...computedTrainingHistory,
+      anchorWeek: { ...computedTrainingHistory.anchorWeek, callout: null },
+    } as const;
+    const previousRide = {
+      ...trainingHistoryRides[1],
+      localDate: "1998-07-03",
+    } as const;
+    const previousCallout = {
+      ...trainingHistoryCallout,
+      rideId: previousRide.id,
+      durationSeconds: previousRide.ridingSeconds,
+      window: { start: "1998-06-08", end: "1998-07-05" },
+    } as const;
+    const withPreviousCallout = {
+      ...lastGood,
+      previousWeek: {
+        ...lastGood.previousWeek,
+        rides: { count: { kind: "exact", value: 1 }, items: [previousRide], truncated: false },
+        callout: previousCallout,
+      },
+    } as const;
+    expect(TrainingHistoryPanelSchema.safeParse(computedTrainingHistory).success).toBe(true);
+    expect(TrainingHistoryPanelSchema.safeParse(withPreviousCallout).success).toBe(true);
+    for (const invalidLastGood of [computedTrainingHistory, withPreviousCallout]) {
+      expect(
+        TrainingHistoryPanelSchema.safeParse({
+          kind: "stale",
+          failedAt: "1998-07-13T00:05:00.000Z",
+          reason: "temporary-failure",
+          lastGood: invalidLastGood,
+        }).success,
+      ).toBe(false);
+    }
   });
 
   it("bounds Power Progress and preserves explicit unavailable and stale states", () => {

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1940,7 +1940,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-32 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-33 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1948,8 +1948,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 32,
-      serverProtocolVersion: 32,
+      clientProtocolVersion: 33,
+      serverProtocolVersion: 33,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1958,7 +1958,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(31);
+    expect(previous).toBe(32);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -2031,9 +2031,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 32 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 33 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(32);
+    expect(client.clientProtocolVersion).toBe(33);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2159,7 +2159,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 32", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("uses protocol version 33", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
   });
 });

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -5,11 +5,15 @@ import {
   EMPTY_DROPPED_ACTIVITIES,
   PowerProgressPanelSchema,
   RecentRidesPanelSchema,
+  TrainingHistoryPanelSchema,
+  TrainingHistoryProjectionSchema,
   UNKNOWN_CYCLING_TRAINING_CONTEXT,
   type AthleteState,
   type DroppedActivities,
   type PowerProgressPanel,
   type RecentRidesPanel,
+  type TrainingHistoryComputed,
+  type TrainingHistoryPanel,
 } from "@enduragent/coach-contract";
 import type { AthleteStateReaderPort } from "@enduragent/engine";
 import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
@@ -22,6 +26,7 @@ import {
   SchedulerStateSchema,
 } from "@enduragent/kernel/reference/schemas";
 import { projectCyclingTrainingContext } from "./training-context.js";
+import type { TrainingHistorySource } from "./training-history.js";
 
 export interface PersistedAthleteStateSource extends AthleteStateReaderPort {}
 
@@ -54,7 +59,7 @@ function isFiniteInstant(value: string): boolean {
   );
 }
 
-export interface CreatePersistedAthleteStateSourceOptions {
+interface PersistedAthleteStateSourceBaseOptions {
   readonly dataDir: string;
   readonly cyclingFtpAnchorResolver: CyclingFtpAnchorResolver;
   readonly now?: () => Date;
@@ -68,6 +73,56 @@ export interface CreatePersistedAthleteStateSourceOptions {
     }): Promise<RecentRidesPanel>;
   };
   readonly droppedActivitiesSource?: () => DroppedActivities;
+}
+
+type TrainingHistorySourceOptions =
+  | {
+      readonly trainingHistorySource: TrainingHistorySource;
+      readonly sourceOwner: () => string;
+      readonly calendarTimeZone: () => string;
+    }
+  | {
+      readonly trainingHistorySource?: undefined;
+      readonly sourceOwner?: never;
+      readonly calendarTimeZone?: never;
+    };
+
+export type CreatePersistedAthleteStateSourceOptions =
+  PersistedAthleteStateSourceBaseOptions & TrainingHistorySourceOptions;
+
+interface TrainingHistoryCacheIdentity {
+  readonly athleteHomeRoot: string;
+  readonly sourceOwner: string;
+  readonly calendarTimeZone: string;
+}
+
+interface TrainingHistoryLastGood {
+  readonly identity: TrainingHistoryCacheIdentity;
+  readonly panel: TrainingHistoryComputed;
+}
+
+function sameTrainingHistoryIdentity(
+  left: TrainingHistoryCacheIdentity,
+  right: TrainingHistoryCacheIdentity,
+): boolean {
+  return (
+    left.athleteHomeRoot === right.athleteHomeRoot &&
+    left.sourceOwner === right.sourceOwner &&
+    left.calendarTimeZone === right.calendarTimeZone
+  );
+}
+
+function withoutTrainingHistoryCallouts(
+  panel: TrainingHistoryComputed,
+): TrainingHistoryComputed {
+  return {
+    ...panel,
+    anchorWeek: { ...panel.anchorWeek, callout: null },
+    previousWeek:
+      panel.previousWeek === null
+        ? null
+        : { ...panel.previousWeek, callout: null },
+  };
 }
 
 function isMissingFile(error: unknown): boolean {
@@ -104,8 +159,55 @@ export function createPersistedAthleteStateSource(
   const latestPath = join(input.dataDir, "data", "latest.json");
   const errorPath = join(input.dataDir, "data", "error_state.json");
   const schedulerPath = join(input.dataDir, "data", ".scheduler.json");
+  let lastGoodTrainingHistory: TrainingHistoryLastGood | null = null;
+  const readTrainingHistory = async (
+    identity: TrainingHistoryCacheIdentity | null,
+    request: Parameters<TrainingHistorySource["readTrainingHistory"]>[0],
+  ): Promise<TrainingHistoryPanel> => {
+    if (input.trainingHistorySource === undefined || identity === null) {
+      return { kind: "unavailable", reason: "not-synced" };
+    }
+    try {
+      const projection = await input.trainingHistorySource.readTrainingHistory(request);
+      const parsed = TrainingHistoryProjectionSchema.safeParse(projection);
+      if (!parsed.success) throw new TypeError("training history projection is invalid");
+      if (parsed.data.kind === "computed") {
+        lastGoodTrainingHistory = { identity, panel: parsed.data };
+      }
+      return parsed.data;
+    } catch {
+      const cached = lastGoodTrainingHistory;
+      if (cached === null || !sameTrainingHistoryIdentity(cached.identity, identity)) {
+        return { kind: "unavailable", reason: "temporary-failure" };
+      }
+      return TrainingHistoryPanelSchema.parse({
+        kind: "stale",
+        failedAt: request.asOf,
+        reason: "temporary-failure",
+        lastGood: withoutTrainingHistoryCallouts(cached.panel),
+      });
+    }
+  };
   return {
     async getAthleteState(): Promise<AthleteState> {
+      const trainingHistoryIdentity: TrainingHistoryCacheIdentity | null =
+        input.trainingHistorySource === undefined
+          ? null
+          : {
+              athleteHomeRoot: input.dataDir,
+              sourceOwner: input.sourceOwner(),
+              calendarTimeZone: input.calendarTimeZone(),
+            };
+      if (
+        lastGoodTrainingHistory !== null &&
+        (trainingHistoryIdentity === null ||
+          !sameTrainingHistoryIdentity(
+            lastGoodTrainingHistory.identity,
+            trainingHistoryIdentity,
+          ))
+      ) {
+        lastGoodTrainingHistory = null;
+      }
       const [schedulerResult] = await Promise.allSettled([readJson(schedulerPath)]);
       const [latestResult, errorResult] = await Promise.allSettled([
         readJson(latestPath),
@@ -173,7 +275,7 @@ export function createPersistedAthleteStateSource(
       const parsedAsOf = Date.parse(latest.metadata.last_updated);
       const asOfEpochS =
         Number.isFinite(parsedAsOf) && parsedAsOf >= 0 ? Math.floor(parsedAsOf / 1_000) : null;
-      const [anchor, performanceProgress, recentRides] = await Promise.all([
+      const [anchor, performanceProgress, recentRides, trainingHistory] = await Promise.all([
         asOfEpochS === null
           ? Promise.resolve(null)
           : input.cyclingFtpAnchorResolver
@@ -202,6 +304,15 @@ export function createPersistedAthleteStateSource(
               latest.metadata.last_updated,
               asOfEpochS,
             ),
+        asOfEpochS === null || trainingHistoryIdentity === null
+          ? Promise.resolve({ kind: "unavailable", reason: "not-synced" } as const)
+          : readTrainingHistory(trainingHistoryIdentity, {
+              asOf: latest.metadata.last_updated,
+              asOfEpochSeconds: asOfEpochS,
+              calendarTimeZone: trainingHistoryIdentity.calendarTimeZone,
+              freshness: latest.metadata.freshness,
+              sourceRestricted: errorState?.mitigation === "block_coaching",
+            }),
       ]);
       const trainingContext = projectCyclingTrainingContext({
         asOf: latest.metadata.last_updated,
@@ -212,6 +323,7 @@ export function createPersistedAthleteStateSource(
         wellness: latest.wellness_data,
         performanceProgress,
         recentRides,
+        trainingHistory,
         droppedActivities:
           input.droppedActivitiesSource?.() ?? EMPTY_DROPPED_ACTIVITIES,
       });

--- a/packages/coach/src/backfill-command.ts
+++ b/packages/coach/src/backfill-command.ts
@@ -165,7 +165,8 @@ async function real(options: CommandOptions): Promise<BackfillBenchmarkRecord> {
     finally { phases.push({ name, ms: performance.now() - phaseStarted, count: 1 }); }
   };
   const common = { env, apiKey: process.env.INTERVALS_ICU_API_KEY!, athleteId: process.env.INTERVALS_ICU_ATHLETE_ID!,
-    historyNewestDate: process.env.BACKFILL_HISTORY_NEWEST_DATE!, requestIntervalMs: options.requestIntervalMs,
+    historyNewestDate: process.env.BACKFILL_HISTORY_NEWEST_DATE!, calendarTimeZone: "UTC",
+    requestIntervalMs: options.requestIntervalMs,
     batchSize: options.batchSize, perRequestTimeoutMs: options.perRequestTimeoutMs, backfillPageDeadlineMs: options.pageDeadlineMs,
     sleep, measurePhase, baseFetch };
   const dual = options.dualPresentationAudit ? await runIntervalsDualPresentationAudit(common) : null;

--- a/packages/coach/src/backfill.ts
+++ b/packages/coach/src/backfill.ts
@@ -1,6 +1,14 @@
+import { randomUUID } from "node:crypto";
 import type { ArchiveInstant, ArchiveWriteResult } from "@enduragent/kernel/archive";
 import type { ImportArtifact, ImportReport, ImportReportDeps, PairDiagnostic, PlatformImportArtifact } from "@enduragent/kernel/ingest";
-import { createSyncStateRepository, dumpStore, type SourceArtifactDraft, type SqlStore, type SyncBudget } from "@enduragent/kernel/store";
+import {
+  createSyncStateRepository,
+  createTrainingCoverageRepository,
+  dumpStore,
+  type SourceArtifactDraft,
+  type SqlStore,
+  type SyncBudget,
+} from "@enduragent/kernel/store";
 import { createNodeImportRuntime, type NodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import {
@@ -48,6 +56,7 @@ export type { BackfillClock } from "./intervals-source.js";
 
 export const DEFAULT_BACKFILL_BATCH_SIZE = 400;
 export const DEFAULT_BACKFILL_PAGE_DEADLINE_MS = 21_600_000;
+export const TRAINING_HISTORY_BACKFILL_OLDEST = "1900-01-01";
 
 function configured(value: unknown, fallback: number, minimum: number, maximum: number, name: string): number {
   const selected = value === undefined ? fallback : value;
@@ -93,6 +102,13 @@ export interface RunBackfillPagesOptions {
   readonly onPageCommitted?: (input: { readonly pages: number; readonly artifacts: number; readonly report: ImportReport | null }) => void;
 }
 
+export interface RunActivityAuditPagesOptions extends RunBackfillPagesOptions {
+  readonly historyOldestDate: string;
+  readonly historyNewestDate: string;
+  readonly calendarTimeZone: string;
+  readonly cycleId?: () => string;
+}
+
 export interface BackfillRunResult { readonly pages: number; readonly artifacts: number; readonly reports: readonly ImportReport[];
   readonly droppedActivityRows: DroppedActivityRowCounts; }
 
@@ -101,15 +117,27 @@ function addDropped(total: DroppedActivityRowCounts, page: DroppedActivityRowCou
   return { sourceRestricted: total.sourceRestricted + page.sourceRestricted, other: total.other + page.other };
 }
 
-export async function runActivityAuditPages(options: RunBackfillPagesOptions): Promise<BackfillRunResult> {
+interface AuthoritativeBackfillCycle {
+  readonly authorityId: string;
+  readonly sourceCycle: number;
+  readonly nextPageOrdinal: number;
+}
+
+export async function runActivityAuditPages(
+  options: RunActivityAuditPagesOptions,
+): Promise<BackfillRunResult> {
   const batchSize = configured(options.batchSize, DEFAULT_BACKFILL_BATCH_SIZE, 1, 1_000, "batch size");
   const perRequestTimeoutMs = configured(options.perRequestTimeoutMs, DEFAULT_PER_REQUEST_TIMEOUT_MS, 1_000, 300_000, "request timeout");
   const pageDeadlineMs = configured(options.backfillPageDeadlineMs, DEFAULT_BACKFILL_PAGE_DEADLINE_MS, 60_000, 86_400_000, "page deadline");
   let pages = 0, artifacts = 0;
   let droppedActivityRows: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS;
   const reports: ImportReport[] = [];
+  const coverage = createTrainingCoverageRepository();
+  let authoritativeCycle: AuthoritativeBackfillCycle | null | undefined;
   for (;;) {
     const before = await createSyncStateRepository(options.store).readWatermark("intervals-icu", "activities");
+    const beforeValue = before.value;
+    const beforeCursor = beforeValue === null ? null : cursor(beforeValue);
     const controller = new AbortController();
     const abort = (): void => controller.abort(options.signal?.reason);
     if (options.signal?.aborted) abort(); else options.signal?.addEventListener("abort", abort, { once: true });
@@ -138,26 +166,114 @@ export async function runActivityAuditPages(options: RunBackfillPagesOptions): P
     if (checkpoint === null || checkpoint.watermark.source !== "intervals-icu" || checkpoint.watermark.lane !== "activities") {
       throw new Error("invalid source checkpoint");
     }
-    droppedActivityRows = addDropped(droppedActivityRows, checkpoint.droppedActivityRows);
     const checkpointValue = checkpoint.watermark.value;
+    if (checkpointValue === null) throw new Error("invalid source checkpoint");
     const parsed = cursor(checkpointValue);
+    if (authoritativeCycle === undefined) {
+      if (beforeValue === null || beforeCursor === null || beforeCursor.complete) {
+        authoritativeCycle = {
+          authorityId: (options.cycleId ?? randomUUID)(),
+          sourceCycle: parsed.cycle,
+          nextPageOrdinal: 0,
+        };
+      } else {
+        const previous = await coverage.readBackfillCheckpoint(options.store, {
+          sourceCycle: beforeCursor.cycle,
+          cursorAfter: beforeValue,
+        });
+        if (
+          previous === undefined ||
+          previous.terminal ||
+          previous.requestedOldest !== options.historyOldestDate ||
+          previous.requestedNewest !== options.historyNewestDate ||
+          previous.calendarTimeZone !== options.calendarTimeZone
+        ) {
+          authoritativeCycle = null;
+        } else {
+          authoritativeCycle = {
+            authorityId: previous.authorityId,
+            sourceCycle: previous.sourceCycle,
+            nextPageOrdinal: previous.pageOrdinal + 1,
+          };
+          droppedActivityRows = {
+            sourceRestricted: previous.droppedSourceRestricted,
+            other: previous.droppedOther,
+          };
+        }
+      }
+    }
+    if (
+      authoritativeCycle !== null &&
+      authoritativeCycle.sourceCycle !== parsed.cycle
+    ) {
+      throw new Error("activity backfill cycle changed unexpectedly");
+    }
+    droppedActivityRows = addDropped(droppedActivityRows, checkpoint.droppedActivityRows);
+    const terminalCommitEpochSeconds = parsed.complete
+      ? Math.floor(options.clock.now() / 1_000)
+      : null;
+    if (
+      terminalCommitEpochSeconds !== null &&
+      (!Number.isSafeInteger(terminalCommitEpochSeconds) || terminalCommitEpochSeconds < 0)
+    ) {
+      throw new TypeError("activity backfill clock is invalid");
+    }
+    const appendCoverage = async (transactionStore: SqlStore): Promise<void> => {
+      if (authoritativeCycle === null || authoritativeCycle === undefined) return;
+      await coverage.appendBackfillCheckpointInTransaction(transactionStore, {
+        authorityId: authoritativeCycle.authorityId,
+        sourceCycle: authoritativeCycle.sourceCycle,
+        pageOrdinal: authoritativeCycle.nextPageOrdinal,
+        requestedOldest: options.historyOldestDate,
+        requestedNewest: options.historyNewestDate,
+        calendarTimeZone: options.calendarTimeZone,
+        cursorAfter: checkpointValue,
+        droppedSourceRestricted: droppedActivityRows.sourceRestricted,
+        droppedOther: droppedActivityRows.other,
+        terminal: parsed.complete,
+      });
+      if (terminalCommitEpochSeconds !== null) {
+        await coverage.appendCommitInTransaction(transactionStore, {
+          source: "intervals-icu",
+          lane: "activities",
+          authorityKind: "activity-backfill",
+          authorityId: authoritativeCycle.authorityId,
+          calendarTimeZone: options.calendarTimeZone,
+          coveredOldest: options.historyOldestDate,
+          coveredNewest: options.historyNewestDate,
+          committedEpochSeconds: terminalCommitEpochSeconds,
+          gapState:
+            droppedActivityRows.sourceRestricted > 0 || droppedActivityRows.other > 0
+              ? "undated-dropped-rows"
+              : "none",
+        });
+      }
+    };
     let report: ImportReport | null = null;
     if (platformRecords.length === 0) {
       await options.store.transaction(async () => {
         await createSyncStateRepository(options.store).recordCompletionInTransaction({ source: "intervals-icu", lane: "activities",
           watermarkBefore: before.value, watermarkAfter: checkpointValue, artifactsSeen: 0, sourceChanges: 0 });
+        await appendCoverage(options.store);
       });
     } else {
       report = await options.node.importBatchWithReport({ files: [], platform_records: platformRecords }, {
         ...(options.measurePhase === undefined ? {} : { measurePhase: options.measurePhase }),
-        finalizeBatchInTransaction: async (_store, result) => {
+        finalizeBatchInTransaction: async (transactionStore, result) => {
           const sourceChanges = result.source_artifact_inserted + result.raw_file_inserted
             + result.source_record_inserted + result.source_record_updated;
-          await createSyncStateRepository(options.store).recordCompletionInTransaction({ source: "intervals-icu", lane: "activities",
+          await createSyncStateRepository(transactionStore).recordCompletionInTransaction({ source: "intervals-icu", lane: "activities",
             watermarkBefore: before.value, watermarkAfter: checkpointValue, artifactsSeen: platformRecords.length, sourceChanges });
+          await appendCoverage(transactionStore);
         },
       });
       reports.push(report);
+    }
+    if (authoritativeCycle !== null) {
+      authoritativeCycle = {
+        ...authoritativeCycle,
+        nextPageOrdinal: authoritativeCycle.nextPageOrdinal + 1,
+      };
     }
     pages += 1; artifacts += platformRecords.length;
     options.onPageCommitted?.({ pages, artifacts, report });
@@ -244,6 +360,7 @@ export interface RunIntervalsBackfillOptions {
   readonly apiKey: string;
   readonly athleteId: string;
   readonly historyNewestDate: string;
+  readonly calendarTimeZone: string;
   readonly requestIntervalMs?: number;
   readonly batchSize?: number;
   readonly perRequestTimeoutMs?: number;
@@ -317,6 +434,9 @@ export function runIntervalsDualPresentationAudit(options: RunIntervalsBackfillO
       historyNewestDate: options.historyNewestDate, minRequestIntervalMs: requestIntervalMs, archive: node.archive,
       clock, sleep, ...(options.baseFetch === undefined ? {} : { baseFetch: options.baseFetch }) });
     const shared = { store, node, source, clock,
+      historyOldestDate: TRAINING_HISTORY_BACKFILL_OLDEST,
+      historyNewestDate: options.historyNewestDate,
+      calendarTimeZone: options.calendarTimeZone,
       ...(options.signal === undefined ? {} : { signal: options.signal }),
       ...(options.batchSize === undefined ? {} : { batchSize: options.batchSize }),
       ...(options.perRequestTimeoutMs === undefined ? {} : { perRequestTimeoutMs: options.perRequestTimeoutMs }),

--- a/packages/coach/src/capture-command.ts
+++ b/packages/coach/src/capture-command.ts
@@ -72,7 +72,8 @@ export async function runCaptureReferenceCommand(
   }
   try {
     const manifest = await (dependencies.runCapture ?? runReferenceCapture)({ env, apiKey: credentials.apiKey,
-      athleteId: credentials.athleteId, reviewedOn: options.reviewedOn, reason: options.reason,
+      athleteId: credentials.athleteId, calendarTimeZone: "UTC", reviewedOn: options.reviewedOn,
+      reason: options.reason,
       ...(options.replacesCaptureId === undefined ? {} : { replacesCaptureId: options.replacesCaptureId }) }, {
       uuid: dependencies.uuid ?? randomUUID,
       wallClock: dependencies.wallClock ?? (() => new Date()),

--- a/packages/coach/src/capture.ts
+++ b/packages/coach/src/capture.ts
@@ -4,12 +4,24 @@ import { setTimeout as setTimeoutPromise } from "node:timers/promises";
 import {
   REFERENCE_CAPTURE_STREAM_LIMIT,
   assertReferenceCaptureReplayable,
+  createReferenceCapturePlan,
+  planCalendarTimeZone,
   serializeReferenceCaptureManifest,
+  serializeReferenceCapturePlan,
   validateReferenceCaptureManifest,
   type RecordRef,
   type ReferenceCaptureManifest,
+  type ReferenceCapturePlan,
 } from "@enduragent/kernel/reference/capture";
-import { H, createIntervalsSourceRepository, type PhysicalRequestLedger, type SourceArtifactDraft, type SyncBudget } from "@enduragent/kernel/store";
+import {
+  H,
+  createIntervalsSourceRepository,
+  createTrainingCoverageRepository,
+  type CoverageCommitInput,
+  type PhysicalRequestLedger,
+  type SourceArtifactDraft,
+  type SyncBudget,
+} from "@enduragent/kernel/store";
 import {
   loadReferenceCaptureSidecars,
   readVerifiedReferenceSnapshot,
@@ -44,6 +56,7 @@ export interface RunReferenceCaptureOptions {
   readonly writerContext?: CoachStoreWriterContext;
   readonly apiKey: string;
   readonly athleteId: string;
+  readonly calendarTimeZone: string;
   readonly reviewedOn: string;
   readonly reason: ReferenceCaptureReview["reason"];
   readonly replacesCaptureId?: string;
@@ -101,8 +114,13 @@ export async function runReferenceCapture(
     maxRequests: REQUEST_ATTEMPTS * (3 + REFERENCE_CAPTURE_STREAM_LIMIT),
     maxArtifacts: 10_000,
   };
+  let plan: ReferenceCapturePlan;
   let review: ReferenceCaptureReview;
   try {
+    plan = createReferenceCapturePlan({
+      now,
+      calendarTimeZone: options.calendarTimeZone,
+    });
     review = validateReferenceCaptureReview({ schema_version: 1, capture_id: captureId,
       reviewed_on: options.reviewedOn, replaces_capture_id: options.replacesCaptureId ?? null,
       reason: options.reason });
@@ -116,7 +134,7 @@ export async function runReferenceCapture(
     const source = createIntervalsBackfillSource({
       apiKey: options.apiKey,
       athleteId: options.athleteId,
-      historyNewestDate: now.toISOString().slice(0, 10),
+      historyNewestDate: plan.window.newest,
       minRequestIntervalMs: DEFAULT_REQUEST_INTERVAL_MS,
       archive: node.archive,
       clock: { now: () => now.getTime(), monotonicNow },
@@ -125,20 +143,61 @@ export async function runReferenceCapture(
       ...(options.attemptLedger === undefined ? {} : { attemptLedger: options.attemptLedger }),
     }) as IntervalsIcuCaptureSource;
     let batch: ReferenceCaptureBatch;
-    try { batch = await source.captureReference(now, budget); }
+    try {
+      batch = await source.captureReference(plan, budget);
+      if (serializeReferenceCapturePlan(batch.plan) !== serializeReferenceCapturePlan(plan)) {
+        throw new TypeError("reference capture plan changed");
+      }
+      if (
+        !Number.isSafeInteger(batch.dropped_activity_rows.sourceRestricted) ||
+        batch.dropped_activity_rows.sourceRestricted < 0 ||
+        !Number.isSafeInteger(batch.dropped_activity_rows.other) ||
+        batch.dropped_activity_rows.other < 0
+      ) {
+        throw new TypeError("reference capture dropped activity counts are invalid");
+      }
+    }
     catch (error) { throw new ReferenceCaptureRunError("capture", { cause: error }); }
 
     const repository = createIntervalsSourceRepository(store, (fields) => {
       if (fields.length === 0) throw new TypeError("empty key tuple");
       return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
     });
+    const coverage = createTrainingCoverageRepository();
+    const coverageCommit: CoverageCommitInput = {
+      source: "intervals-icu",
+      lane: "activities",
+      authorityKind: "reference-capture",
+      authorityId: captureId,
+      calendarTimeZone: planCalendarTimeZone(plan),
+      coveredOldest: plan.window.oldest,
+      coveredNewest: plan.window.newest,
+      committedEpochSeconds: Math.floor(plan.capture_epoch_ms / 1_000),
+      gapState:
+        batch.dropped_activity_rows.sourceRestricted > 0 ||
+        batch.dropped_activity_rows.other > 0
+          ? "undated-dropped-rows"
+          : "none",
+    };
     const wellnessArtifactKeys = new Map<string, string>();
     try {
       if (batch.records.activities.length > 0) {
-        await node.importBatchWithReport({ files: [],
-          platform_records: batch.records.activities.map((record) => record.landing.platform) });
+        await node.importBatchWithReport(
+          {
+            files: [],
+            platform_records: batch.records.activities.map((record) => record.landing.platform),
+          },
+          {
+            finalizeBatchInTransaction: async (transactionStore) => {
+              await coverage.appendCommitInTransaction(transactionStore, coverageCommit);
+            },
+          },
+        );
       }
       await store.transaction(async () => {
+        if (batch.records.activities.length === 0) {
+          await coverage.appendCommitInTransaction(store, coverageCommit);
+        }
         for (const record of batch.records.settings) {
           const evidence = await repository.recordArtifact(sourceArtifact(record));
           await repository.recordGenericLanding({ externalId: record.landing.sourceRecordExternalId,

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -67,10 +67,13 @@ import {
   createAnalyticsCurveStateReader,
   createCanonicalActivityReader,
   createIntervalsSourceRepository,
+  createTrainingCoverageReader,
+  createTrainingHistoryReader,
   createTrustedActivitySourceResolver,
   H,
   type AnchorRepository,
 } from "@enduragent/kernel/store";
+import { createReferenceCapturePlan } from "@enduragent/kernel/reference/capture";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import { createAuthoredIdentity, type AthleteHome } from "@enduragent/kernel-node/home";
 import {
@@ -123,6 +126,7 @@ import { projectAnalyticsCurveEvidence } from "@enduragent/sync-intervals-icu";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
 import { createPowerProgressStateSource } from "./power-progress.js";
 import { createRecentRidesSource } from "./recent-rides.js";
+import { createTrainingHistorySource } from "./training-history.js";
 import {
   assertRuntimeAthleteOwner,
   RuntimeAthleteOwnerRefusal,
@@ -882,17 +886,23 @@ export async function createLocalCoachComposition(
     now,
   });
   const ownerClock = { now, monotonicNow: () => performance.now() };
+  const referencePlan = (config: Config) =>
+    createReferenceCapturePlan({
+      now: new Date(now()),
+      calendarTimeZone: resolveUserTimezone(config.session.timezone),
+    });
   const intervalsCredentialApprovals = createIntervalsCredentialApprovalStore({ now });
   let intervalsConfigRevision = 0;
-  const ownerLookup = (intervals: Config["intervals"]) => ({
-    apiKey: intervals.apiKey,
-    athleteId: intervals.athleteId.length === 0 ? "0" : intervals.athleteId,
-    historyNewestDate: new Date(now()).toISOString().slice(0, 10),
+  const ownerLookup = (config: Config) => ({
+    apiKey: config.intervals.apiKey,
+    athleteId:
+      config.intervals.athleteId.length === 0 ? "0" : config.intervals.athleteId,
+    historyNewestDate: referencePlan(config).window.newest,
     clock: ownerClock,
   });
   const assertIntervalsOwner = async (
-    current: Config["intervals"],
-    candidate: Config["intervals"],
+    current: Config,
+    candidate: Config,
     signal: AbortSignal,
     claimUnownedCandidateWithoutCurrent = false,
     verificationEvidence?: IntervalsCredentialVerificationEvidence,
@@ -937,12 +947,13 @@ export async function createLocalCoachComposition(
     const configRevision = intervalsConfigRevision;
     let athleteSelector = configuredAthleteSelector;
     let usedCurrentAthleteFallback = false;
+    const verificationPlan = referencePlan(unapprovedConfig);
     let verification = await verifyIntervalsCredentialAtPathWithEvidence(
       join(input.home.storeDir, "store.db"),
       {
         apiKey: request.api_key,
         athleteId: athleteSelector,
-        historyNewestDate: new Date(now()).toISOString().slice(0, 10),
+        historyNewestDate: verificationPlan.window.newest,
         clock: ownerClock,
         signal,
       },
@@ -960,7 +971,7 @@ export async function createLocalCoachComposition(
         {
           apiKey: request.api_key,
           athleteId: athleteSelector,
-          historyNewestDate: new Date(now()).toISOString().slice(0, 10),
+          historyNewestDate: verificationPlan.window.newest,
           clock: ownerClock,
           signal,
         },
@@ -999,8 +1010,8 @@ export async function createLocalCoachComposition(
   try {
     if (!input.deferInitialRefresh && unapprovedConfig.intervals.apiKey.length > 0) {
       const startupOwnerClaim = await assertIntervalsOwner(
-        unapprovedConfig.intervals,
-        unapprovedConfig.intervals,
+        unapprovedConfig,
+        unapprovedConfig,
         new AbortController().signal,
       );
       await startupOwnerClaim?.claim();
@@ -1243,12 +1254,19 @@ export async function createLocalCoachComposition(
       now,
     });
     const canonicalActivities = createCanonicalActivityReader(input.context.store);
+    const trainingHistory = createTrainingHistorySource({
+      facts: createTrainingHistoryReader(input.context.store),
+      coverage: createTrainingCoverageReader(input.context.store),
+    });
     const stateReader = createPersistedAthleteStateSource({
       dataDir: input.home.root,
       cyclingFtpAnchorResolver,
       now: () => new Date(now()),
       powerProgressSource: powerProgress,
       recentRidesSource: createRecentRidesSource(canonicalActivities),
+      trainingHistorySource: trainingHistory,
+      sourceOwner: () => approvedConfig().intervals.athleteId,
+      calendarTimeZone: () => resolveUserTimezone(approvedConfig().session.timezone),
       droppedActivitiesSource: () => runtime!.currentDroppedActivities(),
     });
     const buildBundle = (config: Config): RuntimeBundle => {
@@ -1557,8 +1575,8 @@ export async function createLocalCoachComposition(
         }
         try {
           pendingOwnerClaim = await assertIntervalsOwner(
-            unapprovedConfig.intervals,
-            candidate.intervals,
+            unapprovedConfig,
+            candidate,
             signal,
             unapprovedConfig.intervals.apiKey.length === 0 && candidate.intervals.apiKey.length > 0,
             verificationEvidence,
@@ -1695,11 +1713,11 @@ export async function createLocalCoachComposition(
           const initializationSignal = AbortSignal.any([signal, initialRefreshController.signal]);
           initializationSignal.throwIfAborted();
           initialRefreshConfigCaptured = true;
-          const initialIntervals = { ...unapprovedConfig.intervals };
-          if (initialIntervals.apiKey.length > 0 && !intervalsOwnerReady) {
+          const initialConfig = copyConfig(unapprovedConfig);
+          if (initialConfig.intervals.apiKey.length > 0 && !intervalsOwnerReady) {
             const ownerClaim = await assertIntervalsOwner(
-              initialIntervals,
-              initialIntervals,
+              initialConfig,
+              initialConfig,
               initializationSignal,
             );
             initializationSignal.throwIfAborted();
@@ -1831,7 +1849,9 @@ export async function createLocalCoachComposition(
         context: input.context,
         runtime,
         intervalsCredentials: options.liveIntervals,
-        historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
+        historyNewestDate: () => referencePlan(approvedConfig()).window.newest,
+        calendarTimeZone: () =>
+          resolveUserTimezone(approvedConfig().session.timezone),
         readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
         readArchivedConversations: (request) => reconfigurable.listArchivedConversations(request),
         readArchivedTranscriptPage: (request) => reconfigurable.getArchivedTranscriptPage(request),

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -78,6 +78,7 @@ export interface CreateCoachOperationsInput {
   }>;
   readonly intervalsVerificationPending?: () => boolean;
   readonly historyNewestDate: () => string;
+  readonly calendarTimeZone: () => string;
   readonly readTranscriptPage?: (
     request: GetTranscriptPageRpcParams,
   ) => Promise<GetTranscriptPageRpcResult>;
@@ -242,6 +243,7 @@ export function createCoachOperations(
             apiKey: credentials.apiKey,
             athleteId: credentials.athleteId === "" ? "0" : credentials.athleteId,
             historyNewestDate: input.historyNewestDate(),
+            calendarTimeZone: input.calendarTimeZone(),
             signal,
           });
         })

--- a/packages/coach/src/power-progress.ts
+++ b/packages/coach/src/power-progress.ts
@@ -1,5 +1,6 @@
 import {
   PowerProgressPanelSchema,
+  type PowerProgressAnchor,
   type PowerProgressComputed,
   type PowerProgressPanel,
 } from "@enduragent/coach-contract";
@@ -19,6 +20,7 @@ import {
   computeHrCurveDelta,
   computePowerCurveDelta,
   computeSustainabilityProfile,
+  roundHalfEven,
   type HrCurveAnchor,
   type PowerCurveAnchor,
   type SustainabilitySportBlock,
@@ -177,11 +179,50 @@ function sourceContext(
   return "unknown";
 }
 
+function windowPowerValue(
+  curves: ProjectedCurves,
+  window: { readonly start: string; readonly end: string },
+  durationSeconds: number,
+): number | null {
+  const curve = curves.powerCurves?.list.find(
+    (candidate) => candidate.id === `r.${window.start}.${window.end}`,
+  );
+  if (curve === undefined) return null;
+  const index = curve.secs.indexOf(durationSeconds);
+  const value = index < 0 ? null : curve.watts[index];
+  return typeof value === "number" && value > 0 ? value : null;
+}
+
+function powerAnchorsFromCurves(
+  curves: ProjectedCurves,
+  currentWindow: { readonly start: string; readonly end: string },
+  previousWindow: { readonly start: string; readonly end: string },
+): readonly PowerProgressAnchor[] | null {
+  const anchors = POWER_ANCHORS.map(([durationSeconds]) => {
+    const current = windowPowerValue(curves, currentWindow, durationSeconds);
+    const previous = windowPowerValue(curves, previousWindow, durationSeconds);
+    return {
+      durationSeconds,
+      current: watts(current),
+      previous: watts(previous),
+      change:
+        current === null || previous === null
+          ? change(null)
+          : change(roundHalfEven(((current - previous) / previous) * 100, 1)),
+    };
+  });
+  return anchors.some(
+    (anchor) => anchor.current.kind === "computed" || anchor.previous.kind === "computed",
+  )
+    ? anchors
+    : null;
+}
+
 function projectPowerProgressPanelUnchecked(input: {
   readonly current: NonNullable<AnalyticsCurveState["current"]>;
   readonly curves: ProjectedCurves;
   readonly nowEpochMilliseconds: number;
-}): PowerProgressComputed {
+}): PowerProgressPanel {
   const generation = input.current.generation;
   const metricInput = buildMetricInput(
     {
@@ -193,11 +234,29 @@ function projectPowerProgressPanelUnchecked(input: {
     `${generation.frozenOn}T12:00:00.000Z`,
   );
   const power = computePowerCurveDelta(metricInput);
+  if (power.window_days !== 28) {
+    invalidProjection();
+  }
+  const projectedPower =
+    power.anchors === null
+      ? powerAnchorsFromCurves(
+          input.curves,
+          generation.windows.current,
+          generation.windows.previous,
+        )
+      : POWER_ANCHORS.map(([durationSeconds, key]) =>
+          powerAnchor(durationSeconds, power.anchors?.[key]),
+        );
+  if (projectedPower === null) {
+    return PowerProgressPanelSchema.parse({
+      kind: "unavailable",
+      reason: "insufficient-data",
+    });
+  }
   if (
-    power.window_days !== 28 ||
-    power.anchors === null ||
-    !exactWindow(power.current_window, generation.windows.current) ||
-    !exactWindow(power.previous_window, generation.windows.previous)
+    power.anchors !== null &&
+    (!exactWindow(power.current_window, generation.windows.current) ||
+      !exactWindow(power.previous_window, generation.windows.previous))
   ) {
     invalidProjection();
   }
@@ -238,10 +297,8 @@ function projectPowerProgressPanelUnchecked(input: {
     kind: "computed",
     currentWindow: generation.windows.current,
     previousWindow: generation.windows.previous,
-    anchors: POWER_ANCHORS.map(([durationSeconds, key]) =>
-      powerAnchor(durationSeconds, power.anchors?.[key]),
-    ),
-    rotation: rotation(power.rotation_index),
+    anchors: projectedPower,
+    rotation: power.anchors === null ? "unknown" : rotation(power.rotation_index),
     heartRateContext,
     sustainabilityContext,
     freshness: freshnessAt(generation.frozenEpochSeconds, input.nowEpochMilliseconds),
@@ -253,7 +310,7 @@ function projectPowerProgressPanelUnchecked(input: {
 
 export function projectPowerProgressPanel(
   input: Parameters<typeof projectPowerProgressPanelUnchecked>[0],
-): PowerProgressComputed {
+): PowerProgressPanel {
   try {
     return projectPowerProgressPanelUnchecked(input);
   } catch (error) {
@@ -282,6 +339,7 @@ export function projectPowerProgressState(input: {
     curves: input.curves,
     nowEpochMilliseconds: input.nowEpochMilliseconds,
   });
+  if (computed.kind === "unavailable") return computed;
   if (input.state.refreshFailure === null) return computed;
   return PowerProgressPanelSchema.parse({
     kind: "stale",

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -6,6 +6,7 @@ import type {
   SubsystemLogger,
 } from "@enduragent/core";
 import { createStoreAthleteDataReader, createSubsystemLogger } from "@enduragent/core";
+import { resolveUserTimezone } from "@enduragent/engine/sport";
 import {
   createCanonicalActivityReader,
   createPhysicalRequestLedger,
@@ -382,6 +383,7 @@ LIMIT 1`,
   private async runWindowInternal(admissionSignal: AbortSignal): Promise<StoreWindowResult> {
     admissionSignal.throwIfAborted();
     const config = this.options.readConfig?.() ?? this.options.config;
+    const calendarTimeZone = resolveUserTimezone(config.session.timezone);
     if (config.intervals.apiKey.length === 0) {
       return Object.freeze({
         published: false,
@@ -420,6 +422,7 @@ LIMIT 1`,
           : { writerContext: this.options.writerContext }),
         apiKey: config.intervals.apiKey,
         athleteId: config.intervals.athleteId,
+        calendarTimeZone,
         reviewedOn: now.toISOString().slice(0, 10),
         reason: this.snapshotValue === undefined ? "initial" : "provider-refresh",
         ...(this.snapshotValue === undefined

--- a/packages/coach/src/training-context.ts
+++ b/packages/coach/src/training-context.ts
@@ -4,6 +4,7 @@ import type {
   DroppedActivities,
   PowerProgressPanel,
   RecentRidesPanel,
+  TrainingHistoryPanel,
   WellnessSeries,
 } from "@enduragent/coach-contract";
 import type { CyclingFtpAnchorResult } from "@enduragent/kernel/anchors";
@@ -23,6 +24,7 @@ export interface ProjectCyclingTrainingContextInput {
   readonly wellness: unknown;
   readonly performanceProgress?: PowerProgressPanel;
   readonly recentRides?: RecentRidesPanel;
+  readonly trainingHistory: TrainingHistoryPanel;
   readonly droppedActivities?: DroppedActivities;
 }
 
@@ -231,6 +233,7 @@ export function projectCyclingTrainingContext(
     recentRides: overallRestricted
       ? { kind: "unknown", reason: "source-restricted" }
       : (input.recentRides ?? { kind: "unknown", reason: "not-synced" }),
+    trainingHistory: input.trainingHistory,
     anchorZones: projectAnchorZones(input),
     cyclingLoad: projectCyclingLoad(input),
     plan: projectPlan(input),

--- a/packages/coach/src/training-history.ts
+++ b/packages/coach/src/training-history.ts
@@ -1,0 +1,630 @@
+import {
+  FreshnessSchema,
+  IsoInstantSchema,
+  TrainingHistoryProjectionSchema,
+  type CivilDateWindow,
+  type CompletedActivityWeek,
+  type DurationMetricValue,
+  type Freshness,
+  type RidingTimeTrend,
+  type TrainingHistoryCoverage,
+  type TrainingHistoryProjection,
+  type TrainingHistoryRide,
+  type WeekCoverage,
+} from "@enduragent/coach-contract";
+import { addCivilDays, mondayOfWeek, todayInTZ } from "@enduragent/engine/sport";
+import {
+  TrainingCoverageError,
+  TrainingHistoryReadError,
+  type CoverageCommitRow,
+  type RecordedFact,
+  type TrainingCoverageReader,
+  type TrainingHistoryFactRow,
+  type TrainingHistoryReader,
+} from "@enduragent/kernel/store";
+
+const MAX_VISIBLE_RIDES = 50;
+const SPARSE_DISCOVERY_START = "1900-01-01";
+
+interface WeekSlot {
+  readonly window: CivilDateWindow;
+  readonly rows: TrainingHistoryFactRow[];
+}
+
+interface ExpectedWindows {
+  readonly anchor: CivilDateWindow;
+  readonly previous: CivilDateWindow;
+  readonly trend: readonly CivilDateWindow[];
+  readonly slots: ReadonlyMap<string, WeekSlot>;
+  readonly readWindow: CivilDateWindow;
+}
+
+type FoldedCoverage =
+  | {
+      readonly kind: "contiguous";
+      readonly start: string;
+      readonly through: string;
+      readonly committedAt: string;
+    }
+  | {
+      readonly kind: "incomplete";
+      readonly provenStart: string | null;
+      readonly provenThrough: string | null;
+      readonly observedThrough: string | null;
+      readonly committedAt: string | null;
+      readonly reason: "source-degraded" | "undated-dropped-rows" | "coverage-timezone-changed";
+    }
+  | { readonly kind: "none" };
+
+export interface TrainingHistorySource {
+  readTrainingHistory(input: {
+    readonly asOf: string;
+    readonly asOfEpochSeconds: number;
+    readonly calendarTimeZone: string;
+    readonly freshness: Freshness;
+    readonly sourceRestricted: boolean;
+  }): Promise<TrainingHistoryProjection>;
+}
+
+function unavailable(
+  reason: "coverage-unavailable" | "temporary-failure" | "invalid-data",
+): TrainingHistoryProjection {
+  return TrainingHistoryProjectionSchema.parse({ kind: "unavailable", reason });
+}
+
+function instantFromEpochSeconds(value: number): string {
+  return new Date(value * 1_000).toISOString();
+}
+
+function utcCivilDateFromEpochSeconds(value: number): string {
+  const date = new Date(value * 1_000);
+  const year = date.getUTCFullYear();
+  if (!Number.isFinite(date.getTime()) || year < 0 || year > 9_999) {
+    throw new TypeError("invalid epoch seconds");
+  }
+  return `${String(year).padStart(4, "0")}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+function mergeCleanCoverage(rows: readonly CoverageCommitRow[]): {
+  readonly start: string;
+  readonly through: string;
+} {
+  const latest = rows.at(-1);
+  if (latest === undefined) throw new TypeError("clean coverage is empty");
+  let start = latest.coveredOldest;
+  let through = latest.coveredNewest;
+  for (let index = rows.length - 2; index >= 0; index -= 1) {
+    const row = rows.at(index);
+    if (row === undefined) throw new TypeError("coverage row is missing");
+    if (row.gapState !== "none") {
+      if (row.coveredOldest >= start && row.coveredNewest <= through) continue;
+      break;
+    }
+    if (
+      row.coveredNewest < addCivilDays(start, -1) ||
+      row.coveredOldest > addCivilDays(through, 1)
+    ) {
+      continue;
+    }
+    if (row.coveredOldest < start) start = row.coveredOldest;
+    if (row.coveredNewest > through) through = row.coveredNewest;
+  }
+  return { start, through };
+}
+
+function foldCoverage(
+  commits: readonly CoverageCommitRow[],
+  calendarTimeZone: string,
+  sourceRestricted: boolean,
+): FoldedCoverage {
+  const matching = commits.filter((commit) => commit.calendarTimeZone === calendarTimeZone);
+  const latestOverall = commits.at(-1);
+  const latestMatching = matching.at(-1);
+  const clean = matching.filter((commit) => commit.gapState === "none");
+  const latestClean = clean.at(-1);
+  const proven = latestClean === undefined ? null : mergeCleanCoverage(clean);
+  if (sourceRestricted) {
+    return {
+      kind: "incomplete",
+      provenStart: proven?.start ?? null,
+      provenThrough: proven?.through ?? null,
+      observedThrough: latestMatching?.coveredNewest ?? null,
+      committedAt:
+        latestMatching === undefined
+          ? null
+          : instantFromEpochSeconds(latestMatching.committedEpochSeconds),
+      reason: "source-degraded",
+    };
+  }
+  if (latestOverall !== undefined && latestOverall.calendarTimeZone !== calendarTimeZone) {
+    return {
+      kind: "incomplete",
+      provenStart: proven?.start ?? null,
+      provenThrough: proven?.through ?? null,
+      observedThrough: latestOverall.coveredNewest,
+      committedAt: instantFromEpochSeconds(latestOverall.committedEpochSeconds),
+      reason: "coverage-timezone-changed",
+    };
+  }
+  if (latestMatching === undefined) return { kind: "none" };
+  if (latestMatching.gapState === "undated-dropped-rows") {
+    return {
+      kind: "incomplete",
+      provenStart: proven?.start ?? null,
+      provenThrough: proven?.through ?? null,
+      observedThrough: latestMatching.coveredNewest,
+      committedAt: instantFromEpochSeconds(latestMatching.committedEpochSeconds),
+      reason: "undated-dropped-rows",
+    };
+  }
+  const current = mergeCleanCoverage(matching);
+  return {
+    kind: "contiguous",
+    start: current.start,
+    through: current.through,
+    committedAt: instantFromEpochSeconds(latestMatching.committedEpochSeconds),
+  };
+}
+
+function weekWindow(date: string): CivilDateWindow {
+  const start = mondayOfWeek(date);
+  return { start, end: addCivilDays(start, 6) };
+}
+
+function expectedWindows(
+  anchorDate: string,
+  today: string,
+  displayMode: "current" | "last-recorded",
+): ExpectedWindows {
+  const anchor = weekWindow(anchorDate);
+  const previous = weekWindow(addCivilDays(anchor.start, -1));
+  const anchorOpen = today >= anchor.start && today <= anchor.end;
+  const newestTrendStart = displayMode === "current" && !anchorOpen ? anchor.start : previous.start;
+  const trend = Array.from({ length: 6 }, (_, index) => {
+    const start = addCivilDays(newestTrendStart, (index - 5) * 7);
+    return { start, end: addCivilDays(start, 6) };
+  });
+  const windows = [anchor, previous, ...trend];
+  const slots = new Map<string, WeekSlot>();
+  for (const window of windows) {
+    if (!slots.has(window.start)) slots.set(window.start, { window, rows: [] });
+  }
+  const starts = windows.map((window) => window.start).sort();
+  const ends = windows.map((window) => window.end).sort();
+  const readStart = starts.at(0);
+  const readEnd = ends.at(-1);
+  if (readStart === undefined || readEnd === undefined) {
+    throw new TypeError("expected training history windows are empty");
+  }
+  return {
+    anchor,
+    previous,
+    trend,
+    slots,
+    readWindow: { start: readStart, end: readEnd },
+  };
+}
+
+function safeCoverageAnchor(coverage: FoldedCoverage): string | null {
+  if (coverage.kind === "contiguous") return coverage.through;
+  if (coverage.kind === "incomplete") {
+    if (coverage.provenThrough !== null) return coverage.provenThrough;
+    if (coverage.reason !== "coverage-timezone-changed") return coverage.observedThrough;
+  }
+  return null;
+}
+
+function latestRideDate(rows: readonly TrainingHistoryFactRow[]): string | null {
+  let latest: string | null = null;
+  for (const row of rows) if (latest === null || row.localDate > latest) latest = row.localDate;
+  return latest;
+}
+
+function scanCutoffDate(
+  rows: readonly TrainingHistoryFactRow[],
+  scanTruncated: boolean,
+): string | null {
+  if (!scanTruncated) return null;
+  const oldestReturned = rows.at(-1);
+  if (oldestReturned === undefined) throw new TypeError("truncated scan has no rows");
+  return addCivilDays(utcCivilDateFromEpochSeconds(oldestReturned.startEpochSeconds), 1);
+}
+
+function projectionCoverage(
+  coverage: FoldedCoverage,
+  sparseRideDate: string | null,
+): TrainingHistoryCoverage | null {
+  if (coverage.kind === "contiguous") return coverage;
+  if (coverage.kind === "incomplete") return coverage;
+  if (sparseRideDate === null) return null;
+  return {
+    kind: "sparse",
+    latestKnownRideDate: sparseRideDate,
+    latestImportAt: null,
+  };
+}
+
+function assignRows(windows: ExpectedWindows, rows: readonly TrainingHistoryFactRow[]): void {
+  for (const row of rows) {
+    const slot = windows.slots.get(mondayOfWeek(row.localDate));
+    if (slot !== undefined) slot.rows.push(row);
+  }
+  for (const slot of windows.slots.values()) {
+    slot.rows.sort(
+      (left, right) =>
+        right.startEpochSeconds - left.startEpochSeconds || left.id.localeCompare(right.id),
+    );
+  }
+}
+
+function recordedCoreFact(value: number | null): RecordedFact<number> {
+  return value === null ? { kind: "absent" } : { kind: "recorded", value };
+}
+
+function aggregateMetric(
+  facts: readonly RecordedFact<number>[],
+  coverageComplete: boolean,
+): DurationMetricValue {
+  if (facts.length === 0) {
+    return coverageComplete
+      ? { kind: "computed", value: 0 }
+      : { kind: "unavailable", reason: "incomplete-coverage" };
+  }
+  const recorded = facts.filter(
+    (fact): fact is Extract<RecordedFact<number>, { readonly kind: "recorded" }> =>
+      fact.kind === "recorded",
+  );
+  const value = recorded.reduce((sum, fact) => sum + fact.value, 0);
+  if (!coverageComplete) {
+    return recorded.length === 0
+      ? { kind: "unavailable", reason: "incomplete-coverage" }
+      : { kind: "partial", value, reason: "incomplete-coverage" };
+  }
+  if (recorded.length === facts.length) return { kind: "computed", value };
+  if (recorded.length > 0) {
+    return {
+      kind: "partial",
+      value,
+      reason: "missing-recorded-value",
+      knownRideMissingValueCount: facts.length - recorded.length,
+    };
+  }
+  return facts.some((fact) => fact.kind === "rejected")
+    ? { kind: "unavailable", reason: "invalid-recorded-value" }
+    : { kind: "unavailable", reason: "no-recorded-value" };
+}
+
+function ridingTime(row: TrainingHistoryFactRow): {
+  readonly seconds: number | null;
+  readonly basis: "moving" | "elapsed" | null;
+} {
+  if (row.movingSeconds !== null) return { seconds: row.movingSeconds, basis: "moving" };
+  if (row.elapsedSeconds !== null) return { seconds: row.elapsedSeconds, basis: "elapsed" };
+  return { seconds: null, basis: null };
+}
+
+function recordedValue(fact: RecordedFact<number>): number | null {
+  return fact.kind === "recorded" ? fact.value : null;
+}
+
+function projectRide(row: TrainingHistoryFactRow): TrainingHistoryRide {
+  const riding = ridingTime(row);
+  return {
+    id: row.id,
+    title: row.title,
+    subSport: row.subSport,
+    startEpochSeconds: row.startEpochSeconds,
+    timezoneOffsetSeconds: row.timezoneOffsetSeconds,
+    localDate: row.localDate,
+    ridingSeconds: riding.seconds,
+    ridingTimeBasis: riding.basis,
+    elapsedSeconds: row.elapsedSeconds,
+    distanceMeters: row.distanceMeters,
+    load: recordedValue(row.load),
+    averagePowerWatts: recordedValue(row.averagePowerWatts),
+    averageHeartRateBpm: recordedValue(row.averageHeartRateBpm),
+    perceivedExertion: recordedValue(row.perceivedExertion),
+    energyKilojoules: recordedValue(row.energyKilojoules),
+  };
+}
+
+function calendarState(
+  window: CivilDateWindow,
+  today: string,
+): CompletedActivityWeek["calendarState"] {
+  return today >= window.start && today <= window.end ? "open" : "closed";
+}
+
+function recordedThrough(coverage: TrainingHistoryCoverage): string | null {
+  if (coverage.kind === "contiguous") return coverage.through;
+  if (coverage.kind === "incomplete") {
+    return coverage.provenThrough ?? coverage.observedThrough;
+  }
+  return coverage.latestKnownRideDate;
+}
+
+function weekCoverage(input: {
+  readonly window: CivilDateWindow;
+  readonly today: string;
+  readonly coverage: TrainingHistoryCoverage;
+  readonly scanCutoffDate: string | null;
+  readonly currentAnchor: boolean;
+}): WeekCoverage {
+  const through = recordedThrough(input.coverage);
+  if (input.scanCutoffDate !== null && input.window.start <= input.scanCutoffDate) {
+    return { kind: "incomplete", recordedThrough: through, reason: "scan-limit" };
+  }
+  if (input.coverage.kind === "sparse") {
+    return { kind: "incomplete", recordedThrough: through, reason: "sparse-imports" };
+  }
+  if (input.coverage.kind === "incomplete") {
+    const reason =
+      input.coverage.reason === "coverage-timezone-changed"
+        ? "coverage-timezone-changed"
+        : input.coverage.reason === "source-degraded" ||
+            input.coverage.reason === "undated-dropped-rows"
+          ? "source-degraded"
+          : "backfill-incomplete";
+    return { kind: "incomplete", recordedThrough: through, reason };
+  }
+  const open = calendarState(input.window, input.today) === "open";
+  const covered =
+    input.coverage.start <= input.window.start &&
+    input.coverage.through >= (open ? input.window.start : input.window.end);
+  if (covered) return { kind: "complete" };
+  return {
+    kind: "incomplete",
+    recordedThrough: input.coverage.through,
+    reason:
+      input.currentAnchor && input.coverage.through < input.window.start
+        ? "coverage-lag"
+        : "backfill-incomplete",
+  };
+}
+
+function rideCountMetric(
+  count: number,
+  complete: boolean,
+): CompletedActivityWeek["totals"]["rideCount"] {
+  if (complete) return { kind: "computed", value: count };
+  return count === 0
+    ? { kind: "unavailable", reason: "incomplete-coverage" }
+    : { kind: "partial", value: count, reason: "incomplete-coverage" };
+}
+
+function trend(input: {
+  readonly windows: ExpectedWindows;
+  readonly today: string;
+  readonly coverage: TrainingHistoryCoverage;
+  readonly scanCutoffDate: string | null;
+}): RidingTimeTrend {
+  const buckets = input.windows.trend.map((window) => {
+    const slot = input.windows.slots.get(window.start);
+    if (slot === undefined) throw new TypeError("trend window is missing");
+    const coverage = weekCoverage({
+      window,
+      today: input.today,
+      coverage: input.coverage,
+      scanCutoffDate: input.scanCutoffDate,
+      currentAnchor: false,
+    });
+    return { slot, coverage };
+  });
+  const incomplete = buckets.filter((bucket) => bucket.coverage.kind === "incomplete");
+  if (
+    incomplete.some(
+      (bucket) =>
+        bucket.coverage.kind === "incomplete" &&
+        (bucket.coverage.reason === "source-degraded" ||
+          bucket.coverage.reason === "coverage-timezone-changed" ||
+          bucket.coverage.reason === "sparse-imports" ||
+          bucket.coverage.reason === "scan-limit" ||
+          bucket.coverage.reason === "invalid-core-record"),
+    )
+  ) {
+    return { kind: "unavailable", reason: "incomplete-source" };
+  }
+  if (incomplete.length > 0) return { kind: "unavailable", reason: "limited-history" };
+  if (buckets.some(({ slot }) => slot.rows.some((row) => ridingTime(row).seconds === null))) {
+    return { kind: "unavailable", reason: "missing-duration" };
+  }
+  return {
+    kind: "computed",
+    buckets: buckets.map(({ slot }) => ({
+      window: slot.window,
+      rideCount: slot.rows.length,
+      ridingSeconds: slot.rows.reduce((sum, row) => sum + (ridingTime(row).seconds ?? 0), 0),
+    })),
+  };
+}
+
+function completedWeek(input: {
+  readonly id: "anchor" | "previous";
+  readonly window: CivilDateWindow;
+  readonly windows: ExpectedWindows;
+  readonly today: string;
+  readonly coverage: TrainingHistoryCoverage;
+  readonly scanCutoffDate: string | null;
+  readonly trend: RidingTimeTrend;
+}): CompletedActivityWeek {
+  const slot = input.windows.slots.get(input.window.start);
+  if (slot === undefined) throw new TypeError("completed week is missing");
+  const coverage = weekCoverage({
+    window: input.window,
+    today: input.today,
+    coverage: input.coverage,
+    scanCutoffDate: input.scanCutoffDate,
+    currentAnchor: input.id === "anchor",
+  });
+  const complete = coverage.kind === "complete";
+  const items = slot.rows.slice(0, MAX_VISIBLE_RIDES).map(projectRide);
+  const scanLimited = input.scanCutoffDate !== null && input.window.start <= input.scanCutoffDate;
+  const truncated = scanLimited || slot.rows.length > items.length;
+  return {
+    id: input.id,
+    window: input.window,
+    calendarState: calendarState(input.window, input.today),
+    coverage,
+    totals: {
+      rideCount: rideCountMetric(slot.rows.length, complete),
+      ridingSeconds: aggregateMetric(
+        slot.rows.map((row) => recordedCoreFact(ridingTime(row).seconds)),
+        complete,
+      ),
+      distanceMeters: aggregateMetric(
+        slot.rows.map((row) => recordedCoreFact(row.distanceMeters)),
+        complete,
+      ),
+      load: aggregateMetric(
+        slot.rows.map((row) => row.load),
+        complete,
+      ),
+    },
+    rides: {
+      count: scanLimited
+        ? { kind: "at-least", value: slot.rows.length }
+        : { kind: "exact", value: slot.rows.length },
+      items,
+      truncated,
+    },
+    trend: input.trend,
+    callout: null,
+  };
+}
+
+function invalidInput(input: Parameters<TrainingHistorySource["readTrainingHistory"]>[0]): boolean {
+  if (!IsoInstantSchema.safeParse(input.asOf).success) return true;
+  if (!FreshnessSchema.safeParse(input.freshness).success) return true;
+  if (!Number.isSafeInteger(input.asOfEpochSeconds) || input.asOfEpochSeconds < 0) return true;
+  return !Number.isFinite(new Date(input.asOfEpochSeconds * 1_000).getTime());
+}
+
+function dependencyFailure(error: unknown): TrainingHistoryProjection {
+  return unavailable(
+    error instanceof TrainingHistoryReadError || error instanceof TrainingCoverageError
+      ? "invalid-data"
+      : "temporary-failure",
+  );
+}
+
+export function createTrainingHistorySource(dependencies: {
+  readonly facts: TrainingHistoryReader;
+  readonly coverage: TrainingCoverageReader;
+}): TrainingHistorySource {
+  if (
+    dependencies === null ||
+    typeof dependencies !== "object" ||
+    dependencies.facts === null ||
+    typeof dependencies.facts !== "object" ||
+    typeof dependencies.facts.readWindow !== "function" ||
+    dependencies.coverage === null ||
+    typeof dependencies.coverage !== "object" ||
+    typeof dependencies.coverage.listCommits !== "function"
+  ) {
+    throw new TypeError("training history dependencies are invalid");
+  }
+  return Object.freeze({
+    async readTrainingHistory(
+      input: Parameters<TrainingHistorySource["readTrainingHistory"]>[0],
+    ): Promise<TrainingHistoryProjection> {
+      if (input === null || typeof input !== "object" || invalidInput(input)) {
+        return unavailable("invalid-data");
+      }
+      let today: string;
+      try {
+        today = todayInTZ(input.calendarTimeZone, new Date(input.asOfEpochSeconds * 1_000));
+      } catch {
+        return unavailable("invalid-data");
+      }
+      let commits: readonly CoverageCommitRow[];
+      try {
+        commits = await dependencies.coverage.listCommits({
+          source: "intervals-icu",
+          lane: "activities",
+        });
+      } catch (error) {
+        return dependencyFailure(error);
+      }
+      let folded: FoldedCoverage;
+      try {
+        folded = foldCoverage(commits, input.calendarTimeZone, input.sourceRestricted);
+      } catch {
+        return unavailable("invalid-data");
+      }
+      const currentAnchor = mondayOfWeek(today);
+      const retainedAnchor = safeCoverageAnchor(folded);
+      const lastRecorded = input.freshness !== "fresh" && input.freshness !== "flag";
+      const discoverSparseHistory =
+        folded.kind === "none" || (lastRecorded && retainedAnchor === null);
+      const provisionalAnchor = lastRecorded ? (retainedAnchor ?? today) : currentAnchor;
+      const provisionalDisplayMode = lastRecorded ? "last-recorded" : "current";
+      let windows = expectedWindows(provisionalAnchor, today, provisionalDisplayMode);
+      const factsWindow = discoverSparseHistory
+        ? { start: SPARSE_DISCOVERY_START, end: windows.readWindow.end }
+        : windows.readWindow;
+      let facts: Awaited<ReturnType<TrainingHistoryReader["readWindow"]>>;
+      try {
+        facts = await dependencies.facts.readWindow(factsWindow);
+      } catch (error) {
+        return dependencyFailure(error);
+      }
+      if (facts.scanTruncated && facts.rows.length === 0) return unavailable("invalid-data");
+      const sparseRideDate = latestRideDate(facts.rows);
+      if (lastRecorded && retainedAnchor === null && sparseRideDate === null) {
+        return unavailable("coverage-unavailable");
+      }
+      const coverage = projectionCoverage(folded, sparseRideDate);
+      if (coverage === null) return unavailable("coverage-unavailable");
+      let anchorDate = provisionalAnchor;
+      let displayMode: "current" | "last-recorded" = provisionalDisplayMode;
+      if (coverage.kind === "sparse") {
+        anchorDate = coverage.latestKnownRideDate;
+        displayMode = "last-recorded";
+      } else if (lastRecorded) {
+        anchorDate = retainedAnchor ?? sparseRideDate ?? provisionalAnchor;
+      }
+      if (mondayOfWeek(anchorDate) !== windows.anchor.start) {
+        windows = expectedWindows(anchorDate, today, displayMode);
+      }
+      try {
+        assignRows(windows, facts.rows);
+        const scanCutoff = scanCutoffDate(facts.rows, facts.scanTruncated);
+        const ridingTrend = trend({
+          windows,
+          today,
+          coverage,
+          scanCutoffDate: scanCutoff,
+        });
+        const projection: TrainingHistoryProjection = {
+          kind: "computed",
+          asOf: input.asOf,
+          calendarTimeZone: input.calendarTimeZone,
+          displayMode,
+          coverage,
+          anchorWeek: completedWeek({
+            id: "anchor",
+            window: windows.anchor,
+            windows,
+            today,
+            coverage,
+            scanCutoffDate: scanCutoff,
+            trend: ridingTrend,
+          }),
+          previousWeek: completedWeek({
+            id: "previous",
+            window: windows.previous,
+            windows,
+            today,
+            coverage,
+            scanCutoffDate: scanCutoff,
+            trend: ridingTrend,
+          }),
+        };
+        return TrainingHistoryProjectionSchema.parse(projection);
+      } catch (error) {
+        if (error instanceof TypeError) throw error;
+        return unavailable("invalid-data");
+      }
+    },
+  });
+}

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -112,6 +112,7 @@ describe("account identity", () => {
       apiKey,
       athleteId: "0",
       historyNewestDate: "1900-12-31",
+      calendarTimeZone: "UTC",
       clock,
       sleep: async () => {},
       baseFetch,
@@ -130,6 +131,7 @@ describe("account identity", () => {
       apiKey: accountKey,
       athleteId: "0",
       historyNewestDate: "1900-12-31",
+      calendarTimeZone: "UTC",
       clock,
       sleep: async () => {},
       baseFetch,
@@ -158,6 +160,7 @@ describe("account identity", () => {
       apiKey: "synthetic-first",
       athleteId: "0",
       historyNewestDate: "1900-12-31",
+      calendarTimeZone: "UTC",
       clock,
       sleep: async () => {},
       baseFetch: firstFetch,
@@ -580,6 +583,7 @@ describe("account identity", () => {
       apiKey: "synthetic-upgrade",
       athleteId: "0",
       historyNewestDate: "2010-12-31",
+      calendarTimeZone: "UTC",
       clock,
       sleep: async () => {},
       baseFetch,
@@ -588,7 +592,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 30 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/athlete-state-reader.test.ts
+++ b/packages/coach/tests/athlete-state-reader.test.ts
@@ -2,7 +2,11 @@ import { mkdir, mkdtemp, realpath, rm, utimes, writeFile } from "node:fs/promise
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AthleteStateSchema } from "@enduragent/coach-contract";
+import {
+  AthleteStateSchema,
+  type TrainingHistoryComputed,
+  type TrainingHistoryProjection,
+} from "@enduragent/coach-contract";
 import {
   ERROR_STATE_SCHEMA_VERSION,
   LATEST_SCHEMA_VERSION,
@@ -92,6 +96,78 @@ const resolver: CyclingFtpAnchorResolver = {
   resolve: async () => ({ kind: "missing", refusal: "missing-cycling-ftp-anchor" }),
 };
 
+function trainingHistoryRide(id: string, localDate: string, startEpochSeconds: number) {
+  return {
+    id: id.repeat(64),
+    title: "Synthetic ride",
+    subSport: "road",
+    startEpochSeconds,
+    timezoneOffsetSeconds: 21_600,
+    localDate,
+    ridingSeconds: 3_600,
+    ridingTimeBasis: "moving" as const,
+    elapsedSeconds: 3_700,
+    distanceMeters: 40_000,
+    load: 70,
+    averagePowerWatts: 200,
+    averageHeartRateBpm: 140,
+    perceivedExertion: 5,
+    energyKilojoules: 720,
+  };
+}
+
+function computedTrainingHistory(): TrainingHistoryComputed {
+  const anchorRide = trainingHistoryRide("a", "1998-07-17", 900_000_000);
+  const previousRide = trainingHistoryRide("b", "1998-07-10", 899_400_000);
+  const week = (
+    id: "anchor" | "previous",
+    window: { readonly start: string; readonly end: string },
+    ride: ReturnType<typeof trainingHistoryRide>,
+  ) => ({
+    id,
+    window,
+    calendarState: id === "anchor" ? ("open" as const) : ("closed" as const),
+    coverage: { kind: "complete" as const },
+    totals: {
+      rideCount: { kind: "computed" as const, value: 1 },
+      ridingSeconds: { kind: "computed" as const, value: 3_600 },
+      distanceMeters: { kind: "computed" as const, value: 40_000 },
+      load: { kind: "computed" as const, value: 70 },
+    },
+    rides: {
+      count: { kind: "exact" as const, value: 1 },
+      items: [ride],
+      truncated: false,
+    },
+    trend: { kind: "unavailable" as const, reason: "limited-history" as const },
+    callout: {
+      kind: "longest-ride-28d" as const,
+      rideId: ride.id,
+      durationSeconds: ride.ridingSeconds,
+      window: { start: "1998-06-21", end: "1998-07-18" },
+      comparisonRideCount: 4,
+    },
+  });
+  return {
+    kind: "computed",
+    asOf: T1,
+    calendarTimeZone: "UTC",
+    displayMode: "current",
+    coverage: {
+      kind: "contiguous",
+      start: "1998-01-01",
+      through: "1998-07-18",
+      committedAt: T0,
+    },
+    anchorWeek: week("anchor", { start: "1998-07-13", end: "1998-07-19" }, anchorRide),
+    previousWeek: week(
+      "previous",
+      { start: "1998-07-06", end: "1998-07-12" },
+      previousRide,
+    ),
+  };
+}
+
 function source(dataDir: string) {
   return createPersistedAthleteStateSource({ dataDir, cyclingFtpAnchorResolver: resolver });
 }
@@ -104,6 +180,139 @@ afterEach(async () => {
 });
 
 describe("persisted athlete state source", () => {
+  it("returns a stale last-good panel for thrown and malformed section reads", async () => {
+    const root = await home();
+    await writeJson(root, "latest.json", latest("fresh", T1));
+    let response: TrainingHistoryProjection | "throw" | "malformed" =
+      computedTrainingHistory();
+    const readTrainingHistory = vi.fn(async (): Promise<TrainingHistoryProjection> => {
+      if (response === "throw") throw new Error("private training history failure");
+      if (response === "malformed") return { kind: "computed" } as never;
+      return response;
+    });
+    const reader = createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      trainingHistorySource: { readTrainingHistory },
+      sourceOwner: () => "synthetic-athlete",
+      calendarTimeZone: () => "UTC",
+    });
+
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory.kind).toBe(
+      "computed",
+    );
+    response = "throw";
+    const thrown = (await reader.getAthleteState()).trainingContext?.trainingHistory;
+    expect(thrown).toMatchObject({
+      kind: "stale",
+      failedAt: T1,
+      reason: "temporary-failure",
+      lastGood: { anchorWeek: { callout: null }, previousWeek: { callout: null } },
+    });
+    expect(JSON.stringify(thrown)).not.toContain("private training history failure");
+
+    response = "malformed";
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toMatchObject({
+      kind: "stale",
+      lastGood: { anchorWeek: { callout: null }, previousWeek: { callout: null } },
+    });
+  });
+
+  it("drops last-good history when the source owner or calendar timezone changes", async () => {
+    const root = await home();
+    await writeJson(root, "latest.json", latest("fresh", T1));
+    let sourceOwner = "synthetic-athlete-a";
+    let calendarTimeZone = "UTC";
+    let fail = false;
+    const reader = createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      trainingHistorySource: {
+        readTrainingHistory: async () => {
+          if (fail) throw new Error("synthetic");
+          return computedTrainingHistory();
+        },
+      },
+      sourceOwner: () => sourceOwner,
+      calendarTimeZone: () => calendarTimeZone,
+    });
+
+    await reader.getAthleteState();
+    fail = true;
+    sourceOwner = "synthetic-athlete-b";
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toEqual({
+      kind: "unavailable",
+      reason: "temporary-failure",
+    });
+    sourceOwner = "synthetic-athlete-a";
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toEqual({
+      kind: "unavailable",
+      reason: "temporary-failure",
+    });
+
+    fail = false;
+    await reader.getAthleteState();
+    fail = true;
+    calendarTimeZone = "Asia/Almaty";
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toEqual({
+      kind: "unavailable",
+      reason: "temporary-failure",
+    });
+    calendarTimeZone = "UTC";
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toEqual({
+      kind: "unavailable",
+      reason: "temporary-failure",
+    });
+  });
+
+  it("passes domain unavailable projections through without consuming last-good history", async () => {
+    const root = await home();
+    await writeJson(root, "latest.json", latest("fresh", T1));
+    let response: TrainingHistoryProjection | "throw" = computedTrainingHistory();
+    const reader = createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      trainingHistorySource: {
+        readTrainingHistory: async () => {
+          if (response === "throw") throw new Error("synthetic");
+          return response;
+        },
+      },
+      sourceOwner: () => "synthetic-athlete",
+      calendarTimeZone: () => "UTC",
+    });
+
+    await reader.getAthleteState();
+    for (const reason of [
+      "coverage-unavailable",
+      "temporary-failure",
+      "invalid-data",
+    ] as const) {
+      response = { kind: "unavailable", reason };
+      expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toEqual(
+        response,
+      );
+    }
+    response = "throw";
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory.kind).toBe(
+      "stale",
+    );
+
+    const withoutCache = createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      trainingHistorySource: {
+        readTrainingHistory: async () => ({ kind: "computed" }) as never,
+      },
+      sourceOwner: () => "synthetic-athlete",
+      calendarTimeZone: () => "UTC",
+    });
+    expect((await withoutCache.getAthleteState()).trainingContext?.trainingHistory).toEqual({
+      kind: "unavailable",
+      reason: "temporary-failure",
+    });
+  });
+
   it("returns canonical recent rides without a Reference snapshot", async () => {
     const root = await home();
     const now = new Date("1998-07-18T12:00:00.000Z");

--- a/packages/coach/tests/backfill-dual-presentation.test.ts
+++ b/packages/coach/tests/backfill-dual-presentation.test.ts
@@ -182,7 +182,46 @@ describe("dual-presentation audit", () => {
           })();
         },
       } as IntervalsIcuSource;
-      expect((await runActivityAuditPages({ store, node, source, clock })).artifacts).toBe(3);
+      expect(
+        (
+          await runActivityAuditPages({
+            store,
+            node,
+            source,
+            clock,
+            historyOldestDate: "1998-01-01",
+            historyNewestDate: "1998-12-31",
+            calendarTimeZone: "UTC",
+            cycleId: () => "synthetic-cycle-a",
+          })
+        ).artifacts,
+      ).toBe(3);
+      expect(
+        await store.get(
+          `SELECT authority_kind, authority_id, calendar_timezone, covered_oldest_date_key,
+  covered_newest_date_key, gap_state
+FROM training_history_coverage_commit`,
+        ),
+      ).toEqual({
+        authority_kind: "activity-backfill",
+        authority_id: "synthetic-cycle-a",
+        calendar_timezone: "UTC",
+        covered_oldest_date_key: 19980101,
+        covered_newest_date_key: 19981231,
+        gap_state: "none",
+      });
+      expect(
+        await store.get(
+          `SELECT authority_id, page_ordinal, dropped_source_restricted, dropped_other, terminal
+FROM training_history_backfill_checkpoint`,
+        ),
+      ).toEqual({
+        authority_id: "synthetic-cycle-a",
+        page_ordinal: 0,
+        dropped_source_restricted: 0,
+        dropped_other: 0,
+        terminal: 1,
+      });
 
       const streamItems = [] as {
         readonly activityId: string;
@@ -363,7 +402,16 @@ JOIN session AS s ON s.session_key = st.session_key WHERE s.start_utc < 10000000
         })();
       } } as IntervalsIcuSource;
 
-      const activities = await runActivityAuditPages({ store: target.store, node: target.node, source, clock });
+      const activities = await runActivityAuditPages({
+        store: target.store,
+        node: target.node,
+        source,
+        clock,
+        historyOldestDate: "1998-01-01",
+        historyNewestDate: "1998-12-31",
+        calendarTimeZone: "UTC",
+        cycleId: () => "synthetic-cycle-b",
+      });
       const fit = await runBackfillPages({ store: target.store, node: target.node, source, clock });
       expect(activities.artifacts).toBe(1);
       expect(fit.artifacts).toBe(1);

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -361,6 +361,7 @@ describe("incremental backfill pages", () => {
           read: async () => ({ apiKey: String.fromCharCode(116, 101, 115, 116), athleteId: "synthetic-athlete" }),
         },
         historyNewestDate: () => new Date(now).toISOString().slice(0, 10),
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       {
@@ -456,6 +457,7 @@ describe("incremental backfill pages", () => {
         apiKey: String.fromCharCode(116, 101, 115, 116),
         athleteId: "synthetic-athlete",
         historyNewestDate: "2010-12-31",
+        calendarTimeZone: "UTC",
         clock,
         sleep: async () => {},
         baseFetch,
@@ -467,6 +469,7 @@ describe("incremental backfill pages", () => {
         apiKey: String.fromCharCode(116, 101, 115, 116),
         athleteId: "synthetic-athlete",
         historyNewestDate: "2010-12-31",
+        calendarTimeZone: "UTC",
         clock,
         sleep: async () => {},
         baseFetch,
@@ -503,6 +506,7 @@ describe("incremental backfill pages", () => {
           apiKey: String.fromCharCode(116, 101, 115, 116),
           athleteId: "synthetic-athlete",
           historyNewestDate: "2010-12-31",
+          calendarTimeZone: "UTC",
           batchSize: 0,
         }),
       ).rejects.toThrow("invalid batch size");

--- a/packages/coach/tests/canonical-activity-coaching.test.ts
+++ b/packages/coach/tests/canonical-activity-coaching.test.ts
@@ -72,6 +72,7 @@ function runtimeFor(
     runtime,
     intervalsCredentials: { read: async () => ({ apiKey: "", athleteId: "" }) },
     historyNewestDate: () => "1998-07-18",
+    calendarTimeZone: () => "UTC",
     applyRuntimeConfig: async () => {},
   });
   return { runtime, operations };
@@ -382,6 +383,7 @@ FROM session`,
         runtime: selected.runtime,
         intervalsCredentials: { read: async () => ({ apiKey: "", athleteId: "" }) },
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },

--- a/packages/coach/tests/capture-command.test.ts
+++ b/packages/coach/tests/capture-command.test.ts
@@ -8,7 +8,10 @@ const ENV = { REFERENCE_CAPTURE_ENABLE: "1", REFERENCE_CAPTURE_API_KEY: "private
   REFERENCE_CAPTURE_ATHLETE_ID: "private-athlete", ENDURAGENT_HOME: "private-home" };
 
 function manifest() {
-  const plan = createReferenceCapturePlan(new Date("1998-07-18T12:00:00.000Z"));
+  const plan = createReferenceCapturePlan({
+    now: new Date("1998-07-18T12:00:00.000Z"),
+    calendarTimeZone: "UTC",
+  });
   const address = "a".repeat(64), snapshot = { address, rel_path: `1998/07/${address}.json.gz` };
   return validateReferenceCaptureManifest({ schema_version: 1, capture_id: UUID, source: "external-oracle", plan,
     operation_ledger: { link_kind: "capture-id", capture_id: UUID }, endpoints: [
@@ -32,6 +35,10 @@ describe("capture-reference command", () => {
     expect(output[0]).not.toContain(UUID);
     expect(output[0]).not.toContain("1998");
     expect(output[0]).not.toContain("private");
+    expect(runCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ calendarTimeZone: "UTC" }),
+      expect.any(Object),
+    );
   });
 
   it("rejects unknown, duplicate, missing, positional, and inconsistent arguments as environment usage", async () => {

--- a/packages/coach/tests/capture.test.ts
+++ b/packages/coach/tests/capture.test.ts
@@ -33,7 +33,8 @@ describe("runReferenceCapture", () => {
     };
     let monotonic = 0;
     const manifest = await runReferenceCapture({ env: { ENDURAGENT_HOME: root }, apiKey: "synthetic-key",
-      athleteId: "synthetic-athlete", reviewedOn: "1998-07-18", reason: "initial", baseFetch }, {
+      athleteId: "synthetic-athlete", calendarTimeZone: "UTC", reviewedOn: "1998-07-18",
+      reason: "initial", baseFetch }, {
       wallClock: () => NOW, uuid: () => CAPTURE_ID, monotonicNow: () => (monotonic += 250), sleep: async () => {},
     });
     expect(requests).toHaveLength(4);
@@ -52,6 +53,76 @@ describe("runReferenceCapture", () => {
     expect((await store.get("SELECT count(*) AS n FROM anchor_history"))?.n).toBeGreaterThan(0);
     expect((await store.get("SELECT count(*) AS n FROM zone_set_history"))?.n).toBeGreaterThan(0);
     expect((await store.get("SELECT count(*) AS n FROM raw_file"))?.n).toBe(0);
+    expect(
+      await store.get(
+        `SELECT authority_kind, authority_id, calendar_timezone, covered_oldest_date_key,
+  covered_newest_date_key, gap_state
+FROM training_history_coverage_commit`,
+      ),
+    ).toEqual({
+      authority_kind: "reference-capture",
+      authority_id: CAPTURE_ID,
+      calendar_timezone: "UTC",
+      covered_oldest_date_key: 19980425,
+      covered_newest_date_key: 19980718,
+      gap_state: "none",
+    });
+    await store.close();
+  });
+
+  it("rolls back an activity landing when the in-transaction coverage commit conflicts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "reference-capture-home-"));
+    const fetchFor = (activityId: number): typeof globalThis.fetch => async (input) => {
+      const url = String(input);
+      if (url.includes("/streams.json")) return json(streams);
+      if (url.includes("/activities?")) return json([{ ...activities[0], id: activityId }]);
+      if (url.includes("/wellness?")) return json(wellness);
+      return json(profile);
+    };
+    let monotonic = 0;
+    const dependencies = {
+      wallClock: () => NOW,
+      uuid: () => CAPTURE_ID,
+      monotonicNow: () => (monotonic += 250),
+      sleep: async () => {},
+    };
+    await runReferenceCapture(
+      {
+        env: { ENDURAGENT_HOME: root },
+        apiKey: "synthetic-key",
+        athleteId: "synthetic-athlete",
+        calendarTimeZone: "UTC",
+        reviewedOn: "1998-07-18",
+        reason: "initial",
+        baseFetch: fetchFor(42),
+      },
+      dependencies,
+    );
+
+    await expect(
+      runReferenceCapture(
+        {
+          env: { ENDURAGENT_HOME: root },
+          apiKey: "synthetic-key",
+          athleteId: "synthetic-athlete",
+          calendarTimeZone: "Asia/Almaty",
+          reviewedOn: "1998-07-18",
+          reason: "initial",
+          baseFetch: fetchFor(43),
+        },
+        dependencies,
+      ),
+    ).rejects.toMatchObject({ cause: { category: "persistence" } });
+
+    const store = openSqliteStorage(join(root, "store", "store.db"));
+    expect(
+      await store.get(
+        "SELECT count(*) AS n FROM source_record WHERE source='intervals-icu' AND external_id='43'",
+      ),
+    ).toEqual({ n: 0 });
+    expect(
+      await store.get("SELECT count(*) AS n FROM training_history_coverage_commit"),
+    ).toEqual({ n: 1 });
     await store.close();
   });
 
@@ -66,7 +137,8 @@ describe("runReferenceCapture", () => {
     };
     let monotonic = 0;
     const manifest = await runReferenceCapture({ env: { ENDURAGENT_HOME: root }, apiKey: "synthetic-key",
-      athleteId: "synthetic-athlete", reviewedOn: "1998-07-18", reason: "initial", baseFetch }, {
+      athleteId: "synthetic-athlete", calendarTimeZone: "UTC", reviewedOn: "1998-07-18",
+      reason: "initial", baseFetch }, {
       wallClock: () => NOW, uuid: () => CAPTURE_ID, monotonicNow: () => (monotonic += 250), sleep: async () => {},
     });
     expect(requests).toHaveLength(3);
@@ -76,5 +148,12 @@ describe("runReferenceCapture", () => {
     expect(manifest.deterministic_order.activities).toEqual([]);
     expect(JSON.parse(await readFile(join(root, "captures", CAPTURE_ID, "manifest.json"), "utf8")))
       .toMatchObject({ records: { activities: [] } });
+    const store = openSqliteStorage(join(root, "store", "store.db"));
+    expect(
+      await store.get(
+        "SELECT authority_kind, authority_id FROM training_history_coverage_commit",
+      ),
+    ).toEqual({ authority_kind: "reference-capture", authority_id: CAPTURE_ID });
+    await store.close();
   });
 });

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -578,7 +578,7 @@ describe("coach sync composition", () => {
             return store.get("PRAGMA user_version");
           },
         );
-        expect(value).toEqual({ user_version: 29 });
+        expect(value).toEqual({ user_version: 30 });
         expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
         expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
         expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -586,7 +586,7 @@ describe("coach sync composition", () => {
         const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
         try {
           await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-            user_version: 29,
+            user_version: 30,
           });
         } finally {
           await reopened.close();

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -71,6 +71,7 @@ const state: AthleteState = {
   trainingContext: {
     performanceProgress: { kind: "unavailable", reason: "not-synced" },
     recentRides: { kind: "unknown", reason: "no-recent-rides" },
+    trainingHistory: { kind: "unavailable", reason: "not-synced" },
     anchorZones: { kind: "unknown", reason: "missing-anchor" },
     cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
     plan: { kind: "unknown", reason: "no-plan" },
@@ -1224,8 +1225,27 @@ describe("local coach composition", () => {
       }),
       createResolver: () => missingResolver(),
     });
-    await expect(received!.ports.stateReader.getAthleteState()).resolves.toEqual(state);
-    await expect(lifecycle.engine.getAthleteState()).resolves.toEqual(state);
+    const projectedState = await received!.ports.stateReader.getAthleteState();
+    const projectedTrainingContext = projectedState.trainingContext;
+    const expectedTrainingContext = state.trainingContext;
+    if (projectedTrainingContext === undefined || expectedTrainingContext === undefined) {
+      throw new TypeError("training context is missing");
+    }
+    expect({
+      ...projectedState,
+      trainingContext: {
+        ...projectedTrainingContext,
+        trainingHistory: expectedTrainingContext.trainingHistory,
+      },
+    }).toEqual(state);
+    expect(projectedTrainingContext.trainingHistory).toMatchObject({
+      kind: "computed",
+      calendarTimeZone: "UTC",
+      coverage: { kind: "incomplete", reason: "source-degraded" },
+      anchorWeek: { coverage: { kind: "incomplete", reason: "source-degraded" } },
+      previousWeek: { coverage: { kind: "incomplete", reason: "source-degraded" } },
+    });
+    await expect(lifecycle.engine.getAthleteState()).resolves.toEqual(projectedState);
     expect(received!.ports.platform.athleteData).toBe(selectedRuntime.athleteData);
     expect(received!.ports.readReferenceState).not.toBe(
       received!.ports.stateReader.getAthleteState,
@@ -5554,7 +5574,7 @@ describe("local coach composition", () => {
     },
   );
 
-  it("passes the live intervals authority and one deterministic UTC history date into sync", async () => {
+  it("passes the live intervals authority and calendar plan into sync", async () => {
     const home = await freshHome();
     const context = fakeContext(home);
     const selectedRuntime = runtime();
@@ -5583,6 +5603,7 @@ describe("local coach composition", () => {
     );
     await lifecycle.operations.configureRuntime({
       intervals: { api_key: String.fromCharCode(110, 101, 119), athlete_id: "live-athlete" },
+      session: { timezone: "Asia/Almaty" },
     });
     await expect(lifecycle.operations.sync({})).resolves.toMatchObject({
       published: true,
@@ -5594,7 +5615,8 @@ describe("local coach composition", () => {
       store: context.store,
       apiKey: String.fromCharCode(110, 101, 119),
       athleteId: "live-athlete",
-      historyNewestDate: "1998-07-18",
+      historyNewestDate: "1998-07-19",
+      calendarTimeZone: "Asia/Almaty",
       signal: expect.any(AbortSignal),
     });
     expect(backfill).not.toHaveBeenCalledWith(

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,12 +85,12 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 32 as const,
-      serverProtocolVersion: 32 as const,
+      clientProtocolVersion: PROTOCOL_VERSION,
+      serverProtocolVersion: PROTOCOL_VERSION,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,
-    }));
+    } as const));
     await expect(
       observeDaemonState(
         { home },

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -305,7 +305,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+    expect(PROTOCOL_VERSION).toBe(33);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -111,6 +111,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       readTranscriptPage,
       applyRuntimeConfig: async () => {},
     });
@@ -156,6 +157,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {},
     };
     const operations = createCoachOperations({
@@ -241,6 +243,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       });
       const paths = ["brick-cycling.fit", "fallback-cycling.tcx", "fallback-cycling.gpx"].map(
@@ -276,6 +279,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       });
       await expect(relaunchedOperations.getSetupStatus?.({})).resolves.toEqual({
@@ -310,6 +314,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       });
       await expect(
@@ -433,6 +438,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       {
@@ -465,6 +471,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       {
@@ -503,6 +510,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(runWindowAfter),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },
@@ -575,6 +583,7 @@ describe("coach operations", () => {
         },
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },
@@ -624,6 +633,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(runWindowAfter),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },
@@ -654,6 +664,7 @@ describe("coach operations", () => {
         intervalsCredentials: intervalsCredentials(),
         intervalsVerificationPending: () => pending.value,
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       { backfill },
@@ -722,6 +733,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(runWindowAfter),
         intervalsCredentials: credentials,
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       },
       { backfill },
@@ -744,6 +756,7 @@ describe("coach operations", () => {
       apiKey: String.fromCharCode(116, 101, 115, 116),
       athleteId: "synthetic-athlete",
       historyNewestDate: "1998-07-18",
+      calendarTimeZone: "UTC",
       signal: expect.any(AbortSignal),
     });
     expect(result).toEqual({
@@ -822,6 +835,7 @@ describe("coach operations", () => {
           runtime,
           intervalsCredentials: runtime.credentials,
           historyNewestDate: () => "1998-07-18",
+          calendarTimeZone: () => "UTC",
           applyRuntimeConfig: async () => {},
         },
         { backfill },
@@ -882,6 +896,7 @@ describe("coach operations", () => {
           runtime,
           intervalsCredentials: runtime.intervals,
           historyNewestDate: () => "1998-07-18",
+          calendarTimeZone: () => "UTC",
           applyRuntimeConfig: async () => {},
         },
         { backfill },
@@ -945,6 +960,7 @@ describe("coach operations", () => {
           runtime,
           intervalsCredentials: runtime.intervals,
           historyNewestDate: () => "1998-07-18",
+          calendarTimeZone: () => "UTC",
           applyRuntimeConfig: async () => {},
         },
         { backfill },
@@ -982,6 +998,7 @@ describe("coach operations", () => {
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {
         trace.push("configure");
       },
@@ -1014,6 +1031,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async (_request, signal) => {
         observedSignal = signal;
         started.release();
@@ -1043,6 +1061,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {},
       verifyIntervalsCredential,
     });
@@ -1068,6 +1087,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {},
       verifyIntervalsCredential: async () => ({ reason: "credential-rejected" }),
     });
@@ -1081,6 +1101,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {},
       verifyIntervalsCredential: async () => ({ approval: "A".repeat(64) }),
     });
@@ -1094,6 +1115,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {},
     });
     expect(() =>
@@ -1110,6 +1132,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {},
       verifyIntervalsCredential: async (_request, signal): Promise<never> => {
         observedSignal = signal;
@@ -1147,6 +1170,7 @@ describe("coach operations", () => {
         runtime: operationRuntime(),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => reason,
       });
 
@@ -1183,6 +1207,7 @@ describe("coach operations", () => {
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async () => {},
       readRuntimeConfig: () => {
         trace.push("read");
@@ -1247,6 +1272,7 @@ describe("coach operations", () => {
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async (request) => {
         if (request.intervals !== undefined) trace.push("intervals");
         if (request.llm !== undefined) {
@@ -1353,6 +1379,7 @@ describe("coach operations", () => {
         }),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig,
       },
       { runtimeConfigurationDeadlineMs: 5 },
@@ -1390,6 +1417,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async (request) => {
         const model = request.llm?.model ?? "intervals-only";
         trace.push(`configure-${model}-start`);
@@ -1487,6 +1515,7 @@ describe("coach operations", () => {
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig: async (request) => {
         if (request.intervals !== undefined) {
           trace.push("intervals-reject");
@@ -1564,6 +1593,7 @@ describe("coach operations", () => {
       runtime: operationRuntime(),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
+      calendarTimeZone: () => "UTC",
       applyRuntimeConfig,
       readRuntimeConfig: () => ({
         schemaVersion: 3,
@@ -1702,6 +1732,7 @@ describe("coach operations", () => {
         }),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",
+        calendarTimeZone: () => "UTC",
         applyRuntimeConfig: async () => {},
       });
       const sync = operations.sync({});

--- a/packages/coach/tests/power-progress.test.ts
+++ b/packages/coach/tests/power-progress.test.ts
@@ -17,7 +17,6 @@ import { nodeFileSystem } from "@enduragent/kernel-node/filesystem";
 import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
-  PowerProgressProjectionError,
   createPowerProgressStateSource,
   projectPowerProgressPanel,
   projectPowerProgressState,
@@ -216,19 +215,42 @@ describe("Power Progress state projection", () => {
     ).toEqual({ kind: "unavailable", reason: "refresh-failed" });
   });
 
-  it("fails closed when the exact prior power window is absent", () => {
+  it("keeps the panel computed when only the current power window has anchors", () => {
     const selected = curves();
-    const malformed = {
+    const currentOnly = {
       ...selected,
       powerCurves: { list: selected.powerCurves!.list.slice(0, 1) },
     };
-    expect(() =>
+    const result = projectPowerProgressPanel({
+      current: current(),
+      curves: currentOnly,
+      nowEpochMilliseconds: Date.parse(FROZEN_AT),
+    });
+
+    expect(result.kind).toBe("computed");
+    if (result.kind !== "computed") return;
+    expect(result.rotation).toBe("unknown");
+    expect(result.anchors[0]).toEqual({
+      durationSeconds: 5,
+      current: { kind: "computed", watts: 1_100 },
+      previous: { kind: "unavailable" },
+      change: { kind: "unavailable" },
+    });
+  });
+
+  it("returns insufficient data when neither power window has an anchor", () => {
+    const selected = curves();
+    const withoutPower = {
+      ...selected,
+      powerCurves: { list: [] },
+    };
+    expect(
       projectPowerProgressPanel({
         current: current(),
-        curves: malformed,
+        curves: withoutPower,
         nowEpochMilliseconds: Date.parse(FROZEN_AT),
       }),
-    ).toThrow(new PowerProgressProjectionError());
+    ).toEqual({ kind: "unavailable", reason: "insufficient-data" });
   });
 
   it("reads verified persisted evidence and retains it after a later failed generation", async () => {

--- a/packages/coach/tests/power-progress.test.ts
+++ b/packages/coach/tests/power-progress.test.ts
@@ -157,6 +157,7 @@ describe("Power Progress state projection", () => {
         sourceContext: "mixed",
       },
     });
+    if (result.kind !== "computed") throw new TypeError("power progress projection is unavailable");
     expect(result.anchors.map((anchor) => anchor.durationSeconds)).toEqual([
       5, 60, 300, 1_200, 3_600,
     ]);

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -129,6 +129,23 @@ async function makeRuntime(
 }
 
 describe("StoreRuntime", () => {
+  it("threads the resolved calendar timezone into Reference capture", async () => {
+    const { runtime, capture } = await makeRuntime({
+      ...config,
+      session: { ...config.session, timezone: "Asia/Almaty" },
+    });
+
+    await runtime.runWindow();
+
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarTimeZone: "Asia/Almaty",
+        reviewedOn: "1998-07-18",
+      }),
+    );
+    await runtime.close();
+  });
+
   it("threads injected win32 semantics into Reference capture", async () => {
     const { runtime, capture } = await makeRuntime(config, undefined, emptyReadonlyStore(), "win32");
 

--- a/packages/coach/tests/training-context.test.ts
+++ b/packages/coach/tests/training-context.test.ts
@@ -3,6 +3,7 @@ import type {
   DroppedActivities,
   PowerProgressPanel,
   RecentRidesPanel,
+  TrainingHistoryPanel,
 } from "@enduragent/coach-contract";
 import type { CyclingFtpAnchorResult } from "@enduragent/kernel/anchors";
 import {
@@ -60,6 +61,11 @@ const recentRides: RecentRidesPanel = {
       distanceMeters: 40_000,
     },
   ],
+};
+
+const trainingHistory: TrainingHistoryPanel = {
+  kind: "unavailable",
+  reason: "coverage-unavailable",
 };
 
 function activity(overrides: Record<string, unknown> = {}) {
@@ -132,6 +138,7 @@ function project(overrides: Partial<Parameters<typeof projectCyclingTrainingCont
     wellness: [wellness("2026-07-17")],
     performanceProgress,
     recentRides,
+    trainingHistory,
     ...overrides,
   });
 }
@@ -243,6 +250,7 @@ describe("cycling training context projection", () => {
       reason: "source-restricted",
     });
     expect(result.recentRides).toEqual({ kind: "unknown", reason: "source-restricted" });
+    expect(result.trainingHistory).toEqual(trainingHistory);
     expect(result.adherence).toEqual({ kind: "unknown", reason: "source-restricted" });
   });
 

--- a/packages/coach/tests/training-history.test.ts
+++ b/packages/coach/tests/training-history.test.ts
@@ -1,0 +1,456 @@
+import { TrainingHistoryProjectionSchema, type Freshness } from "@enduragent/coach-contract";
+import type {
+  CoverageCommitRow,
+  RecordedFact,
+  TrainingCoverageReader,
+  TrainingHistoryFactRow,
+  TrainingHistoryReader,
+} from "@enduragent/kernel/store";
+import { describe, expect, it, vi } from "vitest";
+import { createTrainingHistorySource } from "../src/training-history.js";
+
+const AS_OF = "1998-07-10T12:00:00.000Z";
+
+function absent(): RecordedFact<number> {
+  return { kind: "absent" };
+}
+
+function recorded(value: number): RecordedFact<number> {
+  return { kind: "recorded", value };
+}
+
+function rejected(): RecordedFact<number> {
+  return { kind: "rejected", reason: "invalid-value" };
+}
+
+function ride(input: {
+  readonly id: string;
+  readonly localDate: string;
+  readonly hour?: number;
+  readonly startEpochSeconds?: number;
+  readonly timezoneOffsetSeconds?: number | null;
+  readonly movingSeconds?: number | null;
+  readonly elapsedSeconds?: number | null;
+  readonly distanceMeters?: number | null;
+  readonly load?: RecordedFact<number>;
+}): TrainingHistoryFactRow {
+  const hour = input.hour ?? 12;
+  return {
+    id: input.id,
+    localDate: input.localDate,
+    startEpochSeconds:
+      input.startEpochSeconds ??
+      Date.parse(`${input.localDate}T${String(hour).padStart(2, "0")}:00:00.000Z`) / 1_000,
+    timezoneOffsetSeconds:
+      "timezoneOffsetSeconds" in input ? (input.timezoneOffsetSeconds ?? null) : 0,
+    subSport: "road",
+    movingSeconds: "movingSeconds" in input ? (input.movingSeconds ?? null) : 3_600,
+    elapsedSeconds: "elapsedSeconds" in input ? (input.elapsedSeconds ?? null) : 3_900,
+    distanceMeters: "distanceMeters" in input ? (input.distanceMeters ?? null) : 25_000,
+    title: "Sentinel ride",
+    load: input.load ?? recorded(50),
+    averagePowerWatts: recorded(210),
+    averageHeartRateBpm: recorded(145),
+    perceivedExertion: recorded(6),
+    energyKilojoules: recorded(720),
+  };
+}
+
+function commit(input: {
+  readonly id: number;
+  readonly oldest?: string;
+  readonly newest?: string;
+  readonly committedAt?: string;
+  readonly zone?: string;
+  readonly gapState?: "none" | "undated-dropped-rows";
+}): CoverageCommitRow {
+  const committedAt = input.committedAt ?? AS_OF;
+  return {
+    coverageCommitId: input.id,
+    source: "intervals-icu",
+    lane: "activities",
+    authorityKind: "reference-capture",
+    authorityId: `sentinel-capture-${input.id}`,
+    calendarTimeZone: input.zone ?? "UTC",
+    coveredOldest: input.oldest ?? "1998-05-01",
+    coveredNewest: input.newest ?? "1998-07-10",
+    committedEpochSeconds: Date.parse(committedAt) / 1_000,
+    gapState: input.gapState ?? "none",
+  };
+}
+
+function source(input: {
+  readonly rows?: readonly TrainingHistoryFactRow[];
+  readonly commits?: readonly CoverageCommitRow[];
+  readonly scanTruncated?: boolean;
+  readonly readFailure?: Error;
+}) {
+  const readWindow = vi.fn<TrainingHistoryReader["readWindow"]>(async () => {
+    if (input.readFailure !== undefined) throw input.readFailure;
+    return {
+      rows: input.rows ?? [],
+      scanTruncated: input.scanTruncated ?? false,
+    };
+  });
+  const listCommits = vi.fn<TrainingCoverageReader["listCommits"]>(async () => input.commits ?? []);
+  return {
+    readWindow,
+    listCommits,
+    trainingHistory: createTrainingHistorySource({
+      facts: { readWindow },
+      coverage: { listCommits },
+    }),
+  };
+}
+
+async function read(input: {
+  readonly rows?: readonly TrainingHistoryFactRow[];
+  readonly commits?: readonly CoverageCommitRow[];
+  readonly scanTruncated?: boolean;
+  readonly readFailure?: Error;
+  readonly asOf?: string;
+  readonly calendarTimeZone?: string;
+  readonly freshness?: Freshness;
+  readonly sourceRestricted?: boolean;
+}) {
+  const fixture = source(input);
+  const asOf = input.asOf ?? AS_OF;
+  const projection = await fixture.trainingHistory.readTrainingHistory({
+    asOf,
+    asOfEpochSeconds: Date.parse(asOf) / 1_000,
+    calendarTimeZone: input.calendarTimeZone ?? "UTC",
+    freshness: input.freshness ?? "fresh",
+    sourceRestricted: input.sourceRestricted ?? false,
+  });
+  return { ...fixture, projection };
+}
+
+describe("training history projection", () => {
+  it("projects anchor and previous rides through the contract in one bounded read", async () => {
+    const anchorRide = ride({ id: "a".repeat(64), localDate: "1998-07-08", hour: 14 });
+    const previousRide = ride({ id: "b".repeat(64), localDate: "1998-07-03", hour: 9 });
+    const result = await read({
+      rows: [anchorRide, previousRide],
+      commits: [commit({ id: 1 })],
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    expect(TrainingHistoryProjectionSchema.parse(result.projection)).toEqual(result.projection);
+    expect(result.readWindow).toHaveBeenCalledOnce();
+    expect(result.readWindow).toHaveBeenCalledWith({ start: "1998-05-25", end: "1998-07-12" });
+    expect(result.listCommits).toHaveBeenCalledWith({
+      source: "intervals-icu",
+      lane: "activities",
+    });
+    if (result.projection.kind !== "computed") return;
+    expect(result.projection.anchorWeek.rides.items.map((item) => item.id)).toEqual([
+      anchorRide.id,
+    ]);
+    expect(result.projection.previousWeek?.rides.items.map((item) => item.id)).toEqual([
+      previousRide.id,
+    ]);
+    expect(result.projection.anchorWeek.callout).toBeNull();
+    expect(result.projection.previousWeek?.callout).toBeNull();
+  });
+
+  it("keeps proven zero-ride weeks as empty computed windows", async () => {
+    const result = await read({ commits: [commit({ id: 1 })] });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed") return;
+    expect(result.projection.anchorWeek).toMatchObject({
+      window: { start: "1998-07-06", end: "1998-07-12" },
+      coverage: { kind: "complete" },
+      totals: {
+        rideCount: { kind: "computed", value: 0 },
+        ridingSeconds: { kind: "computed", value: 0 },
+        distanceMeters: { kind: "computed", value: 0 },
+        load: { kind: "computed", value: 0 },
+      },
+      rides: { count: { kind: "exact", value: 0 }, items: [], truncated: false },
+      trend: { kind: "computed" },
+      callout: null,
+    });
+    expect(result.projection.previousWeek).toMatchObject({
+      window: { start: "1998-06-29", end: "1998-07-05" },
+      coverage: { kind: "complete" },
+      rides: { items: [] },
+      callout: null,
+    });
+  });
+
+  it("falls back from absent moving time to elapsed time and records the basis", async () => {
+    const result = await read({
+      rows: [
+        ride({
+          id: "c".repeat(64),
+          localDate: "1998-07-08",
+          movingSeconds: null,
+          elapsedSeconds: 4_200,
+        }),
+      ],
+      commits: [commit({ id: 1 })],
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed") return;
+    expect(result.projection.anchorWeek.rides.items[0]).toMatchObject({
+      ridingSeconds: 4_200,
+      ridingTimeBasis: "elapsed",
+      elapsedSeconds: 4_200,
+    });
+  });
+
+  it("distinguishes rejected and absent Load while counting known missing values", async () => {
+    const result = await read({
+      rows: [
+        ride({
+          id: "d".repeat(64),
+          localDate: "1998-07-09",
+          movingSeconds: null,
+          elapsedSeconds: null,
+          distanceMeters: null,
+          load: rejected(),
+        }),
+        ride({ id: "e".repeat(64), localDate: "1998-07-08", hour: 10 }),
+        ride({ id: "f".repeat(64), localDate: "1998-07-02", load: absent() }),
+      ],
+      commits: [commit({ id: 1 })],
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed" || result.projection.previousWeek === null) return;
+    expect(result.projection.anchorWeek.totals).toMatchObject({
+      ridingSeconds: {
+        kind: "partial",
+        value: 3_600,
+        reason: "missing-recorded-value",
+        knownRideMissingValueCount: 1,
+      },
+      distanceMeters: {
+        kind: "partial",
+        value: 25_000,
+        reason: "missing-recorded-value",
+        knownRideMissingValueCount: 1,
+      },
+      load: {
+        kind: "partial",
+        value: 50,
+        reason: "missing-recorded-value",
+        knownRideMissingValueCount: 1,
+      },
+    });
+    expect(result.projection.previousWeek.totals.load).toEqual({
+      kind: "unavailable",
+      reason: "no-recorded-value",
+    });
+    expect(result.projection.anchorWeek.rides.items[0]?.load).toBeNull();
+
+    const invalidOnly = await read({
+      rows: [ride({ id: "1".repeat(64), localDate: "1998-07-08", load: rejected() })],
+      commits: [commit({ id: 2 })],
+    });
+    expect(invalidOnly.projection.kind).toBe("computed");
+    if (invalidOnly.projection.kind !== "computed") return;
+    expect(invalidOnly.projection.anchorWeek.totals.load).toEqual({
+      kind: "unavailable",
+      reason: "invalid-recorded-value",
+    });
+  });
+
+  it("folds superseding commits into contiguous, incomplete, and sparse coverage", async () => {
+    const supersededGap = commit({
+      id: 1,
+      gapState: "undated-dropped-rows",
+      committedAt: "1998-07-09T12:00:00.000Z",
+    });
+    const clean = commit({ id: 2 });
+    const contiguous = await read({ commits: [supersededGap, clean] });
+    expect(contiguous.projection).toMatchObject({
+      kind: "computed",
+      coverage: {
+        kind: "contiguous",
+        start: "1998-05-01",
+        through: "1998-07-10",
+        committedAt: AS_OF,
+      },
+    });
+
+    const incomplete = await read({
+      commits: [
+        clean,
+        commit({
+          id: 3,
+          gapState: "undated-dropped-rows",
+          committedAt: "1998-07-10T13:00:00.000Z",
+        }),
+      ],
+    });
+    expect(incomplete.projection).toMatchObject({
+      kind: "computed",
+      coverage: {
+        kind: "incomplete",
+        provenStart: "1998-05-01",
+        provenThrough: "1998-07-10",
+        observedThrough: "1998-07-10",
+        committedAt: "1998-07-10T13:00:00.000Z",
+        reason: "undated-dropped-rows",
+      },
+    });
+
+    const sparse = await read({
+      rows: [ride({ id: "2".repeat(64), localDate: "1998-05-26" })],
+      commits: [],
+    });
+    expect(sparse.projection).toMatchObject({
+      kind: "computed",
+      displayMode: "last-recorded",
+      coverage: {
+        kind: "sparse",
+        latestKnownRideDate: "1998-05-26",
+        latestImportAt: null,
+      },
+      anchorWeek: { window: { start: "1998-05-25", end: "1998-05-31" } },
+    });
+    expect(sparse.readWindow).toHaveBeenCalledWith({ start: "1900-01-01", end: "1998-07-12" });
+  });
+
+  it("limits scan coverage at the oldest returned week without degrading newer weeks", async () => {
+    const newestEpoch = Date.parse("1998-07-08T12:00:00.000Z") / 1_000;
+    const anchorRows = Array.from({ length: 999 }, (_, index) =>
+      ride({
+        id: (index + 1).toString(16).padStart(64, "0"),
+        localDate: "1998-07-08",
+        startEpochSeconds: newestEpoch - index,
+      }),
+    );
+    const result = await read({
+      rows: [...anchorRows, ride({ id: "f".repeat(64), localDate: "1998-07-03" })],
+      commits: [commit({ id: 1 })],
+      scanTruncated: true,
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed" || result.projection.previousWeek === null) return;
+    expect(result.projection.anchorWeek.coverage).toEqual({ kind: "complete" });
+    expect(result.projection.anchorWeek.rides.count).toEqual({ kind: "exact", value: 999 });
+    expect(result.projection.previousWeek.coverage).toEqual({
+      kind: "incomplete",
+      recordedThrough: "1998-07-10",
+      reason: "scan-limit",
+    });
+    expect(result.projection.previousWeek.rides.count).toEqual({ kind: "at-least", value: 1 });
+
+    const crossWeekCutoff = await read({
+      rows: [
+        ...anchorRows,
+        ride({
+          id: "e".repeat(64),
+          localDate: "1998-07-05",
+          startEpochSeconds: Date.parse("1998-07-05T23:30:00.000Z") / 1_000,
+          timezoneOffsetSeconds: -43_200,
+        }),
+      ],
+      commits: [commit({ id: 2 })],
+      scanTruncated: true,
+    });
+    expect(crossWeekCutoff.projection.kind).toBe("computed");
+    if (crossWeekCutoff.projection.kind !== "computed") return;
+    expect(crossWeekCutoff.projection.anchorWeek.coverage).toEqual({
+      kind: "incomplete",
+      recordedThrough: "1998-07-10",
+      reason: "scan-limit",
+    });
+  });
+
+  it("returns typed unavailable results and never emits stale", async () => {
+    const noAnchor = await read({ commits: [] });
+    expect(noAnchor.projection).toEqual({
+      kind: "unavailable",
+      reason: "coverage-unavailable",
+    });
+
+    const failed = await read({
+      commits: [commit({ id: 1 })],
+      readFailure: new Error("sentinel read failure"),
+    });
+    expect(failed.projection).toEqual({
+      kind: "unavailable",
+      reason: "temporary-failure",
+    });
+    expect([noAnchor.projection.kind, failed.projection.kind]).not.toContain("stale");
+  });
+
+  it("returns unavailable for stale incomplete history without a safe anchor", async () => {
+    const restricted = await read({
+      freshness: "stale",
+      sourceRestricted: true,
+      commits: [],
+    });
+    expect(restricted.projection).toEqual({
+      kind: "unavailable",
+      reason: "coverage-unavailable",
+    });
+
+    const mismatchedZone = await read({
+      freshness: "critical",
+      commits: [commit({ id: 1, zone: "America/New_York" })],
+    });
+    expect(mismatchedZone.projection).toEqual({
+      kind: "unavailable",
+      reason: "coverage-unavailable",
+    });
+
+    const restrictedMismatch = await read({
+      freshness: "stale",
+      sourceRestricted: true,
+      commits: [commit({ id: 2, zone: "America/New_York" })],
+    });
+    expect(restrictedMismatch.projection).toEqual({
+      kind: "unavailable",
+      reason: "coverage-unavailable",
+    });
+
+    const latestSafeRide = await read({
+      freshness: "stale",
+      sourceRestricted: true,
+      rows: [ride({ id: "4".repeat(64), localDate: "1998-05-26" })],
+      commits: [],
+    });
+    expect(latestSafeRide.projection).toMatchObject({
+      kind: "computed",
+      displayMode: "last-recorded",
+      coverage: { kind: "incomplete", reason: "source-degraded" },
+      anchorWeek: { window: { start: "1998-05-25", end: "1998-05-31" } },
+    });
+    expect(latestSafeRide.readWindow).toHaveBeenCalledWith({
+      start: "1900-01-01",
+      end: "1998-07-12",
+    });
+  });
+
+  it("anchors today in the requested calendar time zone", async () => {
+    const asOf = "1998-07-06T00:30:00.000Z";
+    const zone = "America/Los_Angeles";
+    const result = await read({
+      asOf,
+      calendarTimeZone: zone,
+      commits: [
+        commit({
+          id: 1,
+          zone,
+          newest: "1998-07-05",
+          committedAt: "1998-07-06T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed") return;
+    expect(result.projection.anchorWeek.window).toEqual({
+      start: "1998-06-29",
+      end: "1998-07-05",
+    });
+    expect(result.projection.calendarTimeZone).toBe(zone);
+  });
+});

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -201,7 +201,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   const { client, signal, now } = deps;
   const log = deps.log ?? ((m: string) => console.warn(m));
   const throttleMs = deps.throttleMs ?? STREAM_THROTTLE_MS;
-  const plan = createReferenceCapturePlan(now);
+  const plan = createReferenceCapturePlan({ now, calendarTimeZone: "UTC" });
   const frozenNow = plan.frozenNow;
   const { oldest, newest } = plan.window;
   const cyclingSportTypes = new Set(

--- a/packages/engine/src/planning/civil-week.ts
+++ b/packages/engine/src/planning/civil-week.ts
@@ -1,0 +1,38 @@
+const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+const MILLISECONDS_PER_DAY = 86_400_000;
+
+function civilDateFromEpochMilliseconds(value: number): string {
+  const date = new Date(value);
+  const year = date.getUTCFullYear();
+  if (!Number.isFinite(date.getTime()) || year < 0 || year > 9_999) {
+    throw new TypeError("invalid civil date");
+  }
+  return `${String(year).padStart(4, "0")}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+function civilEpochMilliseconds(value: string): number {
+  if (!CIVIL_DATE_PATTERN.test(value)) throw new TypeError("invalid civil date");
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(year, month - 1, day);
+  if (civilDateFromEpochMilliseconds(date.getTime()) !== value) {
+    throw new TypeError("invalid civil date");
+  }
+  return date.getTime();
+}
+
+export function addCivilDays(value: string, days: number): string {
+  if (!Number.isSafeInteger(days)) throw new TypeError("invalid civil day offset");
+  return civilDateFromEpochMilliseconds(
+    civilEpochMilliseconds(value) + days * MILLISECONDS_PER_DAY,
+  );
+}
+
+export function mondayOfWeek(value: string): string {
+  const epoch = civilEpochMilliseconds(value);
+  const weekday = new Date(epoch).getUTCDay();
+  return addCivilDays(value, -((weekday + 6) % 7));
+}

--- a/packages/engine/src/planning/weekly-review.ts
+++ b/packages/engine/src/planning/weekly-review.ts
@@ -1,4 +1,5 @@
-import { addCivilDays, inclusiveCivilDays, weekdayForDateKey } from "@enduragent/kernel/planning";
+import { dateKeyFromText, inclusiveCivilDays } from "@enduragent/kernel/planning";
+import { addCivilDays, mondayOfWeek } from "./civil-week.js";
 import type { ProjectedWorkoutMatch } from "./workout-match.js";
 
 export const WEEKLY_REVIEW_RACE_QUIET_DAYS = 7 as const;
@@ -16,6 +17,15 @@ export interface WeeklyReviewWindow {
   readonly weekEndDateKey: number;
 }
 
+function civilDateFromDateKey(value: number): string {
+  const compact = String(value).padStart(8, "0");
+  return `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
+}
+
+function addDateKeyDays(value: number, days: number): number {
+  return dateKeyFromText(addCivilDays(civilDateFromDateKey(value), days));
+}
+
 export function selectWeeklyReviewWindow(input: {
   readonly todayDateKey: number;
   readonly planStartDateKey: number;
@@ -24,15 +34,14 @@ export function selectWeeklyReviewWindow(input: {
   readonly enabled: boolean;
 }): WeeklyReviewWindow | null {
   if (!input.enabled || input.lastSuccessfulSyncDateKey === null) return null;
-  const daysSinceMonday = (weekdayForDateKey(input.todayDateKey) + 6) % 7;
-  const currentWeekStart = addCivilDays(input.todayDateKey, -daysSinceMonday);
+  const currentWeekStart = dateKeyFromText(mondayOfWeek(civilDateFromDateKey(input.todayDateKey)));
   if (input.lastSuccessfulSyncDateKey < currentWeekStart) return null;
   if (input.targetDateKey !== null && input.targetDateKey >= input.todayDateKey) {
     const daysToRace = inclusiveCivilDays(input.todayDateKey, input.targetDateKey) - 1;
     if (daysToRace <= WEEKLY_REVIEW_RACE_QUIET_DAYS) return null;
   }
-  const weekStartDateKey = addCivilDays(currentWeekStart, -7);
-  const weekEndDateKey = addCivilDays(weekStartDateKey, 6);
+  const weekStartDateKey = addDateKeyDays(currentWeekStart, -7);
+  const weekEndDateKey = addDateKeyDays(weekStartDateKey, 6);
   if (weekEndDateKey < input.planStartDateKey) return null;
   return Object.freeze({
     weekStartDateKey: Math.max(weekStartDateKey, input.planStartDateKey),

--- a/packages/engine/src/sport.ts
+++ b/packages/engine/src/sport.ts
@@ -242,6 +242,7 @@ export {
   createPureCoreIntervalsTools,
 } from "./sport/platform-tools.js";
 export { resolveUserTimezone, todayInTZ } from "./sport/user-time.js";
+export { addCivilDays, mondayOfWeek } from "./planning/civil-week.js";
 export type {
   PlanFtpAdapter,
   PlanFtpSnapshot,

--- a/packages/kernel-node/tests/capture-manifest.test.ts
+++ b/packages/kernel-node/tests/capture-manifest.test.ts
@@ -20,7 +20,10 @@ const FIRST = "12345678-1234-4123-8123-123456789abc";
 const SECOND = "22345678-1234-4123-8123-123456789abc";
 
 function manifest(captureId = FIRST): ReferenceCaptureManifest {
-  const plan = createReferenceCapturePlan(new Date("1998-07-18T12:00:00.000Z"));
+  const plan = createReferenceCapturePlan({
+    now: new Date("1998-07-18T12:00:00.000Z"),
+    calendarTimeZone: "UTC",
+  });
   const address = "a".repeat(64), snapshot = { address, rel_path: `1998/07/${address}.json.gz` };
   return validateReferenceCaptureManifest({ schema_version: 1, capture_id: captureId, source: "external-oracle", plan,
     operation_ledger: { link_kind: "capture-id", capture_id: captureId },

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -598,7 +598,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -32,9 +32,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 29", async () => {
+  it("applies the full migration list and advances user_version to 30", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -54,7 +54,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
   });
 
   it("upgrades the released Plan version 24 schema through the current schema", async () => {
@@ -66,10 +66,10 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 24,
-      toVersion: 29,
-      applied: [25, 26, 27, 28, 29],
+      toVersion: 30,
+      applied: [25, 26, 27, 28, 29, 30],
     });
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 29 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 30 });
     await expect(
       store.all(
         "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('chat_attachment','planning_request','chat_plan_outbox') ORDER BY name",
@@ -108,11 +108,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 29", async () => {
+  it("upgrades a version-1-on-disk store to version 30", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -134,13 +134,13 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 4,
-      toVersion: 29,
+      toVersion: 30,
       applied: [
         5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-        29,
+        29, 30,
       ],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -193,23 +193,23 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 6,
-      toVersion: 29,
+      toVersion: 30,
       applied: [
-        7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+        7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
       ],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 29,
-      toVersion: 29,
+      fromVersion: 30,
+      toVersion: 30,
       applied: [],
     });
   });
 
-  it("upgrades version 11 through 29 while preserving existing rows", async () => {
+  it("upgrades version 11 through 30 while preserving existing rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 11));
     await store.run("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)", [
       "chronoBridge",
@@ -218,8 +218,8 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 11,
-      toVersion: 29,
-      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+      toVersion: 30,
+      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
     });
     await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings")).resolves.toEqual({
       fixer: "chronoBridge",
@@ -228,7 +228,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     await expect(store.get("SELECT count(*) AS count FROM repair_fixer_settings")).resolves.toEqual(
       { count: 1 },
     );
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 29 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 30 });
   });
 
   it("rolls back a failed migration 12 without partial Planning tables", async () => {
@@ -593,7 +593,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("upgrades migration 28 to 29 without classifying legacy Planning rows", async () => {
+  it("upgrades migration 28 through 30 without classifying legacy Planning rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 28));
     const planId = `${"0".repeat(25)}A`;
     const workoutId = `${"0".repeat(25)}B`;
@@ -683,10 +683,10 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 28,
-      toVersion: 29,
-      applied: [29],
+      toVersion: 30,
+      applied: [29, 30],
     });
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 29 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 30 });
     await expect(
       Promise.all(legacyTables.map((table) => store.all(`SELECT * FROM ${table} ORDER BY 1`))),
     ).resolves.toEqual(rowsBefore);

--- a/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
+++ b/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
@@ -384,7 +384,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 29,
+            targetUserVersion: 30,
             ...webCryptoExportEnv,
           },
           { container },
@@ -434,7 +434,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 29,
+            targetUserVersion: 30,
             ...webCryptoExportEnv,
           },
           { container },
@@ -479,7 +479,7 @@ describe("planning-domain SQLite export round-trip", () => {
         {
           sink: createSqliteImportSink(destination),
           presence: completePresence,
-          targetUserVersion: 29,
+          targetUserVersion: 30,
           ...webCryptoExportEnv,
         },
         { container: built.container },
@@ -495,7 +495,7 @@ describe("planning-domain SQLite export round-trip", () => {
         {
           sink: createSqliteImportSink(destination),
           presence: completePresence,
-          targetUserVersion: 29,
+          targetUserVersion: 30,
           ...webCryptoExportEnv,
         },
         { container: built.container },
@@ -528,7 +528,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 29,
+            targetUserVersion: 30,
             ...webCryptoExportEnv,
           },
           { container },

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -239,7 +239,7 @@ describe("sync failure repository", () => {
     expect(dump).not.toContain("# sync_failure");
     expect(dump).toContain("# plan_reconciliation_job");
     expect(dump).toContain("# plan_reconciliation_item");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 29 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
     expect(DUMP_TABLES).toHaveLength(69);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");

--- a/packages/kernel-node/tests/training-history-reader.test.ts
+++ b/packages/kernel-node/tests/training-history-reader.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import {
+  createTrainingHistoryReader,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const SESSION = "a".repeat(64);
+const WORKOUT = "b".repeat(64);
+const ARTIFACT = "c".repeat(64);
+const ARCHIVE = "d".repeat(64);
+const SOURCE_RECORD = "e".repeat(64);
+
+describe("training history reader with real SQLite", () => {
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    await store.run(
+      "INSERT INTO workout(workout_key,start_utc,tz_offset_s,name,notes,is_multisport,dedup_cluster_id) VALUES(?,?,?,?,?,?,?)",
+      [WORKOUT, 899_712_000, 21_600, "Workout title", null, 0, "cluster-12345"],
+    );
+    await store.run(
+      "INSERT INTO session(session_key,workout_key,session_seq,sport,sub_sport,start_utc,tz_offset_s,local_date_key,elapsed_s,timer_s,moving_s,distance_m,is_transition,summary_json) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      [
+        SESSION,
+        WORKOUT,
+        0,
+        "cycling",
+        "road",
+        899_712_000,
+        21_600,
+        19980706,
+        3_700,
+        3_650,
+        3_600,
+        30_000,
+        0,
+        null,
+      ],
+    );
+    await store.run(
+      "INSERT INTO source_artifact(artifact_key,source,lane,external_id,artifact_kind,archive_address,archive_rel_path,archive_epoch_s) VALUES(?,?,?,?,?,?,?,?)",
+      [
+        ARTIFACT,
+        "intervals-icu",
+        "activities",
+        "12345",
+        "snapshot",
+        ARCHIVE,
+        `1998/07/${ARCHIVE}.json.gz`,
+        899_712_000,
+      ],
+    );
+    await store.run(
+      "INSERT INTO source_record(id,workout_key,session_key,source,external_id,raw_sha256,quality_rank,payload_json,artifact_key) VALUES(?,?,?,?,?,?,?,?,?)",
+      [
+        SOURCE_RECORD,
+        WORKOUT,
+        SESSION,
+        "intervals-icu",
+        "12345",
+        ARCHIVE,
+        300,
+        canonicalJson({
+          activity: {
+            average_heartrate: 142,
+            average_watts: 205,
+            elapsed_time: 3_700,
+            icu_rpe: 7,
+            icu_training_load: 75,
+            id: 12345,
+            kj: 900,
+            moving_time: 3_600,
+            name: "Typed source title",
+            rpe: 6,
+            start_date_local: "1998-07-06T08:00:00",
+            type: "Ride",
+          },
+          concerns: {},
+          dedup: {},
+          schema_version: 1,
+        }),
+        ARTIFACT,
+      ],
+    );
+    await store.run(
+      "INSERT INTO field_merge_override_overlay(id,target_table,target_key,field_name,override_value_json,device_id,hlc_physical_ms,hlc_counter) VALUES(?,?,?,?,?,?,?,?)",
+      [
+        "overlay-12345",
+        "workout",
+        WORKOUT,
+        "name",
+        canonicalJson("Athlete title"),
+        "device-12345",
+        899_712_000_000,
+        0,
+      ],
+    );
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("reads canonical, authored, and trusted payload facts through one call", async () => {
+    const result = await createTrainingHistoryReader(store).readWindow({
+      start: "1998-07-06",
+      end: "1998-07-06",
+    });
+
+    expect(result).toEqual({
+      rows: [
+        {
+          id: SESSION,
+          localDate: "1998-07-06",
+          startEpochSeconds: 899_712_000,
+          timezoneOffsetSeconds: 21_600,
+          subSport: "road",
+          movingSeconds: 3_600,
+          elapsedSeconds: 3_700,
+          distanceMeters: 30_000,
+          title: "Athlete title",
+          load: { kind: "recorded", value: 75 },
+          averagePowerWatts: { kind: "recorded", value: 205 },
+          averageHeartRateBpm: { kind: "recorded", value: 142 },
+          perceivedExertion: { kind: "recorded", value: 7 },
+          energyKilojoules: { kind: "recorded", value: 900 },
+        },
+      ],
+      scanTruncated: false,
+    });
+    expect(Object.keys(result.rows[0]!)).not.toContain("payloadJson");
+    expect(Object.keys(result.rows[0]!)).not.toContain("providerActivityId");
+  });
+});

--- a/packages/kernel-node/tests/training-history-reader.test.ts
+++ b/packages/kernel-node/tests/training-history-reader.test.ts
@@ -138,4 +138,94 @@ describe("training history reader with real SQLite", () => {
     expect(Object.keys(result.rows[0]!)).not.toContain("payloadJson");
     expect(Object.keys(result.rows[0]!)).not.toContain("providerActivityId");
   });
+
+  it("excludes non-cycling, transition, and out-of-window sessions and caps oversized titles", async () => {
+    const runWorkout = "1".repeat(64);
+    const transitionWorkout = "2".repeat(64);
+    const lateWorkout = "3".repeat(64);
+    const longTitleWorkout = "4".repeat(64);
+    const runSession = "5".repeat(64);
+    const transitionSession = "6".repeat(64);
+    const lateSession = "7".repeat(64);
+    const longTitleSession = "8".repeat(64);
+    const insertWorkout = async (key: string, name: string): Promise<void> => {
+      await store.run(
+        "INSERT INTO workout(workout_key,start_utc,tz_offset_s,name,notes,is_multisport,dedup_cluster_id) VALUES(?,?,?,?,?,?,?)",
+        [key, 899_712_000, 21_600, name, null, 0, `cluster-${key.slice(0, 8)}`],
+      );
+    };
+    const insertSession = async (input: {
+      readonly session: string;
+      readonly workout: string;
+      readonly sport: string;
+      readonly localDateKey: number;
+      readonly isTransition: number;
+      readonly startUtc: number;
+    }): Promise<void> => {
+      await store.run(
+        "INSERT INTO session(session_key,workout_key,session_seq,sport,sub_sport,start_utc,tz_offset_s,local_date_key,elapsed_s,timer_s,moving_s,distance_m,is_transition,summary_json) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        [
+          input.session,
+          input.workout,
+          0,
+          input.sport,
+          null,
+          input.startUtc,
+          21_600,
+          input.localDateKey,
+          1_800,
+          1_800,
+          1_800,
+          10_000,
+          input.isTransition,
+          null,
+        ],
+      );
+    };
+    await insertWorkout(runWorkout, "Morning run");
+    await insertSession({
+      session: runSession,
+      workout: runWorkout,
+      sport: "running",
+      localDateKey: 19980706,
+      isTransition: 0,
+      startUtc: 899_713_000,
+    });
+    await insertWorkout(transitionWorkout, "T1");
+    await insertSession({
+      session: transitionSession,
+      workout: transitionWorkout,
+      sport: "cycling",
+      localDateKey: 19980706,
+      isTransition: 1,
+      startUtc: 899_714_000,
+    });
+    await insertWorkout(lateWorkout, "Next week ride");
+    await insertSession({
+      session: lateSession,
+      workout: lateWorkout,
+      sport: "cycling",
+      localDateKey: 19980713,
+      isTransition: 0,
+      startUtc: 900_316_800,
+    });
+    await insertWorkout(longTitleWorkout, "x".repeat(513));
+    await insertSession({
+      session: longTitleSession,
+      workout: longTitleWorkout,
+      sport: "cycling",
+      localDateKey: 19980707,
+      isTransition: 0,
+      startUtc: 899_798_400,
+    });
+
+    const result = await createTrainingHistoryReader(store).readWindow({
+      start: "1998-07-06",
+      end: "1998-07-12",
+    });
+
+    expect(result.rows.map(({ id }) => id)).toEqual([longTitleSession, SESSION]);
+    expect(result.rows[0]!.title).toBeNull();
+    expect(result.scanTruncated).toBe(false);
+  });
 });

--- a/packages/kernel/src/reference/capture.ts
+++ b/packages/kernel/src/reference/capture.ts
@@ -40,9 +40,38 @@ const nonemptyString = z.string().min(1);
 const civilDate = z.string().refine(realDate, "must be a real civil date");
 const localDateTime = z.string().refine(realLocalDateTime, "must be a real local date-time");
 
+function strictUtf8Length(value: string): number | undefined {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return undefined;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return undefined;
+      bytes += 4;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return undefined;
+    } else if (codeUnit <= 0x7f) {
+      bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes += 2;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+const calendarTimeZone = z.string().min(1).refine((value) => {
+  const bytes = strictUtf8Length(value);
+  return bytes !== undefined && bytes <= 255;
+}, "must be at most 255 UTF-8 bytes");
+
 const CapturePlanSchema = z.object({
   capture_epoch_ms: safeInteger,
   frozenNow: localDateTime,
+  calendar_timezone: calendarTimeZone.optional(),
   window: z.object({ oldest: civilDate, newest: civilDate }).strict(),
   stream_cutoff_epoch_ms: safeInteger,
 }).strict().superRefine((value, context) => {
@@ -240,20 +269,91 @@ export interface ReferenceCaptureEndpointPayload {
   readonly payload: unknown;
 }
 
-export function createReferenceCapturePlan(now: Date): ReferenceCapturePlan {
-  if (!(now instanceof Date)) throw new TypeError("capture clock is invalid");
-  const captureEpochMs = now.getTime();
+function calendarDateTime(now: Date, timeZone: string): {
+  readonly date: string;
+  readonly dateTime: string;
+} {
+  const timeZoneBytes =
+    typeof timeZone === "string" ? strictUtf8Length(timeZone) : undefined;
+  if (timeZoneBytes === undefined || timeZoneBytes > 255 || timeZone.length === 0) {
+    throw new TypeError("capture calendar timezone is invalid");
+  }
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(now);
+  } catch {
+    throw new TypeError("capture calendar timezone is invalid");
+  }
+  let year: string | undefined;
+  let month: string | undefined;
+  let day: string | undefined;
+  let hour: string | undefined;
+  let minute: string | undefined;
+  let second: string | undefined;
+  for (const part of parts) {
+    if (part.type === "year") year = part.value;
+    else if (part.type === "month") month = part.value;
+    else if (part.type === "day") day = part.value;
+    else if (part.type === "hour") hour = part.value;
+    else if (part.type === "minute") minute = part.value;
+    else if (part.type === "second") second = part.value;
+  }
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    hour === undefined ||
+    minute === undefined ||
+    second === undefined
+  ) {
+    throw new TypeError("capture calendar timezone is invalid");
+  }
+  const date = `${year}-${month}-${day}`;
+  return { date, dateTime: `${date}T${hour}:${minute}:${second}` };
+}
+
+function addCivilDays(value: string, days: number): string {
+  const [year, month, day] = value.split("-").map(Number);
+  if (year === undefined || month === undefined || day === undefined) {
+    throw new TypeError("capture calendar date is invalid");
+  }
+  const shifted = new Date(Date.UTC(year, month - 1, day + days));
+  return shifted.toISOString().slice(0, 10);
+}
+
+export function createReferenceCapturePlan(input: {
+  readonly now: Date;
+  readonly calendarTimeZone: string;
+}): ReferenceCapturePlan {
+  if (input === null || typeof input !== "object" || !(input.now instanceof Date)) {
+    throw new TypeError("capture clock is invalid");
+  }
+  const captureEpochMs = input.now.getTime();
   if (!Number.isSafeInteger(captureEpochMs)) throw new TypeError("capture clock is invalid");
-  const pad = (value: number): string => String(value).padStart(2, "0");
+  const calendar = calendarDateTime(input.now, input.calendarTimeZone);
   return validateReferenceCapturePlan({
     capture_epoch_ms: captureEpochMs,
-    frozenNow: `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`,
+    frozenNow: calendar.dateTime,
+    calendar_timezone: input.calendarTimeZone,
     window: {
-      newest: now.toISOString().slice(0, 10),
-      oldest: new Date(captureEpochMs - REFERENCE_CAPTURE_WINDOW_DAYS * DAY_MS).toISOString().slice(0, 10),
+      newest: calendar.date,
+      oldest: addCivilDays(calendar.date, -REFERENCE_CAPTURE_WINDOW_DAYS),
     },
     stream_cutoff_epoch_ms: captureEpochMs - REFERENCE_CAPTURE_STREAM_WINDOW_DAYS * DAY_MS,
   });
+}
+
+export function planCalendarTimeZone(plan: ReferenceCapturePlan): string {
+  return plan.calendar_timezone ?? "UTC";
 }
 
 export function validateReferenceCapturePlan(value: unknown): ReferenceCapturePlan {

--- a/packages/kernel/src/reference/schemas/inputs.ts
+++ b/packages/kernel/src/reference/schemas/inputs.ts
@@ -71,6 +71,7 @@ export const ActivitySchema = z.looseObject({
   // ("i12345678") or number form (17654321) depending on the endpoint and
   // sport; we mirror that union so real intervals.icu shape rides through.
   id: z.union([z.string(), z.number()]),
+  name: z.string().nullable().optional(),
   start_date_local: z.string(), // ISO 8601
   type: z.string(), // "Ride", "VirtualRide", "Run", etc.
   moving_time: z.number().nonnegative(),

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -9,6 +9,8 @@ export * from "./dedup-confirmation-repository.js";
 export * from "./intake-repository.js";
 export * from "./activity-repository.js";
 export * from "./canonical-activity-reader.js";
+export * from "./training-history-reader.js";
+export * from "./training-history-coverage.js";
 export * from "./activity-analysis-projection-repository.js";
 export * from "./trusted-activity-source-resolver.js";
 export * from "./analytics-curve-repository.js";

--- a/packages/kernel/src/store/migrations/030_training_history_coverage.sql
+++ b/packages/kernel/src/store/migrations/030_training_history_coverage.sql
@@ -1,0 +1,64 @@
+CREATE TABLE training_history_coverage_commit (
+  coverage_commit_id INTEGER PRIMARY KEY,
+  source TEXT NOT NULL CHECK (source = 'intervals-icu'),
+  lane TEXT NOT NULL CHECK (lane = 'activities'),
+  authority_kind TEXT NOT NULL
+    CHECK (authority_kind IN ('reference-capture','activity-backfill')),
+  authority_id TEXT NOT NULL CHECK (length(authority_id) BETWEEN 1 AND 128),
+  calendar_timezone TEXT NOT NULL
+    CHECK (length(CAST(calendar_timezone AS BLOB)) BETWEEN 1 AND 255),
+  covered_oldest_date_key INTEGER NOT NULL
+    CHECK (covered_oldest_date_key BETWEEN 19000101 AND 29991231),
+  covered_newest_date_key INTEGER NOT NULL
+    CHECK (covered_newest_date_key BETWEEN 19000101 AND 29991231),
+  committed_epoch_seconds INTEGER NOT NULL CHECK (committed_epoch_seconds >= 0),
+  gap_state TEXT NOT NULL CHECK (gap_state IN ('none','undated-dropped-rows')),
+  CHECK (covered_oldest_date_key <= covered_newest_date_key)
+) STRICT;
+
+CREATE UNIQUE INDEX training_history_coverage_commit_authority
+  ON training_history_coverage_commit (authority_kind, authority_id);
+
+CREATE TABLE training_history_backfill_checkpoint (
+  checkpoint_id INTEGER PRIMARY KEY,
+  authority_id TEXT NOT NULL CHECK (length(authority_id) BETWEEN 1 AND 128),
+  source_cycle INTEGER NOT NULL CHECK (source_cycle >= 0),
+  page_ordinal INTEGER NOT NULL CHECK (page_ordinal >= 0),
+  requested_oldest_key INTEGER NOT NULL
+    CHECK (requested_oldest_key BETWEEN 19000101 AND 29991231),
+  requested_newest_key INTEGER NOT NULL
+    CHECK (requested_newest_key BETWEEN 19000101 AND 29991231),
+  calendar_timezone TEXT NOT NULL
+    CHECK (length(CAST(calendar_timezone AS BLOB)) BETWEEN 1 AND 255),
+  cursor_after TEXT NOT NULL,
+  dropped_source_restricted INTEGER NOT NULL CHECK (dropped_source_restricted >= 0),
+  dropped_other INTEGER NOT NULL CHECK (dropped_other >= 0),
+  terminal INTEGER NOT NULL CHECK (terminal IN (0, 1)),
+  UNIQUE (authority_id, page_ordinal),
+  UNIQUE (source_cycle, cursor_after),
+  CHECK (requested_oldest_key <= requested_newest_key)
+) STRICT;
+
+CREATE TRIGGER training_history_coverage_commit_no_update
+BEFORE UPDATE ON training_history_coverage_commit
+BEGIN
+  SELECT RAISE(ABORT, 'training history coverage commit is append-only');
+END;
+
+CREATE TRIGGER training_history_coverage_commit_no_delete
+BEFORE DELETE ON training_history_coverage_commit
+BEGIN
+  SELECT RAISE(ABORT, 'training history coverage commit is append-only');
+END;
+
+CREATE TRIGGER training_history_backfill_checkpoint_no_update
+BEFORE UPDATE ON training_history_backfill_checkpoint
+BEGIN
+  SELECT RAISE(ABORT, 'training history backfill checkpoint is append-only');
+END;
+
+CREATE TRIGGER training_history_backfill_checkpoint_no_delete
+BEFORE DELETE ON training_history_backfill_checkpoint
+BEGIN
+  SELECT RAISE(ABORT, 'training history backfill checkpoint is append-only');
+END;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -27,6 +27,7 @@ import planningRequests026 from "./026_planning_requests.sql";
 import chatPlanOutbox027 from "./027_chat_plan_outbox.sql";
 import planWorkoutAdditions028 from "./028_plan_workout_additions.sql";
 import planningDomain029 from "./029_planning_domain.sql";
+import trainingHistoryCoverage030 from "./030_training_history_coverage.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -71,4 +72,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 27, name: "027_chat_plan_outbox", sql: chatPlanOutbox027 },
   { version: 28, name: "028_plan_workout_additions", sql: planWorkoutAdditions028 },
   { version: 29, name: "029_planning_domain", sql: planningDomain029 },
+  { version: 30, name: "030_training_history_coverage", sql: trainingHistoryCoverage030 },
 ];

--- a/packages/kernel/src/store/training-history-coverage.ts
+++ b/packages/kernel/src/store/training-history-coverage.ts
@@ -1,0 +1,299 @@
+import type { Row, SqlReadStore, SqlStore } from "./ports.js";
+
+export type CoverageAuthorityKind = "reference-capture" | "activity-backfill";
+export type CoverageGapState = "none" | "undated-dropped-rows";
+
+export interface CoverageCommitInput {
+  readonly source: "intervals-icu";
+  readonly lane: "activities";
+  readonly authorityKind: CoverageAuthorityKind;
+  readonly authorityId: string;
+  readonly calendarTimeZone: string;
+  readonly coveredOldest: string;
+  readonly coveredNewest: string;
+  readonly committedEpochSeconds: number;
+  readonly gapState: CoverageGapState;
+}
+
+export interface CoverageCommitRow extends CoverageCommitInput {
+  readonly coverageCommitId: number;
+}
+
+export type CoverageCommitAppendResult =
+  | { readonly kind: "inserted"; readonly commitId: number }
+  | { readonly kind: "already-recorded"; readonly commitId: number };
+
+export type TrainingCoverageErrorCode = "invalid_row" | "authority_conflict";
+
+export class TrainingCoverageError extends Error {
+  readonly code: TrainingCoverageErrorCode;
+
+  constructor(code: TrainingCoverageErrorCode) {
+    super(`training coverage rejected: ${code}`);
+    this.name = "TrainingCoverageError";
+    this.code = code;
+  }
+}
+
+export interface TrainingCoverageRepository {
+  appendCommitInTransaction(
+    store: Pick<SqlStore, "get">,
+    input: CoverageCommitInput,
+  ): Promise<CoverageCommitAppendResult>;
+}
+
+export interface TrainingCoverageReader {
+  listCommits(input: {
+    readonly source: "intervals-icu";
+    readonly lane: "activities";
+  }): Promise<readonly CoverageCommitRow[]>;
+}
+
+const CIVIL_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const ROW_KEYS = [
+  "coverage_commit_id",
+  "source",
+  "lane",
+  "authority_kind",
+  "authority_id",
+  "calendar_timezone",
+  "covered_oldest_date_key",
+  "covered_newest_date_key",
+  "committed_epoch_seconds",
+  "gap_state",
+] as const;
+
+const READ_COMMIT_SQL = `SELECT
+  coverage_commit_id,
+  source,
+  lane,
+  authority_kind,
+  authority_id,
+  calendar_timezone,
+  covered_oldest_date_key,
+  covered_newest_date_key,
+  committed_epoch_seconds,
+  gap_state
+FROM training_history_coverage_commit
+WHERE authority_kind = ? AND authority_id = ?`;
+
+function strictUtf8Length(value: string): number | undefined {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return undefined;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return undefined;
+      bytes += 4;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return undefined;
+    } else if (codeUnit <= 0x7f) {
+      bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes += 2;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function civilDateKey(value: unknown): number | undefined {
+  if (typeof value !== "string" || !CIVIL_DATE.test(value)) return undefined;
+  const epoch = Date.parse(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(epoch) || new Date(epoch).toISOString().slice(0, 10) !== value) {
+    return undefined;
+  }
+  const key = Number(value.replaceAll("-", ""));
+  return key >= 19000101 && key <= 29991231 ? key : undefined;
+}
+
+function civilDateFromKey(value: unknown): string {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) invalidRow();
+  const compact = String(value).padStart(8, "0");
+  if (compact.length !== 8) invalidRow();
+  const candidate = `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
+  if (civilDateKey(candidate) !== value) invalidRow();
+  return candidate;
+}
+
+function hasExactKeys(row: Row, keys: readonly string[]): boolean {
+  const actual = Object.keys(row);
+  return actual.length === keys.length && actual.every((key, index) => key === keys[index]);
+}
+
+function invalidRow(): never {
+  throw new TrainingCoverageError("invalid_row");
+}
+
+function validateInput(input: CoverageCommitInput): {
+  readonly oldestKey: number;
+  readonly newestKey: number;
+} {
+  const oldestKey = civilDateKey(input?.coveredOldest);
+  const newestKey = civilDateKey(input?.coveredNewest);
+  const zoneBytes =
+    typeof input?.calendarTimeZone === "string"
+      ? strictUtf8Length(input.calendarTimeZone)
+      : undefined;
+  if (
+    input === null ||
+    typeof input !== "object" ||
+    input.source !== "intervals-icu" ||
+    input.lane !== "activities" ||
+    (input.authorityKind !== "reference-capture" && input.authorityKind !== "activity-backfill") ||
+    typeof input.authorityId !== "string" ||
+    input.authorityId.length < 1 ||
+    input.authorityId.length > 128 ||
+    zoneBytes === undefined ||
+    zoneBytes < 1 ||
+    zoneBytes > 255 ||
+    oldestKey === undefined ||
+    newestKey === undefined ||
+    oldestKey > newestKey ||
+    !Number.isSafeInteger(input.committedEpochSeconds) ||
+    input.committedEpochSeconds < 0 ||
+    (input.gapState !== "none" && input.gapState !== "undated-dropped-rows")
+  ) {
+    throw new TypeError("invalid training coverage commit");
+  }
+  return { oldestKey, newestKey };
+}
+
+function commitRow(row: Row): CoverageCommitRow {
+  if (!hasExactKeys(row, ROW_KEYS)) invalidRow();
+  const id = row.coverage_commit_id;
+  const committed = row.committed_epoch_seconds;
+  if (
+    typeof id !== "number" ||
+    !Number.isSafeInteger(id) ||
+    id <= 0 ||
+    row.source !== "intervals-icu" ||
+    row.lane !== "activities" ||
+    (row.authority_kind !== "reference-capture" && row.authority_kind !== "activity-backfill") ||
+    typeof row.authority_id !== "string" ||
+    typeof row.calendar_timezone !== "string" ||
+    typeof committed !== "number" ||
+    !Number.isSafeInteger(committed) ||
+    committed < 0 ||
+    (row.gap_state !== "none" && row.gap_state !== "undated-dropped-rows")
+  ) {
+    invalidRow();
+  }
+  const result: CoverageCommitRow = {
+    coverageCommitId: id,
+    source: row.source,
+    lane: row.lane,
+    authorityKind: row.authority_kind,
+    authorityId: row.authority_id,
+    calendarTimeZone: row.calendar_timezone,
+    coveredOldest: civilDateFromKey(row.covered_oldest_date_key),
+    coveredNewest: civilDateFromKey(row.covered_newest_date_key),
+    committedEpochSeconds: committed,
+    gapState: row.gap_state,
+  };
+  validateInput(result);
+  return Object.freeze(result);
+}
+
+function sameCommit(left: CoverageCommitRow, right: CoverageCommitInput): boolean {
+  return (
+    left.source === right.source &&
+    left.lane === right.lane &&
+    left.authorityKind === right.authorityKind &&
+    left.authorityId === right.authorityId &&
+    left.calendarTimeZone === right.calendarTimeZone &&
+    left.coveredOldest === right.coveredOldest &&
+    left.coveredNewest === right.coveredNewest &&
+    left.committedEpochSeconds === right.committedEpochSeconds &&
+    left.gapState === right.gapState
+  );
+}
+
+export function createTrainingCoverageRepository(): TrainingCoverageRepository {
+  return {
+    async appendCommitInTransaction(store, input) {
+      const { oldestKey, newestKey } = validateInput(input);
+      const inserted = await store.get(
+        `INSERT INTO training_history_coverage_commit (
+  source,
+  lane,
+  authority_kind,
+  authority_id,
+  calendar_timezone,
+  covered_oldest_date_key,
+  covered_newest_date_key,
+  committed_epoch_seconds,
+  gap_state
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (authority_kind, authority_id) DO NOTHING
+RETURNING coverage_commit_id`,
+        [
+          input.source,
+          input.lane,
+          input.authorityKind,
+          input.authorityId,
+          input.calendarTimeZone,
+          oldestKey,
+          newestKey,
+          input.committedEpochSeconds,
+          input.gapState,
+        ],
+      );
+      if (
+        inserted !== undefined &&
+        (!hasExactKeys(inserted, ["coverage_commit_id"]) ||
+          typeof inserted.coverage_commit_id !== "number" ||
+          !Number.isSafeInteger(inserted.coverage_commit_id) ||
+          inserted.coverage_commit_id <= 0)
+      ) {
+        invalidRow();
+      }
+      const selected = await store.get(READ_COMMIT_SQL, [input.authorityKind, input.authorityId]);
+      if (selected === undefined) invalidRow();
+      const stored = commitRow(selected);
+      if (!sameCommit(stored, input)) throw new TrainingCoverageError("authority_conflict");
+      return Object.freeze({
+        kind: inserted === undefined ? "already-recorded" : "inserted",
+        commitId: stored.coverageCommitId,
+      });
+    },
+  };
+}
+
+export function createTrainingCoverageReader(
+  store: Pick<SqlReadStore, "all">,
+): TrainingCoverageReader {
+  return {
+    async listCommits(input) {
+      if (
+        input === null ||
+        typeof input !== "object" ||
+        input.source !== "intervals-icu" ||
+        input.lane !== "activities"
+      ) {
+        throw new TypeError("invalid training coverage key");
+      }
+      const rows = await store.all(
+        `SELECT
+  coverage_commit_id,
+  source,
+  lane,
+  authority_kind,
+  authority_id,
+  calendar_timezone,
+  covered_oldest_date_key,
+  covered_newest_date_key,
+  committed_epoch_seconds,
+  gap_state
+FROM training_history_coverage_commit
+WHERE source = ? AND lane = ?
+ORDER BY committed_epoch_seconds ASC, coverage_commit_id ASC`,
+        [input.source, input.lane],
+      );
+      return Object.freeze(rows.map(commitRow));
+    },
+  };
+}

--- a/packages/kernel/src/store/training-history-coverage.ts
+++ b/packages/kernel/src/store/training-history-coverage.ts
@@ -19,6 +19,23 @@ export interface CoverageCommitRow extends CoverageCommitInput {
   readonly coverageCommitId: number;
 }
 
+export interface BackfillCheckpointInput {
+  readonly authorityId: string;
+  readonly sourceCycle: number;
+  readonly pageOrdinal: number;
+  readonly requestedOldest: string;
+  readonly requestedNewest: string;
+  readonly calendarTimeZone: string;
+  readonly cursorAfter: string;
+  readonly droppedSourceRestricted: number;
+  readonly droppedOther: number;
+  readonly terminal: boolean;
+}
+
+export interface BackfillCheckpointRow extends BackfillCheckpointInput {
+  readonly checkpointId: number;
+}
+
 export type CoverageCommitAppendResult =
   | { readonly kind: "inserted"; readonly commitId: number }
   | { readonly kind: "already-recorded"; readonly commitId: number };
@@ -40,6 +57,17 @@ export interface TrainingCoverageRepository {
     store: Pick<SqlStore, "get">,
     input: CoverageCommitInput,
   ): Promise<CoverageCommitAppendResult>;
+  appendBackfillCheckpointInTransaction(
+    store: Pick<SqlStore, "get">,
+    input: BackfillCheckpointInput,
+  ): Promise<{
+    readonly kind: "inserted" | "already-recorded";
+    readonly checkpointId: number;
+  }>;
+  readBackfillCheckpoint(
+    store: Pick<SqlReadStore, "get">,
+    input: { readonly sourceCycle: number; readonly cursorAfter: string },
+  ): Promise<BackfillCheckpointRow | undefined>;
 }
 
 export interface TrainingCoverageReader {
@@ -76,6 +104,35 @@ const READ_COMMIT_SQL = `SELECT
   gap_state
 FROM training_history_coverage_commit
 WHERE authority_kind = ? AND authority_id = ?`;
+
+const CHECKPOINT_ROW_KEYS = [
+  "checkpoint_id",
+  "authority_id",
+  "source_cycle",
+  "page_ordinal",
+  "requested_oldest_key",
+  "requested_newest_key",
+  "calendar_timezone",
+  "cursor_after",
+  "dropped_source_restricted",
+  "dropped_other",
+  "terminal",
+] as const;
+
+const READ_CHECKPOINT_SQL = `SELECT
+  checkpoint_id,
+  authority_id,
+  source_cycle,
+  page_ordinal,
+  requested_oldest_key,
+  requested_newest_key,
+  calendar_timezone,
+  cursor_after,
+  dropped_source_restricted,
+  dropped_other,
+  terminal
+FROM training_history_backfill_checkpoint
+WHERE source_cycle = ? AND cursor_after = ?`;
 
 function strictUtf8Length(value: string): number | undefined {
   let bytes = 0;
@@ -162,6 +219,45 @@ function validateInput(input: CoverageCommitInput): {
   return { oldestKey, newestKey };
 }
 
+function validateCheckpointInput(input: BackfillCheckpointInput): {
+  readonly oldestKey: number;
+  readonly newestKey: number;
+} {
+  const oldestKey = civilDateKey(input?.requestedOldest);
+  const newestKey = civilDateKey(input?.requestedNewest);
+  const zoneBytes =
+    typeof input?.calendarTimeZone === "string"
+      ? strictUtf8Length(input.calendarTimeZone)
+      : undefined;
+  if (
+    input === null ||
+    typeof input !== "object" ||
+    typeof input.authorityId !== "string" ||
+    input.authorityId.length < 1 ||
+    input.authorityId.length > 128 ||
+    !Number.isSafeInteger(input.sourceCycle) ||
+    input.sourceCycle < 0 ||
+    !Number.isSafeInteger(input.pageOrdinal) ||
+    input.pageOrdinal < 0 ||
+    oldestKey === undefined ||
+    newestKey === undefined ||
+    oldestKey > newestKey ||
+    zoneBytes === undefined ||
+    zoneBytes < 1 ||
+    zoneBytes > 255 ||
+    typeof input.cursorAfter !== "string" ||
+    input.cursorAfter.length < 1 ||
+    !Number.isSafeInteger(input.droppedSourceRestricted) ||
+    input.droppedSourceRestricted < 0 ||
+    !Number.isSafeInteger(input.droppedOther) ||
+    input.droppedOther < 0 ||
+    typeof input.terminal !== "boolean"
+  ) {
+    throw new TypeError("invalid training history backfill checkpoint");
+  }
+  return { oldestKey, newestKey };
+}
+
 function commitRow(row: Row): CoverageCommitRow {
   if (!hasExactKeys(row, ROW_KEYS)) invalidRow();
   const id = row.coverage_commit_id;
@@ -212,6 +308,64 @@ function sameCommit(left: CoverageCommitRow, right: CoverageCommitInput): boolea
   );
 }
 
+function checkpointRow(row: Row): BackfillCheckpointRow {
+  if (!hasExactKeys(row, CHECKPOINT_ROW_KEYS)) invalidRow();
+  const checkpointId = row.checkpoint_id;
+  const terminal = row.terminal;
+  if (
+    typeof checkpointId !== "number" ||
+    !Number.isSafeInteger(checkpointId) ||
+    checkpointId <= 0 ||
+    typeof row.authority_id !== "string" ||
+    typeof row.source_cycle !== "number" ||
+    !Number.isSafeInteger(row.source_cycle) ||
+    typeof row.page_ordinal !== "number" ||
+    !Number.isSafeInteger(row.page_ordinal) ||
+    typeof row.calendar_timezone !== "string" ||
+    typeof row.cursor_after !== "string" ||
+    typeof row.dropped_source_restricted !== "number" ||
+    !Number.isSafeInteger(row.dropped_source_restricted) ||
+    typeof row.dropped_other !== "number" ||
+    !Number.isSafeInteger(row.dropped_other) ||
+    (terminal !== 0 && terminal !== 1)
+  ) {
+    invalidRow();
+  }
+  const result: BackfillCheckpointRow = {
+    checkpointId,
+    authorityId: row.authority_id,
+    sourceCycle: row.source_cycle,
+    pageOrdinal: row.page_ordinal,
+    requestedOldest: civilDateFromKey(row.requested_oldest_key),
+    requestedNewest: civilDateFromKey(row.requested_newest_key),
+    calendarTimeZone: row.calendar_timezone,
+    cursorAfter: row.cursor_after,
+    droppedSourceRestricted: row.dropped_source_restricted,
+    droppedOther: row.dropped_other,
+    terminal: terminal === 1,
+  };
+  validateCheckpointInput(result);
+  return Object.freeze(result);
+}
+
+function sameCheckpoint(
+  left: BackfillCheckpointRow,
+  right: BackfillCheckpointInput,
+): boolean {
+  return (
+    left.authorityId === right.authorityId &&
+    left.sourceCycle === right.sourceCycle &&
+    left.pageOrdinal === right.pageOrdinal &&
+    left.requestedOldest === right.requestedOldest &&
+    left.requestedNewest === right.requestedNewest &&
+    left.calendarTimeZone === right.calendarTimeZone &&
+    left.cursorAfter === right.cursorAfter &&
+    left.droppedSourceRestricted === right.droppedSourceRestricted &&
+    left.droppedOther === right.droppedOther &&
+    left.terminal === right.terminal
+  );
+}
+
 export function createTrainingCoverageRepository(): TrainingCoverageRepository {
   return {
     async appendCommitInTransaction(store, input) {
@@ -259,6 +413,76 @@ RETURNING coverage_commit_id`,
         kind: inserted === undefined ? "already-recorded" : "inserted",
         commitId: stored.coverageCommitId,
       });
+    },
+    async appendBackfillCheckpointInTransaction(store, input) {
+      const { oldestKey, newestKey } = validateCheckpointInput(input);
+      const inserted = await store.get(
+        `INSERT INTO training_history_backfill_checkpoint (
+  authority_id,
+  source_cycle,
+  page_ordinal,
+  requested_oldest_key,
+  requested_newest_key,
+  calendar_timezone,
+  cursor_after,
+  dropped_source_restricted,
+  dropped_other,
+  terminal
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT DO NOTHING
+RETURNING checkpoint_id`,
+        [
+          input.authorityId,
+          input.sourceCycle,
+          input.pageOrdinal,
+          oldestKey,
+          newestKey,
+          input.calendarTimeZone,
+          input.cursorAfter,
+          input.droppedSourceRestricted,
+          input.droppedOther,
+          input.terminal ? 1 : 0,
+        ],
+      );
+      if (
+        inserted !== undefined &&
+        (!hasExactKeys(inserted, ["checkpoint_id"]) ||
+          typeof inserted.checkpoint_id !== "number" ||
+          !Number.isSafeInteger(inserted.checkpoint_id) ||
+          inserted.checkpoint_id <= 0)
+      ) {
+        invalidRow();
+      }
+      const selected = await store.get(READ_CHECKPOINT_SQL, [
+        input.sourceCycle,
+        input.cursorAfter,
+      ]);
+      if (selected === undefined) {
+        if (inserted === undefined) throw new TrainingCoverageError("authority_conflict");
+        invalidRow();
+      }
+      const stored = checkpointRow(selected);
+      if (!sameCheckpoint(stored, input)) {
+        throw new TrainingCoverageError("authority_conflict");
+      }
+      return Object.freeze({
+        kind: inserted === undefined ? "already-recorded" : "inserted",
+        checkpointId: stored.checkpointId,
+      });
+    },
+    async readBackfillCheckpoint(store, input) {
+      if (
+        input === null ||
+        typeof input !== "object" ||
+        !Number.isSafeInteger(input.sourceCycle) ||
+        input.sourceCycle < 0 ||
+        typeof input.cursorAfter !== "string" ||
+        input.cursorAfter.length < 1
+      ) {
+        throw new TypeError("invalid training history checkpoint lookup");
+      }
+      const row = await store.get(READ_CHECKPOINT_SQL, [input.sourceCycle, input.cursorAfter]);
+      return row === undefined ? undefined : checkpointRow(row);
     },
   };
 }

--- a/packages/kernel/src/store/training-history-reader.ts
+++ b/packages/kernel/src/store/training-history-reader.ts
@@ -1,0 +1,650 @@
+import { z } from "zod";
+import { parseActivityLandingEnvelope } from "../ingest/source-ledger.js";
+import { ActivitySchema } from "../reference/schemas/inputs.js";
+import type { Row, SqlReadStore } from "./ports.js";
+
+export type RecordedFactRejectionReason =
+  | "invalid-value"
+  | "invalid-envelope"
+  | "oversized-payload"
+  | "ambiguous-source"
+  | "payload-budget-exhausted";
+
+export type RecordedFact<T> =
+  | { readonly kind: "recorded"; readonly value: T }
+  | { readonly kind: "absent" }
+  | { readonly kind: "rejected"; readonly reason: RecordedFactRejectionReason };
+
+export interface TrainingHistoryFactRow {
+  readonly id: string;
+  readonly localDate: string;
+  readonly startEpochSeconds: number;
+  readonly timezoneOffsetSeconds: number | null;
+  readonly subSport: string | null;
+  readonly movingSeconds: number | null;
+  readonly elapsedSeconds: number | null;
+  readonly distanceMeters: number | null;
+  readonly title: string | null;
+  readonly load: RecordedFact<number>;
+  readonly averagePowerWatts: RecordedFact<number>;
+  readonly averageHeartRateBpm: RecordedFact<number>;
+  readonly perceivedExertion: RecordedFact<number>;
+  readonly energyKilojoules: RecordedFact<number>;
+}
+
+export type TrainingHistoryRideFact = TrainingHistoryFactRow;
+
+export interface TrainingHistoryWindowFacts {
+  readonly rows: readonly TrainingHistoryFactRow[];
+  readonly scanTruncated: boolean;
+}
+
+export type TrainingHistoryReadErrorCode = "invalid_input" | "invalid_row";
+
+export class TrainingHistoryReadError extends Error {
+  readonly code: TrainingHistoryReadErrorCode;
+
+  constructor(code: TrainingHistoryReadErrorCode) {
+    super(`training history read rejected: ${code}`);
+    this.name = "TrainingHistoryReadError";
+    this.code = code;
+  }
+}
+
+export interface TrainingHistoryReader {
+  readWindow(input: {
+    readonly start: string;
+    readonly end: string;
+  }): Promise<TrainingHistoryWindowFacts>;
+}
+
+interface CoreFactRow {
+  readonly id: string;
+  readonly localDate: string;
+  readonly startEpochSeconds: number;
+  readonly timezoneOffsetSeconds: number | null;
+  readonly subSport: string | null;
+  readonly movingSeconds: number | null;
+  readonly elapsedSeconds: number | null;
+  readonly distanceMeters: number | null;
+  readonly overlayTitle: string | null;
+  readonly workoutTitle: string | null;
+}
+
+interface PendingFactRow extends CoreFactRow {
+  sourceTitle: string | null;
+  load: RecordedFact<number>;
+  averagePowerWatts: RecordedFact<number>;
+  averageHeartRateBpm: RecordedFact<number>;
+  perceivedExertion: RecordedFact<number>;
+  energyKilojoules: RecordedFact<number>;
+}
+
+interface ParsedPayloadFacts {
+  readonly kind: "parsed";
+  readonly sourceTitle: string | null;
+  readonly load: RecordedFact<number>;
+  readonly averagePowerWatts: RecordedFact<number>;
+  readonly averageHeartRateBpm: RecordedFact<number>;
+  readonly perceivedExertion: RecordedFact<number>;
+  readonly energyKilojoules: RecordedFact<number>;
+}
+
+interface InvalidPayloadEnvelope {
+  readonly kind: "invalid-envelope";
+}
+
+interface ParseBudget {
+  bytes: number;
+  exhausted: boolean;
+}
+
+interface SafeParseSchema {
+  safeParse(
+    value: unknown,
+  ): { readonly success: true; readonly data: unknown } | { readonly success: false };
+}
+
+const SESSION_ID = /^[0-9a-f]{64}$/;
+const CIVIL_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const CORE_PAGE_SIZE = 200;
+const PAYLOAD_PAGE_SIZE = 100;
+const SESSION_LIMIT = 1_000;
+const PAYLOAD_ROW_BYTES = 65_536;
+const PAYLOAD_PROJECTION_BYTES = 16 * 1_024 * 1_024;
+
+const PICKED_ACTIVITY_SCHEMA = z
+  .object({
+    name: ActivitySchema.shape.name,
+    icu_training_load: ActivitySchema.shape.icu_training_load,
+    average_watts: ActivitySchema.shape.average_watts,
+    average_heartrate: ActivitySchema.shape.average_heartrate,
+    icu_rpe: ActivitySchema.shape.icu_rpe,
+    rpe: ActivitySchema.shape.rpe,
+    kj: ActivitySchema.shape.kj,
+  })
+  .strict();
+
+function invalidInput(): never {
+  throw new TrainingHistoryReadError("invalid_input");
+}
+
+function invalidRow(): never {
+  throw new TrainingHistoryReadError("invalid_row");
+}
+
+function absentFact(): RecordedFact<number> {
+  return Object.freeze({ kind: "absent" });
+}
+
+function rejectedFact(reason: RecordedFactRejectionReason): RecordedFact<number> {
+  return Object.freeze({ kind: "rejected", reason });
+}
+
+function recordedFact(value: number): RecordedFact<number> {
+  return Object.freeze({ kind: "recorded", value });
+}
+
+function strictUtf8Length(value: string): number | undefined {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return undefined;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return undefined;
+      bytes += 4;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return undefined;
+    } else if (codeUnit <= 0x7f) {
+      bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes += 2;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function civilDateEpoch(value: unknown): number {
+  if (typeof value !== "string" || !CIVIL_DATE.test(value)) invalidInput();
+  const epoch = Date.parse(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(epoch) || new Date(epoch).toISOString().slice(0, 10) !== value) {
+    invalidInput();
+  }
+  return epoch;
+}
+
+function dateKey(value: string): number {
+  return Number(value.replaceAll("-", ""));
+}
+
+function readInteger(row: Row, key: string): number {
+  const value = row[key];
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) invalidRow();
+  return value;
+}
+
+function readNonnegativeInteger(row: Row, key: string): number {
+  const value = readInteger(row, key);
+  if (value < 0) invalidRow();
+  return value;
+}
+
+function readNullableNonnegativeInteger(row: Row, key: string): number | null {
+  if (row[key] === null) return null;
+  return readNonnegativeInteger(row, key);
+}
+
+function readNullableDistance(row: Row, key: string): number | null {
+  const value = row[key];
+  if (value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 100_000_000) {
+    invalidRow();
+  }
+  return value;
+}
+
+function readFlag(row: Row, key: string): boolean {
+  const value = readInteger(row, key);
+  if (value !== 0 && value !== 1) invalidRow();
+  return value === 1;
+}
+
+function readSessionId(row: Row): string {
+  const value = row.session_key;
+  if (typeof value !== "string" || !SESSION_ID.test(value)) invalidRow();
+  return value;
+}
+
+function readLocalDate(row: Row): string {
+  const value = readNonnegativeInteger(row, "local_date_key");
+  const compact = String(value).padStart(8, "0");
+  if (compact.length !== 8) invalidRow();
+  const candidate = `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
+  const epoch = Date.parse(`${candidate}T00:00:00.000Z`);
+  if (!Number.isFinite(epoch) || new Date(epoch).toISOString().slice(0, 10) !== candidate) {
+    invalidRow();
+  }
+  return candidate;
+}
+
+function readBoundedNullableString(
+  row: Row,
+  key: string,
+  maxBytes: number,
+  allowEmpty: boolean,
+): string | null {
+  const value = row[key];
+  if (value === null) return null;
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) invalidRow();
+  const bytes = strictUtf8Length(value);
+  if (bytes === undefined || bytes > maxBytes) invalidRow();
+  return value;
+}
+
+function overlayTitle(value: string | null): string | null {
+  if (value === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "string") return null;
+  const bytes = strictUtf8Length(parsed);
+  return bytes !== undefined && bytes <= 512 ? parsed : null;
+}
+
+function coreFact(row: Row): CoreFactRow {
+  if (!readFlag(row, "sub_sport_valid")) invalidRow();
+  const startEpochSeconds = readNonnegativeInteger(row, "start_utc");
+  const timezoneOffsetSeconds = row.tz_offset_s === null ? null : readInteger(row, "tz_offset_s");
+  if (
+    timezoneOffsetSeconds !== null &&
+    (timezoneOffsetSeconds < -86_400 || timezoneOffsetSeconds > 86_400)
+  ) {
+    invalidRow();
+  }
+  const overlayValue = readBoundedNullableString(row, "overlay_value_json", 4_096, true);
+  return {
+    id: readSessionId(row),
+    localDate: readLocalDate(row),
+    startEpochSeconds,
+    timezoneOffsetSeconds,
+    subSport: readBoundedNullableString(row, "sub_sport", 128, false),
+    movingSeconds: readNullableNonnegativeInteger(row, "moving_s"),
+    elapsedSeconds: readNullableNonnegativeInteger(row, "elapsed_s"),
+    distanceMeters: readNullableDistance(row, "distance_m"),
+    overlayTitle: overlayTitle(overlayValue),
+    workoutTitle: readBoundedNullableString(row, "workout_name", 512, true),
+  };
+}
+
+function numericFact(
+  value: unknown,
+  schema: SafeParseSchema,
+  valid: (candidate: number) => boolean,
+): RecordedFact<number> {
+  if (value === null || value === undefined) return absentFact();
+  const parsed = schema.safeParse(value);
+  if (
+    !parsed.success ||
+    typeof parsed.data !== "number" ||
+    !Number.isFinite(parsed.data) ||
+    !valid(parsed.data)
+  ) {
+    return rejectedFact("invalid-value");
+  }
+  return recordedFact(parsed.data);
+}
+
+function sourceTitle(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const parsed = ActivitySchema.shape.name.safeParse(value);
+  if (!parsed.success || typeof parsed.data !== "string") return null;
+  const bytes = strictUtf8Length(parsed.data);
+  return bytes !== undefined && bytes <= 512 ? parsed.data : null;
+}
+
+function parsePayloadFacts(payloadJson: string): ParsedPayloadFacts | InvalidPayloadEnvelope {
+  let activity: Readonly<Record<string, unknown>>;
+  try {
+    activity = parseActivityLandingEnvelope(payloadJson).activity;
+  } catch {
+    return { kind: "invalid-envelope" };
+  }
+  const pickedInput = {
+    name: activity.name,
+    icu_training_load: activity.icu_training_load,
+    average_watts: activity.average_watts,
+    average_heartrate: activity.average_heartrate,
+    icu_rpe: activity.icu_rpe,
+    rpe: activity.rpe,
+    kj: activity.kj,
+  };
+  const picked = PICKED_ACTIVITY_SCHEMA.safeParse(pickedInput);
+  const fields = picked.success ? picked.data : pickedInput;
+  const preferredRpe =
+    fields.icu_rpe === null || fields.icu_rpe === undefined ? fields.rpe : fields.icu_rpe;
+  return {
+    kind: "parsed",
+    sourceTitle: sourceTitle(fields.name),
+    load: numericFact(
+      fields.icu_training_load,
+      ActivitySchema.shape.icu_training_load,
+      (value) => value >= 0 && value <= Number.MAX_SAFE_INTEGER,
+    ),
+    averagePowerWatts: numericFact(
+      fields.average_watts,
+      ActivitySchema.shape.average_watts,
+      (value) => value >= 0 && value <= 20_000,
+    ),
+    averageHeartRateBpm: numericFact(
+      fields.average_heartrate,
+      ActivitySchema.shape.average_heartrate,
+      (value) => value > 0 && value <= 500,
+    ),
+    perceivedExertion: numericFact(
+      preferredRpe,
+      preferredRpe === fields.icu_rpe ? ActivitySchema.shape.icu_rpe : ActivitySchema.shape.rpe,
+      (value) => value >= 0 && value <= 10,
+    ),
+    energyKilojoules: numericFact(
+      fields.kj,
+      ActivitySchema.shape.kj,
+      (value) => value >= 0 && value <= Number.MAX_SAFE_INTEGER,
+    ),
+  };
+}
+
+function pendingFact(core: CoreFactRow): PendingFactRow {
+  return {
+    ...core,
+    sourceTitle: null,
+    load: absentFact(),
+    averagePowerWatts: absentFact(),
+    averageHeartRateBpm: absentFact(),
+    perceivedExertion: absentFact(),
+    energyKilojoules: absentFact(),
+  };
+}
+
+function rejectPayloadFacts(row: PendingFactRow, reason: RecordedFactRejectionReason): void {
+  row.load = rejectedFact(reason);
+  row.averagePowerWatts = rejectedFact(reason);
+  row.averageHeartRateBpm = rejectedFact(reason);
+  row.perceivedExertion = rejectedFact(reason);
+  row.energyKilojoules = rejectedFact(reason);
+}
+
+function applyParsedPayload(row: PendingFactRow, parsed: ParsedPayloadFacts): void {
+  row.sourceTitle = parsed.sourceTitle;
+  row.load = parsed.load;
+  row.averagePowerWatts = parsed.averagePowerWatts;
+  row.averageHeartRateBpm = parsed.averageHeartRateBpm;
+  row.perceivedExertion = parsed.perceivedExertion;
+  row.energyKilojoules = parsed.energyKilojoules;
+}
+
+function publicFact(row: PendingFactRow): TrainingHistoryFactRow {
+  return Object.freeze({
+    id: row.id,
+    localDate: row.localDate,
+    startEpochSeconds: row.startEpochSeconds,
+    timezoneOffsetSeconds: row.timezoneOffsetSeconds,
+    subSport: row.subSport,
+    movingSeconds: row.movingSeconds,
+    elapsedSeconds: row.elapsedSeconds,
+    distanceMeters: row.distanceMeters,
+    title: row.overlayTitle ?? row.workoutTitle ?? row.sourceTitle,
+    load: row.load,
+    averagePowerWatts: row.averagePowerWatts,
+    averageHeartRateBpm: row.averageHeartRateBpm,
+    perceivedExertion: row.perceivedExertion,
+    energyKilojoules: row.energyKilojoules,
+  });
+}
+
+async function applyPayloadPage(
+  store: Pick<SqlReadStore, "all">,
+  rows: readonly PendingFactRow[],
+  budget: ParseBudget,
+): Promise<void> {
+  if (budget.exhausted) {
+    for (const row of rows) rejectPayloadFacts(row, "payload-budget-exhausted");
+    return;
+  }
+  const placeholders = rows.map(() => "?").join(", ");
+  const selected = await store.all(
+    `WITH ranked_source AS (
+  SELECT
+    s.session_key,
+    r.payload_json,
+    count(*) OVER (PARTITION BY s.session_key) AS source_count,
+    row_number() OVER (
+      PARTITION BY s.session_key
+      ORDER BY sr.id COLLATE BINARY ASC
+    ) AS source_rank
+  FROM session AS s
+  JOIN source_record AS sr ON sr.session_key = s.session_key
+  JOIN source_record_current AS c ON c.source_record_id = sr.id
+  JOIN source_record_revision AS r
+    ON r.source_record_id = c.source_record_id AND r.revision_id = c.revision_id
+  JOIN source_artifact AS a ON a.artifact_key = r.artifact_key
+  WHERE s.session_key IN (${placeholders})
+    AND sr.source = 'intervals-icu'
+    AND a.source = 'intervals-icu'
+    AND a.lane = 'activities'
+    AND a.external_id = sr.external_id
+)
+SELECT
+  CASE
+    WHEN typeof(session_key) = 'text'
+      AND length(CAST(session_key AS BLOB)) <= 64 THEN session_key
+    ELSE NULL
+  END AS session_key,
+  source_count,
+  CASE WHEN source_count = 1 AND typeof(payload_json) = 'text' THEN 1 ELSE 0 END
+    AS payload_text_valid,
+  CASE
+    WHEN source_count = 1
+      AND typeof(payload_json) = 'text'
+      AND length(CAST(payload_json AS BLOB)) > 65536 THEN 1
+    ELSE 0
+  END AS payload_oversized,
+  CASE
+    WHEN source_count = 1
+      AND typeof(payload_json) = 'text'
+      AND length(CAST(payload_json AS BLOB)) <= 65536
+      THEN length(CAST(payload_json AS BLOB))
+    ELSE NULL
+  END AS payload_bytes,
+  CASE
+    WHEN source_count = 1
+      AND typeof(payload_json) = 'text'
+      AND length(CAST(r.payload_json AS BLOB)) <= 65536 THEN payload_json
+    ELSE NULL
+  END AS payload_json
+FROM ranked_source AS r
+WHERE source_rank = 1
+ORDER BY session_key ASC
+LIMIT 100`,
+    rows.map(({ id }) => id),
+  );
+  if (selected.length > rows.length || selected.length > PAYLOAD_PAGE_SIZE) invalidRow();
+  const expected = new Map(rows.map((row) => [row.id, row]));
+  const resolved = new Map<string, Row>();
+  for (const selectedRow of selected) {
+    const id = readSessionId(selectedRow);
+    if (!expected.has(id) || resolved.has(id)) invalidRow();
+    resolved.set(id, selectedRow);
+  }
+  for (const row of rows) {
+    if (budget.exhausted) {
+      rejectPayloadFacts(row, "payload-budget-exhausted");
+      continue;
+    }
+    const payloadRow = resolved.get(row.id);
+    if (payloadRow === undefined) continue;
+    const sourceCount = readNonnegativeInteger(payloadRow, "source_count");
+    if (sourceCount < 1) invalidRow();
+    if (sourceCount > 1) {
+      rejectPayloadFacts(row, "ambiguous-source");
+      continue;
+    }
+    const textValid = readFlag(payloadRow, "payload_text_valid");
+    const oversized = readFlag(payloadRow, "payload_oversized");
+    if (!textValid) {
+      rejectPayloadFacts(row, "invalid-envelope");
+      continue;
+    }
+    if (oversized) {
+      if (payloadRow.payload_bytes !== null || payloadRow.payload_json !== null) invalidRow();
+      rejectPayloadFacts(row, "oversized-payload");
+      continue;
+    }
+    const payloadBytes = readNonnegativeInteger(payloadRow, "payload_bytes");
+    if (payloadBytes > PAYLOAD_ROW_BYTES || typeof payloadRow.payload_json !== "string")
+      invalidRow();
+    const measured = strictUtf8Length(payloadRow.payload_json);
+    if (measured === undefined || measured !== payloadBytes) invalidRow();
+    if (budget.bytes + payloadBytes > PAYLOAD_PROJECTION_BYTES) {
+      budget.exhausted = true;
+      rejectPayloadFacts(row, "payload-budget-exhausted");
+      continue;
+    }
+    budget.bytes += payloadBytes;
+    const parsed = parsePayloadFacts(payloadRow.payload_json);
+    if (parsed.kind === "invalid-envelope") {
+      rejectPayloadFacts(row, "invalid-envelope");
+    } else {
+      applyParsedPayload(row, parsed);
+    }
+  }
+}
+
+async function applyPayloads(
+  store: Pick<SqlReadStore, "all">,
+  rows: readonly PendingFactRow[],
+  budget: ParseBudget,
+): Promise<void> {
+  for (let index = 0; index < rows.length; index += PAYLOAD_PAGE_SIZE) {
+    await applyPayloadPage(store, rows.slice(index, index + PAYLOAD_PAGE_SIZE), budget);
+  }
+}
+
+export function createTrainingHistoryReader(
+  store: Pick<SqlReadStore, "all">,
+): TrainingHistoryReader {
+  return {
+    async readWindow(input) {
+      if (input === null || typeof input !== "object") invalidInput();
+      const startEpoch = civilDateEpoch(input.start);
+      const endEpoch = civilDateEpoch(input.end);
+      if (startEpoch > endEpoch) invalidInput();
+      const startKey = dateKey(input.start);
+      const endKey = dateKey(input.end);
+      const facts: TrainingHistoryFactRow[] = [];
+      const budget: ParseBudget = { bytes: 0, exhausted: false };
+      let cursor: { readonly startEpochSeconds: number; readonly id: string } | undefined;
+      let scanTruncated = false;
+      while (facts.length < SESSION_LIMIT) {
+        const cursorSql =
+          cursor === undefined
+            ? ""
+            : "\n  AND (s.start_utc < ? OR (s.start_utc = ? AND s.session_key > ?))";
+        const params =
+          cursor === undefined
+            ? [startKey, endKey, CORE_PAGE_SIZE + 1]
+            : [
+                startKey,
+                endKey,
+                cursor.startEpochSeconds,
+                cursor.startEpochSeconds,
+                cursor.id,
+                CORE_PAGE_SIZE + 1,
+              ];
+        const selected = await store.all(
+          `SELECT
+  CASE
+    WHEN typeof(s.session_key) = 'text'
+      AND length(CAST(s.session_key AS BLOB)) <= 64 THEN s.session_key
+    ELSE NULL
+  END AS session_key,
+  CASE
+    WHEN typeof(s.sub_sport) = 'text'
+      AND length(CAST(s.sub_sport AS BLOB)) <= 128 THEN s.sub_sport
+    ELSE NULL
+  END AS sub_sport,
+  CASE
+    WHEN s.sub_sport IS NULL
+      OR (
+        typeof(s.sub_sport) = 'text'
+        AND length(CAST(s.sub_sport AS BLOB)) <= 128
+      ) THEN 1
+    ELSE 0
+  END AS sub_sport_valid,
+  s.start_utc,
+  s.tz_offset_s,
+  s.local_date_key,
+  s.elapsed_s,
+  s.moving_s,
+  s.distance_m,
+  CASE
+    WHEN typeof(w.name) = 'text'
+      AND length(CAST(w.name AS BLOB)) <= 512 THEN w.name
+    ELSE NULL
+  END AS workout_name,
+  CASE
+    WHEN typeof(o.override_value_json) = 'text'
+      AND length(CAST(o.override_value_json AS BLOB)) <= 4096 THEN o.override_value_json
+    ELSE NULL
+  END AS overlay_value_json
+FROM session AS s
+JOIN workout AS w ON w.workout_key = s.workout_key
+LEFT JOIN field_merge_override_overlay AS o
+  ON o.target_table = 'workout'
+  AND o.target_key = s.workout_key
+  AND o.field_name = 'name'
+WHERE s.local_date_key BETWEEN ? AND ?
+  AND s.sport = 'cycling'
+  AND s.is_transition = 0${cursorSql}
+ORDER BY s.start_utc DESC, s.session_key ASC
+LIMIT ?`,
+          params,
+        );
+        if (selected.length > CORE_PAGE_SIZE + 1) invalidRow();
+        const mapped = selected.map(coreFact);
+        let boundary = cursor;
+        for (const row of mapped) {
+          if (row.localDate < input.start || row.localDate > input.end) invalidRow();
+          if (
+            boundary !== undefined &&
+            !(
+              row.startEpochSeconds < boundary.startEpochSeconds ||
+              (row.startEpochSeconds === boundary.startEpochSeconds && row.id > boundary.id)
+            )
+          ) {
+            invalidRow();
+          }
+          boundary = { startEpochSeconds: row.startEpochSeconds, id: row.id };
+        }
+        const page = mapped.slice(0, CORE_PAGE_SIZE).map(pendingFact);
+        await applyPayloads(store, page, budget);
+        facts.push(...page.map(publicFact));
+        if (facts.length === SESSION_LIMIT && mapped.length > CORE_PAGE_SIZE) {
+          scanTruncated = true;
+          break;
+        }
+        if (mapped.length <= CORE_PAGE_SIZE) break;
+        const last = page.at(-1);
+        if (last === undefined) invalidRow();
+        cursor = { startEpochSeconds: last.startEpochSeconds, id: last.id };
+      }
+      return Object.freeze({ rows: Object.freeze(facts), scanTruncated });
+    },
+  };
+}

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -88,6 +88,8 @@ const EXPECTED_FULL_TABLES = [
   "chat_attachment_draft",
   "chat_attachment_draft_ref",
   "chat_message_attachment",
+  "training_history_coverage_commit",
+  "training_history_backfill_checkpoint",
 ];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
@@ -226,6 +228,7 @@ describe("001_init migration", () => {
       { version: 27, name: "027_chat_plan_outbox" },
       { version: 28, name: "028_plan_workout_additions" },
       { version: 29, name: "029_planning_domain" },
+      { version: 30, name: "030_training_history_coverage" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -317,7 +320,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies all migrations with exactly seventy-nine tables and no foreign-key violations", () => {
+  it("applies all migrations with exactly eighty-one tables and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -327,7 +330,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(79);
+    expect(names).toHaveLength(81);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -607,6 +610,10 @@ describe("001_init migration", () => {
         "chat_plan_outbox_no_delete",
         "chat_plan_outbox_cancelled_no_update",
         "chat_plan_outbox_detached_delivered_no_update",
+        "training_history_coverage_commit_no_update",
+        "training_history_coverage_commit_no_delete",
+        "training_history_backfill_checkpoint_no_update",
+        "training_history_backfill_checkpoint_no_delete",
       ]),
     );
 
@@ -1248,5 +1255,75 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       "hlc_physical_ms",
       "hlc_counter",
     ]);
+  });
+
+  it("creates exact strict append-only training history coverage evidence", () => {
+    db = openFull();
+    expect(createHash("sha256").update(MIGRATIONS[29]!.sql).digest("hex")).toBe(
+      "dd4521e15d135335fdc2b119390a90767d85ad6211660c639ef4dbfe78cf6818",
+    );
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{
+      name: string;
+      strict: number;
+    }>;
+    for (const name of [
+      "training_history_coverage_commit",
+      "training_history_backfill_checkpoint",
+    ]) {
+      expect(tables.find((row) => row.name === name)?.strict).toBe(1);
+      expect(db.prepare(`PRAGMA foreign_key_list(${name})`).all()).toEqual([]);
+      expect(PURE_AUTHORED_TABLES).not.toContain(name as never);
+      expect(MIXED_AUTHORED_TABLES).not.toContain(name as never);
+      expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain(name);
+    }
+    db.prepare(
+      `INSERT INTO training_history_coverage_commit (
+  source, lane, authority_kind, authority_id, calendar_timezone,
+  covered_oldest_date_key, covered_newest_date_key, committed_epoch_seconds, gap_state
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "intervals-icu",
+      "activities",
+      "reference-capture",
+      "12345678-1234-4123-8123-123456789abc",
+      "Asia/Almaty",
+      19980413,
+      19980706,
+      899_712_000,
+      "none",
+    );
+    db.prepare(
+      `INSERT INTO training_history_backfill_checkpoint (
+  authority_id, source_cycle, page_ordinal, requested_oldest_key, requested_newest_key,
+  calendar_timezone, cursor_after, dropped_source_restricted, dropped_other, terminal
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "12345678-1234-4123-8123-123456789abc",
+      12345,
+      0,
+      19980413,
+      19980706,
+      "Asia/Almaty",
+      "cursor:12345",
+      0,
+      0,
+      0,
+    );
+    expect(() =>
+      db!
+        .prepare("UPDATE training_history_coverage_commit SET gap_state='undated-dropped-rows'")
+        .run(),
+    ).toThrow(/append-only/);
+    expect(() => db!.prepare("DELETE FROM training_history_coverage_commit").run()).toThrow(
+      /append-only/,
+    );
+    expect(() =>
+      db!.prepare("UPDATE training_history_backfill_checkpoint SET terminal=1").run(),
+    ).toThrow(/append-only/);
+    expect(() => db!.prepare("DELETE FROM training_history_backfill_checkpoint").run()).toThrow(
+      /append-only/,
+    );
+    expect(DUMP_TABLES).toHaveLength(69);
+    expect(DERIVED_TABLES).toHaveLength(12);
   });
 });

--- a/packages/kernel/tests/reference-capture.test.ts
+++ b/packages/kernel/tests/reference-capture.test.ts
@@ -8,6 +8,7 @@ import {
   createReferenceCapturePlan,
   parseReferenceCaptureManifest,
   parseReferenceCapturePlan,
+  planCalendarTimeZone,
   selectReferenceCaptureStreamIds,
   serializeReferenceCaptureManifest,
   serializeReferenceCapturePlan,
@@ -30,7 +31,7 @@ const hashKey = async (fields: readonly (string | number)[]): Promise<string> =>
 function snapshot() { return { address: ADDRESS, rel_path: `1998/07/${ADDRESS}.json.gz` }; }
 
 function manifest(): ReferenceCaptureManifest {
-  const plan = createReferenceCapturePlan(NOW);
+  const plan = createReferenceCapturePlan({ now: NOW, calendarTimeZone: "UTC" });
   return validateReferenceCaptureManifest({
     schema_version: 1, capture_id: CAPTURE_ID, source: "external-oracle", plan,
     operation_ledger: { link_kind: "capture-id", capture_id: CAPTURE_ID },
@@ -62,14 +63,40 @@ function manifest(): ReferenceCaptureManifest {
 }
 
 describe("Reference capture plan and manifest", () => {
+  it("round-trips a stored v1 plan through canonical JSON without adding a timezone", () => {
+    const stored = {
+      capture_epoch_ms: NOW.getTime(),
+      frozenNow: "1998-07-18T12:34:56",
+      stream_cutoff_epoch_ms: NOW.getTime() - 21 * 86_400_000,
+      window: { newest: "1998-07-18", oldest: "1998-04-25" },
+    };
+    const bytes = `${canonicalJson(stored)}\n`;
+    const parsed = parseReferenceCapturePlan(bytes);
+    expect(canonicalJson(parsed)).toBe(canonicalJson(stored));
+    expect(Object.hasOwn(parsed, "calendar_timezone")).toBe(false);
+    expect(planCalendarTimeZone(parsed)).toBe("UTC");
+  });
+
   it("owns one clock and exact canonical bytes", () => {
-    const plan = createReferenceCapturePlan(NOW);
+    const plan = createReferenceCapturePlan({ now: NOW, calendarTimeZone: "UTC" });
     expect(plan.capture_epoch_ms).toBe(NOW.getTime());
     expect(plan.stream_cutoff_epoch_ms).toBe(NOW.getTime() - 21 * 86_400_000);
     expect(plan.frozenNow).toMatch(/^1998-07-18T/);
     expect(parseReferenceCapturePlan(serializeReferenceCapturePlan(plan))).toEqual(plan);
-    expect(() => createReferenceCapturePlan(new Date(Number.NaN))).toThrow();
+    expect(() =>
+      createReferenceCapturePlan({ now: new Date(Number.NaN), calendarTimeZone: "UTC" }),
+    ).toThrow();
     expect(() => parseReferenceCapturePlan(`${serializeReferenceCapturePlan(plan)} `)).toThrow();
+  });
+
+  it("uses the requested calendar timezone for the civil capture window", () => {
+    const now = new Date("1998-07-18T20:30:00.000Z");
+    const utc = createReferenceCapturePlan({ now, calendarTimeZone: "UTC" });
+    const almaty = createReferenceCapturePlan({ now, calendarTimeZone: "Asia/Almaty" });
+    expect(utc.window).toEqual({ oldest: "1998-04-25", newest: "1998-07-18" });
+    expect(almaty.window).toEqual({ oldest: "1998-04-26", newest: "1998-07-19" });
+    expect(almaty.frozenNow).toBe("1998-07-19T03:30:00");
+    expect(planCalendarTimeZone(almaty)).toBe("Asia/Almaty");
   });
 
   it("strictly validates every manifest object and exact bytes", () => {
@@ -83,7 +110,7 @@ describe("Reference capture plan and manifest", () => {
   });
 
   it("selects by parsed time then encounter index without key ordering", () => {
-    const plan = createReferenceCapturePlan(NOW);
+    const plan = createReferenceCapturePlan({ now: NOW, calendarTimeZone: "UTC" });
     const same = new Date(plan.capture_epoch_ms - 1_000).toISOString();
     expect(selectReferenceCaptureStreamIds([
       { id: "z", type: "Ride", start_date_local: same },

--- a/packages/kernel/tests/training-history-coverage.test.ts
+++ b/packages/kernel/tests/training-history-coverage.test.ts
@@ -90,6 +90,49 @@ describe("training history coverage", () => {
     );
   });
 
+  it("appends and resumes an exact backfill page checkpoint", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+    const cursorAfter = JSON.stringify({
+      v: 1,
+      cycle: 7,
+      window_start: "1998-01-01",
+      window_end: "1998-07-18",
+      last_key: "1998-07-17T12:00:00Z\u001fsynthetic",
+      complete: false,
+    });
+    const checkpoint = {
+      authorityId: "synthetic-backfill-cycle",
+      sourceCycle: 7,
+      pageOrdinal: 0,
+      requestedOldest: "1998-01-01",
+      requestedNewest: "1998-07-18",
+      calendarTimeZone: "Asia/Almaty",
+      cursorAfter,
+      droppedSourceRestricted: 2,
+      droppedOther: 1,
+      terminal: false,
+    } as const;
+
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, checkpoint),
+    ).resolves.toEqual({ kind: "inserted", checkpointId: 1 });
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, checkpoint),
+    ).resolves.toEqual({ kind: "already-recorded", checkpointId: 1 });
+    await expect(
+      repository.readBackfillCheckpoint(store, { sourceCycle: 7, cursorAfter }),
+    ).resolves.toEqual({ checkpointId: 1, ...checkpoint });
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, {
+        ...checkpoint,
+        droppedOther: 2,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+  });
+
   it("enforces append-only commit and checkpoint rows", async () => {
     const store = openStore();
     await createTrainingCoverageRepository().appendCommitInTransaction(store, commit);

--- a/packages/kernel/tests/training-history-coverage.test.ts
+++ b/packages/kernel/tests/training-history-coverage.test.ts
@@ -1,0 +1,153 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createTrainingCoverageReader,
+  createTrainingCoverageRepository,
+  type CoverageCommitInput,
+  type Row,
+  type SqlStore,
+} from "../src/store/index.js";
+import { MIGRATIONS } from "../src/store/migrations/index.js";
+
+const CAPTURE_ID = "12345678-1234-4123-8123-123456789abc";
+
+const commit: CoverageCommitInput = {
+  source: "intervals-icu",
+  lane: "activities",
+  authorityKind: "reference-capture",
+  authorityId: CAPTURE_ID,
+  calendarTimeZone: "Asia/Almaty",
+  coveredOldest: "1998-04-13",
+  coveredNewest: "1998-07-06",
+  committedEpochSeconds: 899_712_000,
+  gapState: "none",
+};
+
+describe("training history coverage", () => {
+  let database: DatabaseSync | undefined;
+
+  afterEach(() => {
+    database?.close();
+    database = undefined;
+  });
+
+  function openStore(): SqlStore {
+    database = new DatabaseSync(":memory:");
+    database.exec("PRAGMA foreign_keys = ON");
+    for (const migration of MIGRATIONS) database.exec(migration.sql);
+    return {
+      async exec(sql) {
+        database!.exec(sql);
+      },
+      async run(sql, params = []) {
+        database!.prepare(sql).run(...params);
+      },
+      async get(sql, params = []) {
+        const row = database!.prepare(sql).get(...params);
+        return row === undefined ? undefined : ({ ...row } as Row);
+      },
+      async all(sql, params = []) {
+        return database!
+          .prepare(sql)
+          .all(...params)
+          .map((row) => ({ ...row }) as Row);
+      },
+      async close() {
+        database!.close();
+      },
+    };
+  }
+
+  it("converges identical authority replay and exposes the original commit id", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+
+    await expect(repository.appendCommitInTransaction(store, commit)).resolves.toEqual({
+      kind: "inserted",
+      commitId: 1,
+    });
+    await expect(repository.appendCommitInTransaction(store, commit)).resolves.toEqual({
+      kind: "already-recorded",
+      commitId: 1,
+    });
+    expect(
+      database!.prepare("SELECT count(*) AS count FROM training_history_coverage_commit").get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("throws authority_conflict when replay changes one stored field", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+    await repository.appendCommitInTransaction(store, commit);
+
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        coveredNewest: "1998-07-07",
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+  });
+
+  it("enforces append-only commit and checkpoint rows", async () => {
+    const store = openStore();
+    await createTrainingCoverageRepository().appendCommitInTransaction(store, commit);
+    database!
+      .prepare(
+        `INSERT INTO training_history_backfill_checkpoint (
+  authority_id, source_cycle, page_ordinal, requested_oldest_key, requested_newest_key,
+  calendar_timezone, cursor_after, dropped_source_restricted, dropped_other, terminal
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(CAPTURE_ID, 12345, 0, 19980413, 19980706, "Asia/Almaty", "cursor:12345", 0, 0, 0);
+
+    expect(() =>
+      database!
+        .prepare("UPDATE training_history_coverage_commit SET gap_state='undated-dropped-rows'")
+        .run(),
+    ).toThrow(/append-only/);
+    expect(() => database!.prepare("DELETE FROM training_history_coverage_commit").run()).toThrow(
+      /append-only/,
+    );
+    expect(() =>
+      database!.prepare("UPDATE training_history_backfill_checkpoint SET terminal=1").run(),
+    ).toThrow(/append-only/);
+    expect(() =>
+      database!.prepare("DELETE FROM training_history_backfill_checkpoint").run(),
+    ).toThrow(/append-only/);
+  });
+
+  it("lists commits by commit time and then id ascending", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+    await repository.appendCommitInTransaction(store, {
+      ...commit,
+      authorityId: "capture-later-12345",
+      committedEpochSeconds: 899_712_100,
+    });
+    await repository.appendCommitInTransaction(store, {
+      ...commit,
+      authorityKind: "activity-backfill",
+      authorityId: "backfill-earlier-12345",
+      committedEpochSeconds: 899_712_000,
+    });
+    await repository.appendCommitInTransaction(store, {
+      ...commit,
+      authorityId: "capture-same-time-12345",
+      committedEpochSeconds: 899_712_000,
+    });
+
+    const rows = await createTrainingCoverageReader(store).listCommits({
+      source: "intervals-icu",
+      lane: "activities",
+    });
+
+    expect(rows.map(({ authorityId }) => authorityId)).toEqual([
+      "backfill-earlier-12345",
+      "capture-same-time-12345",
+      "capture-later-12345",
+    ]);
+    expect(rows.map(({ coverageCommitId }) => coverageCommitId)).toEqual([2, 3, 1]);
+  });
+});

--- a/packages/kernel/tests/training-history-reader.test.ts
+++ b/packages/kernel/tests/training-history-reader.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+import { canonicalJson } from "../src/archive/canonical.js";
+import {
+  TrainingHistoryReadError,
+  createTrainingHistoryReader,
+  type RecordedFact,
+  type Row,
+  type SqlReadStore,
+  type SqlValue,
+} from "../src/store/index.js";
+
+const SESSION_A = "a".repeat(64);
+const SESSION_B = "b".repeat(64);
+const SESSION_C = "c".repeat(64);
+const SESSION_D = "d".repeat(64);
+const SESSION_E = "e".repeat(64);
+const SESSION_F = "f".repeat(64);
+const SESSION_G = "1".repeat(64);
+const SESSION_H = "2".repeat(64);
+
+interface PayloadRowFixture extends Row {
+  readonly session_key: string;
+  readonly source_count: number;
+  readonly payload_text_valid: number;
+  readonly payload_oversized: number;
+  readonly payload_bytes: number | null;
+  readonly payload_json: string | null;
+}
+
+function activityPayload(activity: Readonly<Record<string, unknown>>): string {
+  return canonicalJson({ activity, concerns: {}, dedup: {}, schema_version: 1 });
+}
+
+function payloadRow(sessionKey: string, payloadJson: string): PayloadRowFixture {
+  return {
+    session_key: sessionKey,
+    source_count: 1,
+    payload_text_valid: 1,
+    payload_oversized: 0,
+    payload_bytes: new TextEncoder().encode(payloadJson).byteLength,
+    payload_json: payloadJson,
+  };
+}
+
+function coreRow(
+  sessionKey: string,
+  startUtc: number,
+  input: {
+    readonly overlay?: string | null;
+    readonly workoutName?: string | null;
+  } = {},
+) {
+  return {
+    session_key: sessionKey,
+    sub_sport: "road",
+    sub_sport_valid: 1,
+    start_utc: startUtc,
+    tz_offset_s: 21_600,
+    local_date_key: 19980706,
+    elapsed_s: 3_700,
+    moving_s: 3_600,
+    distance_m: 30_000,
+    workout_name: input.workoutName ?? null,
+    overlay_value_json: input.overlay ?? null,
+  };
+}
+
+class WindowStore implements Pick<SqlReadStore, "all"> {
+  readonly calls: Array<{ readonly sql: string; readonly params: readonly unknown[] }> = [];
+  readonly corePages: Array<readonly ReturnType<typeof coreRow>[]>;
+  readonly payloadRows: ReadonlyMap<string, PayloadRowFixture>;
+
+  constructor(input: {
+    readonly corePages: Array<readonly ReturnType<typeof coreRow>[]>;
+    readonly payloadRows?: readonly PayloadRowFixture[];
+  }) {
+    this.corePages = [...input.corePages];
+    this.payloadRows = new Map(
+      (input.payloadRows ?? []).map((row) => [String(row.session_key), row]),
+    );
+  }
+
+  async all(sql: string, params: readonly SqlValue[] = []): Promise<Row[]> {
+    this.calls.push({ sql, params });
+    if (sql.includes("FROM session AS s") && !sql.includes("source_record_revision")) {
+      return [...(this.corePages.shift() ?? [])];
+    }
+    if (sql.includes("source_record_revision")) {
+      return params.flatMap((value) => {
+        const row = this.payloadRows.get(String(value));
+        return row === undefined ? [] : [row];
+      });
+    }
+    throw new Error(`unexpected SQL: ${sql}`);
+  }
+}
+
+function rejected(reason: Extract<RecordedFact<number>, { kind: "rejected" }>["reason"]) {
+  return { kind: "rejected", reason };
+}
+
+describe("training history reader", () => {
+  it("resolves title precedence and preserves localized RecordedFact outcomes", async () => {
+    const valid = {
+      id: 12345,
+      name: "Source title",
+      start_date_local: "1998-07-06T08:00:00",
+      type: "Ride",
+      moving_time: 3_600,
+      elapsed_time: 3_700,
+      icu_training_load: 75,
+      average_watts: 205,
+      average_heartrate: 142,
+      icu_rpe: 7,
+      rpe: 6,
+      kj: 900,
+    };
+    const invalidValue = activityPayload({
+      ...valid,
+      name: null,
+      icu_training_load: -1,
+      average_heartrate: null,
+      icu_rpe: null,
+      rpe: null,
+      kj: undefined,
+    });
+    const payloads = [
+      payloadRow(SESSION_A, activityPayload(valid)),
+      payloadRow(SESSION_B, activityPayload({ ...valid, name: "Ignored source title" })),
+      payloadRow(SESSION_C, activityPayload({ ...valid, name: "Typed source title" })),
+      {
+        session_key: SESSION_D,
+        source_count: 2,
+        payload_text_valid: 0,
+        payload_oversized: 0,
+        payload_bytes: null,
+        payload_json: null,
+      },
+      {
+        session_key: SESSION_E,
+        source_count: 1,
+        payload_text_valid: 1,
+        payload_oversized: 1,
+        payload_bytes: null,
+        payload_json: null,
+      },
+      payloadRow(SESSION_F, "not-json"),
+      payloadRow(SESSION_G, invalidValue),
+    ];
+    const store = new WindowStore({
+      corePages: [
+        [
+          coreRow(SESSION_A, 900, {
+            overlay: canonicalJson("Athlete title"),
+            workoutName: "Workout title",
+          }),
+          coreRow(SESSION_B, 900, { workoutName: "Workout title" }),
+          coreRow(SESSION_C, 800),
+          coreRow(SESSION_D, 700),
+          coreRow(SESSION_E, 600),
+          coreRow(SESSION_F, 500),
+          coreRow(SESSION_G, 400),
+          coreRow(SESSION_H, 300),
+        ],
+      ],
+      payloadRows: payloads,
+    });
+
+    const result = await createTrainingHistoryReader(store).readWindow({
+      start: "1998-07-06",
+      end: "1998-07-12",
+    });
+
+    expect(result.rows.map(({ id }) => id)).toEqual([
+      SESSION_A,
+      SESSION_B,
+      SESSION_C,
+      SESSION_D,
+      SESSION_E,
+      SESSION_F,
+      SESSION_G,
+      SESSION_H,
+    ]);
+    expect(result.rows.slice(0, 3).map(({ title }) => title)).toEqual([
+      "Athlete title",
+      "Workout title",
+      "Typed source title",
+    ]);
+    expect(result.rows[0]!.load).toEqual({ kind: "recorded", value: 75 });
+    expect(result.rows[0]!.perceivedExertion).toEqual({ kind: "recorded", value: 7 });
+    expect(result.rows[1]!.load).toEqual({ kind: "recorded", value: 75 });
+    expect(result.rows[3]!.load).toEqual(rejected("ambiguous-source"));
+    expect(result.rows[4]!.load).toEqual(rejected("oversized-payload"));
+    expect(result.rows[5]!.load).toEqual(rejected("invalid-envelope"));
+    expect(result.rows[6]!.load).toEqual(rejected("invalid-value"));
+    expect(result.rows[6]!.averagePowerWatts).toEqual({ kind: "recorded", value: 205 });
+    expect(result.rows[6]!.averageHeartRateBpm).toEqual({ kind: "absent" });
+    expect(result.rows[6]!.perceivedExertion).toEqual({ kind: "absent" });
+    expect(result.rows[6]!.energyKilojoules).toEqual({ kind: "absent" });
+    expect(result.rows[7]!.load).toEqual({ kind: "absent" });
+    expect(result.rows[0]!.subSport).toBe("road");
+    expect(result.scanTruncated).toBe(false);
+    expect(store.calls[0]!.sql).toContain("ORDER BY s.start_utc DESC, s.session_key ASC");
+    expect(store.calls[0]!.params.at(-1)).toBe(201);
+    expect(store.calls[1]!.sql).toContain("length(CAST(r.payload_json AS BLOB)) <= 65536");
+    expect(store.calls[1]!.params).toHaveLength(8);
+    expect(JSON.stringify(result)).not.toContain("payload_json");
+    expect(JSON.stringify(result)).not.toContain("providerActivityId");
+  });
+
+  it("returns exactly 1000 safely scanned rows and reports a 1001st match", async () => {
+    const allRows = Array.from({ length: 1_001 }, (_, index) =>
+      coreRow(index.toString(16).padStart(64, "0"), 20_000 - index),
+    );
+    const store = new WindowStore({
+      corePages: [
+        allRows.slice(0, 201),
+        allRows.slice(200, 401),
+        allRows.slice(400, 601),
+        allRows.slice(600, 801),
+        allRows.slice(800, 1_001),
+      ],
+    });
+
+    const result = await createTrainingHistoryReader(store).readWindow({
+      start: "1998-07-06",
+      end: "1998-07-12",
+    });
+
+    expect(result.rows).toHaveLength(1_000);
+    expect(result.scanTruncated).toBe(true);
+    expect(result.rows[0]!.startEpochSeconds).toBe(20_000);
+    expect(result.rows.at(-1)!.startEpochSeconds).toBe(19_001);
+  });
+
+  it("parses exactly 16 MiB and rejects every later payload fact", async () => {
+    const baseActivity = {
+      id: 12345,
+      name: "Budget title",
+      start_date_local: "1998-07-06T08:00:00",
+      type: "Ride",
+      moving_time: 3_600,
+      elapsed_time: 3_700,
+      icu_training_load: 75,
+      padding: "",
+    };
+    const emptyPayload = activityPayload(baseActivity);
+    const payload = activityPayload({
+      ...baseActivity,
+      padding: "x".repeat(65_536 - new TextEncoder().encode(emptyPayload).byteLength),
+    });
+    expect(new TextEncoder().encode(payload).byteLength).toBe(65_536);
+    const rows = Array.from({ length: 258 }, (_, index) =>
+      coreRow(index.toString(16).padStart(64, "0"), 20_000 - index),
+    );
+    const store = new WindowStore({
+      corePages: [rows.slice(0, 201), rows.slice(200)],
+      payloadRows: rows.map((row) => payloadRow(String(row.session_key), payload)),
+    });
+
+    const result = await createTrainingHistoryReader(store).readWindow({
+      start: "1998-07-06",
+      end: "1998-07-12",
+    });
+
+    expect(result.rows[255]!.load).toEqual({ kind: "recorded", value: 75 });
+    expect(result.rows[256]!.load).toEqual(rejected("payload-budget-exhausted"));
+    expect(result.rows[257]!.load).toEqual(rejected("payload-budget-exhausted"));
+    const payloadCalls = store.calls.filter(({ sql }) => sql.includes("source_record_revision"));
+    expect(payloadCalls).toHaveLength(3);
+    expect(payloadCalls.every(({ params }) => params.length <= 100)).toBe(true);
+  });
+
+  it("rejects invalid windows with a typed closed-code error", async () => {
+    const store = new WindowStore({ corePages: [] });
+    await expect(
+      createTrainingHistoryReader(store).readWindow({
+        start: "1998-07-12",
+        end: "1998-07-06",
+      }),
+    ).rejects.toEqual(new TrainingHistoryReadError("invalid_input"));
+    expect(store.calls).toEqual([]);
+  });
+});

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -2,7 +2,6 @@ import { canonicalJson, type ArchiveInstant, type ArchiveWriteResult } from "@en
 import type { HttpRequest, HttpResponse } from "@enduragent/kernel/ports";
 import {
   REFERENCE_CAPTURE_STREAM_TYPES,
-  createReferenceCapturePlan,
   selectReferenceCaptureStreamIds,
   validateReferenceCapturePlan,
   type DerivedCaptureMember,
@@ -521,8 +520,11 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
     });
   }
 
-  async function captureReference(now: Date, budget: SyncBudget): Promise<ReferenceCaptureBatch> {
-    const plan = createReferenceCapturePlan(now);
+  async function captureReference(
+    inputPlan: ReferenceCapturePlan,
+    budget: SyncBudget,
+  ): Promise<ReferenceCaptureBatch> {
+    const plan = validateReferenceCapturePlan(inputPlan);
     const requester = createRequester({
       http: options.httpFactory({ outer: budget.signal, perRequestTimeoutMs: budget.perRequestTimeoutMs }),
       budget,

--- a/packages/sync-intervals-icu/src/types.ts
+++ b/packages/sync-intervals-icu/src/types.ts
@@ -101,7 +101,7 @@ export interface IntervalsIcuSource extends SyncSource {
 }
 
 export interface IntervalsIcuCaptureSource extends IntervalsIcuSource {
-  captureReference(now: Date, budget: SyncBudget): Promise<ReferenceCaptureBatch>;
+  captureReference(plan: ReferenceCapturePlan, budget: SyncBudget): Promise<ReferenceCaptureBatch>;
   deriveReferenceCaptureMembers(
     plan: ReferenceCapturePlan,
     endpointPayloads: readonly ReferenceCaptureEndpointPayload[],

--- a/packages/sync-intervals-icu/tests/capture.test.ts
+++ b/packages/sync-intervals-icu/tests/capture.test.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 import { canonicalJson } from "@enduragent/kernel/archive";
+import { createReferenceCapturePlan } from "@enduragent/kernel/reference/capture";
 import type { SyncBudget } from "@enduragent/kernel/store";
 import { describe, expect, it } from "vitest";
 import { createIntervalsIcuSource } from "../src/source.js";
 
 const NOW = new Date("1998-07-18T12:00:00.000Z");
+const PLAN = createReferenceCapturePlan({ now: NOW, calendarTimeZone: "UTC" });
 const PROFILE = { sportSettings: [{ id: 7, athlete_id: "synthetic-athlete", types: ["Ride"], updated: "1998-07-01T00:00:00.000Z", ftp: 250 }] };
 const ACTIVITY = { id: 42, type: "Ride", start_date: "1998-07-17T10:00:00.000Z",
   start_date_local: "1998-07-17T12:00:00", moving_time: 3600, elapsed_time: 3700, distance: 40_000 };
@@ -40,8 +42,21 @@ function fixture(stream: unknown = { time: [0, 1], watts: [200, 210] }, activiti
 }
 
 describe("captureReference", () => {
+  it("uses the caller plan's non-UTC civil window for both ranged endpoints", async () => {
+    const value = fixture();
+    const plan = createReferenceCapturePlan({
+      now: new Date("1998-07-18T20:30:00.000Z"),
+      calendarTimeZone: "Asia/Almaty",
+    });
+
+    await value.source.captureReference(plan, budget());
+
+    expect(value.requests[1]).toContain("oldest=1998-04-26&newest=1998-07-19");
+    expect(value.requests[2]).toContain("oldest=1998-04-26&newest=1998-07-19");
+  });
+
   it("fetches exact endpoints in selector order and archives whole/member evidence after fetch", async () => {
-    const value = fixture(), batch = await value.source.captureReference(NOW, budget());
+    const value = fixture(), batch = await value.source.captureReference(PLAN, budget());
     expect(value.requests).toHaveLength(4);
     expect(value.requests[0]).toMatch(/\/api\/v1\/athlete\/synthetic-athlete$/);
     expect(value.requests[1]).toContain("/activities?oldest=");
@@ -62,19 +77,19 @@ describe("captureReference", () => {
     const foreign = { id: "9002", icu_athlete_id: "i12345", start_date_local: "1998-07-17T14:09:41", source: "GARMIN_CONNECT" };
     const value = fixture({ time: [0, 1], watts: [200, 210] }, [ACTIVITY, stub, foreign]);
 
-    const batch = await value.source.captureReference(NOW, budget());
+    const batch = await value.source.captureReference(PLAN, budget());
 
     expect(batch.records.activities).toHaveLength(1);
     expect(batch.dropped_activity_rows).toEqual({ sourceRestricted: 1, other: 1 });
   });
 
   it("reports no dropped activity rows for a clean capture", async () => {
-    const batch = await fixture().source.captureReference(NOW, budget());
+    const batch = await fixture().source.captureReference(PLAN, budget());
     expect(batch.dropped_activity_rows).toEqual({ sourceRestricted: 0, other: 0 });
   });
 
   it("omits malformed stream responses without omitting required lanes", async () => {
-    const value = fixture("invalid"), batch = await value.source.captureReference(NOW, budget());
+    const value = fixture("invalid"), batch = await value.source.captureReference(PLAN, budget());
     expect(batch.selected_stream_ids).toEqual(["42"]);
     expect(batch.captured_stream_ids).toEqual([]);
     expect(batch.endpoints).toHaveLength(3);
@@ -83,13 +98,13 @@ describe("captureReference", () => {
 
   it("reserves every selected stream artifact before requests or archives", async () => {
     const value = fixture();
-    await expect(value.source.captureReference(NOW, budget(6))).rejects.toThrow();
+    await expect(value.source.captureReference(PLAN, budget(6))).rejects.toThrow();
     expect(value.requests).toHaveLength(3);
     expect(value.writes).toHaveLength(0);
   });
 
   it("derives live membership in whole-payload encounter order and omits malformed members", async () => {
-    const value = fixture(), plan = (await value.source.captureReference(NOW, budget())).plan;
+    const value = fixture(), plan = (await value.source.captureReference(PLAN, budget())).plan;
     const derived = await value.source.deriveReferenceCaptureMembers(plan, [
       { ordinal: 0, lane: "settings", endpoint: "athlete-profile", request: { oldest: null, newest: null, activity_id: null, stream_types: [], include_defaults: null }, payload: PROFILE },
       { ordinal: 1, lane: "activities", endpoint: "activities", request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, payload: [{ bad: true }, ACTIVITY] },


### PR DESCRIPTION
PR1 of the Training-page week-first redesign: the training-history wire contract and everything beneath it, with zero UI changes.

## What this adds

- **Contract (protocol 32 → 33):** `TrainingHistoryProjectionSchema` (`computed | unavailable`) and `TrainingHistoryPanelSchema` (adds `stale`), week/coverage/trend/callout schemas with invariants enforced in refinements (Monday windows, ride-in-week, unique ids, sort order, truncation coupling, 28-day callout windows, callouts nulled in last-good). `CyclingTrainingContextSchema.trainingHistory` is required with no default; the unknown sentinel carries `{ kind: "unavailable", reason: "not-synced" }`.
- **Kernel reader:** one-call `readWindow({start, end})` over canonical sessions with per-field `RecordedFact` payload facts (`recorded | absent | rejected` with a closed reason vocabulary), title resolution overlay > workout name > typed activity name (512-byte caps), keyset pagination with a 1000-session cap, SQL-side type/byte gating, and a pick-then-strict payload envelope. Provider ids and raw payload JSON never cross the surface; kernel does not import coach-contract.
- **Coverage evidence:** migration 030 adds two append-only STRICT tables (`training_history_coverage_commit` with `UNIQUE(authority_kind, authority_id)`, and per-page backfill checkpoints), both trigger-protected against UPDATE/DELETE and excluded from authored/dump classifications. The repository does insert-or-verify (`inserted | already-recorded`, `authority_conflict` on mismatch) bound to the caller's transaction store.
- **Projection:** `createTrainingHistorySource` computes anchor/previous weeks plus a six-week riding-time trend from pre-generated Monday windows, riding time = moving ?? elapsed with the basis recorded, coverage as a read-time fold, `callout` always null in PR1, output parsed through the contract schema, every failure a typed reason.
- **Last-good cache:** the athlete-state reader wraps thrown/parse failures in the `stale` arm only when a three-field identity (home root, source owner, calendar zone — pulled per read) matches; domain `unavailable` passes through untouched.
- **Calendar threading:** `CapturePlanSchema` gains optional `calendar_timezone` (byte-canonical sidecar compatibility preserved and round-trip tested); `createReferenceCapturePlan({ now, calendarTimeZone })` computes the 84-day window with zone-aware arithmetic; `planCalendarTimeZone` is the single legacy-UTC interpreter; the capture CLI stays pinned to UTC; `historyNewestDate` derives from `plan.window.newest` at every consumer.

## Verification

- Root `pnpm check` green (includes fixture-privacy and the verification catalog).
- Full suites green: coach-contract, kernel, kernel-node, engine, coach (coach requires serial execution when another worktree's vitest is loading the machine; the three affected timeout tests are untouched by this PR and pass in isolation).
- Fresh three-dimension read-only review (design compliance, correctness, test quality) with adversarial verification: four confirmed P2s, all fixed in the final commit (pre-1970 Monday modulo bug, plus three test-coverage gaps: reader SQL exclusion coverage, required-field negative parse, adjacency/contiguity rejections).
- One accepted deviation is recorded in the issue file: sparse-history discovery widens the single `readWindow` call's start to 1900-01-01 (still one call, still capped).

Changeset: patch bumps, infra-only (no user-visible change until PR4).

https://claude.ai/code/session_01MuuxVFiD3aXwBgmNvUSJzm
