### PR TITLE
feat(desktop): move Workout archive export to Plan and retire Training plan panels (PR3)

### DIFF
--- a/.agents/skills/verify-enduragent/references/features/training.md
+++ b/.agents/skills/verify-enduragent/references/features/training.md
@@ -5,7 +5,7 @@
 - Owned user route: **Training** in Main navigation (`activeView: "training"`). Manifest surfaces: `training-setup`, `first-sync`, `training-import`, `training`, `ride-review`, `power-progress`, `wellness`, `training-export`, and `training-sync`.
 - Setup and first sync: [`setup.md`](setup.md) owns the Setup scenarios; Training owns `training.first-sync.provider-backfill` and `training.first-sync.failure-recovery`.
 - Resident overview and recovery: `training.view.panel-inventory`, `training.view.readiness-states`, `training.view.context-recovery`, `training.view.anchor-load-plan-adherence`, `training.power-progress.comparison`, and `training.wellness.trend`.
-- Ride review, import, export, and sync: `training.ride-review.navigation`, `training.ride-review.local-analysis`, `training.import.progress-results`, `training.export.activity-formats`, `training.export.workout-formats`, `training.sync.lifecycle`, and `training.sync.protocol-failure`.
+- Ride review, import, export, and sync: `training.ride-review.navigation`, `training.ride-review.local-analysis`, `training.import.progress-results`, `training.export.activity-formats`, `training.sync.lifecycle`, and `training.sync.protocol-failure`. Plan proves `training.export.workout-formats` beside its WorkoutMatch list.
 
 Fixture/profile: isolated renderer `ready()` state with shifted fixture dates and no athlete profile or credentials. Supported executors: renderer and desktop `vitest`; native Windows scenarios remain `vm-only`.
 
@@ -13,16 +13,16 @@ Fixture/profile: isolated renderer `ready()` state with shifted fixture dates an
 
 - Complete Setup, then choose **Training** in Main navigation.
 - Use **Sync now** or **Import ride files**, open a ride from **Recent rides** for **Ride review**, and use **Back to training** to return with focus restored.
-- Export a reviewed ride as FIT or GPX, or export the visible planned workouts as a ZWO, MRC, ERG, or FIT archive.
+- Export a reviewed ride as FIT or GPX. Choose **Plan** to export its visible Workouts as a ZWO, MRC, ERG, or FIT archive.
 
 ## Driving it with verify-enduragent
 
 ```bash
-pnpm --filter @enduragent/desktop-renderer exec vitest run tests/training-surface.test.tsx tests/training-context.test.ts tests/training-sync.test.ts tests/training-export.test.ts
+pnpm --filter @enduragent/desktop-renderer exec vitest run tests/plan-surface.test.tsx tests/training-surface.test.tsx tests/training-context.test.ts tests/training-sync.test.ts tests/training-export.test.ts
 pnpm --filter @enduragent/desktop exec vitest run tests/windows-parity-scenarios.test.ts
 ```
 
-Require the renderer run to show the **Training** region and shipped panel order, truthful loading and failure states, context recovery, sync retry and protocol handling, import progress, ride-review navigation, and ride/workout export requests. Require the desktop run to validate the frozen Training manifest and its deterministic citations; it does not execute the mapped behavior.
+Require the renderer run to show the **Training** region and shipped panel order without Plan or aggregate Adherence, truthful loading and failure states, context recovery, sync retry and protocol handling, import progress, ride-review navigation, the ride export request, and the Plan WorkoutMatch archive request. Require the desktop run to validate the frozen Training manifest and its deterministic citations; it does not execute the mapped behavior.
 
 ## Gotchas
 

