### PR TITLE
fix(renderer): wrap sidebar sync status

### DIFF
--- a/.changeset/sidebar-sync-chip-wrap.md
+++ b/.changeset/sidebar-sync-chip-wrap.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: The sync status in the sidebar no longer cuts off mid-word.

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -69,7 +69,7 @@ export function SyncChip(): ReactElement {
     <div
       ref={wrapper}
       tabIndex={-1}
-      className="relative flex min-h-ctl min-w-0 w-full items-center gap-2 px-row py-1.5 text-left text-xs font-normal text-ink-2"
+      className="relative grid min-h-ctl min-w-0 w-full grid-cols-[7px_minmax(0,1fr)] items-start gap-x-2 px-row py-1.5 text-left text-xs font-normal text-ink-2"
       data-sync-chip=""
       data-status={status}
     >
@@ -91,7 +91,7 @@ export function SyncChip(): ReactElement {
       />
       <span
         className={cn(
-          "pointer-events-none relative z-[1] size-[7px] flex-none rounded-full bg-ink-3",
+          "pointer-events-none relative z-[1] mt-[5px] size-[7px] rounded-full bg-ink-3",
           status === "synced" && "bg-ok",
           status === "syncing" && "bg-ink-2",
           (status === "attention" || status === "unavailable") && "bg-warn",
@@ -99,13 +99,17 @@ export function SyncChip(): ReactElement {
         data-status={status}
         aria-hidden="true"
       />
-      <span className="pointer-events-none relative z-[1] min-w-0 flex-1">
-        <span className="block truncate" aria-hidden="true">
+      <span className="pointer-events-none relative z-[1] min-w-0">
+        <span className="block whitespace-normal" data-sync-headline="" aria-hidden="true">
           {HEADLINE[status]}
         </span>
         {restriction === null ? (
           detail === null ? null : (
-            <span className="mt-px block truncate text-ink-3" aria-hidden="true">
+            <span
+              className="mt-px block whitespace-normal text-ink-3"
+              data-sync-detail=""
+              aria-hidden="true"
+            >
               {detail}
             </span>
           )
@@ -117,7 +121,8 @@ export function SyncChip(): ReactElement {
               <a
                 href={`#${STRAVA_RESTRICTION_CARD_ID}`}
                 aria-label={`${restrictionLabel}. How to fix this`}
-                className="pointer-events-auto mt-px flex w-full min-w-0 items-center gap-1 text-[11px] no-underline"
+                className="pointer-events-auto mt-px flex w-full min-w-0 flex-wrap items-center gap-x-1 text-[11px] leading-4 no-underline"
+                data-sync-restriction=""
                 onClick={() => {
                   setActiveView("settings");
                   requestTrainingRestrictionFocus();
@@ -129,10 +134,8 @@ export function SyncChip(): ReactElement {
             }
             triggerContent={
               <>
-                <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-warn">
-                  {restrictionLabel}
-                </span>
-                <span className="flex-none font-sans text-brand underline-offset-2 hover:underline">
+                <span className="text-warn">{restrictionLabel}</span>
+                <span className="font-sans text-brand underline-offset-2 hover:underline">
                   · How to fix this
                 </span>
               </>
@@ -140,12 +143,13 @@ export function SyncChip(): ReactElement {
             body={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipBody}
           />
         )}
-      </span>
-      <span
-        className="pointer-events-none relative z-[1] flex-none text-xs text-ink-3 max-[860px]:hidden"
-        aria-hidden="true"
-      >
-        {sync.label}
+        <span
+          className="mt-px block whitespace-normal text-xs text-ink-3"
+          data-sync-action=""
+          aria-hidden="true"
+        >
+          {sync.label}
+        </span>
       </span>
     </div>
   );

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -406,7 +406,8 @@ describe("sidebar sync chip", () => {
     expect(chip()).toHaveAttribute("data-status", "loading");
     expect(chipSurface()).toHaveClass("min-w-0");
     expect(chipSurface()).toHaveTextContent("Loading training data");
-    expect(screen.getByText("Sync now")).toHaveClass("max-[860px]:hidden");
+    expect(screen.getByText("Sync now")).toHaveAttribute("data-sync-action");
+    expect(chip()).toHaveAccessibleName("Sync now · Loading training data");
 
     update({
       training: {
@@ -423,6 +424,7 @@ describe("sidebar sync chip", () => {
     expect(chip()).toHaveAttribute("data-status", "synced");
     expect(chipSurface()).toHaveTextContent("Training data synced");
     expect(chipSurface()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(screen.getByText("Sync now")).toHaveAttribute("data-sync-action");
     expect(chip()).toHaveAccessibleName(
       "Sync now · Training data synced · 1998-07-19 07:55:00 UTC",
     );
@@ -430,6 +432,9 @@ describe("sidebar sync chip", () => {
     update({ sync: toManualSyncViewState({ status: "running", operation: 1 }) });
     expect(chip()).toHaveAttribute("data-status", "syncing");
     expect(chip()).toBeDisabled();
+    expect(chipSurface()).toHaveTextContent("Syncing");
+    expect(screen.getByText("Sync now")).toHaveAttribute("data-sync-action");
+    expect(chip()).toHaveAccessibleName("Sync now · Syncing");
 
     update({
       sync: toManualSyncViewState({
@@ -440,7 +445,10 @@ describe("sidebar sync chip", () => {
       }),
     });
     expect(chip()).toHaveAttribute("data-status", "attention");
+    expect(chipSurface()).toHaveTextContent("Sync needs attention");
     expect(chipSurface()).toHaveTextContent("Try again");
+    expect(screen.getByText("Try again")).toHaveAttribute("data-sync-action");
+    expect(chip()).toHaveAccessibleName("Try again · Sync needs attention");
   });
 
   it("keeps Strava remedy navigation independent from syncing", async () => {
@@ -471,6 +479,7 @@ describe("sidebar sync chip", () => {
     expect(chip()).toHaveAttribute("data-status", "synced");
     expect(chipSurface()).toHaveTextContent("60 hidden by Strava");
     expect(chipSurface()).toHaveTextContent("How to fix this");
+    expect(screen.getByText("Sync again")).toHaveAttribute("data-sync-action");
     expect(chipSurface()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAttribute("title", "1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAccessibleName(
@@ -551,10 +560,14 @@ describe("sidebar sync chip", () => {
     update({ training: { ...EMPTY_TRAINING_SURFACE, status: "ready" } });
     expect(chip()).toHaveAttribute("data-status", "never");
     expect(chipSurface()).toHaveTextContent("Not synced yet");
+    expect(screen.getByText("Sync now")).toHaveAttribute("data-sync-action");
+    expect(chip()).toHaveAccessibleName("Sync now · Not synced yet");
 
     update({ training: { ...EMPTY_TRAINING_SURFACE, status: "unavailable" } });
     expect(chip()).toHaveAttribute("data-status", "unavailable");
     expect(chipSurface()).toHaveTextContent("Training data unavailable");
+    expect(screen.getByText("Sync now")).toHaveAttribute("data-sync-action");
+    expect(chip()).toHaveAccessibleName("Sync now · Training data unavailable");
   });
 
   it("requests a manual sync and restores keyboard focus to the activator", async () => {

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -2443,9 +2443,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly chipReachable: boolean;
       readonly syncFitsRail: boolean;
       readonly syncHasNoOverflow: boolean;
-      readonly syncLabelHidden: boolean;
+      readonly completeStatusVisible: boolean;
       readonly surfaceMinWidthZero: boolean;
-      readonly truncationApplied: boolean;
+      readonly readableWrapping: boolean;
       readonly trainingOpen: boolean;
       readonly panelOrder: readonly string[];
       readonly retiredPanelsAbsent: boolean;
@@ -2471,8 +2471,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const chip = document.querySelector("button.sync-chip");
       const syncSurface = document.querySelector("[data-sync-chip]");
       const sidebar = syncSurface.closest("aside");
-      const syncLabel = syncSurface.lastElementChild;
-      const truncatedRows = [...syncSurface.querySelectorAll(".truncate")];
+      const headline = syncSurface.querySelector("[data-sync-headline]");
+      const detail = syncSurface.querySelector("[data-sync-detail]");
+      const action = syncSurface.querySelector("[data-sync-action]");
       const railRect = rail.getBoundingClientRect();
       const settingsRect = settings.getBoundingClientRect();
       const chipRect = chip.getBoundingClientRect();
@@ -2499,18 +2500,18 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         syncFitsRail:
           syncRect.left >= sidebarRect.left && syncRect.right <= sidebarRect.right,
         syncHasNoOverflow: syncSurface.scrollWidth <= syncSurface.clientWidth,
-        syncLabelHidden: getComputedStyle(syncLabel).display === "none",
+        completeStatusVisible:
+          headline.textContent === "Training data synced" &&
+          detail.textContent === "2026-07-19 07:55:01 UTC" &&
+          action.textContent === "Sync again" &&
+          [headline, detail, action].every((row) => getComputedStyle(row).display !== "none"),
         surfaceMinWidthZero: getComputedStyle(syncSurface).minWidth === "0px",
-        truncationApplied:
-          truncatedRows.length === 2 &&
-          truncatedRows.every((row) => {
-            const style = getComputedStyle(row);
-            return (
-              style.overflow === "hidden" &&
-              style.textOverflow === "ellipsis" &&
-              style.whiteSpace === "nowrap"
-            );
-          }),
+        readableWrapping:
+          syncSurface.querySelectorAll(".truncate").length === 0 &&
+          [headline, detail, action].every(
+            (row) =>
+              getComputedStyle(row).whiteSpace === "normal" && row.scrollWidth <= row.clientWidth,
+          ),
         trainingOpen: page.getAttribute("aria-hidden") === null,
         panelOrder: panels.map((panel) => panel.dataset.panel),
         retiredPanelsAbsent: ["anchor", "load", "wellness", "plan", "adherence"].every(
@@ -2532,9 +2533,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       chipReachable: true,
       syncFitsRail: true,
       syncHasNoOverflow: true,
-      syncLabelHidden: true,
+      completeStatusVisible: true,
       surfaceMinWidthZero: true,
-      truncationApplied: true,
+      readableWrapping: true,
       trainingOpen: true,
       panelOrder: ["weekly-summary", "recent-rides", "power-progress"],
       retiredPanelsAbsent: true,
@@ -2695,7 +2696,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly enabledAfterSync: boolean;
       readonly longStatusAbsent: boolean;
       readonly surfaceMinWidthZero: boolean;
-      readonly truncationApplied: boolean;
+      readonly readableStatus: boolean;
       readonly chipHasNoOverflow: boolean;
       readonly keyboardFocusRestored: boolean;
       readonly horizontalOverflow: boolean;
@@ -2731,7 +2732,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const chipRect = syncButton.getBoundingClientRect();
       const syncRect = syncSurface.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
-      const truncatedRows = [...syncSurface.querySelectorAll(".truncate")];
+      const headline = syncSurface.querySelector("[data-sync-headline]");
+      const action = syncSurface.querySelector("[data-sync-action]");
       return {
         trainingOpen: page.getAttribute("aria-hidden") === null,
         panelOrder: panels.map((panel) => panel.dataset.panel),
@@ -2761,16 +2763,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
           "Training-data processing partially completed. Try again to finish.",
         ),
         surfaceMinWidthZero: getComputedStyle(syncSurface).minWidth === "0px",
-        truncationApplied:
-          truncatedRows.length === 1 &&
-          truncatedRows.every((row) => {
-            const style = getComputedStyle(row);
-            return (
-              style.overflow === "hidden" &&
-              style.textOverflow === "ellipsis" &&
-              style.whiteSpace === "nowrap"
-            );
-          }),
+        readableStatus:
+          headline.textContent === "Sync needs attention" &&
+          action.textContent === "Try again" &&
+          getComputedStyle(headline).whiteSpace === "normal" &&
+          getComputedStyle(action).display !== "none" &&
+          headline.scrollWidth <= headline.clientWidth &&
+          action.scrollWidth <= action.clientWidth,
         chipHasNoOverflow:
           syncRect.left >= sidebarRect.left &&
           syncRect.right <= sidebarRect.right &&
@@ -2797,7 +2796,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       enabledAfterSync: true,
       longStatusAbsent: true,
       surfaceMinWidthZero: true,
-      truncationApplied: true,
+      readableStatus: true,
       chipHasNoOverflow: true,
       keyboardFocusRestored: true,
       horizontalOverflow: false,


### PR DESCRIPTION
## Summary

- place the sync action under the status headline in the fixed-width sidebar
- keep all status and Strava-restriction text readable without truncation
- preserve the complete accessible name and focus behavior

## Verification

- sidebar renderer tests: 18 passed
- two 720 px Electron integration contracts
- live 191 px rail inspection with no overflow
- renderer and desktop type checks
- dependency, renderer, and desktop builds
- formatting, changeset validation, and `git diff --check`

This child PR targets `epic/training-page`; umbrella PR #857 remains untouched.