### PR TITLE
feat(renderer): localize training dates

### DIFF
--- a/.changeset/training-locale-dates.md
+++ b/.changeset/training-locale-dates.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Training dates and ride times now follow your computer's regional format.

--- a/apps/desktop-renderer/src/lib/date.ts
+++ b/apps/desktop-renderer/src/lib/date.ts
@@ -1,0 +1,39 @@
+const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+
+function civilDate(value: string): Date | null {
+  if (!CIVIL_DATE_PATTERN.test(value)) return null;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value ? date : null;
+}
+
+export function formatCivilDate(value: string, options?: Intl.DateTimeFormatOptions): string {
+  const date = civilDate(value);
+  if (date === null) return "Unknown date";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: options === undefined ? "medium" : undefined,
+    ...options,
+    timeZone: "UTC",
+  }).format(date);
+}
+
+export function formatInstantDateTime(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "Unknown date and time";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export function formatOffsetWallTime(
+  startEpochSeconds: number,
+  timezoneOffsetSeconds: number | null,
+): string | null {
+  if (timezoneOffsetSeconds === null) return null;
+  const date = new Date((startEpochSeconds + timezoneOffsetSeconds) * 1_000);
+  if (!Number.isFinite(date.getTime())) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(date);
+}

--- a/apps/desktop-renderer/src/training-context/format.ts
+++ b/apps/desktop-renderer/src/training-context/format.ts
@@ -1,20 +1,5 @@
 import type { UnitsPreference } from "@enduragent/coach-contract";
 
-export function formatDateLabel(value: string): string {
-  const match = /^(\d{4}-\d{2}-\d{2})/u.exec(value);
-  if (match === null) return "Unknown date";
-  const date = new Date(`${match[1]}T00:00:00.000Z`);
-  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === match[1]
-    ? match[1]
-    : "Unknown date";
-}
-
-export function formatShortDateLabel(value: string): string {
-  const label = formatDateLabel(value);
-  if (label === "Unknown date") return label;
-  return `${Number(label.slice(5, 7))}/${Number(label.slice(8, 10))}`;
-}
-
 const UTC_INSTANT_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|([+-])(\d{2}):(\d{2}))$/u;
 

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -47,6 +47,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../../components/ui/dialog";
+import { formatCivilDate } from "../../lib/date";
 import { planReadModel } from "../../state/plan-slice";
 import { useEnduragentStore } from "../../state/store";
 import { CoachDecisionPanel } from "../chat/CoachDecisionPanel";