--- a/.changeset/plan-training-migration.md
+++ b/.changeset/plan-training-migration.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+Move planned Workout archive export to Plan and remove the Plan preview and aggregate adherence display from Training.
+
+User-facing: Export your planned workouts from the Plan page, right under this week's workout list. The Training page no longer shows the plan preview or the adherence percentage.

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -53,6 +53,7 @@ import { CoachDecisionPanel } from "../chat/CoachDecisionPanel";
 import { Composer, type ComposerHandle } from "../chat/Composer";
 import { ConversationTranscript } from "../chat/Transcript";
 import { Page } from "../shared/Page";
+import { WorkoutArchiveExportControl } from "../training/TrainingExportControls";
 
 const SUPPORT_PAIR = "grid gap-[calc(var(--inset)/2)]";
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
@@ -3617,6 +3618,9 @@ function ActiveProjection(): ReactElement {
   if (["PL-S032", "PL-S033", "PL-S034", "PL-S035", "PL-S036"].includes(model.scenarioId)) {
     return <WorkoutDriftProjection data={data} scenarioId={model.scenarioId} />;
   }
+  const workoutDates = data.workouts.map((workout) => workout.date).sort();
+  const oldestWorkoutDate = workoutDates.at(0);
+  const newestWorkoutDate = workoutDates.at(-1);
   return (
     <div className="grid gap-6" data-plan-scenario={model.scenarioId}>
       {model.scenarioId === "PL-S097" ? (
@@ -3817,6 +3821,11 @@ function ActiveProjection(): ReactElement {
             );
           })}
         </div>
+        {oldestWorkoutDate === undefined || newestWorkoutDate === undefined ? null : (
+          <div className="border-t border-line px-5 py-row">
+            <WorkoutArchiveExportControl oldest={oldestWorkoutDate} newest={newestWorkoutDate} />
+          </div>
+        )}
       </section>
 
       <section className="flex flex-col gap-row rounded-card bg-surface p-5 shadow-elev-1 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
@@ -109,7 +109,7 @@ export function WorkoutArchiveExportControl(props: {
   const actions = useEnduragentStore((store) => store.trainingExportActions);
   const busy = state.status === "running";
   return (
-    <div className={styles.planExport}>
+    <div>
       <p className={styles.support}>
         Save the visible planned workouts as a ZIP. Exporting does not change your plan.
       </p>

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -1,8 +1,6 @@
 import type {
-  AdherencePanel,
   AnchorZonesPanel,
   CyclingLoadPanel,
-  PlanPanel,
   PowerProgressPanel,
   RecentRide,
   WellnessTrendPanel,
@@ -18,14 +16,12 @@ import {
 import { useEnduragentStore } from "../../state/store";
 import {
   formatDateLabel,
-  formatPercentage,
   formatSleepDuration,
   formatUtcTimestamp,
   formatWholeNumber,
 } from "../../training-context/format";
 import { Page } from "../shared/Page";
 import {
-  MAX_VISIBLE_PLAN_ITEMS,
   RIDE_IMPORT_DESCRIPTION,
   TRAINING_UNKNOWN_COPY,
   WELLNESS_LABELS,
@@ -36,7 +32,6 @@ import { overviewStyles as styles } from "./overviewStyles";
 import { PowerProgressContent } from "./PowerProgressPanel";
 import { RecentRidesStatePanel, RideDetailView } from "./RideReview";
 import { WellnessSparkline } from "./WellnessSparkline";
-import { WorkoutArchiveExportControl } from "./TrainingExportControls";
 
 function Panel(props: {
   readonly name: string;
@@ -192,60 +187,6 @@ function LoadPanel(props: { readonly panel: CyclingLoadPanel }): ReactElement {
   );
 }
 
-function UpcomingPlanPanel(props: { readonly panel: PlanPanel }): ReactElement {
-  if (props.panel.kind === "unknown") {
-    return (
-      <Panel name="plan" title="Plan">
-        <Unknown reason={props.panel.reason} />
-      </Panel>
-    );
-  }
-  const dates = props.panel.items
-    .slice(0, MAX_VISIBLE_PLAN_ITEMS)
-    .map((item) => item.date)
-    .sort();
-  const oldest = dates[0];
-  const newest = dates.at(-1);
-  return (
-    <Panel name="plan" title="Plan">
-      <ol className={styles.plan}>
-        {props.panel.items.slice(0, MAX_VISIBLE_PLAN_ITEMS).map((item) => (
-          <li className={styles.planItem} key={item.id}>
-            <strong>{item.name ?? "Cycling workout"}</strong>
-            <span>
-              {formatDateLabel(item.date)} · {item.workoutType}
-            </span>
-          </li>
-        ))}
-      </ol>
-      {oldest === undefined || newest === undefined ? null : (
-        <WorkoutArchiveExportControl oldest={oldest} newest={newest} />
-      )}
-    </Panel>
-  );
-}
-
-function AdherenceStatePanel(props: { readonly panel: AdherencePanel }): ReactElement {
-  if (props.panel.kind === "unknown") {
-    return (
-      <Panel name="adherence" title="Adherence">
-        <Unknown reason={props.panel.reason} />
-      </Panel>
-    );
-  }
-  return (
-    <Panel name="adherence" title="Adherence">
-      <p className={styles.value}>{formatPercentage(props.panel.ratio)}</p>
-      <p className={styles.support}>
-        {props.panel.matchedDays}/{props.panel.plannedDays} planned days matched
-      </p>
-      <p className={styles.meta}>
-        {props.panel.completedDays} completed days · As of {formatDateLabel(props.panel.asOf)}
-      </p>
-    </Panel>
-  );
-}
-
 function WellnessPanel(props: { readonly panel: WellnessTrendPanel }): ReactElement {
   if (props.panel.kind === "unknown") {
     return (
@@ -387,8 +328,6 @@ export function TrainingView(): ReactElement {
       />
       <AnchorPanel panel={training.trainingContext.anchorZones} />
       <LoadPanel panel={training.trainingContext.cyclingLoad} />
-      <UpcomingPlanPanel panel={training.trainingContext.plan} />
-      <AdherenceStatePanel panel={training.trainingContext.adherence} />
       <WellnessPanel panel={training.trainingContext.wellnessTrend} />
       <RideImportPanel />
     </Page>

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -10,8 +10,6 @@ import type {
 import { PLATFORM_COPY } from "../../platform-copy";
 import type { TrainingContextStatus } from "../../training-context/controller";
 
-export const MAX_VISIBLE_PLAN_ITEMS = 7;
-
 export const TRAINING_UNKNOWN_COPY: Readonly<Record<TrainingContextUnknownReason, string>> = {
   "not-synced": "Not synced yet",
   "missing-anchor": "No cycling FTP anchor is available",

--- a/apps/desktop-renderer/src/ui/training/overviewStyles.ts
+++ b/apps/desktop-renderer/src/ui/training/overviewStyles.ts
@@ -37,10 +37,6 @@ export const overviewStyles = {
   zoneName:
     "m-0 min-w-0 [overflow-wrap:anywhere] data-[overlaps=true]:after:text-ink-3 data-[overlaps=true]:after:content-['_·_overlaps']",
   zoneRange: "m-0 shrink-0 tabular-nums",
-  plan: "m-0 grid list-none gap-2.5 p-0",
-  planItem:
-    "grid min-w-0 gap-[3px] rounded-ctl bg-sunk px-3 py-2.5 [&_strong]:[overflow-wrap:anywhere] [&_strong]:text-sm [&_strong]:font-semibold [&_span]:text-xs [&_span]:leading-5 [&_span]:text-ink-2",
-  planExport: "mt-3.5 border-t border-line pt-3.5",
   exportControls: "mt-3 flex flex-wrap items-center gap-[9px] [&_label]:text-xs [&_label]:font-semibold [&_label]:text-ink-2",
   exportStatus: "mt-2.5 text-xs leading-[1.45] text-ink-2",
   wellness: "mt-3 grid gap-2.5",

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -1202,6 +1202,69 @@ describe("Plan surface", () => {
     expect(useEnduragentStore.getState().plan).toBe(planBeforeExport);
   });
 
+  it("disables the export controls and reports status while a workout archive runs", () => {
+    const state = activePlanState([
+      {
+        id: "00000000000000000000000005",
+        date: "1998-07-17",
+        sport: "cycling",
+        name: "Long endurance",
+        durationS: 7_200,
+      },
+    ]);
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planActions: actions(),
+      trainingExport: { status: "running", target: "workout-archive" },
+      trainingExportActions: {
+        exportActivity: vi.fn(async () => {}),
+        exportWorkoutArchive: vi.fn(async () => {}),
+      },
+    });
+    render(<PlanView />);
+
+    const matchSection = screen
+      .getByRole("heading", { name: "WorkoutMatch · this week" })
+      .closest("section");
+    if (matchSection === null) throw new Error("WorkoutMatch section is missing");
+    const match = within(matchSection);
+    expect(match.getByRole("combobox", { name: "Workout format" })).toBeDisabled();
+    const exportButton = match.getByRole("button", { name: "Export workouts" });
+    expect(exportButton).toBeDisabled();
+    expect(exportButton).toHaveAttribute("aria-busy", "true");
+    expect(match.getByRole("status")).toHaveTextContent("Choose where to save the file.");
+  });
+
+  it("shows the workout-archive outcome in the Plan status region", () => {
+    const state = activePlanState([
+      {
+        id: "00000000000000000000000005",
+        date: "1998-07-17",
+        sport: "cycling",
+        name: "Long endurance",
+        durationS: 7_200,
+      },
+    ]);
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planActions: actions(),
+      trainingExport: { status: "cancelled", target: "workout-archive" },
+      trainingExportActions: {
+        exportActivity: vi.fn(async () => {}),
+        exportWorkoutArchive: vi.fn(async () => {}),
+      },
+    });
+    render(<PlanView />);
+
+    const matchSection = screen
+      .getByRole("heading", { name: "WorkoutMatch · this week" })
+      .closest("section");
+    if (matchSection === null) throw new Error("WorkoutMatch section is missing");
+    expect(within(matchSection).getByRole("status")).toHaveTextContent(
+      "Export cancelled. No file was changed.",
+    );
+  });
+
   it("does not render Workout archive export when WorkoutMatch has no workouts", () => {
     const state = activePlanState([]);
     useEnduragentStore.setState({

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlanActiveProjectionDataSchema } from "@enduragent/coach-contract";
 import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice";
 import { useEnduragentStore } from "../src/state/store";
+import { IDLE_TRAINING_EXPORT } from "../src/training-export/controller";
 import { PlanView } from "../src/ui/plan/PlanView";
 import { PLAN_ERROR, planCoachData, planReadModel } from "./plan-fixtures";
 
@@ -87,8 +88,42 @@ function actions(): PlanActions {
   };
 }
 
+function activePlanState(
+  workouts: ReturnType<typeof PlanActiveProjectionDataSchema.parse>["workouts"],
+) {
+  return planReadModel({
+    lifecycle: "active",
+    scenarioId: "PL-S004",
+    projection: "active",
+    planId: "00000000000000000000000003",
+    data: {
+      plan: {
+        id: "00000000000000000000000003",
+        name: "Gran Fondo Almaty",
+        primaryGoal: "Finish in the front half",
+        startDate: "1998-07-06",
+        targetDate: "1998-10-04",
+        kind: "full-plan",
+        totalWeeks: 12,
+        weekStartDay: 1,
+        workoutCount: 58,
+        plannedDurationS: 309_600,
+      },
+      today: "1998-07-13",
+      weekIndex: 2,
+      todayWorkout: null,
+      workouts,
+    },
+  });
+}
+
 beforeEach(() => {
-  useEnduragentStore.setState({ plan: EMPTY_PLAN_SURFACE, planActions: actions() });
+  useEnduragentStore.setState({
+    plan: EMPTY_PLAN_SURFACE,
+    planActions: actions(),
+    trainingExport: IDLE_TRAINING_EXPORT,
+    trainingExportActions: null,
+  });
 });
 
 afterEach(() => {
@@ -98,6 +133,8 @@ afterEach(() => {
     plan: EMPTY_PLAN_SURFACE,
     planActions: null,
     planningReadActions: null,
+    trainingExport: IDLE_TRAINING_EXPORT,
+    trainingExportActions: null,
   });
 });
 
@@ -1098,6 +1135,87 @@ describe("Plan surface", () => {
     expect(container.querySelector('[id^="workout-row-"]')).toHaveClass(
       "min-[760px]:grid-cols-[minmax(6rem,0.8fr)_minmax(0,2fr)_minmax(4rem,0.6fr)_minmax(8rem,1fr)_auto]",
     );
+  });
+
+  it("offers every workout format and exports exactly the visible WorkoutMatch date range without changing the Plan", async () => {
+    const user = userEvent.setup();
+    const exportWorkoutArchive = vi.fn(async () => {});
+    const state = activePlanState([
+      {
+        id: "00000000000000000000000005",
+        date: "1998-07-17",
+        sport: "cycling",
+        name: "Long endurance",
+        durationS: 7_200,
+      },
+      {
+        id: "00000000000000000000000006",
+        date: "1998-07-11",
+        sport: "cycling",
+        name: "Tempo intervals",
+        durationS: 3_600,
+      },
+      {
+        id: "00000000000000000000000007",
+        date: "1998-07-14",
+        sport: "cycling",
+        name: "Recovery spin",
+        durationS: 2_700,
+      },
+    ]);
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planActions: actions(),
+      trainingExportActions: {
+        exportActivity: vi.fn(async () => {}),
+        exportWorkoutArchive,
+      },
+    });
+    render(<PlanView />);
+
+    const matchSection = screen
+      .getByRole("heading", { name: "WorkoutMatch · this week" })
+      .closest("section");
+    if (matchSection === null) throw new Error("WorkoutMatch section is missing");
+    const match = within(matchSection);
+    expect(
+      match.getByText(
+        "Save the visible planned workouts as a ZIP. Exporting does not change your plan.",
+      ),
+    ).toBeInTheDocument();
+    await user.click(match.getByRole("combobox", { name: "Workout format" }));
+    expect((await screen.findAllByRole("option")).map((option) => option.textContent)).toEqual([
+      "ZWO",
+      "MRC",
+      "ERG",
+      "FIT",
+    ]);
+    await user.click(screen.getByRole("option", { name: "FIT" }));
+    const planBeforeExport = useEnduragentStore.getState().plan;
+    await user.click(match.getByRole("button", { name: "Export workouts" }));
+
+    expect(exportWorkoutArchive).toHaveBeenCalledWith({
+      oldest: "1998-07-11",
+      newest: "1998-07-17",
+      format: "fit",
+    });
+    expect(useEnduragentStore.getState().plan).toBe(planBeforeExport);
+  });
+
+  it("does not render Workout archive export when WorkoutMatch has no workouts", () => {
+    const state = activePlanState([]);
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planActions: actions(),
+      trainingExportActions: {
+        exportActivity: vi.fn(async () => {}),
+        exportWorkoutArchive: vi.fn(async () => {}),
+      },
+    });
+    render(<PlanView />);
+
+    expect(screen.getByRole("heading", { name: "WorkoutMatch · this week" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Export workouts" })).not.toBeInTheDocument();
   });
 
   it("confirms End Plan with Cancel focused and keeps failed cleanup recoverable", async () => {

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -302,8 +302,6 @@ describe("training page", () => {
       "Recent rides",
       "Current cycling anchor",
       "Cycling Load",
-      "Plan",
-      "Adherence",
       "Wellness trend",
       "Import ride files",
     ]);
@@ -313,8 +311,6 @@ describe("training page", () => {
     expect(screen.getByText("412")).toBeInTheDocument();
     expect(screen.getByText("5 cycling activities")).toBeInTheDocument();
     expect(screen.getByText("2 cycling activities have no platform Load")).toBeInTheDocument();
-    expect(screen.getByText("80%")).toBeInTheDocument();
-    expect(screen.getByText("4/5 planned days matched")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",
@@ -872,43 +868,15 @@ describe("training page", () => {
     expect(within(progress).getByText("1120 W")).toBeInTheDocument();
   });
 
-  it("renders the power zones and caps the plan at seven upcoming workouts", () => {
+  it("renders the power zones while keeping Plan and Adherence panels off Training", () => {
     render(<TrainingView />);
 
     const zones = within(screen.getByRole("region", { name: "Current cycling anchor" }));
     expect(zones.getByText("Recovery")).toBeInTheDocument();
     expect(zones.getByText("148–201 W")).toBeInTheDocument();
     expect(zones.getByText("Endurance")).toHaveAttribute("data-overlaps", "true");
-
-    const plan = within(screen.getByRole("region", { name: "Plan" }));
-    expect(plan.getAllByRole("listitem")).toHaveLength(7);
-    expect(plan.getByText("Endurance ride 1")).toBeInTheDocument();
-    expect(plan.queryByText("Endurance ride 8")).toBeNull();
-  });
-
-  it("offers every workout format and exports exactly the visible planned-workout date range", async () => {
-    const user = userEvent.setup();
-    const exportWorkoutArchive = vi.fn(async () => {});
-    useEnduragentStore.setState({
-      trainingExportActions: { exportActivity: vi.fn(async () => {}), exportWorkoutArchive },
-    });
-    render(<TrainingView />);
-
-    const plan = screen.getByRole("region", { name: "Plan" });
-    await user.click(within(plan).getByRole("combobox", { name: "Workout format" }));
-    expect((await screen.findAllByRole("option")).map((option) => option.textContent)).toEqual([
-      "ZWO",
-      "MRC",
-      "ERG",
-      "FIT",
-    ]);
-    await user.click(screen.getByRole("option", { name: "FIT" }));
-    await user.click(within(plan).getByRole("button", { name: "Export workouts" }));
-    expect(exportWorkoutArchive).toHaveBeenCalledWith({
-      oldest: "1998-07-11",
-      newest: "1998-07-17",
-      format: "fit",
-    });
+    expect(document.querySelector('[data-panel="plan"]')).not.toBeInTheDocument();
+    expect(document.querySelector('[data-panel="adherence"]')).not.toBeInTheDocument();
   });
 
   it("draws a sparkline per wellness series from the athlete-state readings", () => {
@@ -937,8 +905,6 @@ describe("training page", () => {
       "Sync or import a cycling ride to review it here.",
       "No cycling FTP anchor is available",
       "No platform Load is available for the last 7 days",
-      "No planned cycling workouts are available",
-      "Not enough persisted data to show this yet",
       "No wellness readings are available",
     ]) {
       expect(screen.getByText(copy)).toBeInTheDocument();

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -2091,7 +2091,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         anchorValue: panel("anchor").querySelector("p").textContent,
         wellnessValue: panel("wellness").querySelector("span").textContent,
       };
-      const dataPanels = ["anchor", "load", "plan", "adherence", "wellness"];
+      const dataPanels = ["anchor", "load", "wellness"];
       const syncButton = page.querySelector(".training-sync-action");
       const syncStatus = page.querySelector(".training-sync-message");
       const metadataText = () => [...page.querySelectorAll(".training-metadata-item")].map((node) => node.textContent ?? "");
@@ -2184,8 +2184,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "Recent rides",
         "Current cycling anchor",
         "Cycling Load",
-        "Plan",
-        "Adherence",
         "Wellness trend",
         "Import ride files",
       ],

--- a/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
@@ -139,7 +139,7 @@
     {
       "id": "training.view.panel-inventory",
       "surface": "training",
-      "expected": "Training renders Sync, Power progress, Recent rides, Current cycling anchor, Cycling Load, Plan, Adherence, Wellness trend, and Import ride files in the shipped order with each panel's own known or unknown state.",
+      "expected": "Training renders Sync, Power progress, Recent rides, Current cycling anchor, Cycling Load, Wellness trend, and Import ride files in the shipped order with each panel's own known or unknown state.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders every panel in the pinned order with the training data as of its own timestamps",
@@ -230,11 +230,11 @@
     {
       "id": "training.view.anchor-load-plan-adherence",
       "surface": "training",
-      "expected": "Training shows the current cycling anchor and power zones, seven-day Cycling Load and missing-Load count, at most seven upcoming workouts, and matched-versus-planned adherence using plain-English metrics.",
+      "expected": "Training shows the current cycling anchor and power zones plus seven-day Cycling Load and its missing-Load count, while the retired Plan and aggregate Adherence panels remain absent.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders every panel in the pinned order with the training data as of its own timestamps",
-        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders the power zones and caps the plan at seven upcoming workouts"
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders the power zones while keeping Plan and Adherence panels off Training"
       ]
     },
     {
@@ -251,10 +251,10 @@
     {
       "id": "training.export.workout-formats",
       "surface": "training-export",
-      "expected": "Plan export offers ZWO, MRC, ERG, and FIT in a ZIP and exports exactly the date range of the seven visible planned workouts without changing the plan.",
+      "expected": "The Workout archive export control lives on Plan beside the WorkoutMatch list, offers ZWO, MRC, ERG, and FIT in a ZIP, and exports exactly the visible Workout date range without changing the Plan.",
       "automation": "deterministic",
       "tests": [
-        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > offers every workout format and exports exactly the visible planned-workout date range",
+        "apps/desktop-renderer/tests/plan-surface.test.tsx > Plan surface > offers every workout format and exports exactly the visible WorkoutMatch date range without changing the Plan",
         "apps/desktop-renderer/tests/training-export.test.ts > routes workout archives and preserves cancellations and refusal reasons",
         "apps/desktop/tests/training-export-ipc.test.ts > routes a closed workout archive request and handles cancellation without daemon work"
       ]


### PR DESCRIPTION
PR3 of the Training-page week-first redesign: Plan absorbs the Workout tasks (decision G-06).

## What this changes

- **Plan:** the Workout archive export control (ZWO/MRC/ERG/FIT, unchanged wire contract `{ kind: "workout-archive", oldest, newest, format }`) now renders inside the `WorkoutMatch · this week` card, exporting exactly the visible workout date range. It appears only when workouts are visible.
- **Training:** the Plan preview panel and the aggregate Adherence panel are removed. The percentage adherence display is retired per G-06; per-Workout matching in Plan is untouched. The contract fields keep flowing on the wire for rollback — they are simply no longer rendered.
- **Verification catalog:** `training.export.workout-formats` re-pointed at the new Plan test; panel-inventory and anchor-load scenarios updated to prove the retired panels stay absent; the training feature page rewritten to match.

## Verification

- Mapped renderer suites → 74 passed; renderer typecheck green; verification-catalog suite green; root `pnpm check` green.
- Packaged desktop integration (`chat-panels.integration.test.ts`) rerun against a freshly rebuilt deps → renderer → desktop chain → 8 passed.
- Fresh three-dimension read-only review with adversarial verification: one confirmed P1 (the packaged integration test still expected the removed panels — fixed and proven against the fresh build), two confirmed P2 test gaps (running-state disablement and the workout-archive status region had no UI coverage on Plan — both closed), one P3 dead export deleted.

Changeset: patch bumps, user-facing.

https://claude.ai/code/session_01MuuxVFiD3aXwBgmNvUSJzm
