### PR TITLE
fix(renderer): match training responsive layout

### DIFF
--- a/.changeset/training-visual-parity.md
+++ b/.changeset/training-visual-parity.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Training now reflows cleanly at the minimum window size and keeps ride callouts readable.

--- a/apps/desktop-renderer/src/ui/training/overviewStyles.ts
+++ b/apps/desktop-renderer/src/ui/training/overviewStyles.ts
@@ -8,7 +8,7 @@ export const overviewStyles = {
   weekHeading:
     "mb-3.5 flex min-w-0 items-baseline justify-between gap-3 max-[520px]:grid [&_h2]:m-0 [&_h2]:text-lg [&_h2]:leading-7 [&_h2]:font-semibold [&_p]:m-0 [&_p]:text-xs [&_p]:leading-4 [&_p]:text-ink-3",
   weekHero:
-    "grid min-w-0 grid-cols-[minmax(210px,0.82fr)_minmax(0,1.18fr)] items-stretch gap-6 max-[760px]:grid-cols-1 max-[760px]:gap-[18px]",
+    "grid min-w-0 grid-cols-[minmax(210px,0.82fr)_minmax(0,1.18fr)] items-stretch gap-6 max-[761px]:grid-cols-1 max-[761px]:gap-[18px]",
   weekFacts: "min-w-0",
   weekEyebrow: "m-0 text-xs leading-4 font-semibold text-ink-3",
   weekTime:
@@ -16,10 +16,10 @@ export const overviewStyles = {
   weekMetrics:
     "mt-2.5 flex min-w-0 flex-wrap gap-x-[18px] gap-y-2 [&>div]:min-w-0 [&_dt]:text-xs [&_dt]:leading-4 [&_dt]:text-ink-3 [&_dd]:mt-0.5 [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-sm [&_dd]:leading-5 [&_dd]:font-medium [&_dd]:tabular-nums",
   trend:
-    "m-0 grid min-w-0 grid-rows-[auto_1fr] gap-2.5 border-l border-line pl-6 max-[760px]:border-t max-[760px]:border-l-0 max-[760px]:pt-3.5 max-[760px]:pl-0",
+    "m-0 grid min-w-0 grid-rows-[auto_1fr] gap-2.5 border-l border-line pl-6 max-[761px]:border-t max-[761px]:border-l-0 max-[761px]:pt-3.5 max-[761px]:pl-0",
   trendCaption: "text-xs leading-4 font-medium text-ink-2",
   trendBars:
-    "grid min-h-[92px] grid-cols-6 items-end gap-inset border-b border-line max-[760px]:min-h-[76px]",
+    "grid min-h-[92px] grid-cols-6 items-end gap-inset border-b border-line max-[761px]:min-h-[76px]",
   trendColumn: "grid h-full min-w-0 grid-rows-[1fr_auto] items-end gap-1",
   trendBar: "training-trend-bar w-full rounded-t-chip bg-line-2",
   trendLabel:
@@ -31,17 +31,17 @@ export const overviewStyles = {
   historyRideItem:
     "border-t border-line last:border-b data-[callout=true]:bg-[color-mix(in_srgb,var(--brand-soft)_58%,transparent)]",
   historyRideButton:
-    "group/ride relative grid min-h-[78px] w-full min-w-0 grid-cols-[minmax(0,1fr)_auto_auto_18px] items-center gap-3.5 bg-transparent px-inset py-row text-left text-ink outline-none transition-colors hover:bg-[color-mix(in_srgb,var(--ink)_5%,transparent)] focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink motion-reduce:transition-none max-[760px]:grid-cols-[minmax(0,1fr)_auto_18px] max-[520px]:gap-2.5",
+    "group/ride relative grid min-h-[78px] w-full min-w-0 grid-cols-[minmax(0,1fr)_auto_auto_18px] items-center gap-3.5 bg-transparent px-inset py-row text-left text-ink outline-none transition-colors hover:bg-[color-mix(in_srgb,var(--ink)_5%,transparent)] focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink motion-reduce:transition-none max-[761px]:grid-cols-[minmax(0,1fr)_auto_18px] max-[520px]:gap-2.5",
   historyRideMain: "grid min-w-0 gap-1",
   historyRideTitle:
     "flex min-w-0 flex-wrap items-center gap-inset [&>strong]:overflow-hidden [&>strong]:text-sm [&>strong]:font-semibold [&>strong]:text-ellipsis [&>strong]:whitespace-nowrap [&>span]:inline-flex [&>span]:min-h-5 [&>span]:items-center [&>span]:rounded-chip [&>span]:bg-brand-soft [&>span]:px-1.5 [&>span]:text-xs [&>span]:font-medium [&>span]:text-brand",
   historyRideReason:
-    "overflow-hidden text-xs leading-4 font-medium text-brand text-ellipsis whitespace-nowrap",
+    "[overflow-wrap:anywhere] text-xs leading-4 font-medium whitespace-normal text-brand",
   historyRideStats:
-    "grid min-w-[76px] gap-1 text-right text-xs leading-4 text-ink-2 tabular-nums max-[760px]:col-start-1 max-[760px]:row-start-2 max-[760px]:min-w-0 max-[760px]:grid-flow-col max-[760px]:justify-start max-[760px]:gap-3 max-[760px]:text-left",
-  historyRideLoad: "text-xs leading-4 text-ink-2 tabular-nums max-[760px]:hidden",
+    "grid min-w-[76px] gap-1 text-right text-xs leading-4 text-ink-2 tabular-nums max-[761px]:col-start-1 max-[761px]:row-start-2 max-[761px]:min-w-0 max-[761px]:grid-flow-col max-[761px]:justify-start max-[761px]:gap-3 max-[761px]:text-left",
+  historyRideLoad: "text-xs leading-4 text-ink-2 tabular-nums max-[761px]:hidden",
   historyRideArrow:
-    "text-sm text-ink-3 transition-transform group-hover/ride:translate-x-0.5 motion-reduce:transition-none max-[760px]:col-start-3 max-[760px]:row-span-2 max-[760px]:row-start-1",
+    "text-sm text-ink-3 transition-transform group-hover/ride:translate-x-0.5 motion-reduce:transition-none max-[761px]:col-start-3 max-[761px]:row-span-2 max-[761px]:row-start-1",
   historyEmpty: "m-0 py-3.5 text-sm leading-5 text-ink-2",
   truncation: "mt-3 text-xs leading-5 text-ink-3",
   importStatus: "mt-7 border-t border-line pt-3.5 [&>h2]:m-0 [&>h2]:text-sm [&>h2]:font-semibold",

--- a/apps/desktop-renderer/src/ui/training/responseStyles.ts
+++ b/apps/desktop-renderer/src/ui/training/responseStyles.ts
@@ -26,10 +26,10 @@ export const responseStyles = {
   responseFitLine: "response-fit-line flex-[0_0_34px] border-t-[3px] border-brand",
   responseFitNote: "mt-2 max-w-[660px] text-xs leading-[1.5] text-ink-3",
   responseSummary:
-    "mt-4 grid grid-cols-[repeat(2,minmax(0,1fr))_auto] items-center gap-3 max-[760px]:grid-cols-2 [&>div]:min-w-0 [&>div]:border-r [&>div]:border-line [&>div]:pr-3 [&_p]:m-0 [&>div>p:last-child]:mt-1 [&>div>p:last-child]:text-xs [&>div>p:last-child]:text-ink-3",
+    "mt-4 grid grid-cols-[repeat(2,minmax(0,1fr))_auto] items-center gap-3 max-[761px]:grid-cols-2 [&>div]:min-w-0 [&>div]:border-r [&>div]:border-line [&>div]:pr-3 [&_p]:m-0 [&>div>p:last-child]:mt-1 [&>div>p:last-child]:text-xs [&>div>p:last-child]:text-ink-3",
   responseValue: "text-xl leading-6 font-semibold tabular-nums",
   responseCoverage:
-    "justify-self-end rounded-chip border border-line-2 px-2 py-[5px] text-xs font-medium text-ink-2 data-[limited=true]:border-brand max-[760px]:col-span-full max-[760px]:justify-self-start",
+    "justify-self-end rounded-chip border border-line-2 px-2 py-[5px] text-xs font-medium text-ink-2 data-[limited=true]:border-brand max-[761px]:col-span-full max-[761px]:justify-self-start",
   responseMeta:
-    "mt-3.5 grid grid-cols-3 gap-2.5 max-[760px]:grid-cols-1 [&>div]:min-w-0 [&>div]:rounded-card [&>div]:border [&>div]:border-line [&>div]:p-2.5 [&_dt]:text-xs [&_dt]:font-medium [&_dt]:text-ink-3 [&_dd]:mt-[5px] [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.4] [&_dd]:text-ink-2 [&_dd]:tabular-nums",
+    "mt-3.5 grid grid-cols-3 gap-2.5 max-[761px]:grid-cols-1 [&>div]:min-w-0 [&>div]:rounded-card [&>div]:border [&>div]:border-line [&>div]:p-2.5 [&_dt]:text-xs [&_dt]:font-medium [&_dt]:text-ink-3 [&_dd]:mt-[5px] [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.4] [&_dd]:text-ink-2 [&_dd]:tabular-nums",
 } as const;

--- a/apps/desktop-renderer/src/ui/training/rideStyles.ts
+++ b/apps/desktop-renderer/src/ui/training/rideStyles.ts
@@ -3,10 +3,10 @@ import { overviewStyles } from "./overviewStyles";
 export const rideStyles = {
   ...overviewStyles,
   rideOverview:
-    "rounded-card border border-line bg-surface p-5 shadow-elev-1 [&_h2]:m-0 [&_h2]:text-2xl [&_h2]:leading-7 [&_h2]:font-semibold [&_h2]:tracking-normal",
+    "rounded-card border border-line bg-surface p-5 shadow-elev-1 [&_h2]:m-0 [&_h2]:text-2xl [&_h2]:leading-8 [&_h2]:font-semibold [&_h2]:tracking-normal",
   elapsedFallback: "mt-2 text-xs leading-5 text-ink-3",
   recordedMetrics:
-    "mt-4 grid grid-cols-4 gap-3.5 border-y border-line py-3.5 max-[760px]:grid-cols-2 max-[520px]:grid-cols-1 [&>div]:min-w-0 [&_dt]:text-xs [&_dt]:font-medium [&_dt]:text-ink-3 [&_dd]:mt-1 [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-sm [&_dd]:font-medium [&_dd]:tabular-nums",
+    "mt-4 grid grid-cols-4 gap-3.5 border-y border-line py-3.5 max-[761px]:grid-cols-2 max-[520px]:grid-cols-1 [&>div]:min-w-0 [&_dt]:text-xs [&_dt]:font-medium [&_dt]:text-ink-3 [&_dd]:mt-1 [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-sm [&_dd]:font-medium [&_dd]:tabular-nums",
   calloutReason:
     "mt-3.5 flex flex-wrap items-baseline gap-x-2.5 gap-y-1 rounded-ctl bg-brand-soft px-3 py-2.5 text-sm text-brand [&_strong]:font-semibold [&_span]:text-xs [&_span]:leading-5",
   recordedDisclosure:
@@ -51,20 +51,20 @@ export const rideStyles = {
   intervalGroupIdentity:
     "flex min-w-0 items-end justify-between gap-3 max-[520px]:flex-col max-[520px]:items-start [&>div]:grid [&>div]:min-w-0 [&>div]:gap-[3px] [&_span]:text-xs [&_span]:text-ink-3 [&_strong]:text-sm [&_strong]:font-semibold [&_p]:m-0 [&_p]:[overflow-wrap:anywhere] [&_p]:text-right [&_p]:text-xs [&_p]:leading-[1.3] [&_p]:text-ink-3 max-[520px]:[&_p]:text-left",
   intervalItem:
-    "grid min-w-0 grid-cols-[minmax(155px,0.72fr)_minmax(0,1.6fr)] items-center gap-4 rounded-card border-l-[3px] border-line-2 bg-sunk px-3.5 py-[13px] data-[kind=recovery]:border-l-ink-3 data-[kind=work]:border-l-brand max-[760px]:grid-cols-1",
+    "grid min-w-0 grid-cols-[minmax(155px,0.72fr)_minmax(0,1.6fr)] items-center gap-4 rounded-card border-l-[3px] border-line-2 bg-sunk px-3.5 py-[13px] data-[kind=recovery]:border-l-ink-3 data-[kind=work]:border-l-brand max-[761px]:grid-cols-1",
   intervalIdentity:
     "grid min-w-0 grid-cols-[27px_minmax(0,1fr)] items-start gap-2.5 [&_h3]:mt-1 [&_h3]:[overflow-wrap:anywhere] [&_h3]:text-sm [&_h3]:font-semibold [&_p]:mt-1 [&_p]:text-xs [&_p]:leading-[1.3] [&_p]:text-ink-3",
   intervalOrdinal:
     "grid size-[25px] place-items-center rounded-full border border-line-2 text-xs text-ink-2 tabular-nums",
   intervalKind: "text-xs text-ink-3",
   intervalMetrics:
-    "m-0 grid min-w-0 grid-cols-4 gap-2.5 max-[760px]:grid-cols-2 max-[520px]:grid-cols-1 [&>div]:min-w-0 [&_dt]:text-xs [&_dt]:text-ink-3 [&_dd]:mt-[5px] [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.4] [&_dd]:text-ink-2 [&_dd]:tabular-nums",
+    "m-0 grid min-w-0 grid-cols-4 gap-2.5 max-[761px]:grid-cols-2 max-[520px]:grid-cols-1 [&>div]:min-w-0 [&_dt]:text-xs [&_dt]:text-ink-3 [&_dd]:mt-[5px] [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.4] [&_dd]:text-ink-2 [&_dd]:tabular-nums",
   effortList:
-    "mt-3.5 grid list-none grid-cols-3 gap-[9px] p-0 max-[760px]:grid-cols-2 max-[520px]:grid-cols-1 [&_strong]:text-xl [&_strong]:leading-[1.1] [&_strong]:font-semibold [&_strong]:tabular-nums",
+    "mt-3.5 grid list-none grid-cols-3 gap-[9px] p-0 max-[761px]:grid-cols-2 max-[520px]:grid-cols-1 [&_strong]:text-xl [&_strong]:leading-[1.1] [&_strong]:font-semibold [&_strong]:tabular-nums",
   effortItem:
     "grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2.5 gap-y-[5px] rounded-card bg-sunk px-3.5 py-[13px] [&>span:last-child]:[overflow-wrap:anywhere] [&>span:last-child]:text-xs [&>span:last-child]:leading-[1.4] [&>span:last-child]:text-ink-3",
   effortRank: "row-span-2 row-start-1 text-xs text-ink-3",
   rideEyebrow: "mb-2 text-xs font-medium text-ink-3",
   rideSummary:
-    "mt-[22px] grid grid-cols-3 border-t border-line max-[520px]:grid-cols-1 [&>div]:min-w-0 [&>div]:pt-3.5 [&>div]:pr-3.5 [&_dt]:mb-[5px] [&_dt]:text-xs [&_dt]:font-medium [&_dt]:text-ink-3 [&_dd]:m-0 [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.45] [&_dd]:text-ink [&_dd]:tabular-nums",
+    "mt-[calc(var(--row-inset)+var(--inset))] grid grid-cols-3 gap-3.5 border-t border-line max-[520px]:grid-cols-1 [&>div]:min-w-0 [&>div]:pt-3.5 [&>div]:pr-3.5 [&_dt]:mb-[5px] [&_dt]:text-xs [&_dt]:font-medium [&_dt]:text-ink-3 [&_dd]:m-0 [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.45] [&_dd]:text-ink [&_dd]:tabular-nums",
 } as const;

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -472,7 +472,10 @@ describe("training landing page", () => {
     const figure = screen.getByRole("figure", {
       name: "Six complete weeks of riding time",
     });
+    expect(figure.parentElement).toHaveClass("max-[761px]:grid-cols-1", "max-[761px]:gap-[18px]");
+    expect(figure).toHaveClass("max-[761px]:border-t", "max-[761px]:pt-3.5");
     expect(figure.querySelectorAll(".training-trend-bar")).toHaveLength(6);
+    expect(figure.querySelector('[aria-hidden="true"]')).toHaveClass("max-[761px]:min-h-[76px]");
     const table = within(figure).getByRole("table", {
       name: "Six complete weeks of riding time data",
     });
@@ -507,14 +510,16 @@ describe("training landing page", () => {
     expect(within(recent).getByText("1998-07-09 · 22:00")).toBeInTheDocument();
     expect(within(recent).getByText("1h 25m")).toBeInTheDocument();
     expect(within(recent).getByText("42.1 km")).toBeInTheDocument();
-    expect(within(recent).getByText("Load 91")).toHaveClass("max-[760px]:hidden");
+    expect(within(recent).getByText("Load 91")).toHaveClass("max-[761px]:hidden");
     expect(within(recent).getByText("Indoor ride")).toBeInTheDocument();
     expect(within(recent).getByText("1998-07-08")).toBeInTheDocument();
     expect(within(recent).queryByText(/1998-07-08 ·/u)).not.toBeInTheDocument();
     expect(within(recent).getAllByText("Worth a look")).toHaveLength(1);
-    expect(
-      within(recent).getByText("Longest recorded ride in the 28 days ending 1998-07-09"),
-    ).toBeInTheDocument();
+    const reason = within(recent).getByText(
+      "Longest recorded ride in the 28 days ending 1998-07-09",
+    );
+    expect(reason).toHaveClass("[overflow-wrap:anywhere]", "whitespace-normal");
+    expect(reason).not.toHaveClass("text-ellipsis", "whitespace-nowrap");
   });
 
   it("uses the units preference across the weekly summary, ride row, and Ride review", async () => {
@@ -632,10 +637,15 @@ describe("ride review", () => {
     );
 
     const overview = screen.getByRole("region", { name: "River tempo" });
+    expect(overview).toHaveClass("[&_h2]:leading-8");
     expect(within(overview).getByText("Road ride")).toBeInTheDocument();
     expect(within(overview).getByText("1998-07-09 · 22:00")).toBeInTheDocument();
     expect(within(overview).getByText("1h 25m")).toBeInTheDocument();
     expect(within(overview).getByText("42.1 km")).toBeInTheDocument();
+    const rideSummary = overview.querySelector("dl:first-of-type");
+    expect(rideSummary).toHaveClass("mt-[calc(var(--row-inset)+var(--inset))]", "gap-3.5");
+    const recordedMetrics = overview.querySelector("dl:nth-of-type(2)");
+    expect(recordedMetrics).toHaveClass("max-[761px]:grid-cols-2");
     const metricLabels = [...overview.querySelectorAll("dl:nth-of-type(2) dt")].map(
       (node) => node.textContent,
     );


### PR DESCRIPTION
## Summary

- make the 760 px Training breakpoint inclusive
- stack weekly summary and trend at the minimum window width
- preserve full ride callout copy and align Ride review type, spacing, and metric columns

## Verification

- Training surface tests: 30 passed
- renderer type check
- dependency, renderer, and desktop builds
- wide and compact Electron QA in light and dark mode
- Training and Ride review screenshots plus pixel diffs
- no horizontal overflow
- formatting and `git diff --check`

This child PR targets `epic/training-page`; umbrella PR #857 remains untouched.