### PR TITLE
fix(desktop): stop pinning the viewport of visible fixture windows

### DIFF
--- a/.changeset/fixture-visible-viewport.md
+++ b/.changeset/fixture-visible-viewport.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Visible desktop test-harness windows no longer pin the page to a fake fixed viewport, so resizing the window resizes the app.

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -727,7 +727,7 @@ export async function launchDesktopFixture(input: {
       consoleMessages.push(args.map((arg) => String(arg.value ?? "")).join(" "));
     });
     cdp = nextCdp;
-    await Promise.all([
+    const setup = [
       nextCdp.call("Runtime.enable"),
       nextCdp.call("Page.enable"),
       nextCdp.call("Emulation.setEmulatedMedia", {
@@ -739,13 +739,18 @@ export async function launchDesktopFixture(input: {
           },
         ],
       }),
-      nextCdp.call("Emulation.setDeviceMetricsOverride", {
-        width: input.width,
-        height: input.height,
-        deviceScaleFactor: 1,
-        mobile: false,
-      }),
-    ]);
+    ];
+    if (input.hidden !== false) {
+      setup.push(
+        nextCdp.call("Emulation.setDeviceMetricsOverride", {
+          width: input.width,
+          height: input.height,
+          deviceScaleFactor: 1,
+          mobile: false,
+        }),
+      );
+    }
+    await Promise.all(setup);
     await refreshSurfaces();
   };
   const cleanupFixture = async (): Promise<void> => {


### PR DESCRIPTION
## Problem

A desktop window launched by the test harness with `hidden: false` (the `dev:isolated` inspection fixtures) showed blank space whenever the window was resized. The page kept its 1180×820 launch size and rendered at 1x on Retina displays.

## Root cause

`launchDesktopFixture` applied `Emulation.setDeviceMetricsOverride` on every launch. That override replaces the real viewport, so the renderer ignores window resizes. Live measurement on the affected window: `outerWidth/outerHeight` 1422×949, `innerWidth/innerHeight` 1180×788, shell rect 1180×788. The renderer CSS was never the problem; the shell is `fixed inset-0` and fills whatever viewport it gets.

## Fix

Skip the device-metrics override when the fixture window is visible. Hidden fixtures keep the override for deterministic screenshots. `setViewport` is unchanged.

## Verified

Proof script launches a visible fixture, resizes the real `BrowserWindow` to 1400×900 from the main process, and probes the renderer.

Before (origin/main):

```
launch:       inner [1180,820] outer [1180,820] dpr 1
after-resize: inner [1180,820] outer [1400,900] dpr 1
```

After:

```
launch:       inner [1180,788] outer [1180,820] dpr 2
after-resize: inner [1400,868] outer [1400,900] dpr 2
```

Root `pnpm check` green. `vitest run tests/desktop-fixture-wait-for-page.test.ts` 1 passed.

## Not done

Visible windows ignore the `width`/`height` launch options and open at the app's default size. Honoring them would need a real window-bounds path; out of scope here.

https://claude.ai/code/session_019iPXVGuPXzeswKB4DSdswm
