### PR TITLE
fix(training): surface truthful status messages

### DIFF
--- a/.changeset/training-status-truth.md
+++ b/.changeset/training-status-truth.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Training now shows refresh failures and incomplete data without hiding them behind older successful sync details. The sidebar also keeps the exact sync outcome visible and announces it accessibly.

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -29,8 +29,10 @@ function syncChipStatus(
   if (sync.busy) return "syncing";
   if (sync.tone === "failure" || sync.tone === "partial") return "attention";
   if (training.status === "loading") return "loading";
+  if (training.status === "refresh-unavailable") return "attention";
+  if (training.status === "unavailable") return "unavailable";
   if (training.metadata !== null && training.metadata.lastSynced !== null) return "synced";
-  return training.status === "unavailable" ? "unavailable" : "never";
+  return "never";
 }
 
 const HEADLINE: Readonly<Record<SyncChipStatus, string>> = {
@@ -51,7 +53,8 @@ export function SyncChip(): ReactElement {
   const wrapper = useRef<HTMLDivElement>(null);
   const status = syncChipStatus(training, sync);
   const synced = training.metadata?.lastSynced ?? null;
-  const detail = status === "synced" && synced !== null ? formatUtcTimestamp(synced) : null;
+  const syncedDetail = status === "synced" && synced !== null ? formatUtcTimestamp(synced) : null;
+  const detail = sync.message === "" ? syncedDetail : sync.message;
   const restriction = sourceRestrictionSummary(sync.droppedActivities, "STRAVA");
   const restrictionLabel =
     restriction === null
@@ -80,7 +83,7 @@ export function SyncChip(): ReactElement {
         size="default"
         className="sync-chip absolute inset-0 z-0 h-auto w-full p-0"
         data-status={status}
-        title={restriction === null || detail === null ? undefined : detail}
+        title={restriction === null || syncedDetail === null ? undefined : syncedDetail}
         disabled={sync.disabled || actions === null}
         aria-label={[sync.label, HEADLINE[status], detail].filter(Boolean).join(" · ")}
         onClick={(event) => {
@@ -103,17 +106,16 @@ export function SyncChip(): ReactElement {
         <span className="block whitespace-normal" data-sync-headline="" aria-hidden="true">
           {HEADLINE[status]}
         </span>
-        {restriction === null ? (
-          detail === null ? null : (
-            <span
-              className="mt-px block whitespace-normal text-ink-3"
-              data-sync-detail=""
-              aria-hidden="true"
-            >
-              {detail}
-            </span>
-          )
-        ) : (
+        <span
+          className={cn(detail === null ? "sr-only" : "mt-px block whitespace-normal text-ink-3")}
+          data-sync-detail=""
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {detail}
+        </span>
+        {restriction === null ? null : (
           <InfoTip
             label="Why are activities hidden?"
             lead={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipLead(restriction.count)}

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -25,7 +25,7 @@ import {
   formatWholeNumber,
 } from "../../training-context/format";
 import { Page } from "../shared/Page";
-import { TRAINING_HISTORY_COPY } from "./copy";
+import { TRAINING_DEGRADED_COPY, TRAINING_HISTORY_COPY, trainingStatusCopy } from "./copy";
 import { overviewStyles as styles } from "./overviewStyles";
 import { PowerProgressContent } from "./PowerProgressPanel";
 import { RideDetailView, trainingRideDateTime, trainingRideKind } from "./RideReview";
@@ -464,10 +464,18 @@ export function TrainingView(): ReactElement {
   const activeWeek = history === null ? null : selectedWeek(history, period);
   const warning =
     history === null || activeWeek === null ? null : dataWarning(panel, history, activeWeek);
+  const statusWarning =
+    training.status === "unavailable" || training.status === "refresh-unavailable"
+      ? trainingStatusCopy(training.status)
+      : null;
+  const notice =
+    statusWarning ??
+    warning ??
+    (training.metadata?.degraded === true ? TRAINING_DEGRADED_COPY : null);
   const label = history === null ? null : periodLabel(history, period, retained);
   const announcement = useMemo(
-    () => (label === null ? null : warning === null ? label : `${label}. ${warning}`),
-    [label, warning],
+    () => (label === null ? null : notice === null ? label : `${label}. ${notice}`),
+    [label, notice],
   );
 
   if (resolvedRide !== null) {
@@ -490,7 +498,12 @@ export function TrainingView(): ReactElement {
 
   let historyContent: ReactNode;
   if (history === null || activeWeek === null) {
-    historyContent = <UnavailableHistory />;
+    historyContent = (
+      <>
+        {notice === null ? null : <p className={styles.dataNotice}>{notice}</p>}
+        <UnavailableHistory />
+      </>
+    );
   } else {
     historyContent = (
       <>
@@ -514,7 +527,7 @@ export function TrainingView(): ReactElement {
         <p className={styles.srOnly} role="status" aria-live="polite" aria-atomic="true">
           {announcement}
         </p>
-        {warning === null ? null : <p className={styles.dataNotice}>{warning}</p>}
+        {notice === null ? null : <p className={styles.dataNotice}>{notice}</p>}
         <WeeklySummary
           history={history}
           retained={retained}

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -174,6 +174,8 @@ export function trainingStatusCopy(status: TrainingContextStatus): string {
   return "";
 }
 
+export const TRAINING_DEGRADED_COPY = "Data may be incomplete";
+
 export function stalenessCopy(band: CyclingAnchor["stalenessBand"], ageDays: number): string {
   const days = Math.floor(ageDays);
   if (band === "fresh") return "Fresh";

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -11,7 +11,10 @@ import { EMPTY_SETTINGS_SURFACE } from "../src/state/settings-slice";
 import { useEnduragentStore } from "../src/state/store";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice";
-import { toManualSyncViewState } from "../src/training-context/manual-sync";
+import {
+  type ManualSyncViewState,
+  toManualSyncViewState,
+} from "../src/training-context/manual-sync";
 import { Sidebar } from "../src/ui/sidebar/Sidebar";
 import { clearTrainingRestrictionFocusRequest } from "../src/ui/settings/restriction-focus";
 import { planReadModel } from "./plan-fixtures";
@@ -159,6 +162,13 @@ function stravaDroppedActivities() {
       restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 4 }],
       other: 0,
     },
+  };
+}
+
+function noDroppedActivities() {
+  return {
+    overall: { total: 5, visible: 5, restrictions: [], other: 0 },
+    recent7Days: { total: 5, visible: 5, restrictions: [], other: 0 },
   };
 }
 
@@ -434,7 +444,7 @@ describe("sidebar sync chip", () => {
     expect(chip()).toBeDisabled();
     expect(chipSurface()).toHaveTextContent("Syncing");
     expect(screen.getByText("Sync now")).toHaveAttribute("data-sync-action");
-    expect(chip()).toHaveAccessibleName("Sync now · Syncing");
+    expect(chip()).toHaveAccessibleName("Sync now · Syncing · Syncing training data…");
 
     update({
       sync: toManualSyncViewState({
@@ -448,7 +458,84 @@ describe("sidebar sync chip", () => {
     expect(chipSurface()).toHaveTextContent("Sync needs attention");
     expect(chipSurface()).toHaveTextContent("Try again");
     expect(screen.getByText("Try again")).toHaveAttribute("data-sync-action");
-    expect(chip()).toHaveAccessibleName("Try again · Sync needs attention");
+    expect(chip()).toHaveAccessibleName(
+      "Try again · Sync needs attention · Training-data processing partially completed. Try again to finish.",
+    );
+  });
+
+  it("keeps refresh failure ahead of retained sync success", () => {
+    useEnduragentStore.setState({
+      training: {
+        ...EMPTY_TRAINING_SURFACE,
+        status: "refresh-unavailable",
+        metadata: {
+          lastUpdated: "1998-07-19T08:00:00.000Z",
+          lastSynced: "1998-07-19T07:55:00.000Z",
+          freshness: "flag",
+          degraded: false,
+        },
+      },
+    });
+    render(<Sidebar />);
+
+    expect(chip()).toHaveAttribute("data-status", "attention");
+    expect(chipSurface()).toHaveTextContent("Sync needs attention");
+    expect(chipSurface()).not.toHaveTextContent("Training data synced");
+  });
+
+  it("shows and politely announces each exact manual sync message once", () => {
+    render(<Sidebar />);
+
+    const announcement = chipSurface().querySelector('[role="status"]');
+    expect(announcement).toHaveAttribute("aria-live", "polite");
+    expect(announcement).toHaveAttribute("aria-atomic", "true");
+
+    const syncMessages = [
+      [toManualSyncViewState({ status: "queued", operation: 1 }), "Sync queued."],
+      [toManualSyncViewState({ status: "running", operation: 1 }), "Syncing training data…"],
+      [
+        toManualSyncViewState({
+          status: "succeeded",
+          operation: 1,
+          kind: "published",
+          droppedActivities: noDroppedActivities(),
+        }),
+        "Training-data check completed.",
+      ],
+      [
+        toManualSyncViewState({
+          status: "failed",
+          operation: 1,
+          kind: "partial",
+          retryable: true,
+        }),
+        "Training-data processing partially completed. Try again to finish.",
+      ],
+      [
+        toManualSyncViewState({
+          status: "failed",
+          operation: 1,
+          kind: "indeterminate",
+          retryable: true,
+        }),
+        "Connection interrupted. The sync may still be finishing. Enduragent won’t retry it automatically.",
+      ],
+      [
+        toManualSyncViewState({
+          status: "failed",
+          operation: 1,
+          kind: "protocol",
+          retryable: false,
+        }),
+        "Enduragent couldn’t verify the sync result. Quit and reopen Enduragent.",
+      ],
+    ] satisfies ReadonlyArray<readonly [ManualSyncViewState, string]>;
+
+    for (const [state, message] of syncMessages) {
+      update({ sync: state });
+      expect(announcement?.textContent).toBe(message);
+      expect(chipSurface().querySelectorAll('[role="status"]')).toHaveLength(1);
+    }
   });
 
   it("keeps Strava remedy navigation independent from syncing", async () => {
@@ -483,7 +570,7 @@ describe("sidebar sync chip", () => {
     expect(chipSurface()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAttribute("title", "1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAccessibleName(
-      "Sync again · Training data synced · 1998-07-19 07:55:00 UTC",
+      "Sync again · Training data synced · Training-data check completed. A Strava API restriction prevents intervals.icu from sharing 60 activities, so they aren’t included.",
     );
     expect(
       chip().querySelector("a, button, input, select, textarea, [role='button'], [tabindex]"),
@@ -549,7 +636,8 @@ describe("sidebar sync chip", () => {
         },
       }),
     });
-    expect(chipSurface()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chipSurface()).toHaveTextContent("Local training-data processing completed.");
+    expect(chipSurface()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).not.toHaveAttribute("title");
     expect(chipSurface().querySelector("[data-info-tip]")).toBeNull();
   });

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -1284,9 +1284,67 @@ describe("training history states and import status", () => {
 
     setTraining(ready(history(), { status: "unavailable" }));
     expect(page).not.toHaveAttribute("aria-busy");
+    expect(screen.getByText("Training data unavailable")).toBeVisible();
 
     setTraining(ready(history(), { status: "refresh-unavailable" }));
     expect(page).not.toHaveAttribute("aria-busy");
+    expect(screen.getByText("Refresh unavailable")).toBeVisible();
+    expect(screen.queryByText("Training data unavailable")).not.toBeInTheDocument();
+  });
+
+  it("renders one training notice with failure, history, then degraded precedence", () => {
+    const stalePanel: TrainingHistoryPanel = {
+      kind: "stale",
+      failedAt: "1998-07-12T08:15:00.000Z",
+      reason: "temporary-failure",
+      lastGood: history(),
+    };
+    setTraining(
+      ready(stalePanel, {
+        status: "refresh-unavailable",
+        metadata: {
+          lastUpdated: "1998-07-12T08:00:00.000Z",
+          lastSynced: "1998-07-12T07:55:00.000Z",
+          freshness: "flag",
+          degraded: true,
+        },
+      }),
+    );
+    render(<TrainingView />);
+
+    expect(screen.getByText("Refresh unavailable")).toBeVisible();
+    expect(
+      screen.queryByText("Training could not be refreshed. Showing the last recorded data."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Data may be incomplete")).not.toBeInTheDocument();
+
+    setTraining(
+      ready(stalePanel, {
+        metadata: {
+          lastUpdated: "1998-07-12T08:00:00.000Z",
+          lastSynced: "1998-07-12T07:55:00.000Z",
+          freshness: "flag",
+          degraded: true,
+        },
+      }),
+    );
+    expect(
+      screen.getByText("Training could not be refreshed. Showing the last recorded data."),
+    ).toBeVisible();
+    expect(screen.queryByText("Data may be incomplete")).not.toBeInTheDocument();
+
+    setTraining(
+      ready(history(), {
+        metadata: {
+          lastUpdated: "1998-07-12T08:00:00.000Z",
+          lastSynced: "1998-07-12T07:55:00.000Z",
+          freshness: "flag",
+          degraded: true,
+        },
+      }),
+    );
+    expect(screen.getByText("Data may be incomplete")).toBeVisible();
+    expect(screen.queryByText("Refresh unavailable")).not.toBeInTheDocument();
   });
 
   it("renders a retained stale wrapper as last-recorded with one refresh-failure warning", () => {

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -2124,7 +2124,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         readonly terminalLabel: string | null;
         readonly busyCleared: boolean;
         readonly keyboardFocusRestored: boolean;
-        readonly metadataDetailChanged: boolean;
+        readonly syncDetailChanged: boolean;
         readonly trainingPanelsUnchanged: boolean;
         readonly detailBefore: string;
         readonly detailAfter: string;
@@ -2154,14 +2154,11 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const syncButton = document.querySelector("button.sync-chip");
       const syncSurface = document.querySelector("[data-sync-chip]");
       const sidebar = syncSurface.closest("aside");
-      const metadataDetail = () =>
-        [...syncSurface.querySelectorAll('span[aria-hidden="true"]')]
-          .map((node) => node.textContent?.trim() ?? "")
-          .find((value) => value.endsWith(" UTC")) ?? "";
+      const syncDetail = () => syncSurface.querySelector('[role="status"]')?.textContent ?? "";
       const panelsBefore = panels.map((panel) => panel.textContent ?? "");
       const initialStatus = syncButton.dataset.status;
       const initialLabel = syncButton.getAttribute("aria-label");
-      const detailBefore = metadataDetail();
+      const detailBefore = syncDetail();
       syncButton.focus();
       syncButton.click();
       const syncingDeadline = Date.now() + 5000;
@@ -2176,13 +2173,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       syncButton.blur();
       const syncDeadline = Date.now() + 5000;
       while (
-        (syncButton.dataset.status !== "synced" || metadataDetail() === detailBefore) &&
+        (syncButton.dataset.status !== "synced" || syncDetail() === detailBefore) &&
         Date.now() < syncDeadline
       ) {
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
       await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-      const detailAfter = metadataDetail();
+      const detailAfter = syncDetail();
       const panelsAfter = [...page.querySelectorAll("[data-panel]")].map(
         (panel) => panel.textContent ?? "",
       );
@@ -2203,7 +2200,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         terminalLabel: syncButton.getAttribute("aria-label"),
         busyCleared: !syncButton.hasAttribute("aria-busy") && !syncButton.disabled,
         keyboardFocusRestored: document.activeElement === syncButton,
-        metadataDetailChanged: detailAfter !== detailBefore,
+        syncDetailChanged: detailAfter !== detailBefore,
         trainingPanelsUnchanged: JSON.stringify(panelsBefore) === JSON.stringify(panelsAfter),
         detailBefore,
         detailAfter,
@@ -2236,17 +2233,18 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         initialStatus: "synced",
         initialLabel: "Sync now · Training data synced · 2026-07-19 07:55:00 UTC",
         syncingObserved: true,
-        syncingLabel: "Sync now · Syncing",
+        syncingLabel: "Sync now · Syncing · Sync queued.",
         disabledWhileSyncing: true,
         ariaBusyAbsentWhileSyncing: true,
         terminalStatus: "synced",
-        terminalLabel: "Sync again · Training data synced · 2026-07-19 07:55:01 UTC",
+        terminalLabel:
+          "Sync again · Training data synced · Local training-data processing completed.",
         busyCleared: true,
         keyboardFocusRestored: true,
-        metadataDetailChanged: true,
+        syncDetailChanged: true,
         trainingPanelsUnchanged: true,
         detailBefore: "2026-07-19 07:55:00 UTC",
-        detailAfter: "2026-07-19 07:55:01 UTC",
+        detailAfter: "Local training-data processing completed.",
         chipFitsSidebar: true,
         chipHasNoOverflow: true,
         buttonReachable: true,
@@ -2451,7 +2449,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly retiredPanelsAbsent: boolean;
       readonly chipResident: boolean;
       readonly chipAccessibleLabel: string | null;
-      readonly metadataDetailVisible: boolean;
+      readonly syncOutcomeVisible: boolean;
       readonly horizontalOverflow: boolean;
     }>(`
       const rail = document.querySelector('nav[aria-label="Main navigation"]');
@@ -2502,7 +2500,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         syncHasNoOverflow: syncSurface.scrollWidth <= syncSurface.clientWidth,
         completeStatusVisible:
           headline.textContent === "Training data synced" &&
-          detail.textContent === "2026-07-19 07:55:01 UTC" &&
+          detail.textContent === "Local training-data processing completed." &&
           action.textContent === "Sync again" &&
           [headline, detail, action].every((row) => getComputedStyle(row).display !== "none"),
         surfaceMinWidthZero: getComputedStyle(syncSurface).minWidth === "0px",
@@ -2520,7 +2518,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         chipResident:
           sidebar.contains(chip) && document.querySelectorAll("button.sync-chip").length === 1,
         chipAccessibleLabel: chip.getAttribute("aria-label"),
-        metadataDetailVisible: syncSurface.textContent.includes("2026-07-19 07:55:01 UTC"),
+        syncOutcomeVisible: syncSurface.textContent.includes(
+          "Local training-data processing completed.",
+        ),
         horizontalOverflow: page.scrollWidth > page.clientWidth,
       };
     `);
@@ -2540,8 +2540,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       panelOrder: ["weekly-summary", "recent-rides", "power-progress"],
       retiredPanelsAbsent: true,
       chipResident: true,
-      chipAccessibleLabel: "Sync again · Training data synced · 2026-07-19 07:55:01 UTC",
-      metadataDetailVisible: true,
+      chipAccessibleLabel:
+        "Sync again · Training data synced · Local training-data processing completed.",
+      syncOutcomeVisible: true,
       horizontalOverflow: false,
     });
     const runtimeReadsBeforeSettings = calls.filter(
@@ -2694,7 +2695,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly terminalLabel: string | null;
       readonly terminalText: string;
       readonly enabledAfterSync: boolean;
-      readonly longStatusAbsent: boolean;
+      readonly longStatusPresent: boolean;
       readonly surfaceMinWidthZero: boolean;
       readonly readableStatus: boolean;
       readonly chipHasNoOverflow: boolean;
@@ -2759,7 +2760,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         terminalLabel: syncButton.getAttribute("aria-label"),
         terminalText: syncSurface.textContent ?? "",
         enabledAfterSync: !syncButton.disabled,
-        longStatusAbsent: !syncSurface.textContent.includes(
+        longStatusPresent: syncSurface.textContent.includes(
           "Training-data processing partially completed. Try again to finish.",
         ),
         surfaceMinWidthZero: getComputedStyle(syncSurface).minWidth === "0px",
@@ -2791,10 +2792,12 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       disabledWhileSyncing: true,
       ariaBusyAbsentWhileSyncing: true,
       terminalStatus: "attention",
-      terminalLabel: "Try again · Sync needs attention",
-      terminalText: "Sync needs attentionTry again",
+      terminalLabel:
+        "Try again · Sync needs attention · Training-data processing partially completed. Try again to finish.",
+      terminalText:
+        "Sync needs attentionTraining-data processing partially completed. Try again to finish.Try again",
       enabledAfterSync: true,
-      longStatusAbsent: true,
+      longStatusPresent: true,
       surfaceMinWidthZero: true,
       readableStatus: true,
       chipHasNoOverflow: true,


### PR DESCRIPTION
## Why

The Training page stopped displaying unavailable-refresh and degraded-data states, while the sidebar discarded the exact manual-sync outcome and no longer announced it to assistive technology.

## Scope

- Restore one Training notice with failure, retained-history, then degraded precedence.
- Map unavailable refreshes to the sidebar attention state.
- Render the exact manual-sync message once in a polite, atomic live region.
- Reuse the existing production copy contract.

## Tradeoffs

Only one page-level warning is shown at a time. The highest-actionability state wins so multiple stale or degraded messages do not compete.

## Blast radius

Training page notices, sidebar sync status, accessibility announcements, and their renderer tests.

## Verification

- 51 focused renderer tests passed.
- 8 focused built-desktop integration tests passed, including compact-sidebar geometry.
- Renderer typecheck, Oxlint, formatting, and whitespace checks passed.
- Isolated built-desktop QA showed one degraded notice and announced “Training-data check completed.” exactly once with polite, atomic semantics.
- Changeset user-facing validation passed.