@@ -103,14 +104,6 @@ function civilDays(start: string, end: string): number {
 
 function weekdayIndex(value: string): number {
   return civilDate(value).getUTCDay();
-}
-
-function formatCivilDate(value: string, options?: Intl.DateTimeFormatOptions): string {
-  return new Intl.DateTimeFormat(undefined, {
-    timeZone: "UTC",
-    dateStyle: options === undefined ? "medium" : undefined,
-    ...options,
-  }).format(civilDate(value));
 }
 
 function plannedTime(durationS: number): string {

--- a/apps/desktop-renderer/src/ui/training/PowerProgressPanel.tsx
+++ b/apps/desktop-renderer/src/ui/training/PowerProgressPanel.tsx
@@ -1,10 +1,7 @@
 import type { PowerProgressComputed, PowerProgressPanel } from "@enduragent/coach-contract";
 import type { ReactElement } from "react";
-import {
-  formatDateLabel,
-  formatUtcTimestamp,
-  formatWholeNumber,
-} from "../../training-context/format";
+import { formatCivilDate, formatInstantDateTime } from "../../lib/date";
+import { formatWholeNumber } from "../../training-context/format";
 import {
   POWER_PROGRESS_FRESHNESS_COPY,
   POWER_PROGRESS_REFRESH_FAILURE_COPY,
@@ -185,7 +182,7 @@ export function PowerProgressContent(props: { readonly panel: PowerProgressPanel
           {POWER_PROGRESS_REFRESH_FAILURE_COPY[props.panel.refreshFailure.code]} Showing the last
           complete comparison. Failed{" "}
           <time dateTime={props.panel.refreshFailure.failedAt}>
-            {formatUtcTimestamp(props.panel.refreshFailure.failedAt)}
+            {formatInstantDateTime(props.panel.refreshFailure.failedAt)}
           </time>
           .
         </p>
@@ -194,8 +191,8 @@ export function PowerProgressContent(props: { readonly panel: PowerProgressPanel
         <div>
           <p className={styles.progressLead}>{POWER_PROGRESS_ROTATION_COPY[progress.rotation]}</p>
           <p className={styles.meta}>
-            {formatDateLabel(progress.currentWindow.start)}–
-            {formatDateLabel(progress.currentWindow.end)} · compared with the prior 28 days
+            {formatCivilDate(progress.currentWindow.start)}–
+            {formatCivilDate(progress.currentWindow.end)} · compared with the prior 28 days
           </p>
         </div>
         <p className={styles.badge} data-freshness={progress.freshness}>

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -8,8 +8,8 @@ import type {
 import { useRef, type ReactElement, type ReactNode, type Ref } from "react";
 import type { RideAnalysisViewState } from "../../activity-analysis/controller";
 import { Button } from "../../components/ui/button";
+import { formatCivilDate, formatOffsetWallTime } from "../../lib/date";
 import {
-  formatDateLabel,
   formatDistance,
   formatRidingDuration,
   formatWholeNumber,
@@ -46,17 +46,14 @@ function rideDistance(ride: TrainingHistoryRide, units: UnitsPreference): string
 }
 
 export function trainingRideTime(ride: TrainingHistoryRide): string | null {
-  if (ride.timezoneOffsetSeconds === null) return null;
-  const milliseconds = (ride.startEpochSeconds + ride.timezoneOffsetSeconds) * 1_000;
-  const date = new Date(milliseconds);
-  return Number.isFinite(date.getTime()) ? date.toISOString().slice(11, 16) : null;
+  return formatOffsetWallTime(ride.startEpochSeconds, ride.timezoneOffsetSeconds);
 }
 
 export function trainingRideDateTime(ride: TrainingHistoryRide): string {
   const time = trainingRideTime(ride);
   return time === null
-    ? formatDateLabel(ride.localDate)
-    : `${formatDateLabel(ride.localDate)} · ${time}`;
+    ? formatCivilDate(ride.localDate)
+    : `${formatCivilDate(ride.localDate)} · ${time}`;
 }
 
 function RideSummary(props: {

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -15,14 +15,13 @@ import {
   type ReactNode,
 } from "react";
 import { Button } from "../../components/ui/button";
+import { formatCivilDate } from "../../lib/date";
 import { rideImportStatusCopy } from "../../ride-import";
 import { rideImportStatusSuppressed } from "../../state/onboarding-slice";
 import { useEnduragentStore } from "../../state/store";
 import {
-  formatDateLabel,
   formatDistance,
   formatRidingDuration,
-  formatShortDateLabel,
   formatWholeNumber,
 } from "../../training-context/format";
 import { Page } from "../shared/Page";
@@ -68,10 +67,10 @@ function dataWarning(
   const through = coverageDate(history);
   if (history.displayMode === "last-recorded" && through !== null) {
     return history.coverage.kind === "incomplete"
-      ? `Training may be out of date, and some rides may be missing. Showing recorded rides through ${formatDateLabel(
+      ? `Training may be out of date, and some rides may be missing. Showing recorded rides through ${formatCivilDate(
           through,
         )}.`
-      : `Training may be out of date. Showing recorded rides through ${formatDateLabel(through)}.`;
+      : `Training may be out of date. Showing recorded rides through ${formatCivilDate(through)}.`;
   }
   if (week.coverage.kind === "complete") return null;
   if (week.coverage.reason === "coverage-lag") return TRAINING_HISTORY_COPY.coverageLag;
@@ -124,7 +123,9 @@ function Trend(props: { readonly week: CompletedActivityWeek }): ReactElement {
               className={styles.trendBar}
               style={{ height: `${(bucket.ridingSeconds / maximum) * 100}%` }}
             />
-            <span className={styles.trendLabel}>{formatShortDateLabel(bucket.window.start)}</span>
+            <span className={styles.trendLabel}>
+              {formatCivilDate(bucket.window.start, { day: "numeric", month: "numeric" })}
+            </span>
           </span>
         ))}
       </div>
@@ -141,7 +142,7 @@ function Trend(props: { readonly week: CompletedActivityWeek }): ReactElement {
           {trend.buckets.map((bucket) => (
             <tr key={bucket.window.start}>
               <th scope="row">
-                {formatDateLabel(bucket.window.start)} to {formatDateLabel(bucket.window.end)}
+                {formatCivilDate(bucket.window.start)} to {formatCivilDate(bucket.window.end)}
               </th>
               <td>{rideCountCopy(bucket.rideCount)}</td>
               <td>{formatRidingDuration(bucket.ridingSeconds)}</td>
@@ -173,7 +174,7 @@ function WeeklySummary(props: {
         <h2 id="weekly-summary-title">Weekly summary</h2>
         {recordedThrough === null ? null : (
           <p>
-            {TRAINING_HISTORY_COPY.coverage} {formatDateLabel(recordedThrough)}
+            {TRAINING_HISTORY_COPY.coverage} {formatCivilDate(recordedThrough)}
           </p>
         )}
       </div>
@@ -213,7 +214,7 @@ function WeeklySummary(props: {
 function calloutReason(week: CompletedActivityWeek, rideId: string): string | null {
   const callout = week.callout;
   if (callout === null || callout.rideId !== rideId) return null;
-  return `Longest recorded ride in the 28 days ending ${formatDateLabel(callout.window.end)}`;
+  return `Longest recorded ride in the 28 days ending ${formatCivilDate(callout.window.end)}`;
 }
 
 function RideRow(props: {

--- a/apps/desktop-renderer/tests/date.test.ts
+++ b/apps/desktop-renderer/tests/date.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatCivilDate, formatInstantDateTime, formatOffsetWallTime } from "../src/lib/date";
+import { pinDefaultLocale } from "./intl";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("regional date and time formatting", () => {
+  it("uses US date order and a 12-hour wall clock", () => {
+    pinDefaultLocale("en-US");
+
+    expect(formatCivilDate("1998-07-18")).toBe("Jul 18, 1998");
+    expect(formatCivilDate("1998-07-18", { day: "numeric", month: "numeric" })).toBe("7/18");
+    expect(formatOffsetWallTime(900_000_000, 21_600)).toBe("10:00 PM");
+    expect(formatInstantDateTime("1998-07-20T08:00:00.000Z")).toBe("Jul 20, 1998, 8:00 AM");
+  });
+
+  it("uses British date order and a 24-hour wall clock", () => {
+    pinDefaultLocale("en-GB");
+
+    expect(formatCivilDate("1998-07-18")).toBe("18 Jul 1998");
+    expect(formatCivilDate("1998-07-18", { day: "numeric", month: "numeric" })).toBe("18/07");
+    expect(formatOffsetWallTime(900_000_000, 21_600)).toBe("22:00");
+    expect(formatInstantDateTime("1998-07-20T08:00:00.000Z")).toBe("20 Jul 1998, 08:00");
+  });
+
+  it("uses the device zone only for real instants", () => {
+    pinDefaultLocale("en-US", "America/Los_Angeles");
+
+    expect(formatInstantDateTime("1998-07-20T08:00:00.000Z")).toBe("Jul 20, 1998, 1:00 AM");
+    expect(formatOffsetWallTime(900_000_000, 21_600)).toBe("10:00 PM");
+  });
+
+  it("rejects invalid civil dates and omits wall time without an offset", () => {
+    pinDefaultLocale("en-US");
+
+    expect(formatCivilDate("1998-02-30")).toBe("Unknown date");
+    expect(formatCivilDate("1998-07-18T12:00:00Z")).toBe("Unknown date");
+    expect(formatInstantDateTime("not-an-instant")).toBe("Unknown date and time");
+    expect(formatOffsetWallTime(900_000_000, null)).toBeNull();
+  });
+});

--- a/apps/desktop-renderer/tests/intl.ts
+++ b/apps/desktop-renderer/tests/intl.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+
+export function pinDefaultLocale(locale: "en-GB" | "en-US", timeZone = "UTC"): void {
+  const NativeDateTimeFormat = Intl.DateTimeFormat;
+  vi.spyOn(Intl, "DateTimeFormat").mockImplementation(function DateTimeFormat(locales, options) {
+    return new NativeDateTimeFormat(locales ?? locale, {
+      ...options,
+      timeZone: options?.timeZone ?? timeZone,
+    });
+  });
+}

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -8,6 +8,7 @@ import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice";
 import { useEnduragentStore } from "../src/state/store";
 import { IDLE_TRAINING_EXPORT } from "../src/training-export/controller";
 import { PlanView } from "../src/ui/plan/PlanView";
+import { pinDefaultLocale } from "./intl";
 import { PLAN_ERROR, planCoachData, planReadModel } from "./plan-fixtures";
 
 function actions(): PlanActions {
@@ -118,6 +119,7 @@ function activePlanState(
 }
 
 beforeEach(() => {
+  pinDefaultLocale("en-US");
   useEnduragentStore.setState({
     plan: EMPTY_PLAN_SURFACE,
     planActions: actions(),

--- a/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
@@ -14,6 +14,7 @@ import { useEnduragentStore } from "../src/state/store";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice";
 import { TrainingView } from "../src/ui/training/TrainingView";
+import { pinDefaultLocale } from "./intl";
 
 const PATHS = ["/rides/tuesday.fit"] as const;
 
@@ -74,6 +75,7 @@ function status(): HTMLElement {
 }
 
 beforeEach(() => {
+  pinDefaultLocale("en-US");
   useEnduragentStore.setState({
     activeView: "training",
     training: EMPTY_TRAINING_SURFACE,
@@ -86,6 +88,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   useEnduragentStore.setState({
     activeView: "chat",
     rideImport: IDLE_RIDE_IMPORT,
@@ -214,7 +217,7 @@ describe("resident ride import glue", () => {
     expect(screen.queryByText("Training history is not available yet.")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", {
-        name: "Open ride review: Road ride, 1998-07-09 · 16:00",
+        name: "Open ride review: Road ride, Jul 9, 1998 · 4:00 PM",
       }),
     ).toBeInTheDocument();
   });

--- a/apps/desktop-renderer/tests/training-context.test.ts
+++ b/apps/desktop-renderer/tests/training-context.test.ts
@@ -7,11 +7,9 @@ import {
   type TrainingContextViewState,
 } from "../src/training-context/controller";
 import {
-  formatDateLabel,
   formatDistance,
   formatPercentage,
   formatRidingDuration,
-  formatShortDateLabel,
   formatSleepDuration,
   formatUtcTimestamp,
   formatWholeNumber,
@@ -330,9 +328,6 @@ describe("training context controller", () => {
 
 describe("training context display formatters", () => {
   it("formats only display values without clock or locale inputs", () => {
-    expect(formatDateLabel("1998-07-18T12:00:00Z")).toBe("1998-07-18");
-    expect(formatDateLabel("1998-02-30")).toBe("Unknown date");
-    expect(formatShortDateLabel("1998-07-18")).toBe("7/18");
     expect(formatWholeNumber(12.6)).toBe("13");
     expect(formatPercentage(0.756)).toBe("76%");
     expect(formatSleepDuration(27_901)).toBe("7h 45m");
@@ -345,7 +340,6 @@ describe("training context display formatters", () => {
   it("distinguishes same-day sync seconds while mutation labels remain date-only", () => {
     expect(formatUtcTimestamp("1998-07-18T12:34:56.999Z")).toBe("1998-07-18 12:34:56 UTC");
     expect(formatUtcTimestamp("1998-07-18T12:34:57.001Z")).toBe("1998-07-18 12:34:57 UTC");
-    expect(formatDateLabel("1998-07-18T12:34:57.001Z")).toBe("1998-07-18");
   });
 
   it("normalizes valid offsets to UTC and uses fixed copy for invalid sync times", () => {

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -20,6 +20,7 @@ import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice";
 import { IDLE_TRAINING_EXPORT } from "../src/training-export/controller";
 import type { TrainingContextViewState } from "../src/training-context/controller";
 import { TrainingView } from "../src/ui/training/TrainingView";
+import { pinDefaultLocale } from "./intl";
 
 const FIRST_ID = "a".repeat(64);
 const SECOND_ID = "b".repeat(64);
@@ -303,7 +304,7 @@ function setRideImport(next: RideImportState): void {
 async function openFirstRide(user: ReturnType<typeof userEvent.setup>): Promise<void> {
   await user.click(
     screen.getByRole("button", {
-      name: "Open ride review: River tempo, 1998-07-09 · 22:00",
+      name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
     }),
   );
 }
@@ -314,6 +315,7 @@ async function openFirstRideAnalysis(user: ReturnType<typeof userEvent.setup>): 
 }
 
 beforeEach(() => {
+  pinDefaultLocale("en-US");
   useEnduragentStore.setState({
     activeView: "training",
     training: ready(),
@@ -332,6 +334,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   useEnduragentStore.setState({
     activeView: "chat",
     training: EMPTY_TRAINING_SURFACE,
@@ -479,7 +482,8 @@ describe("training landing page", () => {
     const table = within(figure).getByRole("table", {
       name: "Six complete weeks of riding time data",
     });
-    expect(within(table).getByText("1998-06-15 to 1998-06-21")).toBeInTheDocument();
+    expect(within(figure).getByText("6/15")).toBeInTheDocument();
+    expect(within(table).getByText("Jun 15, 1998 to Jun 21, 1998")).toBeInTheDocument();
     expect(within(table).getByText("0 rides")).toBeInTheDocument();
     expect(within(table).getByText("0m")).toBeInTheDocument();
   });
@@ -507,16 +511,18 @@ describe("training landing page", () => {
 
     const recent = screen.getByRole("region", { name: "Recent rides" });
     expect(within(recent).getByText("River tempo")).toBeInTheDocument();
-    expect(within(recent).getByText("1998-07-09 · 22:00")).toBeInTheDocument();
+    const datedRide = within(recent).getByText("Jul 9, 1998 · 10:00 PM");
+    expect(datedRide).toBeInTheDocument();
+    expect(datedRide).toHaveAttribute("datetime", "1998-07-09");
     expect(within(recent).getByText("1h 25m")).toBeInTheDocument();
     expect(within(recent).getByText("42.1 km")).toBeInTheDocument();
     expect(within(recent).getByText("Load 91")).toHaveClass("max-[761px]:hidden");
     expect(within(recent).getByText("Indoor ride")).toBeInTheDocument();
-    expect(within(recent).getByText("1998-07-08")).toBeInTheDocument();
-    expect(within(recent).queryByText(/1998-07-08 ·/u)).not.toBeInTheDocument();
+    expect(within(recent).getByText("Jul 8, 1998")).toBeInTheDocument();
+    expect(within(recent).queryByText(/Jul 8, 1998 ·/u)).not.toBeInTheDocument();
     expect(within(recent).getAllByText("Worth a look")).toHaveLength(1);
     const reason = within(recent).getByText(
-      "Longest recorded ride in the 28 days ending 1998-07-09",
+      "Longest recorded ride in the 28 days ending Jul 9, 1998",
     );
     expect(reason).toHaveClass("[overflow-wrap:anywhere]", "whitespace-normal");
     expect(reason).not.toHaveClass("text-ellipsis", "whitespace-nowrap");
@@ -609,7 +615,7 @@ describe("ride review", () => {
     const user = userEvent.setup();
     render(<TrainingView />);
     const opener = screen.getByRole("button", {
-      name: "Open ride review: River tempo, 1998-07-09 · 22:00",
+      name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
     });
     opener.focus();
 
@@ -619,7 +625,7 @@ describe("ride review", () => {
     await user.click(screen.getByRole("button", { name: "Back to training" }));
     expect(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, 1998-07-09 · 22:00",
+        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
       }),
     ).toHaveFocus();
   });
@@ -632,14 +638,16 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, 1998-07-09 · 22:00",
+        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
       }),
     );
 
     const overview = screen.getByRole("region", { name: "River tempo" });
     expect(overview).toHaveClass("[&_h2]:leading-8");
     expect(within(overview).getByText("Road ride")).toBeInTheDocument();
-    expect(within(overview).getByText("1998-07-09 · 22:00")).toBeInTheDocument();
+    const reviewDate = within(overview).getByText("Jul 9, 1998 · 10:00 PM");
+    expect(reviewDate).toBeInTheDocument();
+    expect(reviewDate).toHaveAttribute("datetime", "1998-07-09");
     expect(within(overview).getByText("1h 25m")).toBeInTheDocument();
     expect(within(overview).getByText("42.1 km")).toBeInTheDocument();
     const rideSummary = overview.querySelector("dl:first-of-type");
@@ -711,7 +719,7 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: Indoor ride, 1998-07-08",
+        name: "Open ride review: Indoor ride, Jul 8, 1998",
       }),
     );
 
@@ -1048,7 +1056,7 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, 1998-07-09 · 22:00",
+        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
       }),
     );
     await user.click(screen.getByText("Recorded analysis and export"));
@@ -1062,7 +1070,7 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, 1998-07-09 · 22:00",
+        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
       }),
     );
     const withoutFirst = week("anchor", {
@@ -1102,7 +1110,7 @@ describe("power progress", () => {
       within(progress).getByText("Short efforts changed more favorably than long efforts."),
     ).toBeInTheDocument();
     expect(
-      within(progress).getByText("1998-06-22–1998-07-19 · compared with the prior 28 days"),
+      within(progress).getByText("Jun 22, 1998–Jul 19, 1998 · compared with the prior 28 days"),
     ).toBeInTheDocument();
     expect(within(progress).getByText("Fresh")).toBeInTheDocument();
     const powerTable = within(progress).getByRole("table", {
@@ -1155,7 +1163,7 @@ describe("power progress", () => {
     );
     const progress = screen.getByRole("region", { name: "Power progress" });
     expect(within(progress).getByText(/latest refresh timed out/i)).toHaveTextContent(
-      "The latest refresh timed out. Showing the last complete comparison. Failed 1998-07-20 08:00:00 UTC.",
+      "The latest refresh timed out. Showing the last complete comparison. Failed Jul 20, 1998, 8:00 AM.",
     );
     expect(within(progress).getByText("Stale")).toBeInTheDocument();
     expect(within(progress).getByText("1120 W")).toBeInTheDocument();
@@ -1201,7 +1209,7 @@ describe("training history states and import status", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "This week" })).not.toBeInTheDocument();
     expect(screen.queryByText("Worth a look")).not.toBeInTheDocument();
-    expect(screen.getByText("Recorded through 1998-07-12")).toBeInTheDocument();
+    expect(screen.getByText("Recorded through Jul 12, 1998")).toBeInTheDocument();
   });
 
   it("combines stale and incomplete history into one warning", () => {
@@ -1229,7 +1237,7 @@ describe("training history states and import status", () => {
 
     expect(
       screen.getByText(
-        "Training may be out of date, and some rides may be missing. Showing recorded rides through 1998-07-09.",
+        "Training may be out of date, and some rides may be missing. Showing recorded rides through Jul 9, 1998.",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Some rides may be missing.")).not.toBeInTheDocument();

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1276,7 +1276,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       view: "training",
       weeklySummary: "Weekly summary",
       recentRides: "Recent rides",
-      historyStatus: "Recorded through 2026-07-19",
+      historyStatus: "Recorded through Jul 19, 2026",
     });
     liveTurn.emit({ type: "text_delta", turnId: streamTurnId, delta: thirdStreamDelta });
     const hiddenUpdate = await fixture.evaluate<{
@@ -2321,7 +2321,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     expect(rideReview).toEqual({
       page: "Ride review",
       titleFocused: true,
-      overview: "Road rideRoad rideDate2026-07-18 · 12:00Riding time1h 25mDistance42.1 km",
+      overview: "Road rideRoad rideDateJul 18, 2026 · 12:00 PMRiding time1h 25mDistance42.1 km",
       canonicalIdVisible: false,
       pageOverflow: false,
       documentOverflow: false,


### PR DESCRIPTION
## Summary

- share one regional date/time formatter between Plan and Training
- format every athlete-visible Training date and time with the OS locale
- keep civil dates in UTC, ride wall clocks on their recorded offset, and real instants in the device zone
- preserve ISO `dateTime` attributes

## Verification

- focused locale, Training, Plan, and ride-import tests
- full renderer suite: 1,169 passed
- renderer type check and lint
- dependency, renderer, and desktop builds
- wide and compact Electron QA in light and dark mode
- US, UK, and device-zone regression assertions
- verification catalog, changeset validation, formatting, and `git diff --check`

This child PR targets `epic/training-page`; umbrella PR #857 remains untouched.