### PR TITLE
fix(desktop): add valid training inspection fixture

### DIFF
--- a/.changeset/desktop-inspection-fixtures.md
+++ b/.changeset/desktop-inspection-fixtures.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Add schema-valid Plan and populated Training inspection fixtures for isolated desktop development.

--- a/apps/desktop/scripts/interactive-development.d.mts
+++ b/apps/desktop/scripts/interactive-development.d.mts
@@ -9,6 +9,7 @@ export interface InteractiveDevelopmentPlanInput {
 
 export const DESKTOP_INSPECTION_FIXTURE_ENV: "ENDURAGENT_DESKTOP_INSPECTION_FIXTURE";
 export const PLAN_CURRENT_INSPECTION_FIXTURE: "plan-current";
+export const TRAINING_CURRENT_INSPECTION_FIXTURE: "training-current";
 
 export interface InteractiveDevelopmentPlan {
   readonly command: "/usr/bin/caffeinate";

--- a/apps/desktop/scripts/interactive-development.mjs
+++ b/apps/desktop/scripts/interactive-development.mjs
@@ -9,6 +9,7 @@ const canonicalDesktopRoot = resolve(scriptDirectory, "..");
 const SCRATCH_PREFIX = "enduragent-desktop-development-";
 export const DESKTOP_INSPECTION_FIXTURE_ENV = "ENDURAGENT_DESKTOP_INSPECTION_FIXTURE";
 export const PLAN_CURRENT_INSPECTION_FIXTURE = "plan-current";
+export const TRAINING_CURRENT_INSPECTION_FIXTURE = "training-current";
 
 export function selectInteractiveDevelopmentTemporaryRoot(platform, configuredRoot) {
   return configuredRoot ?? (platform === "darwin" ? "/tmp" : tmpdir());
@@ -36,10 +37,14 @@ export function createInteractiveDevelopmentPlan(input) {
   const userData = join(scratchRoot, "electron-user-data");
   const environment = { ...input.environment };
   const inspectionFixture = environment[DESKTOP_INSPECTION_FIXTURE_ENV];
-  if (inspectionFixture !== undefined && inspectionFixture !== PLAN_CURRENT_INSPECTION_FIXTURE) {
+  if (
+    inspectionFixture !== undefined &&
+    inspectionFixture !== PLAN_CURRENT_INSPECTION_FIXTURE &&
+    inspectionFixture !== TRAINING_CURRENT_INSPECTION_FIXTURE
+  ) {
     throw new TypeError("unknown desktop inspection fixture");
   }
-  if (inspectionFixture === PLAN_CURRENT_INSPECTION_FIXTURE) {
+  if (inspectionFixture !== undefined) {
     delete environment.PLAN_QA_SCENARIO;
     delete environment.PLAN_QA_OUTCOME;
   }
@@ -58,7 +63,7 @@ export function createInteractiveDevelopmentPlan(input) {
       nodeExecutable,
       packageManagerScript,
       "exec",
-      ...(inspectionFixture === PLAN_CURRENT_INSPECTION_FIXTURE
+      ...(inspectionFixture !== undefined
         ? ["tsx", "tests/helpers/plan-inspection-live.ts"]
         : ["electron-vite", "dev"]),
     ]),

--- a/apps/desktop/tests/helpers/inspection-athlete-states.ts
+++ b/apps/desktop/tests/helpers/inspection-athlete-states.ts
@@ -1,0 +1,48 @@
+import { AthleteStateSchema, type AthleteState } from "@enduragent/coach-contract";
+
+const LAST_UPDATED = "1998-08-22T08:00:00.000Z";
+const LAST_SYNCED = "1998-08-22T07:55:00.000Z";
+
+export function createInspectionAthleteState(trainingContext: unknown): AthleteState {
+  return AthleteStateSchema.parse({
+    schemaVersion: "1",
+    lastUpdated: LAST_UPDATED,
+    freshness: "fresh",
+    degraded: false,
+    lastSynced: LAST_SYNCED,
+    athleteProfile: {},
+    currentStatus: {},
+    derivedMetrics: {},
+    recentActivities: [],
+    plannedWorkouts: [],
+    wellness: {},
+    trainingContext,
+  });
+}
+
+export const PLAN_QA_ATHLETE_STATE = createInspectionAthleteState({
+  performanceProgress: { kind: "unavailable", reason: "not-synced" },
+  recentRides: {
+    kind: "computed",
+    asOf: LAST_UPDATED,
+    windowDays: 28,
+    items: [
+      {
+        id: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        subSport: "road",
+        startEpochSeconds: 903_751_200,
+        timezoneOffsetSeconds: 21_600,
+        localDate: "1998-08-22",
+        elapsedSeconds: 7_800,
+        movingSeconds: 7_500,
+        distanceMeters: 61_800,
+      },
+    ],
+  },
+  trainingHistory: { kind: "unavailable", reason: "not-synced" },
+  anchorZones: { kind: "unknown", reason: "missing-anchor" },
+  cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
+  plan: { kind: "computed", asOf: LAST_UPDATED, items: [] },
+  adherence: { kind: "unknown", reason: "insufficient-data" },
+  wellnessTrend: { kind: "unknown", reason: "no-wellness" },
+});

--- a/apps/desktop/tests/helpers/plan-inspection-live.ts
+++ b/apps/desktop/tests/helpers/plan-inspection-live.ts
@@ -1,10 +1,15 @@
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import type { AthleteState } from "@enduragent/coach-contract";
 import type { DesktopFixtureScript, RunningDesktopFixture } from "./desktop-fixture.js";
 import { launchDesktopFixture } from "./desktop-fixture.js";
+import { PLAN_QA_ATHLETE_STATE } from "./inspection-athlete-states.js";
 import { createPlanQaFixtureScript } from "./plan-qa-live.js";
+import { TRAINING_CURRENT_ATHLETE_STATE } from "./training-current-athlete-state.js";
 
 export const PLAN_INSPECTION_SCENARIO_ID = "PL-S004";
+export const PLAN_CURRENT_INSPECTION_FIXTURE = "plan-current";
+export const TRAINING_CURRENT_INSPECTION_FIXTURE = "training-current";
 
 export const PLAN_INSPECTION_TURNS = Object.freeze([
   Object.freeze({
@@ -46,8 +51,10 @@ function response(value: unknown): readonly string[] {
   return [JSON.stringify(value)];
 }
 
-export function createPlanInspectionFixtureScript(): DesktopFixtureScript {
-  const plan = createPlanQaFixtureScript(PLAN_INSPECTION_SCENARIO_ID);
+export function createPlanInspectionFixtureScript(
+  athleteState: AthleteState = PLAN_QA_ATHLETE_STATE,
+): DesktopFixtureScript {
+  const plan = createPlanQaFixtureScript(PLAN_INSPECTION_SCENARIO_ID, athleteState);
   return {
     onRequest(value) {
       const request = value as { readonly method: string };
@@ -70,6 +77,16 @@ export function createPlanInspectionFixtureScript(): DesktopFixtureScript {
   };
 }
 
+export function inspectionAthleteState(inspectionFixture: string | undefined): AthleteState {
+  if (inspectionFixture === undefined || inspectionFixture === PLAN_CURRENT_INSPECTION_FIXTURE) {
+    return PLAN_QA_ATHLETE_STATE;
+  }
+  if (inspectionFixture === TRAINING_CURRENT_INSPECTION_FIXTURE) {
+    return TRAINING_CURRENT_ATHLETE_STATE;
+  }
+  throw new TypeError("unknown desktop inspection fixture");
+}
+
 const token = "v".repeat(43);
 let fixture: RunningDesktopFixture | undefined;
 
@@ -82,8 +99,11 @@ const directExecution =
   process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 
 if (directExecution) {
+  const inspectionFixture =
+    process.env.ENDURAGENT_DESKTOP_INSPECTION_FIXTURE ?? PLAN_CURRENT_INSPECTION_FIXTURE;
+  const athleteState = inspectionAthleteState(inspectionFixture);
   fixture = await launchDesktopFixture({
-    script: createPlanInspectionFixtureScript(),
+    script: createPlanInspectionFixtureScript(athleteState),
     token,
     width: 1180,
     height: 820,
@@ -94,5 +114,7 @@ if (directExecution) {
   });
   process.on("SIGINT", () => void close());
   process.on("SIGTERM", () => void close());
-  process.stdout.write(`PLAN_INSPECTION_READY ${PLAN_INSPECTION_SCENARIO_ID}\n`);
+  process.stdout.write(
+    `DESKTOP_INSPECTION_READY ${inspectionFixture} ${PLAN_INSPECTION_SCENARIO_ID}\n`,
+  );
 }

--- a/apps/desktop/tests/helpers/plan-qa-live.ts
+++ b/apps/desktop/tests/helpers/plan-qa-live.ts
@@ -2,11 +2,13 @@ import type { DesktopFixtureScript, RunningDesktopFixture } from "./desktop-fixt
 import {
   PlanCoachProjectionDataSchema,
   PlanReadModelSchema,
+  type AthleteState,
   type PlanScenarioId,
 } from "@enduragent/coach-contract";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { launchDesktopFixture } from "./desktop-fixture.js";
+import { PLAN_QA_ATHLETE_STATE } from "./inspection-athlete-states.js";
 import {
   planQaOutcomeIsRejected,
   planQaScenario,
@@ -1338,6 +1340,7 @@ function qaOutcome(): PlanQaTransitionOutcome {
 
 export function createPlanQaFixtureScript(
   initialScenarioId: string = requestedScenario.id,
+  athleteState: AthleteState = PLAN_QA_ATHLETE_STATE,
 ): DesktopFixtureScript {
   let current = createPlanQaHydratedModel(initialScenarioId);
   let intakeStatus: "incomplete" | "ready" = "ready";
@@ -1540,34 +1543,7 @@ export function createPlanQaFixtureScript(
         });
       }
       if (request.method === "getAthleteState") {
-        return response({
-          schemaVersion: "1",
-          lastUpdated: "1998-08-22T08:00:00.000Z",
-          freshness: "fresh",
-          degraded: false,
-          lastSynced: "1998-08-22T07:55:00.000Z",
-          athleteProfile: {},
-          currentStatus: {},
-          derivedMetrics: {},
-          recentActivities: [],
-          plannedWorkouts: [],
-          wellness: {},
-          trainingContext: {
-            performanceProgress: { kind: "unavailable", reason: "not-synced" },
-            recentRides: {
-              kind: "computed",
-              asOf: "1998-08-22T08:00:00.000Z",
-              windowDays: 28,
-              items: [],
-            },
-            trainingHistory: { kind: "unavailable", reason: "not-synced" },
-            anchorZones: { kind: "unavailable", reason: "not-synced" },
-            cyclingLoad: { kind: "unavailable", reason: "not-synced" },
-            plan: { kind: "computed", asOf: "1998-08-22T08:00:00.000Z", items: [] },
-            adherence: { kind: "unavailable", reason: "not-synced" },
-            wellnessTrend: { kind: "unavailable", reason: "not-synced" },
-          },
-        });
+        return response(athleteState);
       }
       if (request.method === "getRuntimeConfig") {
         return response({

--- a/apps/desktop/tests/helpers/training-current-athlete-state.ts
+++ b/apps/desktop/tests/helpers/training-current-athlete-state.ts
@@ -1,0 +1,599 @@
+import { createInspectionAthleteState } from "./inspection-athlete-states.js";
+
+const TRAINING_CONTEXT_JSON = `
+{
+  "performanceProgress": {
+    "kind": "computed",
+    "currentWindow": {
+      "start": "1998-07-26",
+      "end": "1998-08-22"
+    },
+    "previousWindow": {
+      "start": "1998-06-28",
+      "end": "1998-07-25"
+    },
+    "anchors": [
+      {
+        "durationSeconds": 5,
+        "current": {
+          "kind": "computed",
+          "watts": 1120
+        },
+        "previous": {
+          "kind": "computed",
+          "watts": 1050
+        },
+        "change": {
+          "kind": "computed",
+          "percent": 6.7
+        }
+      },
+      {
+        "durationSeconds": 60,
+        "current": {
+          "kind": "computed",
+          "watts": 620
+        },
+        "previous": {
+          "kind": "computed",
+          "watts": 600
+        },
+        "change": {
+          "kind": "computed",
+          "percent": 3.3
+        }
+      },
+      {
+        "durationSeconds": 300,
+        "current": {
+          "kind": "computed",
+          "watts": 390
+        },
+        "previous": {
+          "kind": "computed",
+          "watts": 400
+        },
+        "change": {
+          "kind": "computed",
+          "percent": -2.5
+        }
+      },
+      {
+        "durationSeconds": 1200,
+        "current": {
+          "kind": "computed",
+          "watts": 310
+        },
+        "previous": {
+          "kind": "computed",
+          "watts": 310
+        },
+        "change": {
+          "kind": "computed",
+          "percent": 0
+        }
+      },
+      {
+        "durationSeconds": 3600,
+        "current": {
+          "kind": "unavailable"
+        },
+        "previous": {
+          "kind": "unavailable"
+        },
+        "change": {
+          "kind": "unavailable"
+        }
+      }
+    ],
+    "rotation": "sprint",
+    "heartRateContext": {
+      "kind": "computed",
+      "anchors": [
+        {
+          "durationSeconds": 60,
+          "current": {
+            "kind": "computed",
+            "bpm": 181
+          },
+          "previous": {
+            "kind": "computed",
+            "bpm": 178
+          },
+          "change": {
+            "kind": "computed",
+            "percent": 1.7
+          }
+        },
+        {
+          "durationSeconds": 300,
+          "current": {
+            "kind": "computed",
+            "bpm": 176
+          },
+          "previous": {
+            "kind": "computed",
+            "bpm": 175
+          },
+          "change": {
+            "kind": "computed",
+            "percent": 0.6
+          }
+        },
+        {
+          "durationSeconds": 1200,
+          "current": {
+            "kind": "computed",
+            "bpm": 165
+          },
+          "previous": {
+            "kind": "computed",
+            "bpm": 166
+          },
+          "change": {
+            "kind": "computed",
+            "percent": -0.6
+          }
+        },
+        {
+          "durationSeconds": 3600,
+          "current": {
+            "kind": "computed",
+            "bpm": 151
+          },
+          "previous": {
+            "kind": "computed",
+            "bpm": 152
+          },
+          "change": {
+            "kind": "computed",
+            "percent": -0.7
+          }
+        }
+      ]
+    },
+    "sustainabilityContext": {
+      "kind": "computed",
+      "window": {
+        "start": "1998-07-12",
+        "end": "1998-08-22"
+      },
+      "coverageRatio": 0.83,
+      "sourceContext": "mixed"
+    },
+    "freshness": "fresh",
+    "asOf": "1998-08-22T08:00:00.000Z"
+  },
+  "recentRides": {
+    "kind": "computed",
+    "asOf": "1998-08-22T08:00:00.000Z",
+    "windowDays": 28,
+    "items": [
+      {
+        "id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "subSport": "road",
+        "startEpochSeconds": 903751200,
+        "timezoneOffsetSeconds": 21600,
+        "localDate": "1998-08-22",
+        "elapsedSeconds": 7800,
+        "movingSeconds": 7500,
+        "distanceMeters": 61800
+      },
+      {
+        "id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "subSport": "indoor_cycling",
+        "startEpochSeconds": 903618000,
+        "timezoneOffsetSeconds": 21600,
+        "localDate": "1998-08-20",
+        "elapsedSeconds": 3300,
+        "movingSeconds": 3000,
+        "distanceMeters": 24100
+      },
+      {
+        "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "subSport": "road",
+        "startEpochSeconds": 903528000,
+        "timezoneOffsetSeconds": 21600,
+        "localDate": "1998-08-19",
+        "elapsedSeconds": 5100,
+        "movingSeconds": 4800,
+        "distanceMeters": 41000
+      },
+      {
+        "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "subSport": "road",
+        "startEpochSeconds": 903402000,
+        "timezoneOffsetSeconds": 21600,
+        "localDate": "1998-08-18",
+        "elapsedSeconds": 5700,
+        "movingSeconds": 5400,
+        "distanceMeters": 48300
+      },
+      {
+        "id": "7777777777777777777777777777777777777777777777777777777777777777",
+        "subSport": "road",
+        "startEpochSeconds": 903232800,
+        "timezoneOffsetSeconds": 21600,
+        "localDate": "1998-08-16",
+        "elapsedSeconds": 7500,
+        "movingSeconds": 7200,
+        "distanceMeters": 60100
+      },
+      {
+        "id": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "subSport": "road",
+        "startEpochSeconds": 903009600,
+        "timezoneOffsetSeconds": 21600,
+        "localDate": "1998-08-13",
+        "elapsedSeconds": 4800,
+        "movingSeconds": 4500,
+        "distanceMeters": 39200
+      },
+      {
+        "id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "subSport": "road",
+        "startEpochSeconds": 902797200,
+        "timezoneOffsetSeconds": 21600,
+        "localDate": "1998-08-11",
+        "elapsedSeconds": 5700,
+        "movingSeconds": 5400,
+        "distanceMeters": 47900
+      }
+    ]
+  },
+  "trainingHistory": {
+    "kind": "computed",
+    "asOf": "1998-08-22T08:00:00.000Z",
+    "calendarTimeZone": "Asia/Almaty",
+    "displayMode": "current",
+    "coverage": {
+      "kind": "contiguous",
+      "start": "1998-05-01",
+      "through": "1998-08-22",
+      "committedAt": "1998-08-22T07:55:00.000Z"
+    },
+    "anchorWeek": {
+      "id": "anchor",
+      "window": {
+        "start": "1998-08-17",
+        "end": "1998-08-23"
+      },
+      "calendarState": "open",
+      "coverage": {
+        "kind": "complete"
+      },
+      "totals": {
+        "rideCount": {
+          "kind": "computed",
+          "value": 4
+        },
+        "ridingSeconds": {
+          "kind": "computed",
+          "value": 20700
+        },
+        "distanceMeters": {
+          "kind": "computed",
+          "value": 175200
+        },
+        "load": {
+          "kind": "computed",
+          "value": 307
+        }
+      },
+      "rides": {
+        "count": {
+          "kind": "exact",
+          "value": 4
+        },
+        "items": [
+          {
+            "id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "title": "Café ride",
+            "subSport": "road",
+            "startEpochSeconds": 903751200,
+            "timezoneOffsetSeconds": 21600,
+            "localDate": "1998-08-22",
+            "ridingSeconds": 7500,
+            "ridingTimeBasis": "moving",
+            "elapsedSeconds": 7800,
+            "distanceMeters": 61800,
+            "load": 96,
+            "averagePowerWatts": 181,
+            "averageHeartRateBpm": 139,
+            "perceivedExertion": 4,
+            "energyKilojoules": 1358
+          },
+          {
+            "id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "title": null,
+            "subSport": "indoor_cycling",
+            "startEpochSeconds": 903618000,
+            "timezoneOffsetSeconds": 21600,
+            "localDate": "1998-08-20",
+            "ridingSeconds": 3000,
+            "ridingTimeBasis": "moving",
+            "elapsedSeconds": 3300,
+            "distanceMeters": 24100,
+            "load": 31,
+            "averagePowerWatts": 165,
+            "averageHeartRateBpm": 128,
+            "perceivedExertion": 3,
+            "energyKilojoules": 495
+          },
+          {
+            "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "title": "Threshold 4×8",
+            "subSport": "road",
+            "startEpochSeconds": 903528000,
+            "timezoneOffsetSeconds": 21600,
+            "localDate": "1998-08-19",
+            "ridingSeconds": 4800,
+            "ridingTimeBasis": "moving",
+            "elapsedSeconds": 5100,
+            "distanceMeters": 41000,
+            "load": 102,
+            "averagePowerWatts": 236,
+            "averageHeartRateBpm": 158,
+            "perceivedExertion": 8,
+            "energyKilojoules": 1133
+          },
+          {
+            "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "title": "Endurance",
+            "subSport": "road",
+            "startEpochSeconds": 903402000,
+            "timezoneOffsetSeconds": 21600,
+            "localDate": "1998-08-18",
+            "ridingSeconds": 5400,
+            "ridingTimeBasis": "moving",
+            "elapsedSeconds": 5700,
+            "distanceMeters": 48300,
+            "load": 78,
+            "averagePowerWatts": 198,
+            "averageHeartRateBpm": 142,
+            "perceivedExertion": 5,
+            "energyKilojoules": 1070
+          }
+        ],
+        "truncated": false
+      },
+      "trend": {
+        "kind": "computed",
+        "buckets": [
+          {
+            "window": {
+              "start": "1998-07-06",
+              "end": "1998-07-12"
+            },
+            "rideCount": 3,
+            "ridingSeconds": 12600
+          },
+          {
+            "window": {
+              "start": "1998-07-13",
+              "end": "1998-07-19"
+            },
+            "rideCount": 4,
+            "ridingSeconds": 16200
+          },
+          {
+            "window": {
+              "start": "1998-07-20",
+              "end": "1998-07-26"
+            },
+            "rideCount": 2,
+            "ridingSeconds": 9000
+          },
+          {
+            "window": {
+              "start": "1998-07-27",
+              "end": "1998-08-02"
+            },
+            "rideCount": 4,
+            "ridingSeconds": 15300
+          },
+          {
+            "window": {
+              "start": "1998-08-03",
+              "end": "1998-08-09"
+            },
+            "rideCount": 3,
+            "ridingSeconds": 13500
+          },
+          {
+            "window": {
+              "start": "1998-08-10",
+              "end": "1998-08-16"
+            },
+            "rideCount": 3,
+            "ridingSeconds": 17100
+          }
+        ]
+      },
+      "callout": {
+        "kind": "longest-ride-28d",
+        "rideId": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "durationSeconds": 7500,
+        "window": {
+          "start": "1998-07-26",
+          "end": "1998-08-22"
+        },
+        "comparisonRideCount": 14
+      }
+    },
+    "previousWeek": {
+      "id": "previous",
+      "window": {
+        "start": "1998-08-10",
+        "end": "1998-08-16"
+      },
+      "calendarState": "closed",
+      "coverage": {
+        "kind": "complete"
+      },
+      "totals": {
+        "rideCount": {
+          "kind": "computed",
+          "value": 3
+        },
+        "ridingSeconds": {
+          "kind": "computed",
+          "value": 17100
+        },
+        "distanceMeters": {
+          "kind": "computed",
+          "value": 147200
+        },
+        "load": {
+          "kind": "computed",
+          "value": 262
+        }
+      },
+      "rides": {
+        "count": {
+          "kind": "exact",
+          "value": 3
+        },
+        "items": [
+          {
+            "id": "7777777777777777777777777777777777777777777777777777777777777777",
+            "title": "Long ride",
+            "subSport": "road",
+            "startEpochSeconds": 903232800,
+            "timezoneOffsetSeconds": 21600,
+            "localDate": "1998-08-16",
+            "ridingSeconds": 7200,
+            "ridingTimeBasis": "moving",
+            "elapsedSeconds": 7500,
+            "distanceMeters": 60100,
+            "load": 98,
+            "averagePowerWatts": 186,
+            "averageHeartRateBpm": 143,
+            "perceivedExertion": 5,
+            "energyKilojoules": 1339
+          },
+          {
+            "id": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "title": "Sweet spot 3×12",
+            "subSport": "road",
+            "startEpochSeconds": 903009600,
+            "timezoneOffsetSeconds": 21600,
+            "localDate": "1998-08-13",
+            "ridingSeconds": 4500,
+            "ridingTimeBasis": "moving",
+            "elapsedSeconds": 4800,
+            "distanceMeters": 39200,
+            "load": 88,
+            "averagePowerWatts": 228,
+            "averageHeartRateBpm": 154,
+            "perceivedExertion": 7,
+            "energyKilojoules": 1026
+          },
+          {
+            "id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "title": "Endurance",
+            "subSport": "road",
+            "startEpochSeconds": 902797200,
+            "timezoneOffsetSeconds": 21600,
+            "localDate": "1998-08-11",
+            "ridingSeconds": 5400,
+            "ridingTimeBasis": "moving",
+            "elapsedSeconds": 5700,
+            "distanceMeters": 47900,
+            "load": 76,
+            "averagePowerWatts": 195,
+            "averageHeartRateBpm": 141,
+            "perceivedExertion": 5,
+            "energyKilojoules": 1053
+          }
+        ],
+        "truncated": false
+      },
+      "trend": {
+        "kind": "computed",
+        "buckets": [
+          {
+            "window": {
+              "start": "1998-06-29",
+              "end": "1998-07-05"
+            },
+            "rideCount": 2,
+            "ridingSeconds": 9900
+          },
+          {
+            "window": {
+              "start": "1998-07-06",
+              "end": "1998-07-12"
+            },
+            "rideCount": 3,
+            "ridingSeconds": 12600
+          },
+          {
+            "window": {
+              "start": "1998-07-13",
+              "end": "1998-07-19"
+            },
+            "rideCount": 4,
+            "ridingSeconds": 16200
+          },
+          {
+            "window": {
+              "start": "1998-07-20",
+              "end": "1998-07-26"
+            },
+            "rideCount": 2,
+            "ridingSeconds": 9000
+          },
+          {
+            "window": {
+              "start": "1998-07-27",
+              "end": "1998-08-02"
+            },
+            "rideCount": 4,
+            "ridingSeconds": 15300
+          },
+          {
+            "window": {
+              "start": "1998-08-03",
+              "end": "1998-08-09"
+            },
+            "rideCount": 3,
+            "ridingSeconds": 13500
+          }
+        ]
+      },
+      "callout": null
+    }
+  },
+  "anchorZones": {
+    "kind": "unknown",
+    "reason": "missing-anchor"
+  },
+  "cyclingLoad": {
+    "kind": "computed",
+    "asOf": "1998-08-22T08:00:00.000Z",
+    "source": "intervals.icu",
+    "windowDays": 7,
+    "value": 307,
+    "activityCount": 4,
+    "missingLoadCount": 0
+  },
+  "plan": {
+    "kind": "computed",
+    "asOf": "1998-08-22T08:00:00.000Z",
+    "items": []
+  },
+  "adherence": {
+    "kind": "unknown",
+    "reason": "insufficient-data"
+  },
+  "wellnessTrend": {
+    "kind": "unknown",
+    "reason": "no-wellness"
+  }
+}
+`;
+
+export const TRAINING_CURRENT_ATHLETE_STATE = createInspectionAthleteState(
+  JSON.parse(TRAINING_CONTEXT_JSON) as unknown,
+);

--- a/apps/desktop/tests/interactive-development.test.ts
+++ b/apps/desktop/tests/interactive-development.test.ts
@@ -5,6 +5,7 @@ import {
   DESKTOP_INSPECTION_FIXTURE_ENV,
   PLAN_CURRENT_INSPECTION_FIXTURE,
   selectInteractiveDevelopmentTemporaryRoot,
+  TRAINING_CURRENT_INSPECTION_FIXTURE,
 } from "../scripts/interactive-development.mjs";
 
 const desktopRoot = join("/private", "tmp", "enduragent", "apps", "desktop");
@@ -57,27 +58,30 @@ describe("interactive desktop development plan", () => {
     expect(value.athleteHome).not.toBe(value.userData);
   });
 
-  it("launches the bounded Plan inspection fixture through the isolated command", () => {
-    const value = plan({
-      environment: {
-        [DESKTOP_INSPECTION_FIXTURE_ENV]: PLAN_CURRENT_INSPECTION_FIXTURE,
-        PLAN_QA_SCENARIO: "PL-S089",
-        PLAN_QA_OUTCOME: "failure",
-      },
-    });
+  it.each([PLAN_CURRENT_INSPECTION_FIXTURE, TRAINING_CURRENT_INSPECTION_FIXTURE])(
+    "launches the bounded %s inspection fixture through the isolated command",
+    (inspectionFixture) => {
+      const value = plan({
+        environment: {
+          [DESKTOP_INSPECTION_FIXTURE_ENV]: inspectionFixture,
+          PLAN_QA_SCENARIO: "PL-S089",
+          PLAN_QA_OUTCOME: "failure",
+        },
+      });
 
-    expect(value.args).toEqual([
-      "-dimsu",
-      nodeExecutable,
-      packageManagerScript,
-      "exec",
-      "tsx",
-      "tests/helpers/plan-inspection-live.ts",
-    ]);
-    expect(value.environment[DESKTOP_INSPECTION_FIXTURE_ENV]).toBe(PLAN_CURRENT_INSPECTION_FIXTURE);
-    expect(value.environment.PLAN_QA_SCENARIO).toBeUndefined();
-    expect(value.environment.PLAN_QA_OUTCOME).toBeUndefined();
-  });
+      expect(value.args).toEqual([
+        "-dimsu",
+        nodeExecutable,
+        packageManagerScript,
+        "exec",
+        "tsx",
+        "tests/helpers/plan-inspection-live.ts",
+      ]);
+      expect(value.environment[DESKTOP_INSPECTION_FIXTURE_ENV]).toBe(inspectionFixture);
+      expect(value.environment.PLAN_QA_SCENARIO).toBeUndefined();
+      expect(value.environment.PLAN_QA_OUTCOME).toBeUndefined();
+    },
+  );
 
   it("refuses an unknown inspection fixture", () => {
     expect(() =>

--- a/apps/desktop/tests/plan-inspection-live.test.ts
+++ b/apps/desktop/tests/plan-inspection-live.test.ts
@@ -1,4 +1,5 @@
 import {
+  AthleteStateSchema,
   GetRuntimeConfigRpcResultSchema,
   GetSetupStatusRpcResultSchema,
   GetTranscriptPageRpcResultSchema,
@@ -8,11 +9,16 @@ import {
   ChatAttachmentComposerReadModelSchema,
 } from "@enduragent/coach-contract";
 import { describe, expect, it } from "vitest";
+import { PLAN_QA_ATHLETE_STATE } from "./helpers/inspection-athlete-states.js";
 import {
   createPlanInspectionFixtureScript,
+  inspectionAthleteState,
+  PLAN_CURRENT_INSPECTION_FIXTURE,
   PLAN_INSPECTION_SCENARIO_ID,
   PLAN_INSPECTION_TURNS,
+  TRAINING_CURRENT_INSPECTION_FIXTURE,
 } from "./helpers/plan-inspection-live.js";
+import { TRAINING_CURRENT_ATHLETE_STATE } from "./helpers/training-current-athlete-state.js";
 
 function request(method: string, params: Record<string, unknown> = {}) {
   return { jsonrpc: "2.0", method, params };
@@ -28,6 +34,52 @@ async function result(
 }
 
 describe("Plan inspection live fixture", () => {
+  it.each([
+    [PLAN_CURRENT_INSPECTION_FIXTURE, PLAN_QA_ATHLETE_STATE, 1],
+    [TRAINING_CURRENT_INSPECTION_FIXTURE, TRAINING_CURRENT_ATHLETE_STATE, 7],
+  ])("returns schema-valid athlete state for %s", async (name, expected, expectedRideCount) => {
+    const athleteState = inspectionAthleteState(name);
+    const script = createPlanInspectionFixtureScript(athleteState);
+    const state = AthleteStateSchema.parse(await result(script, "getAthleteState"));
+    expect(state).toEqual(expected);
+    expect(state.trainingContext?.recentRides.kind).toBe("computed");
+    expect(
+      state.trainingContext?.recentRides.kind === "computed"
+        ? state.trainingContext.recentRides.items
+        : [],
+    ).toHaveLength(expectedRideCount);
+  });
+
+  it("refuses an unknown fixture at direct-execution selection", () => {
+    expect(() => inspectionAthleteState("arbitrary-script")).toThrow(
+      "unknown desktop inspection fixture",
+    );
+  });
+
+  it("provides the populated Training inspection story", async () => {
+    const script = createPlanInspectionFixtureScript(TRAINING_CURRENT_ATHLETE_STATE);
+    const state = AthleteStateSchema.parse(await result(script, "getAthleteState"));
+    const context = state.trainingContext;
+
+    expect(context?.recentRides.kind).toBe("computed");
+    expect(context?.recentRides.kind === "computed" ? context.recentRides.items : []).toHaveLength(
+      7,
+    );
+    expect(context?.trainingHistory.kind).toBe("computed");
+    if (context?.trainingHistory.kind !== "computed") throw new TypeError("expected history");
+    expect(context.trainingHistory.anchorWeek.rides.items).toHaveLength(4);
+    expect(context.trainingHistory.previousWeek?.rides.items).toHaveLength(3);
+    expect(context.trainingHistory.anchorWeek.trend.kind).toBe("computed");
+    expect(
+      context.trainingHistory.anchorWeek.trend.kind === "computed"
+        ? context.trainingHistory.anchorWeek.trend.buckets
+        : [],
+    ).toHaveLength(6);
+    expect(context.trainingHistory.anchorWeek.callout?.kind).toBe("longest-ride-28d");
+    expect(context.performanceProgress.kind).toBe("computed");
+    expect(context.cyclingLoad).toMatchObject({ kind: "computed", value: 307 });
+  });
+
   it("uses privacy-safe ordinary Main Chat turns", async () => {
     const script = createPlanInspectionFixtureScript();
     const transcript = GetTranscriptPageRpcResultSchema.parse(


### PR DESCRIPTION
## Summary

- make the existing Plan inspection athlete state schema-valid
- add a bounded `training-current` fixture with populated rides, history, Power, and Load
- validate both fixture responses and reject unknown fixture names

## Verification

- focused desktop tests: 17 passed
- desktop type check
- dependency, renderer, and desktop builds
- fixture privacy check
- changeset validation
- live launcher readiness and four-view Electron inspection
- disposable-root cleanup
- `git diff --check`

This child PR targets `epic/training-page`; umbrella PR #857 remains untouched.