### PR TITLE
fix(training): preserve calendar time authority

### DIFF
--- a/.changeset/training-calendar-time.md
+++ b/.changeset/training-calendar-time.md
@@ -1,0 +1,11 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/core": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Keep Training History freshness and calendar windows anchored to the current successful sync and the athlete's active timezone.
+
+User-facing: Training History now stays current after a successful sync that finds no new data, and its week boundaries follow your active timezone without requiring a restart.

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -25,6 +25,7 @@ import {
   SCHEDULER_SCHEMA_VERSION,
   SchedulerStateSchema,
 } from "@enduragent/kernel/reference/schemas";
+import { referenceFreshnessAt } from "@enduragent/kernel/reference/freshness";
 import { projectCyclingTrainingContext } from "./training-context.js";
 import type { TrainingHistorySource } from "./training-history.js";
 
@@ -190,6 +191,7 @@ export function createPersistedAthleteStateSource(
   };
   return {
     async getAthleteState(): Promise<AthleteState> {
+      const evaluatedAt = input.now?.() ?? new Date();
       const trainingHistoryIdentity: TrainingHistoryCacheIdentity | null =
         input.trainingHistorySource === undefined
           ? null
@@ -215,9 +217,8 @@ export function createPersistedAthleteStateSource(
       ]);
       if (latestResult.status === "rejected") {
         if (input.recentRidesSource !== undefined && isMissingFile(latestResult.reason)) {
-          const now = input.now?.() ?? new Date();
-          const asOf = now.toISOString();
-          const asOfEpochSeconds = Math.floor(now.getTime() / 1_000);
+          const asOf = evaluatedAt.toISOString();
+          const asOfEpochSeconds = Math.floor(evaluatedAt.getTime() / 1_000);
           const [recentRides, trainingHistory] = await Promise.all([
             readRecentRides(input.recentRidesSource, asOf, asOfEpochSeconds),
             trainingHistoryIdentity === null
@@ -278,6 +279,10 @@ export function createPersistedAthleteStateSource(
       const lastSynced =
         committedSyncAt !== null && isFiniteInstant(committedSyncAt) ? committedSyncAt : null;
       const latest = latestParsed.data;
+      const trainingHistoryFreshness = referenceFreshnessAt(
+        lastSynced ?? latest.metadata.last_updated,
+        evaluatedAt,
+      );
       const derivedMetrics = { ...latest.derived_metrics };
       delete derivedMetrics.acwr;
       delete derivedMetrics["capability.dfa_a1_profile"];
@@ -316,10 +321,10 @@ export function createPersistedAthleteStateSource(
         asOfEpochS === null || trainingHistoryIdentity === null
           ? Promise.resolve({ kind: "unavailable", reason: "not-synced" } as const)
           : readTrainingHistory(trainingHistoryIdentity, {
-              asOf: latest.metadata.last_updated,
-              asOfEpochSeconds: asOfEpochS,
+              asOf: evaluatedAt.toISOString(),
+              asOfEpochSeconds: Math.floor(evaluatedAt.getTime() / 1_000),
               calendarTimeZone: trainingHistoryIdentity.calendarTimeZone,
-              freshness: latest.metadata.freshness,
+              freshness: trainingHistoryFreshness,
               sourceRestricted: errorState?.mitigation === "block_coaching",
             }),
       ]);

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -1021,6 +1021,7 @@ export async function createLocalCoachComposition(
       dataDir: input.home.root,
       intervals: approvedConfig().intervals,
       readIntervals: () => approvedConfig().intervals,
+      readCalendarTimeZone: () => resolveUserTimezone(approvedConfig().session.timezone),
       sport: cyclingSport,
       startScheduler: false,
       attemptLedgerForRun: () => {

--- a/packages/coach/src/local-bot.ts
+++ b/packages/coach/src/local-bot.ts
@@ -40,6 +40,7 @@ export async function prepareStoreCoachComposition(
   const reference = await (dependencies.bootstrap ?? bootstrapReference)({
     dataDir: input.config.dataDir,
     intervals: input.config.intervals,
+    readCalendarTimeZone: () => input.config.session.timezone,
     sport: input.sport,
     startScheduler: false,
     attemptLedgerForRun: () => {

--- a/packages/coach/src/local-bundle-producer.ts
+++ b/packages/coach/src/local-bundle-producer.ts
@@ -4,7 +4,10 @@ import {
   readSelectedSourceRows,
   readSourceArtifactRows,
 } from "@enduragent/kernel/ingest";
-import type { ReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
+import {
+  referenceCaptureClock,
+  type ReferenceCaptureManifest,
+} from "@enduragent/kernel/reference/capture";
 import {
   IDENTITY_REFERENCE_BUNDLE_PROJECTION,
   KEEP_ALL_ACTIVITIES,
@@ -132,7 +135,7 @@ export function createLocalBundleProducer(
         } catch {
           curveProjection = {};
         }
-        produced = { captureId: manifest.capture_id, frozenNow: manifest.plan.frozenNow,
+        produced = { captureId: manifest.capture_id, captureClock: referenceCaptureClock(manifest.plan),
           bundle: bundleProjection({ ...bundle, ...curveProjection }) };
       } catch {
         projectionFailed = true;

--- a/packages/coach/src/reference-capture-command.ts
+++ b/packages/coach/src/reference-capture-command.ts
@@ -29,6 +29,7 @@ import type { FileSystemPort } from "@enduragent/kernel/ports";
 import {
   assertReferenceCaptureReplayable,
   parseReferenceCaptureManifest,
+  referenceCaptureClock,
   type RecordRef,
   type ReferenceCaptureManifest,
   type SnapshotRef,
@@ -826,7 +827,13 @@ export async function runReferenceCaptureCommand(
           ? await (await import(new URL("./local-bundle-producer.js", import.meta.url).href))
             .createLocalBundleProducer({ ...destination, bundleProjection }).produce(manifest)
           : await dependencies.produceLocalBundle(destination, manifest);
-        if (produced.captureId !== manifest.capture_id || produced.frozenNow !== manifest.plan.frozenNow) {
+        const expectedClock = referenceCaptureClock(manifest.plan);
+        if (
+          produced.captureId !== manifest.capture_id ||
+          produced.captureClock.captureEpochMs !== expectedClock.captureEpochMs ||
+          produced.captureClock.civilDateTime !== expectedClock.civilDateTime ||
+          produced.captureClock.calendarTimeZone !== expectedClock.calendarTimeZone
+        ) {
           throw new TypeError("local bundle identity changed");
         }
         const projected = buildFixtureShape(produced.bundle);

--- a/packages/coach/src/store-gate-command.ts
+++ b/packages/coach/src/store-gate-command.ts
@@ -217,6 +217,7 @@ async function runRealWindow(): Promise<WindowEvidence> {
   const home = resolveAthleteHome(env);
   let runtime: StoreRuntime | undefined;
   const reference = await bootstrapReference({ dataDir: config.dataDir, intervals: config.intervals,
+    readCalendarTimeZone: () => config.session.timezone,
     sport: cyclingSport, startScheduler: false, attemptLedgerForRun: () => {
       if (runtime === undefined) throw new Error("Store runtime is unavailable.");
       return runtime.attemptLedgerForRun();

--- a/packages/coach/tests/athlete-state-reader.test.ts
+++ b/packages/coach/tests/athlete-state-reader.test.ts
@@ -196,6 +196,7 @@ describe("persisted athlete state source", () => {
     const reader = createPersistedAthleteStateSource({
       dataDir: root,
       cyclingFtpAnchorResolver: resolver,
+      now: () => new Date(T2),
       trainingHistorySource: { readTrainingHistory },
       sourceOwner: () => "synthetic-athlete",
       calendarTimeZone: () => "UTC",
@@ -211,7 +212,7 @@ describe("persisted athlete state source", () => {
     const thrown = (await reader.getAthleteState()).trainingContext?.trainingHistory;
     expect(thrown).toMatchObject({
       kind: "stale",
-      failedAt: T1,
+      failedAt: new Date(T2).toISOString(),
       reason: "temporary-failure",
       lastGood: { anchorWeek: { callout: null }, previousWeek: { callout: null } },
     });
@@ -347,6 +348,55 @@ describe("persisted athlete state source", () => {
       sourceRestricted: false,
     });
     expect(state.trainingContext?.trainingHistory).toMatchObject({ kind: "computed" });
+  });
+
+  it("evaluates training history now and prefers the successful sync marker for freshness", async () => {
+    const root = await home();
+    const now = new Date("1998-07-23T00:00:00.000Z");
+    await writeJson(root, "latest.json", latest("critical", T1));
+    await writeJson(root, ".scheduler.json", schedulerState(now.toISOString()));
+    const readTrainingHistory = vi.fn(async () => computedTrainingHistory());
+
+    await createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      now: () => now,
+      trainingHistorySource: { readTrainingHistory },
+      sourceOwner: () => "synthetic-athlete",
+      calendarTimeZone: () => "UTC",
+    }).getAthleteState();
+
+    expect(readTrainingHistory).toHaveBeenCalledWith({
+      asOf: now.toISOString(),
+      asOfEpochSeconds: now.getTime() / 1_000,
+      calendarTimeZone: "UTC",
+      freshness: "fresh",
+      sourceRestricted: false,
+    });
+  });
+
+  it("falls back to payload time when no successful sync marker exists", async () => {
+    const root = await home();
+    const now = new Date("1998-07-23T00:00:00.000Z");
+    await writeJson(root, "latest.json", latest("fresh", T1));
+    const readTrainingHistory = vi.fn(async () => computedTrainingHistory());
+
+    await createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      now: () => now,
+      trainingHistorySource: { readTrainingHistory },
+      sourceOwner: () => "synthetic-athlete",
+      calendarTimeZone: () => "UTC",
+    }).getAthleteState();
+
+    expect(readTrainingHistory).toHaveBeenCalledWith({
+      asOf: now.toISOString(),
+      asOfEpochSeconds: now.getTime() / 1_000,
+      calendarTimeZone: "UTC",
+      freshness: "stale",
+      sourceRestricted: false,
+    });
   });
 
   it("returns canonical recent rides without a Reference snapshot", async () => {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -581,11 +581,19 @@ describe("local coach composition", () => {
     });
     const manifest = {
       capture_id: "12345678-1234-4123-8123-123456789abc",
-      plan: { frozenNow: "1998-07-18T12:00:00.000Z" },
+      plan: {
+        capture_epoch_ms: Date.parse("1998-07-18T12:00:00.000Z"),
+        frozenNow: "1998-07-18T12:00:00.000Z",
+        calendar_timezone: "UTC",
+      },
     } as ReferenceCaptureManifest;
     const produced: ProducedLocalBundle = {
       captureId: manifest.capture_id,
-      frozenNow: manifest.plan.frozenNow,
+      captureClock: {
+        captureEpochMs: manifest.plan.capture_epoch_ms,
+        civilDateTime: manifest.plan.frozenNow,
+        calendarTimeZone: "UTC",
+      },
       bundle: { activities: [], wellness: [], ftpHistory: [] },
     };
     const capture = vi.fn(
@@ -1224,6 +1232,7 @@ describe("local coach composition", () => {
         readCurrent: async () => undefined,
       }),
       createResolver: () => missingResolver(),
+      now: () => Date.parse(state.lastUpdated),
     });
     const projectedState = await received!.ports.stateReader.getAthleteState();
     const projectedTrainingContext = projectedState.trainingContext;
@@ -3368,7 +3377,7 @@ describe("local coach composition", () => {
     await lifecycle.close();
   });
 
-  it("passes reference bootstrap a live intervals reader updated by runtime configuration", async () => {
+  it("passes reference bootstrap live credentials and calendar zone readers", async () => {
     const home = await freshHome();
     let referenceOptions:
       | Parameters<NonNullable<LocalCoachCompositionDependencies["bootstrap"]>>[0]
@@ -3397,12 +3406,14 @@ describe("local coach composition", () => {
         api_key: "placeholder",
         athlete_id: "fake-configured-athlete",
       },
+      session: { timezone: "Europe/Berlin" },
     });
 
     expect(referenceOptions?.readIntervals?.()).toEqual({
       apiKey: "placeholder",
       athleteId: "fake-configured-athlete",
     });
+    expect(referenceOptions?.readCalendarTimeZone()).toBe("Europe/Berlin");
     await lifecycle.close();
   });
 

--- a/packages/coach/tests/local-bot-composition.test.ts
+++ b/packages/coach/tests/local-bot-composition.test.ts
@@ -95,7 +95,11 @@ describe("local bot composition", () => {
       const before = await Promise.all(paths.map(digest));
       const snapshot: ProducedLocalBundle = {
         captureId: "12345678-1234-4123-8123-123456789abc",
-        frozenNow: "2023-09-11T00:00:00.000Z",
+        captureClock: {
+          captureEpochMs: Date.parse("2023-09-11T00:00:00.000Z"),
+          civilDateTime: "2023-09-11T00:00:00.000Z",
+          calendarTimeZone: "UTC",
+        },
         bundle: {
           athlete: { sportSettings: [] },
           wellness: [],
@@ -144,7 +148,7 @@ describe("local bot composition", () => {
           ],
         },
       };
-      let clockNow = Date.parse(snapshot.frozenNow);
+      let clockNow = snapshot.captureClock.captureEpochMs;
       const summaries = snapshot.bundle.activities.map((activity, index) => ({
         id: String.fromCharCode(97 + index).repeat(64),
         workoutId: String.fromCharCode(101 + index).repeat(64),

--- a/packages/coach/tests/local-bundle-producer.test.ts
+++ b/packages/coach/tests/local-bundle-producer.test.ts
@@ -10,11 +10,12 @@ import {
 } from "../src/local-bundle-producer.js";
 
 function manifest() {
-  const captureEpoch = Date.UTC(1998, 5, 10);
+  const captureEpoch = Date.UTC(1998, 5, 10, 12);
   const snapshot = (value: string) => ({ address: value.repeat(64), rel_path: `1998/06/${value.repeat(64)}.json.gz` });
   return validateReferenceCaptureManifest({
     schema_version: 1, capture_id: "123e4567-e89b-42d3-a456-426614174000", source: "external-oracle",
-    plan: { capture_epoch_ms: captureEpoch, frozenNow: "1998-06-10T12:00:00",
+    plan: { capture_epoch_ms: captureEpoch, frozenNow: "1998-06-10T18:00:00",
+      calendar_timezone: "Asia/Almaty",
       window: { oldest: "1998-06-01", newest: "1998-06-10" },
       stream_cutoff_epoch_ms: captureEpoch - 21 * 24 * 60 * 60 * 1_000 },
     operation_ledger: { link_kind: "capture-id", capture_id: "123e4567-e89b-42d3-a456-426614174000" },
@@ -88,7 +89,12 @@ describe("local bundle producer composition", () => {
       }));
     const value = await producer.produce(manifest());
     expect(value).toEqual({ captureId: "123e4567-e89b-42d3-a456-426614174000",
-      frozenNow: "1998-06-10T12:00:00", bundle: emptyBundle });
+      captureClock: {
+        captureEpochMs: Date.UTC(1998, 5, 10, 12),
+        civilDateTime: "1998-06-10T18:00:00",
+        calendarTimeZone: "Asia/Almaty",
+      },
+      bundle: emptyBundle });
     expect(store.calls).toEqual([
       ["intervals-icu", "activities"], ["intervals-icu", "settings"],
       ["intervals-icu", "wellness"], ["intervals-icu", "streams"],
@@ -127,7 +133,12 @@ describe("local bundle producer composition", () => {
 
     await expect(producer.produce(manifest())).resolves.toEqual({
       captureId: "123e4567-e89b-42d3-a456-426614174000",
-      frozenNow: "1998-06-10T12:00:00", bundle: emptyBundle,
+      captureClock: {
+        captureEpochMs: Date.UTC(1998, 5, 10, 12),
+        civilDateTime: "1998-06-10T18:00:00",
+        calendarTimeZone: "Asia/Almaty",
+      },
+      bundle: emptyBundle,
     });
     expect(close).toHaveBeenCalledTimes(1);
   });

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -34,11 +34,19 @@ const config: Config = {
 };
 const manifest = {
   capture_id: "12345678-1234-4123-8123-123456789abc",
-  plan: { frozenNow: "1998-07-18T12:00:00.000Z" },
+  plan: {
+    capture_epoch_ms: Date.parse("1998-07-18T12:00:00.000Z"),
+    frozenNow: "1998-07-18T12:00:00.000Z",
+    calendar_timezone: "UTC",
+  },
 } as ReferenceCaptureManifest;
 const produced: ProducedLocalBundle = {
   captureId: manifest.capture_id,
-  frozenNow: manifest.plan.frozenNow,
+  captureClock: {
+    captureEpochMs: manifest.plan.capture_epoch_ms,
+    civilDateTime: manifest.plan.frozenNow,
+    calendarTimeZone: "UTC",
+  },
   bundle: { activities: [], wellness: [], ftpHistory: [], athlete: { sportSettings: [] } },
 };
 

--- a/packages/core/src/athlete-data.ts
+++ b/packages/core/src/athlete-data.ts
@@ -155,7 +155,7 @@ export function isRealCivilDate(value: string): boolean {
 }
 
 function freshnessFor(snapshot: ProducedLocalBundle, clockNow: number): StoredDataFreshness | undefined {
-  const capturedMs = Date.parse(snapshot.frozenNow);
+  const capturedMs = snapshot.captureClock.captureEpochMs;
   if (!Number.isFinite(capturedMs) || !Number.isSafeInteger(capturedMs) || capturedMs < 0
     || capturedMs - clockNow > 300_000) return undefined;
   const ageMs = Math.max(0, clockNow - capturedMs);
@@ -164,7 +164,7 @@ function freshnessFor(snapshot: ProducedLocalBundle, clockNow: number): StoredDa
     : ageMs < 172_800_000
       ? `${Math.floor(ageMs / 60_000)} minutes`
       : `${Math.floor(ageMs / 86_400_000)} days`;
-  return Object.freeze({ capturedAt: snapshot.frozenNow, ageMs, label });
+  return Object.freeze({ capturedAt: snapshot.captureClock.civilDateTime, ageMs, label });
 }
 
 export function formatStoreFreshness(freshness: StoredDataFreshness): string {
@@ -192,7 +192,7 @@ export function createStoreAthleteDataReader(input: {
     snapshot: ProducedLocalBundle,
     candidate: { start: string; end?: string },
   ): { start: string; end: string } | undefined => {
-    const end = candidate.end ?? snapshot.frozenNow.slice(0, 10);
+    const end = candidate.end ?? snapshot.captureClock.civilDateTime.slice(0, 10);
     if (!isRealCivilDate(candidate.start) || !isRealCivilDate(end) || candidate.start > end) return undefined;
     return { start: candidate.start, end };
   };

--- a/packages/core/src/reference/runtime.ts
+++ b/packages/core/src/reference/runtime.ts
@@ -36,11 +36,13 @@ export interface BootstrapReferenceDeps {
   readonly dataDir: string;
   readonly intervals: { readonly apiKey: string; readonly athleteId?: string };
   readonly readIntervals?: () => { readonly apiKey: string; readonly athleteId?: string };
+  readonly readCalendarTimeZone: () => string;
   readonly sport: Sport;
   /** Inject a fetcher for tests. Defaults to `makeProductionFetcher`. */
   readonly fetchReferenceData?: (
     signal: AbortSignal,
     intervals: { readonly apiKey: string; readonly athleteId?: string },
+    calendarTimeZone: string,
   ) => Promise<FetchedReference>;
   readonly startScheduler?: boolean;
   readonly attemptLedgerForRun?: () => PhysicalRequestLedger;
@@ -83,7 +85,7 @@ export async function bootstrapReference(
       attemptLedgerForRun: deps.attemptLedgerForRun,
     });
   const fetchReferenceDataForRun = (signal: AbortSignal) =>
-    fetchReferenceData(signal, readIntervals());
+    fetchReferenceData(signal, readIntervals(), deps.readCalendarTimeZone());
 
   const mutex = new AsyncMutex();
   const cooldown = new Cooldown();

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -152,6 +152,7 @@ interface LiveFetchDeps {
   readonly client: BundleFetchClient;
   readonly signal: AbortSignal;
   readonly now: Date;
+  readonly calendarTimeZone: string;
   readonly sportTypes?: readonly string[];
   /** Override the inter-request throttle (tests pass 0). */
   readonly throttleMs?: number;
@@ -201,7 +202,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   const { client, signal, now } = deps;
   const log = deps.log ?? ((m: string) => console.warn(m));
   const throttleMs = deps.throttleMs ?? STREAM_THROTTLE_MS;
-  const plan = createReferenceCapturePlan({ now, calendarTimeZone: "UTC" });
+  const plan = createReferenceCapturePlan({ now, calendarTimeZone: deps.calendarTimeZone });
   const frozenNow = plan.frozenNow;
   const { oldest, newest } = plan.window;
   const cyclingSportTypes = new Set(

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -99,8 +99,9 @@ export function makeProductionFetcher(deps: {
 }): (
   signal: AbortSignal,
   intervals: { readonly apiKey: string; readonly athleteId?: string },
+  calendarTimeZone: string,
 ) => Promise<FetchedReference> {
-  return async (signal, intervals) => {
+  return async (signal, intervals, calendarTimeZone) => {
     const client = makeAbortableClient({
       apiKey: intervals.apiKey,
       athleteId: intervals.athleteId,
@@ -108,7 +109,7 @@ export function makeProductionFetcher(deps: {
       perRequestMs: PER_REQUEST_TIMEOUT_MS,
       attemptLedger: deps.attemptLedgerForRun?.(),
     });
-    return await fetchOnce(client, signal, deps.adapters, deps.sportTypes);
+    return await fetchOnce(client, signal, deps.adapters, deps.sportTypes, calendarTimeZone);
   };
 }
 
@@ -117,8 +118,15 @@ async function fetchOnce(
   signal: AbortSignal,
   adapters: readonly ReferenceSportAdapter[],
   sportTypes: readonly IntervalsActivityType[],
+  calendarTimeZone: string,
 ): Promise<FetchedReference> {
-  const live = await fetchLiveBundle({ client, signal, now: new Date(), sportTypes });
+  const live = await fetchLiveBundle({
+    client,
+    signal,
+    now: new Date(),
+    calendarTimeZone,
+    sportTypes,
+  });
   const runs: readonly AdapterRun[] = runAdaptersForActivities(
     adapters,
     sportTypes,

--- a/packages/core/src/reference/sync/freshness-check.ts
+++ b/packages/core/src/reference/sync/freshness-check.ts
@@ -1,6 +1,9 @@
-import { CRITICAL_MS, FRESH_MS, FUTURE_TOLERANCE_MS, STALE_MS } from "../freshness.js";
+import {
+  referenceFreshnessAt,
+  type ReferenceFreshness,
+} from "@enduragent/kernel/reference/freshness";
 
-export type Freshness = "fresh" | "flag" | "stale" | "critical";
+export type Freshness = ReferenceFreshness;
 
 /**
  * Map a cache file's `metadata.last_updated` to one of four freshness bands:
@@ -12,14 +15,5 @@ export function freshnessOf(
   metadata: { last_updated: string },
   now: Date = new Date(),
 ): Freshness {
-  const elapsed = now.getTime() - new Date(metadata.last_updated).getTime();
-  // A `last_updated` in the future beyond a small skew tolerance is impossible;
-  // a backward/frozen clock would otherwise leave `elapsed` negative forever and
-  // mask arbitrarily old data as fresh. Treat it as stale so the freshness
-  // annotator raises a warning instead of silently trusting it.
-  if (elapsed < -FUTURE_TOLERANCE_MS) return "stale";
-  if (elapsed >= CRITICAL_MS) return "critical";
-  if (elapsed >= STALE_MS) return "stale";
-  if (elapsed >= FRESH_MS) return "flag";
-  return "fresh";
+  return referenceFreshnessAt(metadata.last_updated, now);
 }

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -416,6 +416,7 @@ export async function runBinary(
     (await bootstrapReference({
       dataDir: config.dataDir,
       intervals: config.intervals,
+      readCalendarTimeZone: () => config.session.timezone,
       sport,
     }));
   let runtimeClosed = false;

--- a/packages/core/tests/athlete-data-tools.test.ts
+++ b/packages/core/tests/athlete-data-tools.test.ts
@@ -19,7 +19,11 @@ import { COACH_EVENT_TAG } from "../../engine/src/sport/event-provenance.js";
 function produced(frozenNow = "1998-07-18T12:00:00.000Z"): ProducedLocalBundle {
   return {
     captureId: "12345678-1234-4123-8123-123456789abc",
-    frozenNow,
+    captureClock: {
+      captureEpochMs: Date.parse(frozenNow),
+      civilDateTime: frozenNow,
+      calendarTimeZone: "UTC",
+    },
     bundle: {
       athlete: { sportSettings: [{ types: ["Ride"], ftp: 250 }] },
       activities: [
@@ -180,6 +184,27 @@ describe("store athlete reader", () => {
       ok: false,
       error: "invalid_input",
       message: "Dates must be real YYYY-MM-DD values with start on or before end.",
+    });
+  });
+
+  it("derives snapshot age from the capture epoch instead of civil text", async () => {
+    const snapshot = {
+      ...produced("not-an-instant"),
+      captureClock: {
+        captureEpochMs: Date.parse("1998-07-18T20:30:00.000Z"),
+        civilDateTime: "1998-07-19T03:30:00",
+        calendarTimeZone: "Asia/Almaty",
+      },
+    };
+    const reader = createStoreAthleteDataReader({
+      snapshot: () => snapshot,
+      clockNow: () => Date.parse("1998-07-18T20:32:00.000Z"),
+    });
+    const result = await reader.getAthlete();
+    expect(result.ok && result.freshness).toEqual({
+      capturedAt: "1998-07-19T03:30:00",
+      ageMs: 120_000,
+      label: "2 minutes",
     });
   });
 

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -104,6 +104,20 @@ function fakeClient(opts: FakeOpts): {
 }
 
 describe("fetchLiveBundle", () => {
+  it("uses the supplied calendar zone for the run window", async () => {
+    const { client, eventCalls } = fakeClient({});
+    const result = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: new Date("2026-06-08T15:30:00.000Z"),
+      calendarTimeZone: "Australia/Sydney",
+      throttleMs: 0,
+    });
+
+    expect(result.frozenNow).toBe("2026-06-09T01:30:00");
+    expect(eventCalls[0]).toMatchObject({ oldest: "2026-06-03", newest: "2026-07-07" });
+  });
+
   it("snake-cases + renames TP fields on activities and wellness", async () => {
     const { client } = fakeClient({
       activities: [camelActivity({ id: 7 })],
@@ -113,6 +127,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
 
@@ -149,6 +164,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
 
@@ -172,6 +188,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(streamCalls).toEqual(["90", "10"]);
@@ -190,6 +207,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: () => {},
     });
@@ -203,7 +221,13 @@ describe("fetchLiveBundle", () => {
     const { client, streamCalls } = fakeClient({
       activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],
     });
-    const res = await fetchLiveBundle({ client, signal: ac.signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: ac.signal,
+      now: NOW,
+      calendarTimeZone: "UTC",
+      throttleMs: 0,
+    });
     expect(streamCalls).toHaveLength(0);
     expect(res.bundle.streams).toBeUndefined();
   });
@@ -220,6 +244,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.bundle.ftpHistory).toEqual([
@@ -239,6 +264,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.recentActivities).toHaveLength(1);
@@ -253,6 +279,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.bundle.athlete?.sportSettings[0]?.ftp).toBe(250);
@@ -261,7 +288,13 @@ describe("fetchLiveBundle", () => {
   it("throws when the activities list is unreachable", async () => {
     const { client } = fakeClient({ activitiesFail: true });
     await expect(
-      fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 }),
+      fetchLiveBundle({
+        client,
+        signal: new AbortController().signal,
+        now: NOW,
+        calendarTimeZone: "UTC",
+        throttleMs: 0,
+      }),
     ).rejects.toThrow(/activities\.list failed/);
   });
 
@@ -320,6 +353,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       sportTypes: ["Ride", "VirtualRide", "Run"],
       throttleMs: 0,
       log: () => {},
@@ -347,6 +381,7 @@ describe("fetchLiveBundle", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       sportTypes: ["Ride"],
       throttleMs: 0,
       log: () => {},
@@ -379,6 +414,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.bundle.streams?.["1"]?.dfa_a1).toEqual([1, 0.8]);
@@ -406,6 +442,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: (message) => logs.push(message),
     });
@@ -426,6 +463,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.bundle.streams?.["1"]?.dfa_a1).toEqual([1, 0.8]);
@@ -440,6 +478,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: () => {},
     });
@@ -454,6 +493,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.bundle.athlete?.sportSettings[0]?.indoor_ftp).toBe(240);
@@ -474,6 +514,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: (m) => logs.push(m),
     });
@@ -501,6 +542,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: (message) => logs.push(message),
     });
@@ -527,6 +569,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: () => {},
     });
@@ -551,6 +594,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: (m) => logs.push(m),
     });
@@ -573,6 +617,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: () => {},
     });
@@ -587,6 +632,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.fetchErrors).toBeUndefined();
@@ -610,6 +656,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: () => {},
     });
@@ -638,6 +685,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
 
@@ -662,6 +710,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
       log: (m) => logs.push(m),
     });
@@ -683,7 +732,13 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
         return STREAM_OK;
       },
     });
-    await fetchLiveBundle({ client, signal: ac.signal, now: NOW, throttleMs: 0 });
+    await fetchLiveBundle({
+      client,
+      signal: ac.signal,
+      now: NOW,
+      calendarTimeZone: "UTC",
+      throttleMs: 0,
+    });
     expect(streamCalls).toHaveLength(1);
   });
 
@@ -693,6 +748,7 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       client,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       throttleMs: 0,
     });
     expect(res.frozenNow).not.toMatch(/[Z+]/);

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -130,6 +130,7 @@ async function composeFetched(): Promise<FetchedReference> {
     client: fakeClient(),
     signal: new AbortController().signal,
     now: NOW,
+      calendarTimeZone: "UTC",
     sportTypes: SPORT_TYPES,
     throttleMs: 0,
   });
@@ -237,6 +238,7 @@ describe("live-data bridge integration", () => {
       client: emptyClient,
       signal: new AbortController().signal,
       now: NOW,
+      calendarTimeZone: "UTC",
       sportTypes: SPORT_TYPES,
       throttleMs: 0,
     });

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -1418,6 +1418,7 @@ describe("latest derived_metrics structured schema + version gate", () => {
     const runtime = await bootstrapReference({
       dataDir: dir,
       intervals: { apiKey: "test-key" },
+      readCalendarTimeZone: () => "UTC",
       sport: fakeSport(),
       fetchReferenceData: fetchSpy,
     });

--- a/packages/core/tests/reference-runtime.test.ts
+++ b/packages/core/tests/reference-runtime.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, rmSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { bootstrapReference, INITIAL_SYNC_FAILED_LOG_PREFIX } from "../src/reference/runtime.js";
+import {
+  bootstrapReference as bootstrapReferenceRuntime,
+  INITIAL_SYNC_FAILED_LOG_PREFIX,
+  type BootstrapReferenceDeps,
+} from "../src/reference/runtime.js";
 import { ReferenceConfigError } from "../src/reference/errors.js";
 import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { Sport } from "../src/sport.js";
@@ -28,6 +32,15 @@ const fetchedWithAthlete = (id: string) => ({
   ...emptyFetched,
   latest: { ...emptyFetched.latest, athlete_profile: { id } },
 });
+
+function bootstrapReference(
+  deps: Omit<BootstrapReferenceDeps, "readCalendarTimeZone"> & {
+    readonly readCalendarTimeZone?: () => string;
+  },
+) {
+  const { readCalendarTimeZone = () => "UTC", ...rest } = deps;
+  return bootstrapReferenceRuntime({ ...rest, readCalendarTimeZone });
+}
 
 describe("bootstrapReference (behavioral)", () => {
   let dataDir: string;
@@ -104,6 +117,29 @@ describe("bootstrapReference (behavioral)", () => {
       { apiKey: "", athleteId: "fake-athlete-first" },
       { apiKey: "placeholder", athleteId: "fake-athlete-second" },
     ]);
+    runtime.scheduler.stop();
+  });
+
+  it("resolves the live calendar zone for every run", async () => {
+    let calendarTimeZone = "UTC";
+    const observed: string[] = [];
+    const runtime = await bootstrapReference({
+      dataDir,
+      intervals: { apiKey: "placeholder" },
+      readCalendarTimeZone: () => calendarTimeZone,
+      sport: fakeSport(),
+      fetchReferenceData: async (_signal, _credentials, zone = "missing") => {
+        observed.push(zone);
+        return emptyFetched;
+      },
+      startScheduler: false,
+    });
+
+    await runtime.runScheduledOnce();
+    calendarTimeZone = "Australia/Sydney";
+    await runtime.services.runSync({ chatId: "fake-chat" });
+
+    expect(observed).toEqual(["UTC", "Australia/Sydney"]);
     runtime.scheduler.stop();
   });
 

--- a/packages/kernel/src/reference/capture.ts
+++ b/packages/kernel/src/reference/capture.ts
@@ -356,6 +356,20 @@ export function planCalendarTimeZone(plan: ReferenceCapturePlan): string {
   return plan.calendar_timezone ?? "UTC";
 }
 
+export interface ReferenceCaptureClock {
+  readonly captureEpochMs: number;
+  readonly civilDateTime: string;
+  readonly calendarTimeZone: string;
+}
+
+export function referenceCaptureClock(plan: ReferenceCapturePlan): ReferenceCaptureClock {
+  return Object.freeze({
+    captureEpochMs: plan.capture_epoch_ms,
+    civilDateTime: plan.frozenNow,
+    calendarTimeZone: planCalendarTimeZone(plan),
+  });
+}
+
 export function validateReferenceCapturePlan(value: unknown): ReferenceCapturePlan {
   return CapturePlanSchema.parse(value);
 }

--- a/packages/kernel/src/reference/freshness.ts
+++ b/packages/kernel/src/reference/freshness.ts
@@ -17,6 +17,23 @@ export const CRITICAL_MS = 7 * 24 * 60 * 60 * 1000;
  */
 export const FUTURE_TOLERANCE_MS = 5 * 60 * 1000;
 
+export type ReferenceFreshness = "fresh" | "flag" | "stale" | "critical";
+
+export function referenceFreshnessAt(
+  instant: string,
+  now: Date = new Date(),
+): ReferenceFreshness {
+  const refreshedAt = Date.parse(instant);
+  const evaluatedAt = now.getTime();
+  if (!Number.isFinite(refreshedAt) || !Number.isFinite(evaluatedAt)) return "stale";
+  const elapsed = evaluatedAt - refreshedAt;
+  if (elapsed < -FUTURE_TOLERANCE_MS) return "stale";
+  if (elapsed >= CRITICAL_MS) return "critical";
+  if (elapsed >= STALE_MS) return "stale";
+  if (elapsed >= FRESH_MS) return "flag";
+  return "fresh";
+}
+
 // ─── Retention windows ─────────────────────────────────────────────────
 /** Days of history retained at "latest" granularity (recent activities + wellness). */
 export const LATEST_RETENTION_DAYS = 7;

--- a/packages/kernel/src/reference/local-bundle.ts
+++ b/packages/kernel/src/reference/local-bundle.ts
@@ -1,4 +1,4 @@
-import type { ReferenceCaptureManifest, SnapshotRef } from "./capture.js";
+import type { ReferenceCaptureClock, ReferenceCaptureManifest, SnapshotRef } from "./capture.js";
 import type { MetricInput } from "./metrics/metric-input.js";
 import { SPORT_FAMILIES } from "./metrics/sport-families.js";
 import {
@@ -66,7 +66,7 @@ export function projectCyclingReferenceBundle(bundle: ReferenceBundle): Referenc
 
 export interface ProducedLocalBundle {
   readonly captureId: string;
-  readonly frozenNow: string;
+  readonly captureClock: ReferenceCaptureClock;
   readonly bundle: ReferenceBundle;
 }
 

--- a/packages/kernel/tests/reference-capture.test.ts
+++ b/packages/kernel/tests/reference-capture.test.ts
@@ -9,6 +9,7 @@ import {
   parseReferenceCaptureManifest,
   parseReferenceCapturePlan,
   planCalendarTimeZone,
+  referenceCaptureClock,
   selectReferenceCaptureStreamIds,
   serializeReferenceCaptureManifest,
   serializeReferenceCapturePlan,
@@ -97,6 +98,18 @@ describe("Reference capture plan and manifest", () => {
     expect(almaty.window).toEqual({ oldest: "1998-04-26", newest: "1998-07-19" });
     expect(almaty.frozenNow).toBe("1998-07-19T03:30:00");
     expect(planCalendarTimeZone(almaty)).toBe("Asia/Almaty");
+  });
+
+  it("projects the authoritative instant, civil time, and calendar zone together", () => {
+    const plan = createReferenceCapturePlan({
+      now: new Date("1998-07-18T20:30:00.000Z"),
+      calendarTimeZone: "Asia/Almaty",
+    });
+    expect(referenceCaptureClock(plan)).toEqual({
+      captureEpochMs: Date.parse("1998-07-18T20:30:00.000Z"),
+      civilDateTime: "1998-07-19T03:30:00",
+      calendarTimeZone: "Asia/Almaty",
+    });
   });
 
   it("strictly validates every manifest object and exact bytes", () => {


### PR DESCRIPTION
## Why

The training-page work mixed calendar-zone wall time with epoch freshness checks. Athletes whose configured zone differed from the host could receive an invalid snapshot immediately after sync, and the legacy live-bundle lane still planned in UTC.

## Scope

- Carry epoch time, civil time, and calendar zone as one capture-clock value.
- Use the canonical Kernel freshness calculation from Core and Coach.
- Evaluate Training History at the current read time while keeping persisted sync metadata as evidence.
- Read the configured calendar zone for every live-bundle run, with host-zone fallback.

## Tradeoffs

The clock contract becomes explicit across package boundaries. This adds plumbing, but removes implicit host parsing and makes every lane use the same authority.

## Blast radius

Kernel capture and freshness contracts, Core live sync and athlete-data reads, Coach composition and state reads, plus their focused tests.

## Verification

- 312 focused tests passed across Kernel, Core, Coach, and desktop call sites.
- Kernel, Core, and Coach package checks passed.
- Oxlint and whitespace checks passed.
- Changeset user-facing validation passed.

