### PR TITLE
fix(training): preserve coverage gap evidence

### DIFF
--- a/.changeset/training-coverage-truth.md
+++ b/.changeset/training-coverage-truth.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/sync-intervals-icu": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Training History now marks only the dates affected by dropped activities as incomplete. Open weeks and comparison callouts no longer claim totals for days that have not finished.

--- a/packages/coach/src/backfill.ts
+++ b/packages/coach/src/backfill.ts
@@ -14,11 +14,13 @@ import type { AthleteHome } from "@enduragent/kernel-node/home";
 import {
   REQUEST_ATTEMPTS,
   ZERO_DROPPED_ACTIVITY_ROWS,
-  type DroppedActivityRowCounts,
+  type DroppedActivityRowEvidence,
   type IntervalsIcuArtifact,
   type IntervalsIcuSource,
 } from "@enduragent/sync-intervals-icu";
+import { addCivilDays, todayInTZ } from "@enduragent/engine/sport";
 import { enforceIntervalsStoreOwner } from "./account-identity.js";
+import { coverageGapsWithinWindow } from "./coverage-gaps.js";
 import {
   createIntervalsBackfillSource,
   DEFAULT_PER_REQUEST_TIMEOUT_MS,
@@ -110,11 +112,16 @@ export interface RunActivityAuditPagesOptions extends RunBackfillPagesOptions {
 }
 
 export interface BackfillRunResult { readonly pages: number; readonly artifacts: number; readonly reports: readonly ImportReport[];
-  readonly droppedActivityRows: DroppedActivityRowCounts; }
+  readonly droppedActivityRows: DroppedActivityRowEvidence; }
 
-function addDropped(total: DroppedActivityRowCounts, page: DroppedActivityRowCounts | undefined): DroppedActivityRowCounts {
+function addDropped(total: DroppedActivityRowEvidence, page: DroppedActivityRowEvidence | undefined): DroppedActivityRowEvidence {
   if (page === undefined) return total;
-  return { sourceRestricted: total.sourceRestricted + page.sourceRestricted, other: total.other + page.other };
+  return {
+    sourceRestricted: total.sourceRestricted + page.sourceRestricted,
+    other: total.other + page.other,
+    datedLocalDates: [...new Set([...total.datedLocalDates, ...page.datedLocalDates])].sort(),
+    undatedCount: total.undatedCount + page.undatedCount,
+  };
 }
 
 interface AuthoritativeBackfillCycle {
@@ -130,7 +137,7 @@ export async function runActivityAuditPages(
   const perRequestTimeoutMs = configured(options.perRequestTimeoutMs, DEFAULT_PER_REQUEST_TIMEOUT_MS, 1_000, 300_000, "request timeout");
   const pageDeadlineMs = configured(options.backfillPageDeadlineMs, DEFAULT_BACKFILL_PAGE_DEADLINE_MS, 60_000, 86_400_000, "page deadline");
   let pages = 0, artifacts = 0;
-  let droppedActivityRows: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS;
+  let droppedActivityRows: DroppedActivityRowEvidence = ZERO_DROPPED_ACTIVITY_ROWS;
   const reports: ImportReport[] = [];
   const coverage = createTrainingCoverageRepository();
   let authoritativeCycle: AuthoritativeBackfillCycle | null | undefined;
@@ -198,6 +205,8 @@ export async function runActivityAuditPages(
           droppedActivityRows = {
             sourceRestricted: previous.droppedSourceRestricted,
             other: previous.droppedOther,
+            datedLocalDates: previous.gaps.datedLocalDates,
+            undatedCount: previous.gaps.undatedCount,
           };
         }
       }
@@ -230,9 +239,26 @@ export async function runActivityAuditPages(
         cursorAfter: checkpointValue,
         droppedSourceRestricted: droppedActivityRows.sourceRestricted,
         droppedOther: droppedActivityRows.other,
+        gaps: coverageGapsWithinWindow({
+          evidence: droppedActivityRows,
+          oldest: options.historyOldestDate,
+          newest: options.historyNewestDate,
+        }),
         terminal: parsed.complete,
       });
       if (terminalCommitEpochSeconds !== null) {
+        const elapsedThrough = addCivilDays(
+          todayInTZ(
+            options.calendarTimeZone,
+            new Date(terminalCommitEpochSeconds * 1_000),
+          ),
+          -1,
+        );
+        const coverageNewest =
+          options.historyNewestDate < elapsedThrough
+            ? options.historyNewestDate
+            : elapsedThrough;
+        if (coverageNewest < options.historyOldestDate) return;
         await coverage.appendCommitInTransaction(transactionStore, {
           source: "intervals-icu",
           lane: "activities",
@@ -240,12 +266,13 @@ export async function runActivityAuditPages(
           authorityId: authoritativeCycle.authorityId,
           calendarTimeZone: options.calendarTimeZone,
           coveredOldest: options.historyOldestDate,
-          coveredNewest: options.historyNewestDate,
+          coveredNewest: coverageNewest,
           committedEpochSeconds: terminalCommitEpochSeconds,
-          gapState:
-            droppedActivityRows.sourceRestricted > 0 || droppedActivityRows.other > 0
-              ? "undated-dropped-rows"
-              : "none",
+          gaps: coverageGapsWithinWindow({
+            evidence: droppedActivityRows,
+            oldest: options.historyOldestDate,
+            newest: coverageNewest,
+          }),
         });
       }
     };
@@ -288,7 +315,7 @@ export async function runBackfillPages(options: RunBackfillPagesOptions): Promis
   const perRequestTimeoutMs = configured(options.perRequestTimeoutMs, DEFAULT_PER_REQUEST_TIMEOUT_MS, 1_000, 300_000, "request timeout");
   const pageDeadlineMs = configured(options.backfillPageDeadlineMs, DEFAULT_BACKFILL_PAGE_DEADLINE_MS, 60_000, 86_400_000, "page deadline");
   let pages = 0, artifacts = 0, terminalCursor: string | null = null;
-  let droppedActivityRows: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS;
+  let droppedActivityRows: DroppedActivityRowEvidence = ZERO_DROPPED_ACTIVITY_ROWS;
   const reports: ImportReport[] = [];
   for (;;) {
     const before = await createSyncStateRepository(options.store).readWatermark("intervals-icu", "bulk-fit");

--- a/packages/coach/src/capture.ts
+++ b/packages/coach/src/capture.ts
@@ -32,7 +32,9 @@ import {
 } from "@enduragent/kernel-node/capture-manifest";
 import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import { REQUEST_ATTEMPTS, type IntervalsIcuCaptureSource, type ReferenceCaptureBatch } from "@enduragent/sync-intervals-icu";
+import { addCivilDays, todayInTZ } from "@enduragent/engine/sport";
 import { createIntervalsBackfillSource, DEFAULT_PER_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_INTERVAL_MS } from "./backfill.js";
+import { coverageGapsWithinWindow } from "./coverage-gaps.js";
 import {
   withCoachStoreWriter,
   type CoachStoreWriterContext,
@@ -156,6 +158,13 @@ export async function runReferenceCapture(
       ) {
         throw new TypeError("reference capture dropped activity counts are invalid");
       }
+      if (
+        !Array.isArray(batch.dropped_activity_rows.datedLocalDates) ||
+        !Number.isSafeInteger(batch.dropped_activity_rows.undatedCount) ||
+        batch.dropped_activity_rows.undatedCount < 0
+      ) {
+        throw new TypeError("reference capture dropped activity evidence is invalid");
+      }
     }
     catch (error) { throw new ReferenceCaptureRunError("capture", { cause: error }); }
 
@@ -164,6 +173,12 @@ export async function runReferenceCapture(
       return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
     });
     const coverage = createTrainingCoverageRepository();
+    const elapsedThrough = addCivilDays(
+      todayInTZ(planCalendarTimeZone(plan), new Date(plan.capture_epoch_ms)),
+      -1,
+    );
+    const coverageNewest =
+      plan.window.newest < elapsedThrough ? plan.window.newest : elapsedThrough;
     const coverageCommit: CoverageCommitInput = {
       source: "intervals-icu",
       lane: "activities",
@@ -171,13 +186,13 @@ export async function runReferenceCapture(
       authorityId: captureId,
       calendarTimeZone: planCalendarTimeZone(plan),
       coveredOldest: plan.window.oldest,
-      coveredNewest: plan.window.newest,
+      coveredNewest: coverageNewest,
       committedEpochSeconds: Math.floor(plan.capture_epoch_ms / 1_000),
-      gapState:
-        batch.dropped_activity_rows.sourceRestricted > 0 ||
-        batch.dropped_activity_rows.other > 0
-          ? "undated-dropped-rows"
-          : "none",
+      gaps: coverageGapsWithinWindow({
+        evidence: batch.dropped_activity_rows,
+        oldest: plan.window.oldest,
+        newest: coverageNewest,
+      }),
     };
     const wellnessArtifactKeys = new Map<string, string>();
     try {

--- a/packages/coach/src/coverage-gaps.ts
+++ b/packages/coach/src/coverage-gaps.ts
@@ -1,0 +1,14 @@
+import type { CoverageGapEvidence } from "@enduragent/kernel/store";
+
+export function coverageGapsWithinWindow(input: {
+  readonly evidence: CoverageGapEvidence;
+  readonly oldest: string;
+  readonly newest: string;
+}): CoverageGapEvidence {
+  return {
+    datedLocalDates: input.evidence.datedLocalDates.filter(
+      (date) => date >= input.oldest && date <= input.newest,
+    ),
+    undatedCount: input.evidence.undatedCount,
+  };
+}

--- a/packages/coach/src/training-history.ts
+++ b/packages/coach/src/training-history.ts
@@ -39,22 +39,23 @@ interface ExpectedWindows {
   readonly readWindow: CivilDateWindow;
 }
 
+interface CoverageSpan {
+  readonly start: string;
+  readonly end: string;
+}
+
 type FoldedCoverage =
+  | { readonly kind: "none" }
   | {
-      readonly kind: "contiguous";
-      readonly start: string;
-      readonly through: string;
-      readonly committedAt: string;
-    }
-  | {
-      readonly kind: "incomplete";
-      readonly provenStart: string | null;
-      readonly provenThrough: string | null;
+      readonly kind: "covered";
+      readonly start: string | null;
+      readonly through: string | null;
       readonly observedThrough: string | null;
       readonly committedAt: string | null;
-      readonly reason: "source-degraded" | "undated-dropped-rows" | "coverage-timezone-changed";
-    }
-  | { readonly kind: "none" };
+      readonly reason: "source-degraded" | "coverage-timezone-changed" | null;
+      readonly datedLocalDates: ReadonlySet<string>;
+      readonly undatedWindows: readonly CoverageSpan[];
+    };
 
 export interface TrainingHistorySource {
   readTrainingHistory(input: {
@@ -85,31 +86,59 @@ function utcCivilDateFromEpochSeconds(value: number): string {
   return `${String(year).padStart(4, "0")}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
 }
 
-function mergeCleanCoverage(rows: readonly CoverageCommitRow[]): {
-  readonly start: string;
-  readonly through: string;
-} {
-  const latest = rows.at(-1);
-  if (latest === undefined) throw new TypeError("clean coverage is empty");
-  let start = latest.coveredOldest;
-  let through = latest.coveredNewest;
-  for (let index = rows.length - 2; index >= 0; index -= 1) {
-    const row = rows.at(index);
-    if (row === undefined) throw new TypeError("coverage row is missing");
-    if (row.gapState !== "none") {
-      if (row.coveredOldest >= start && row.coveredNewest <= through) continue;
-      break;
-    }
-    if (
-      row.coveredNewest < addCivilDays(start, -1) ||
-      row.coveredOldest > addCivilDays(through, 1)
-    ) {
+function effectiveCommit(row: CoverageCommitRow): CoverageCommitRow | null {
+  const committedDate = todayInTZ(
+    row.calendarTimeZone,
+    new Date(row.committedEpochSeconds * 1_000),
+  );
+  const elapsedThrough = addCivilDays(committedDate, -1);
+  const coveredNewest =
+    row.coveredNewest < elapsedThrough ? row.coveredNewest : elapsedThrough;
+  return coveredNewest < row.coveredOldest ? null : { ...row, coveredNewest };
+}
+
+function mergeSpans(values: readonly CoverageSpan[]): CoverageSpan[] {
+  const sorted = [...values].sort(
+    (left, right) => left.start.localeCompare(right.start) || left.end.localeCompare(right.end),
+  );
+  const result: CoverageSpan[] = [];
+  for (const span of sorted) {
+    const previous = result.at(-1);
+    if (previous === undefined || span.start > addCivilDays(previous.end, 1)) {
+      result.push(span);
       continue;
     }
-    if (row.coveredOldest < start) start = row.coveredOldest;
-    if (row.coveredNewest > through) through = row.coveredNewest;
+    result[result.length - 1] = {
+      start: previous.start,
+      end: previous.end > span.end ? previous.end : span.end,
+    };
   }
-  return { start, through };
+  return result;
+}
+
+function subtractOwned(span: CoverageSpan, owned: readonly CoverageSpan[]): CoverageSpan[] {
+  let remaining = [span];
+  for (const claimed of owned) {
+    const next: CoverageSpan[] = [];
+    for (const candidate of remaining) {
+      if (claimed.end < candidate.start || claimed.start > candidate.end) {
+        next.push(candidate);
+        continue;
+      }
+      if (claimed.start > candidate.start) {
+        next.push({ start: candidate.start, end: addCivilDays(claimed.start, -1) });
+      }
+      if (claimed.end < candidate.end) {
+        next.push({ start: addCivilDays(claimed.end, 1), end: candidate.end });
+      }
+    }
+    remaining = next;
+  }
+  return remaining;
+}
+
+function intersects(left: CoverageSpan, right: CoverageSpan): boolean {
+  return left.start <= right.end && left.end >= right.start;
 }
 
 function foldCoverage(
@@ -117,52 +146,58 @@ function foldCoverage(
   calendarTimeZone: string,
   sourceRestricted: boolean,
 ): FoldedCoverage {
-  const matching = commits.filter((commit) => commit.calendarTimeZone === calendarTimeZone);
-  const latestOverall = commits.at(-1);
-  const latestMatching = matching.at(-1);
-  const clean = matching.filter((commit) => commit.gapState === "none");
-  const latestClean = clean.at(-1);
-  const proven = latestClean === undefined ? null : mergeCleanCoverage(clean);
-  if (sourceRestricted) {
-    return {
-      kind: "incomplete",
-      provenStart: proven?.start ?? null,
-      provenThrough: proven?.through ?? null,
-      observedThrough: latestMatching?.coveredNewest ?? null,
-      committedAt:
-        latestMatching === undefined
-          ? null
-          : instantFromEpochSeconds(latestMatching.committedEpochSeconds),
-      reason: "source-degraded",
-    };
+  const effective = commits.flatMap((commit) => {
+    const row = effectiveCommit(commit);
+    return row === null ? [] : [row];
+  });
+  const latestOverall = effective.at(-1);
+  if (latestOverall === undefined) {
+    return sourceRestricted
+      ? {
+          kind: "covered",
+          start: null,
+          through: null,
+          observedThrough: null,
+          committedAt: null,
+          reason: "source-degraded",
+          datedLocalDates: new Set<string>(),
+          undatedWindows: Object.freeze([]),
+        }
+      : { kind: "none" };
   }
-  if (latestOverall !== undefined && latestOverall.calendarTimeZone !== calendarTimeZone) {
-    return {
-      kind: "incomplete",
-      provenStart: proven?.start ?? null,
-      provenThrough: proven?.through ?? null,
-      observedThrough: latestOverall.coveredNewest,
-      committedAt: instantFromEpochSeconds(latestOverall.committedEpochSeconds),
-      reason: "coverage-timezone-changed",
-    };
+  const matching = effective.filter((commit) => commit.calendarTimeZone === calendarTimeZone);
+  let owned: CoverageSpan[] = [];
+  const datedLocalDates = new Set<string>();
+  const undatedWindows: CoverageSpan[] = [];
+  for (let index = matching.length - 1; index >= 0; index -= 1) {
+    const row = matching[index]!;
+    const pieces = subtractOwned(
+      { start: row.coveredOldest, end: row.coveredNewest },
+      owned,
+    );
+    for (const date of row.gaps.datedLocalDates) {
+      if (pieces.some((piece) => date >= piece.start && date <= piece.end)) {
+        datedLocalDates.add(date);
+      }
+    }
+    if (row.gaps.undatedCount > 0) undatedWindows.push(...pieces);
+    owned = mergeSpans([...owned, ...pieces]);
   }
-  if (latestMatching === undefined) return { kind: "none" };
-  if (latestMatching.gapState === "undated-dropped-rows") {
-    return {
-      kind: "incomplete",
-      provenStart: proven?.start ?? null,
-      provenThrough: proven?.through ?? null,
-      observedThrough: latestMatching.coveredNewest,
-      committedAt: instantFromEpochSeconds(latestMatching.committedEpochSeconds),
-      reason: "undated-dropped-rows",
-    };
-  }
-  const current = mergeCleanCoverage(matching);
+  const latestSpan = owned.at(-1);
   return {
-    kind: "contiguous",
-    start: current.start,
-    through: current.through,
-    committedAt: instantFromEpochSeconds(latestMatching.committedEpochSeconds),
+    kind: "covered",
+    start: latestSpan?.start ?? null,
+    through: latestSpan?.end ?? null,
+    observedThrough: latestOverall.coveredNewest,
+    committedAt: instantFromEpochSeconds(latestOverall.committedEpochSeconds),
+    reason:
+      latestOverall.calendarTimeZone !== calendarTimeZone
+        ? "coverage-timezone-changed"
+        : sourceRestricted
+          ? "source-degraded"
+          : null,
+    datedLocalDates,
+    undatedWindows: Object.freeze(undatedWindows),
   };
 }
 
@@ -206,12 +241,8 @@ function expectedWindows(
 }
 
 function safeCoverageAnchor(coverage: FoldedCoverage): string | null {
-  if (coverage.kind === "contiguous") return coverage.through;
-  if (coverage.kind === "incomplete") {
-    if (coverage.provenThrough !== null) return coverage.provenThrough;
-    if (coverage.reason !== "coverage-timezone-changed") return coverage.observedThrough;
-  }
-  return null;
+  if (coverage.kind === "none" || coverage.reason === "coverage-timezone-changed") return null;
+  return coverage.through;
 }
 
 function latestRideDate(rows: readonly TrainingHistoryFactRow[]): string | null {
@@ -234,13 +265,41 @@ function projectionCoverage(
   coverage: FoldedCoverage,
   sparseRideDate: string | null,
 ): TrainingHistoryCoverage | null {
-  if (coverage.kind === "contiguous") return coverage;
-  if (coverage.kind === "incomplete") return coverage;
-  if (sparseRideDate === null) return null;
+  if (coverage.kind === "none") {
+    if (sparseRideDate === null) return null;
+    return {
+      kind: "sparse",
+      latestKnownRideDate: sparseRideDate,
+      latestImportAt: null,
+    };
+  }
+  const hasGaps =
+    coverage.datedLocalDates.size > 0 || coverage.undatedWindows.length > 0;
+  if (
+    coverage.reason === null &&
+    !hasGaps &&
+    coverage.start !== null &&
+    coverage.through !== null &&
+    coverage.committedAt !== null
+  ) {
+    return {
+      kind: "contiguous",
+      start: coverage.start,
+      through: coverage.through,
+      committedAt: coverage.committedAt,
+    };
+  }
   return {
-    kind: "sparse",
-    latestKnownRideDate: sparseRideDate,
-    latestImportAt: null,
+    kind: "incomplete",
+    provenStart: coverage.start,
+    provenThrough: coverage.through,
+    observedThrough: coverage.observedThrough,
+    committedAt: coverage.committedAt,
+    reason:
+      coverage.reason ??
+      (coverage.undatedWindows.length > 0
+        ? "undated-dropped-rows"
+        : "source-degraded"),
   };
 }
 
@@ -332,23 +391,22 @@ function longestRecordedRideCallout(input: {
   readonly selectedWeek: CivilDateWindow;
   readonly rows: readonly TrainingHistoryFactRow[];
   readonly returnedRides: readonly TrainingHistoryRide[];
-  readonly coverage: TrainingHistoryCoverage;
+  readonly foldedCoverage: FoldedCoverage;
   readonly scanTruncated: boolean;
   readonly displayMode: "current" | "last-recorded";
 }): CompletedActivityWeek["callout"] {
-  if (
-    input.displayMode === "last-recorded" ||
-    input.scanTruncated ||
-    input.coverage.kind !== "contiguous"
-  ) {
+  if (input.displayMode === "last-recorded" || input.scanTruncated) {
+    return null;
+  }
+  if (input.foldedCoverage.kind === "none" || input.foldedCoverage.through === null) {
     return null;
   }
   const end =
-    input.coverage.through < input.selectedWeek.end
-      ? input.coverage.through
+    input.foldedCoverage.through < input.selectedWeek.end
+      ? input.foldedCoverage.through
       : input.selectedWeek.end;
   const window = { start: addCivilDays(end, -27), end };
-  if (input.coverage.start > window.start) return null;
+  if (!coverageForWindow(input.foldedCoverage, window)) return null;
   const rows = input.rows.filter(
     (row) => row.localDate >= window.start && row.localDate <= window.end,
   );
@@ -400,10 +458,31 @@ function recordedThrough(coverage: TrainingHistoryCoverage): string | null {
   return coverage.latestKnownRideDate;
 }
 
+function coverageForWindow(
+  coverage: FoldedCoverage,
+  window: CoverageSpan,
+): boolean {
+  if (
+    coverage.kind === "none" ||
+    coverage.reason !== null ||
+    coverage.start === null ||
+    coverage.through === null ||
+    coverage.start > window.start ||
+    coverage.through < window.end
+  ) {
+    return false;
+  }
+  for (const date of coverage.datedLocalDates) {
+    if (date >= window.start && date <= window.end) return false;
+  }
+  return !coverage.undatedWindows.some((gap) => intersects(gap, window));
+}
+
 function weekCoverage(input: {
   readonly window: CivilDateWindow;
   readonly today: string;
   readonly coverage: TrainingHistoryCoverage;
+  readonly foldedCoverage: FoldedCoverage;
   readonly scanCutoffDate: string | null;
   readonly currentAnchor: boolean;
 }): WeekCoverage {
@@ -414,28 +493,29 @@ function weekCoverage(input: {
   if (input.coverage.kind === "sparse") {
     return { kind: "incomplete", recordedThrough: through, reason: "sparse-imports" };
   }
-  if (input.coverage.kind === "incomplete") {
-    const reason =
-      input.coverage.reason === "coverage-timezone-changed"
-        ? "coverage-timezone-changed"
-        : input.coverage.reason === "source-degraded" ||
-            input.coverage.reason === "undated-dropped-rows"
-          ? "source-degraded"
-          : "backfill-incomplete";
-    return { kind: "incomplete", recordedThrough: through, reason };
-  }
   const open = calendarState(input.window, input.today) === "open";
-  const covered =
-    input.coverage.start <= input.window.start &&
-    input.coverage.through >= (open ? input.window.start : input.window.end);
+  const requiredThrough =
+    open && input.today < input.window.end ? input.today : input.window.end;
+  const covered = coverageForWindow(input.foldedCoverage, {
+    start: input.window.start,
+    end: requiredThrough,
+  });
   if (covered) return { kind: "complete" };
+  const reason =
+    input.coverage.kind === "incomplete" &&
+    input.coverage.reason === "coverage-timezone-changed"
+      ? "coverage-timezone-changed"
+      : input.coverage.kind === "incomplete" &&
+          (input.coverage.reason === "source-degraded" ||
+            input.coverage.reason === "undated-dropped-rows")
+        ? "source-degraded"
+        : input.currentAnchor && through !== null && through < input.window.start
+          ? "coverage-lag"
+          : "backfill-incomplete";
   return {
     kind: "incomplete",
-    recordedThrough: input.coverage.through,
-    reason:
-      input.currentAnchor && input.coverage.through < input.window.start
-        ? "coverage-lag"
-        : "backfill-incomplete",
+    recordedThrough: through,
+    reason,
   };
 }
 
@@ -453,6 +533,7 @@ function trend(input: {
   readonly windows: ExpectedWindows;
   readonly today: string;
   readonly coverage: TrainingHistoryCoverage;
+  readonly foldedCoverage: FoldedCoverage;
   readonly scanCutoffDate: string | null;
 }): RidingTimeTrend {
   const buckets = input.windows.trend.map((window) => {
@@ -462,6 +543,7 @@ function trend(input: {
       window,
       today: input.today,
       coverage: input.coverage,
+      foldedCoverage: input.foldedCoverage,
       scanCutoffDate: input.scanCutoffDate,
       currentAnchor: false,
     });
@@ -501,6 +583,7 @@ function completedWeek(input: {
   readonly windows: ExpectedWindows;
   readonly today: string;
   readonly coverage: TrainingHistoryCoverage;
+  readonly foldedCoverage: FoldedCoverage;
   readonly scanCutoffDate: string | null;
   readonly trend: RidingTimeTrend;
 }): CompletedActivityWeek {
@@ -510,13 +593,14 @@ function completedWeek(input: {
     window: input.window,
     today: input.today,
     coverage: input.coverage,
+    foldedCoverage: input.foldedCoverage,
     scanCutoffDate: input.scanCutoffDate,
     currentAnchor: input.id === "anchor",
   });
   const complete = coverage.kind === "complete";
   const items = slot.rows.slice(0, MAX_VISIBLE_RIDES).map(projectRide);
   const scanLimited = input.scanCutoffDate !== null && input.window.start <= input.scanCutoffDate;
-  const truncated = scanLimited || slot.rows.length > items.length;
+  const truncated = !complete || scanLimited || slot.rows.length > items.length;
   return {
     id: input.id,
     window: input.window,
@@ -538,7 +622,7 @@ function completedWeek(input: {
       ),
     },
     rides: {
-      count: scanLimited
+      count: !complete
         ? { kind: "at-least", value: slot.rows.length }
         : { kind: "exact", value: slot.rows.length },
       items,
@@ -650,6 +734,7 @@ export function createTrainingHistorySource(dependencies: {
           windows,
           today,
           coverage,
+          foldedCoverage: folded,
           scanCutoffDate: scanCutoff,
         });
         const anchorWeekWithoutCallout = completedWeek({
@@ -658,6 +743,7 @@ export function createTrainingHistorySource(dependencies: {
           windows,
           today,
           coverage,
+          foldedCoverage: folded,
           scanCutoffDate: scanCutoff,
           trend: ridingTrend,
         });
@@ -667,7 +753,7 @@ export function createTrainingHistorySource(dependencies: {
             selectedWeek: windows.anchor,
             rows: facts.rows,
             returnedRides: anchorWeekWithoutCallout.rides.items,
-            coverage,
+            foldedCoverage: folded,
             scanTruncated: facts.scanTruncated,
             displayMode,
           }),
@@ -685,6 +771,7 @@ export function createTrainingHistorySource(dependencies: {
             windows,
             today,
             coverage,
+            foldedCoverage: folded,
             scanCutoffDate: scanCutoff,
             trend: ridingTrend,
           }),

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -592,7 +592,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 31 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -15,6 +15,7 @@ import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { EMPTY_DROPPED_ACTIVITIES } from "@enduragent/coach-contract";
 import {
   createIntervalsBackfillSource,
+  runActivityAuditPages,
   runBackfillPages,
   runIntervalsBackfill,
   runIntervalsBackfillInWriter,
@@ -134,7 +135,12 @@ describe("incremental backfill pages", () => {
           yield {
             kind: "checkpoint",
             watermark: { source: "intervals-icu", lane: "bulk-fit", value: call === 0 ? midway : complete },
-            droppedActivityRows: { sourceRestricted: call === 0 ? 60 : 3, other: call === 0 ? 0 : 2 },
+            droppedActivityRows: {
+              sourceRestricted: call === 0 ? 60 : 3,
+              other: call === 0 ? 0 : 2,
+              datedLocalDates: call === 0 ? ["1998-07-16"] : ["1998-07-17"],
+              undatedCount: 0,
+            },
           };
         })(),
       );
@@ -145,7 +151,128 @@ describe("incremental backfill pages", () => {
         clock,
       });
       expect(result).toMatchObject({ pages: 3 });
-      expect(result.droppedActivityRows).toEqual({ sourceRestricted: 63, other: 2 });
+      expect(result.droppedActivityRows).toEqual({
+        sourceRestricted: 63,
+        other: 2,
+        datedLocalDates: ["1998-07-16", "1998-07-17"],
+        undatedCount: 0,
+      });
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("persists only in-window activity-audit gap evidence without claiming the commit day", async () => {
+    const value = await fresh();
+    const checkpoint = JSON.stringify({
+      v: 1,
+      cycle: 0,
+      window_start: "1998-01-01",
+      window_end: "1998-07-18",
+      last_key: null,
+      complete: true,
+    });
+    const fake = source(() =>
+      (async function* () {
+        yield {
+          kind: "checkpoint",
+          watermark: { source: "intervals-icu", lane: "activities", value: checkpoint },
+          droppedActivityRows: {
+            sourceRestricted: 3,
+            other: 1,
+            datedLocalDates: ["1997-12-31", "1998-07-16", "1998-07-19"],
+            undatedCount: 1,
+          },
+        } as SourceArtifact;
+      })(),
+    );
+    try {
+      await runActivityAuditPages({
+        store: value.store,
+        node: value.node,
+        source: fake,
+        clock: {
+          now: () => Date.parse("1998-07-18T12:00:00.000Z"),
+          monotonicNow: () => 1_000,
+        },
+        historyOldestDate: "1998-01-01",
+        historyNewestDate: "1998-07-18",
+        calendarTimeZone: "UTC",
+        cycleId: () => "activity-audit-cycle",
+      });
+
+      expect(
+        await value.store.get(
+          `SELECT covered_newest_date_key, dropped_local_dates_json, undated_dropped_count
+FROM training_history_coverage_commit`,
+        ),
+      ).toEqual({
+        covered_newest_date_key: 19980717,
+        dropped_local_dates_json: '["1998-07-16"]',
+        undated_dropped_count: 1,
+      });
+      expect(
+        await value.store.get(
+          `SELECT dropped_local_dates_json, undated_dropped_count
+FROM training_history_backfill_checkpoint`,
+        ),
+      ).toEqual({
+        dropped_local_dates_json: '["1998-07-16"]',
+        undated_dropped_count: 1,
+      });
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("finishes a same-day activity audit without claiming future coverage", async () => {
+    const value = await fresh();
+    const checkpoint = JSON.stringify({
+      v: 1,
+      cycle: 0,
+      window_start: "1998-07-18",
+      window_end: "1998-07-18",
+      last_key: null,
+      complete: true,
+    });
+    const fake = source(() =>
+      (async function* () {
+        yield {
+          kind: "checkpoint",
+          watermark: { source: "intervals-icu", lane: "activities", value: checkpoint },
+          droppedActivityRows: {
+            sourceRestricted: 0,
+            other: 0,
+            datedLocalDates: [],
+            undatedCount: 0,
+          },
+        } as SourceArtifact;
+      })(),
+    );
+    try {
+      await expect(
+        runActivityAuditPages({
+          store: value.store,
+          node: value.node,
+          source: fake,
+          clock: {
+            now: () => Date.parse("1998-07-18T12:00:00.000Z"),
+            monotonicNow: () => 1_000,
+          },
+          historyOldestDate: "1998-07-18",
+          historyNewestDate: "1998-07-18",
+          calendarTimeZone: "UTC",
+          cycleId: () => "same-day-activity-audit-cycle",
+        }),
+      ).resolves.toMatchObject({ pages: 1 });
+      expect(
+        await value.store.get("SELECT count(*) AS n FROM training_history_coverage_commit"),
+      ).toEqual({ n: 0 });
+      expect(
+        await value.store.get(
+          "SELECT count(*) AS n FROM training_history_backfill_checkpoint WHERE terminal = 1",
+        ),
+      ).toEqual({ n: 1 });
     } finally {
       await value.store.close();
     }

--- a/packages/coach/tests/capture.test.ts
+++ b/packages/coach/tests/capture.test.ts
@@ -27,7 +27,20 @@ describe("runReferenceCapture", () => {
     const baseFetch: typeof globalThis.fetch = async (input) => {
       const url = String(input); requests.push(url);
       if (url.includes("/streams.json")) return json(streams);
-      if (url.includes("/activities?")) return json(activities);
+      if (url.includes("/activities?")) {
+        return json([
+          ...activities,
+          {
+            id: 43,
+            type: "Ride",
+            start_date: "1998-04-24T10:00:00.000Z",
+            start_date_local: "1998-04-24T12:00:00",
+            moving_time: null,
+            elapsed_time: 3_700,
+            distance: 40_000,
+          },
+        ]);
+      }
       if (url.includes("/wellness?")) return json(wellness);
       return json(profile);
     };
@@ -56,7 +69,7 @@ describe("runReferenceCapture", () => {
     expect(
       await store.get(
         `SELECT authority_kind, authority_id, calendar_timezone, covered_oldest_date_key,
-  covered_newest_date_key, gap_state
+  covered_newest_date_key, gap_state, dropped_local_dates_json, undated_dropped_count
 FROM training_history_coverage_commit`,
       ),
     ).toEqual({
@@ -64,8 +77,10 @@ FROM training_history_coverage_commit`,
       authority_id: CAPTURE_ID,
       calendar_timezone: "UTC",
       covered_oldest_date_key: 19980425,
-      covered_newest_date_key: 19980718,
+      covered_newest_date_key: 19980717,
       gap_state: "none",
+      dropped_local_dates_json: "[]",
+      undated_dropped_count: 0,
     });
     await store.close();
   });

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -578,7 +578,7 @@ describe("coach sync composition", () => {
             return store.get("PRAGMA user_version");
           },
         );
-        expect(value).toEqual({ user_version: 30 });
+        expect(value).toEqual({ user_version: 31 });
         expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
         expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
         expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -586,7 +586,7 @@ describe("coach sync composition", () => {
         const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
         try {
           await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-            user_version: 30,
+            user_version: 31,
           });
         } finally {
           await reopened.close();

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1744,7 +1744,7 @@ describe("local coach composition", () => {
       pages: 1,
       artifacts: 0,
       reports: [],
-      droppedActivityRows: { sourceRestricted: 0, other: 0 },
+      droppedActivityRows: { sourceRestricted: 0, other: 0, datedLocalDates: [], undatedCount: 0 },
     }));
     let runtimeOptions: LocalStoreRuntimeOptions | undefined;
     let readReferenceIntervals:
@@ -5593,7 +5593,7 @@ describe("local coach composition", () => {
       pages: 1,
       artifacts: 0,
       reports: [],
-      droppedActivityRows: { sourceRestricted: 0, other: 0 },
+      droppedActivityRows: { sourceRestricted: 0, other: 0, datedLocalDates: [], undatedCount: 0 },
     }));
     const lifecycle = await compose(
       home,

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -653,7 +653,7 @@ describe("coach operations", () => {
       pages: 0,
       artifacts: 0,
       reports: [],
-      droppedActivityRows: { sourceRestricted: 0, other: 0 },
+      droppedActivityRows: { sourceRestricted: 0, other: 0, datedLocalDates: [], undatedCount: 0 },
     }));
     const pending = { value: true };
     const operations = createCoachOperations(
@@ -699,7 +699,7 @@ describe("coach operations", () => {
         pages: 1,
         artifacts: 1,
         reports: [],
-        droppedActivityRows: { sourceRestricted: 60, other: 2 },
+        droppedActivityRows: { sourceRestricted: 60, other: 2, datedLocalDates: [], undatedCount: 62 },
       };
     });
     const runWindowAfter = vi.fn(async (work: (signal: AbortSignal) => Promise<void>) => {
@@ -813,7 +813,7 @@ describe("coach operations", () => {
         pages: 1,
         artifacts: 0,
         reports: [],
-        droppedActivityRows: { sourceRestricted: 0, other: 0 },
+        droppedActivityRows: { sourceRestricted: 0, other: 0, datedLocalDates: [], undatedCount: 0 },
       }));
       const refresh = vi.fn();
       const runtime = {
@@ -870,7 +870,7 @@ describe("coach operations", () => {
           pages: 1,
           artifacts: 1,
           reports: [],
-          droppedActivityRows: { sourceRestricted: 60, other: 2 },
+          droppedActivityRows: { sourceRestricted: 60, other: 2, datedLocalDates: [], undatedCount: 62 },
         };
       });
       const runtime = {
@@ -932,7 +932,7 @@ describe("coach operations", () => {
           pages: 1,
           artifacts: 0,
           reports: [],
-          droppedActivityRows: { sourceRestricted: 0, other: 0 },
+          droppedActivityRows: { sourceRestricted: 0, other: 0, datedLocalDates: [], undatedCount: 0 },
         };
       });
       const runtime = {

--- a/packages/coach/tests/training-history.test.ts
+++ b/packages/coach/tests/training-history.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createTrainingHistorySource } from "../src/training-history.js";
 
 const AS_OF = "1998-07-10T12:00:00.000Z";
+const DEFAULT_COMMITTED_AT = "1998-07-11T12:00:00.000Z";
 
 function absent(): RecordedFact<number> {
   return { kind: "absent" };
@@ -62,9 +63,10 @@ function commit(input: {
   readonly newest?: string;
   readonly committedAt?: string;
   readonly zone?: string;
-  readonly gapState?: "none" | "undated-dropped-rows";
+  readonly datedLocalDates?: readonly string[];
+  readonly undatedCount?: number;
 }): CoverageCommitRow {
-  const committedAt = input.committedAt ?? AS_OF;
+  const committedAt = input.committedAt ?? DEFAULT_COMMITTED_AT;
   return {
     coverageCommitId: input.id,
     source: "intervals-icu",
@@ -75,7 +77,10 @@ function commit(input: {
     coveredOldest: input.oldest ?? "1998-05-01",
     coveredNewest: input.newest ?? "1998-07-10",
     committedEpochSeconds: Date.parse(committedAt) / 1_000,
-    gapState: input.gapState ?? "none",
+    gaps: {
+      datedLocalDates: input.datedLocalDates ?? [],
+      undatedCount: input.undatedCount ?? 0,
+    },
   };
 }
 
@@ -197,7 +202,7 @@ describe("training history projection", () => {
         commit({
           id: 1,
           newest: "1998-07-12",
-          committedAt: "1998-07-12T12:00:00.000Z",
+          committedAt: "1998-07-13T12:00:00.000Z",
         }),
       ],
     });
@@ -358,7 +363,7 @@ describe("training history projection", () => {
     expect(result.projection.anchorWeek.callout).toBeNull();
   });
 
-  it("ends the callout window at proven coverage through when it precedes Sunday", async () => {
+  it("ends the current-week callout at the last elapsed covered day", async () => {
     const winner = ride({
       id: "1".repeat(64),
       localDate: "1998-07-08",
@@ -372,7 +377,13 @@ describe("training history projection", () => {
         ride({ id: "3".repeat(64), localDate: "1998-06-28", movingSeconds: 5_400 }),
         ride({ id: "4".repeat(64), localDate: "1998-06-20", movingSeconds: 4_800 }),
       ],
-      commits: [commit({ id: 1, newest: "1998-07-10" })],
+      commits: [
+        commit({
+          id: 1,
+          newest: "1998-07-09",
+          committedAt: "1998-07-10T08:00:00.000Z",
+        }),
+      ],
     });
 
     expect(result.projection.kind).toBe("computed");
@@ -381,7 +392,7 @@ describe("training history projection", () => {
       kind: "longest-ride-28d",
       rideId: winner.id,
       durationSeconds: 7_200,
-      window: { start: "1998-06-13", end: "1998-07-10" },
+      window: { start: "1998-06-12", end: "1998-07-09" },
       comparisonRideCount: 4,
     });
   });
@@ -486,7 +497,7 @@ describe("training history projection", () => {
   it("folds superseding commits into contiguous, incomplete, and sparse coverage", async () => {
     const supersededGap = commit({
       id: 1,
-      gapState: "undated-dropped-rows",
+      undatedCount: 1,
       committedAt: "1998-07-09T12:00:00.000Z",
     });
     const clean = commit({ id: 2 });
@@ -497,7 +508,7 @@ describe("training history projection", () => {
         kind: "contiguous",
         start: "1998-05-01",
         through: "1998-07-10",
-        committedAt: AS_OF,
+        committedAt: DEFAULT_COMMITTED_AT,
       },
     });
 
@@ -506,8 +517,8 @@ describe("training history projection", () => {
         clean,
         commit({
           id: 3,
-          gapState: "undated-dropped-rows",
-          committedAt: "1998-07-10T13:00:00.000Z",
+          undatedCount: 1,
+          committedAt: "1998-07-12T13:00:00.000Z",
         }),
       ],
     });
@@ -518,7 +529,7 @@ describe("training history projection", () => {
         provenStart: "1998-05-01",
         provenThrough: "1998-07-10",
         observedThrough: "1998-07-10",
-        committedAt: "1998-07-10T13:00:00.000Z",
+        committedAt: "1998-07-12T13:00:00.000Z",
         reason: "undated-dropped-rows",
       },
     });
@@ -538,6 +549,73 @@ describe("training history projection", () => {
       anchorWeek: { window: { start: "1998-05-25", end: "1998-05-31" } },
     });
     expect(sparse.readWindow).toHaveBeenCalledWith({ start: "1900-01-01", end: "1998-07-12" });
+  });
+
+  it("localizes dated dropped rows to intersecting weeks", async () => {
+    const result = await read({
+      rows: [
+        ride({ id: "1".repeat(64), localDate: "1998-07-08" }),
+        ride({ id: "2".repeat(64), localDate: "1998-07-03" }),
+      ],
+      commits: [
+        commit({
+          id: 1,
+          committedAt: "1998-07-11T12:00:00.000Z",
+          datedLocalDates: ["1998-07-03"],
+        }),
+      ],
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed" || result.projection.previousWeek === null) return;
+    expect(result.projection.anchorWeek.coverage).toEqual({ kind: "complete" });
+    expect(result.projection.anchorWeek.rides.count).toEqual({ kind: "exact", value: 1 });
+    expect(result.projection.previousWeek.coverage).toMatchObject({
+      kind: "incomplete",
+      reason: "source-degraded",
+    });
+    expect(result.projection.previousWeek.rides.count).toEqual({ kind: "at-least", value: 1 });
+  });
+
+  it("does not claim the open current day from coverage through yesterday", async () => {
+    const result = await read({
+      rows: [ride({ id: "1".repeat(64), localDate: "1998-07-10" })],
+      commits: [
+        commit({
+          id: 1,
+          newest: "1998-07-09",
+          committedAt: "1998-07-10T12:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed") return;
+    expect(result.projection.anchorWeek.coverage).toMatchObject({
+      kind: "incomplete",
+      recordedThrough: "1998-07-09",
+    });
+    expect(result.projection.anchorWeek.rides.count).toEqual({ kind: "at-least", value: 1 });
+    expect(result.projection.anchorWeek.callout).toBeNull();
+  });
+
+  it("clamps an existing same-day coverage claim when reading it", async () => {
+    const result = await read({
+      commits: [
+        commit({
+          id: 1,
+          newest: "1998-07-10",
+          committedAt: "1998-07-10T12:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(result.projection.kind).toBe("computed");
+    if (result.projection.kind !== "computed") return;
+    expect(result.projection.anchorWeek.coverage).toMatchObject({
+      kind: "incomplete",
+      recordedThrough: "1998-07-09",
+    });
   });
 
   it("limits scan coverage at the oldest returned week without degrading newer weeks", async () => {

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -598,7 +598,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -32,9 +32,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 30", async () => {
+  it("applies the full migration list and advances user_version to 31", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -54,7 +54,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
   });
 
   it("upgrades the released Plan version 24 schema through the current schema", async () => {
@@ -66,10 +66,10 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 24,
-      toVersion: 30,
-      applied: [25, 26, 27, 28, 29, 30],
+      toVersion: 31,
+      applied: [25, 26, 27, 28, 29, 30, 31],
     });
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 30 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 31 });
     await expect(
       store.all(
         "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('chat_attachment','planning_request','chat_plan_outbox') ORDER BY name",
@@ -108,11 +108,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 30", async () => {
+  it("upgrades a version-1-on-disk store to version 31", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -134,13 +134,13 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 4,
-      toVersion: 30,
+      toVersion: 31,
       applied: [
         5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-        29, 30,
+        29, 30, 31,
       ],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -193,23 +193,23 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 6,
-      toVersion: 30,
+      toVersion: 31,
       applied: [
-        7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+        7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
       ],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 30,
-      toVersion: 30,
+      fromVersion: 31,
+      toVersion: 31,
       applied: [],
     });
   });
 
-  it("upgrades version 11 through 30 while preserving existing rows", async () => {
+  it("upgrades version 11 through 31 while preserving existing rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 11));
     await store.run("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)", [
       "chronoBridge",
@@ -218,8 +218,8 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 11,
-      toVersion: 30,
-      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+      toVersion: 31,
+      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
     });
     await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings")).resolves.toEqual({
       fixer: "chronoBridge",
@@ -228,7 +228,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     await expect(store.get("SELECT count(*) AS count FROM repair_fixer_settings")).resolves.toEqual(
       { count: 1 },
     );
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 30 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 31 });
   });
 
   it("rolls back a failed migration 12 without partial Planning tables", async () => {
@@ -593,7 +593,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("upgrades migration 28 through 30 without classifying legacy Planning rows", async () => {
+  it("upgrades migration 28 through 31 without classifying legacy Planning rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 28));
     const planId = `${"0".repeat(25)}A`;
     const workoutId = `${"0".repeat(25)}B`;
@@ -683,10 +683,10 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 28,
-      toVersion: 30,
-      applied: [29, 30],
+      toVersion: 31,
+      applied: [29, 30, 31],
     });
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 30 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 31 });
     await expect(
       Promise.all(legacyTables.map((table) => store.all(`SELECT * FROM ${table} ORDER BY 1`))),
     ).resolves.toEqual(rowsBefore);

--- a/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
+++ b/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
@@ -384,7 +384,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 30,
+            targetUserVersion: 31,
             ...webCryptoExportEnv,
           },
           { container },
@@ -434,7 +434,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 30,
+            targetUserVersion: 31,
             ...webCryptoExportEnv,
           },
           { container },
@@ -479,7 +479,7 @@ describe("planning-domain SQLite export round-trip", () => {
         {
           sink: createSqliteImportSink(destination),
           presence: completePresence,
-          targetUserVersion: 30,
+          targetUserVersion: 31,
           ...webCryptoExportEnv,
         },
         { container: built.container },
@@ -495,7 +495,7 @@ describe("planning-domain SQLite export round-trip", () => {
         {
           sink: createSqliteImportSink(destination),
           presence: completePresence,
-          targetUserVersion: 30,
+          targetUserVersion: 31,
           ...webCryptoExportEnv,
         },
         { container: built.container },
@@ -528,7 +528,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 30,
+            targetUserVersion: 31,
             ...webCryptoExportEnv,
           },
           { container },

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -239,7 +239,7 @@ describe("sync failure repository", () => {
     expect(dump).not.toContain("# sync_failure");
     expect(dump).toContain("# plan_reconciliation_job");
     expect(dump).toContain("# plan_reconciliation_item");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 30 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
     expect(DUMP_TABLES).toHaveLength(69);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");

--- a/packages/kernel/src/store/migrations/031_training_history_gap_evidence.sql
+++ b/packages/kernel/src/store/migrations/031_training_history_gap_evidence.sql
@@ -1,0 +1,29 @@
+ALTER TABLE training_history_coverage_commit
+  ADD COLUMN dropped_local_dates_json TEXT NOT NULL DEFAULT '[]'
+  CHECK (
+    json_valid(dropped_local_dates_json)
+    AND json_type(dropped_local_dates_json) = 'array'
+  );
+
+ALTER TABLE training_history_coverage_commit
+  ADD COLUMN undated_dropped_count INTEGER NOT NULL DEFAULT 0
+  CHECK (undated_dropped_count >= 0);
+
+ALTER TABLE training_history_coverage_commit
+  ADD COLUMN gap_evidence_version INTEGER NOT NULL DEFAULT 0
+  CHECK (gap_evidence_version IN (0, 1));
+
+ALTER TABLE training_history_backfill_checkpoint
+  ADD COLUMN dropped_local_dates_json TEXT NOT NULL DEFAULT '[]'
+  CHECK (
+    json_valid(dropped_local_dates_json)
+    AND json_type(dropped_local_dates_json) = 'array'
+  );
+
+ALTER TABLE training_history_backfill_checkpoint
+  ADD COLUMN undated_dropped_count INTEGER NOT NULL DEFAULT 0
+  CHECK (undated_dropped_count >= 0);
+
+ALTER TABLE training_history_backfill_checkpoint
+  ADD COLUMN gap_evidence_version INTEGER NOT NULL DEFAULT 0
+  CHECK (gap_evidence_version IN (0, 1));

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -28,6 +28,7 @@ import chatPlanOutbox027 from "./027_chat_plan_outbox.sql";
 import planWorkoutAdditions028 from "./028_plan_workout_additions.sql";
 import planningDomain029 from "./029_planning_domain.sql";
 import trainingHistoryCoverage030 from "./030_training_history_coverage.sql";
+import trainingHistoryGapEvidence031 from "./031_training_history_gap_evidence.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -73,4 +74,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 28, name: "028_plan_workout_additions", sql: planWorkoutAdditions028 },
   { version: 29, name: "029_planning_domain", sql: planningDomain029 },
   { version: 30, name: "030_training_history_coverage", sql: trainingHistoryCoverage030 },
+  { version: 31, name: "031_training_history_gap_evidence", sql: trainingHistoryGapEvidence031 },
 ];

--- a/packages/kernel/src/store/training-history-coverage.ts
+++ b/packages/kernel/src/store/training-history-coverage.ts
@@ -1,7 +1,11 @@
 import type { Row, SqlReadStore, SqlStore } from "./ports.js";
 
 export type CoverageAuthorityKind = "reference-capture" | "activity-backfill";
-export type CoverageGapState = "none" | "undated-dropped-rows";
+
+export interface CoverageGapEvidence {
+  readonly datedLocalDates: readonly string[];
+  readonly undatedCount: number;
+}
 
 export interface CoverageCommitInput {
   readonly source: "intervals-icu";
@@ -12,7 +16,7 @@ export interface CoverageCommitInput {
   readonly coveredOldest: string;
   readonly coveredNewest: string;
   readonly committedEpochSeconds: number;
-  readonly gapState: CoverageGapState;
+  readonly gaps: CoverageGapEvidence;
 }
 
 export interface CoverageCommitRow extends CoverageCommitInput {
@@ -29,6 +33,7 @@ export interface BackfillCheckpointInput {
   readonly cursorAfter: string;
   readonly droppedSourceRestricted: number;
   readonly droppedOther: number;
+  readonly gaps: CoverageGapEvidence;
   readonly terminal: boolean;
 }
 
@@ -89,6 +94,9 @@ const ROW_KEYS = [
   "covered_newest_date_key",
   "committed_epoch_seconds",
   "gap_state",
+  "dropped_local_dates_json",
+  "undated_dropped_count",
+  "gap_evidence_version",
 ] as const;
 
 const READ_COMMIT_SQL = `SELECT
@@ -101,7 +109,10 @@ const READ_COMMIT_SQL = `SELECT
   covered_oldest_date_key,
   covered_newest_date_key,
   committed_epoch_seconds,
-  gap_state
+  gap_state,
+  dropped_local_dates_json,
+  undated_dropped_count,
+  gap_evidence_version
 FROM training_history_coverage_commit
 WHERE authority_kind = ? AND authority_id = ?`;
 
@@ -116,6 +127,9 @@ const CHECKPOINT_ROW_KEYS = [
   "cursor_after",
   "dropped_source_restricted",
   "dropped_other",
+  "dropped_local_dates_json",
+  "undated_dropped_count",
+  "gap_evidence_version",
   "terminal",
 ] as const;
 
@@ -130,6 +144,9 @@ const READ_CHECKPOINT_SQL = `SELECT
   cursor_after,
   dropped_source_restricted,
   dropped_other,
+  dropped_local_dates_json,
+  undated_dropped_count,
+  gap_evidence_version,
   terminal
 FROM training_history_backfill_checkpoint
 WHERE source_cycle = ? AND cursor_after = ?`;
@@ -185,6 +202,75 @@ function invalidRow(): never {
   throw new TrainingCoverageError("invalid_row");
 }
 
+function validateGaps(
+  value: CoverageGapEvidence,
+  oldestKey: number,
+  newestKey: number,
+  name: string,
+): CoverageGapEvidence {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    !Array.isArray(value.datedLocalDates) ||
+    !Number.isSafeInteger(value.undatedCount) ||
+    value.undatedCount < 0
+  ) {
+    throw new TypeError(`invalid ${name}`);
+  }
+  const dates = value.datedLocalDates.map((date) => {
+    const key = civilDateKey(date);
+    if (key === undefined || key < oldestKey || key > newestKey) {
+      throw new TypeError(`invalid ${name}`);
+    }
+    return date;
+  });
+  if (dates.some((date, index) => index > 0 && dates[index - 1]! >= date)) {
+    throw new TypeError(`invalid ${name}`);
+  }
+  return Object.freeze({
+    datedLocalDates: Object.freeze([...dates]),
+    undatedCount: value.undatedCount,
+  });
+}
+
+function parseStoredGaps(
+  row: Row,
+  oldestKey: number,
+  newestKey: number,
+  legacyUndatedCount = 0,
+): CoverageGapEvidence {
+  if (
+    typeof row.dropped_local_dates_json !== "string" ||
+    typeof row.undated_dropped_count !== "number" ||
+    !Number.isSafeInteger(row.undated_dropped_count) ||
+    typeof row.gap_evidence_version !== "number" ||
+    !Number.isSafeInteger(row.gap_evidence_version) ||
+    (row.gap_evidence_version !== 0 && row.gap_evidence_version !== 1)
+  ) {
+    invalidRow();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.dropped_local_dates_json);
+  } catch {
+    invalidRow();
+  }
+  const legacyUndated = row.gap_evidence_version === 0 ? legacyUndatedCount : 0;
+  try {
+    return validateGaps(
+      {
+        datedLocalDates: parsed as readonly string[],
+        undatedCount: legacyUndated > 0 ? legacyUndated : row.undated_dropped_count,
+      },
+      oldestKey,
+      newestKey,
+      "stored training coverage gaps",
+    );
+  } catch {
+    invalidRow();
+  }
+}
+
 function validateInput(input: CoverageCommitInput): {
   readonly oldestKey: number;
   readonly newestKey: number;
@@ -212,10 +298,11 @@ function validateInput(input: CoverageCommitInput): {
     oldestKey > newestKey ||
     !Number.isSafeInteger(input.committedEpochSeconds) ||
     input.committedEpochSeconds < 0 ||
-    (input.gapState !== "none" && input.gapState !== "undated-dropped-rows")
+    input.gaps === undefined
   ) {
     throw new TypeError("invalid training coverage commit");
   }
+  validateGaps(input.gaps, oldestKey, newestKey, "training coverage gaps");
   return { oldestKey, newestKey };
 }
 
@@ -251,9 +338,19 @@ function validateCheckpointInput(input: BackfillCheckpointInput): {
     input.droppedSourceRestricted < 0 ||
     !Number.isSafeInteger(input.droppedOther) ||
     input.droppedOther < 0 ||
+    input.gaps === undefined ||
     typeof input.terminal !== "boolean"
   ) {
     throw new TypeError("invalid training history backfill checkpoint");
+  }
+  const gaps = validateGaps(
+    input.gaps,
+    oldestKey,
+    newestKey,
+    "training history checkpoint gaps",
+  );
+  if (gaps.datedLocalDates.length + gaps.undatedCount > input.droppedSourceRestricted + input.droppedOther) {
+    throw new TypeError("invalid training history checkpoint gaps");
   }
   return { oldestKey, newestKey };
 }
@@ -262,6 +359,8 @@ function commitRow(row: Row): CoverageCommitRow {
   if (!hasExactKeys(row, ROW_KEYS)) invalidRow();
   const id = row.coverage_commit_id;
   const committed = row.committed_epoch_seconds;
+  const oldest = civilDateFromKey(row.covered_oldest_date_key);
+  const newest = civilDateFromKey(row.covered_newest_date_key);
   if (
     typeof id !== "number" ||
     !Number.isSafeInteger(id) ||
@@ -288,7 +387,12 @@ function commitRow(row: Row): CoverageCommitRow {
     coveredOldest: civilDateFromKey(row.covered_oldest_date_key),
     coveredNewest: civilDateFromKey(row.covered_newest_date_key),
     committedEpochSeconds: committed,
-    gapState: row.gap_state,
+    gaps: parseStoredGaps(
+      row,
+      civilDateKey(oldest)!,
+      civilDateKey(newest)!,
+      row.gap_state === "undated-dropped-rows" ? 1 : 0,
+    ),
   };
   validateInput(result);
   return Object.freeze(result);
@@ -304,7 +408,7 @@ function sameCommit(left: CoverageCommitRow, right: CoverageCommitInput): boolea
     left.coveredOldest === right.coveredOldest &&
     left.coveredNewest === right.coveredNewest &&
     left.committedEpochSeconds === right.committedEpochSeconds &&
-    left.gapState === right.gapState
+    JSON.stringify(left.gaps) === JSON.stringify(right.gaps)
   );
 }
 
@@ -342,6 +446,12 @@ function checkpointRow(row: Row): BackfillCheckpointRow {
     cursorAfter: row.cursor_after,
     droppedSourceRestricted: row.dropped_source_restricted,
     droppedOther: row.dropped_other,
+    gaps: parseStoredGaps(
+      row,
+      civilDateKey(civilDateFromKey(row.requested_oldest_key))!,
+      civilDateKey(civilDateFromKey(row.requested_newest_key))!,
+      row.dropped_source_restricted + row.dropped_other,
+    ),
     terminal: terminal === 1,
   };
   validateCheckpointInput(result);
@@ -362,6 +472,7 @@ function sameCheckpoint(
     left.cursorAfter === right.cursorAfter &&
     left.droppedSourceRestricted === right.droppedSourceRestricted &&
     left.droppedOther === right.droppedOther &&
+    JSON.stringify(left.gaps) === JSON.stringify(right.gaps) &&
     left.terminal === right.terminal
   );
 }
@@ -380,8 +491,11 @@ export function createTrainingCoverageRepository(): TrainingCoverageRepository {
   covered_oldest_date_key,
   covered_newest_date_key,
   committed_epoch_seconds,
-  gap_state
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  gap_state,
+  dropped_local_dates_json,
+  undated_dropped_count,
+  gap_evidence_version
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (authority_kind, authority_id) DO NOTHING
 RETURNING coverage_commit_id`,
         [
@@ -393,7 +507,10 @@ RETURNING coverage_commit_id`,
           oldestKey,
           newestKey,
           input.committedEpochSeconds,
-          input.gapState,
+          input.gaps.undatedCount > 0 ? "undated-dropped-rows" : "none",
+          JSON.stringify(input.gaps.datedLocalDates),
+          input.gaps.undatedCount,
+          1,
         ],
       );
       if (
@@ -427,8 +544,11 @@ RETURNING coverage_commit_id`,
   cursor_after,
   dropped_source_restricted,
   dropped_other,
+  dropped_local_dates_json,
+  undated_dropped_count,
+  gap_evidence_version,
   terminal
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT DO NOTHING
 RETURNING checkpoint_id`,
         [
@@ -441,6 +561,9 @@ RETURNING checkpoint_id`,
           input.cursorAfter,
           input.droppedSourceRestricted,
           input.droppedOther,
+          JSON.stringify(input.gaps.datedLocalDates),
+          input.gaps.undatedCount,
+          1,
           input.terminal ? 1 : 0,
         ],
       );
@@ -511,7 +634,10 @@ export function createTrainingCoverageReader(
   covered_oldest_date_key,
   covered_newest_date_key,
   committed_epoch_seconds,
-  gap_state
+  gap_state,
+  dropped_local_dates_json,
+  undated_dropped_count,
+  gap_evidence_version
 FROM training_history_coverage_commit
 WHERE source = ? AND lane = ?
 ORDER BY committed_epoch_seconds ASC, coverage_commit_id ASC`,

--- a/packages/kernel/src/store/training-history-coverage.ts
+++ b/packages/kernel/src/store/training-history-coverage.ts
@@ -398,7 +398,30 @@ function commitRow(row: Row): CoverageCommitRow {
   return Object.freeze(result);
 }
 
-function sameCommit(left: CoverageCommitRow, right: CoverageCommitInput): boolean {
+function storedGapEvidenceVersion(row: Row): 0 | 1 {
+  return row.gap_evidence_version === 1 ? 1 : 0;
+}
+
+function hasGaps(gaps: CoverageGapEvidence): boolean {
+  return gaps.datedLocalDates.length + gaps.undatedCount > 0;
+}
+
+function exactGaps(left: CoverageGapEvidence, right: CoverageGapEvidence): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function legacyCommitGapsCompatible(
+  stored: CoverageGapEvidence,
+  retry: CoverageGapEvidence,
+): boolean {
+  return hasGaps(stored) || !hasGaps(retry);
+}
+
+function sameCommit(
+  left: CoverageCommitRow,
+  right: CoverageCommitInput,
+  version: 0 | 1,
+): boolean {
   return (
     left.source === right.source &&
     left.lane === right.lane &&
@@ -408,7 +431,9 @@ function sameCommit(left: CoverageCommitRow, right: CoverageCommitInput): boolea
     left.coveredOldest === right.coveredOldest &&
     left.coveredNewest === right.coveredNewest &&
     left.committedEpochSeconds === right.committedEpochSeconds &&
-    JSON.stringify(left.gaps) === JSON.stringify(right.gaps)
+    (version === 1
+      ? exactGaps(left.gaps, right.gaps)
+      : legacyCommitGapsCompatible(left.gaps, right.gaps))
   );
 }
 
@@ -461,6 +486,7 @@ function checkpointRow(row: Row): BackfillCheckpointRow {
 function sameCheckpoint(
   left: BackfillCheckpointRow,
   right: BackfillCheckpointInput,
+  version: 0 | 1,
 ): boolean {
   return (
     left.authorityId === right.authorityId &&
@@ -472,7 +498,7 @@ function sameCheckpoint(
     left.cursorAfter === right.cursorAfter &&
     left.droppedSourceRestricted === right.droppedSourceRestricted &&
     left.droppedOther === right.droppedOther &&
-    JSON.stringify(left.gaps) === JSON.stringify(right.gaps) &&
+    (version === 0 || exactGaps(left.gaps, right.gaps)) &&
     left.terminal === right.terminal
   );
 }
@@ -525,7 +551,9 @@ RETURNING coverage_commit_id`,
       const selected = await store.get(READ_COMMIT_SQL, [input.authorityKind, input.authorityId]);
       if (selected === undefined) invalidRow();
       const stored = commitRow(selected);
-      if (!sameCommit(stored, input)) throw new TrainingCoverageError("authority_conflict");
+      if (!sameCommit(stored, input, storedGapEvidenceVersion(selected))) {
+        throw new TrainingCoverageError("authority_conflict");
+      }
       return Object.freeze({
         kind: inserted === undefined ? "already-recorded" : "inserted",
         commitId: stored.coverageCommitId,
@@ -585,7 +613,7 @@ RETURNING checkpoint_id`,
         invalidRow();
       }
       const stored = checkpointRow(selected);
-      if (!sameCheckpoint(stored, input)) {
+      if (!sameCheckpoint(stored, input, storedGapEvidenceVersion(selected))) {
         throw new TrainingCoverageError("authority_conflict");
       }
       return Object.freeze({

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -229,6 +229,7 @@ describe("001_init migration", () => {
       { version: 28, name: "028_plan_workout_additions" },
       { version: 29, name: "029_planning_domain" },
       { version: 30, name: "030_training_history_coverage" },
+      { version: 31, name: "031_training_history_gap_evidence" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -1309,6 +1310,42 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       0,
       0,
     );
+    expect(
+      (db.prepare("PRAGMA table_info(training_history_coverage_commit)").all() as Array<{
+        name: string;
+      }>).map(({ name }) => name),
+    ).toEqual(expect.arrayContaining(["dropped_local_dates_json", "gap_evidence_version"]));
+    expect(
+      (db.prepare("PRAGMA table_info(training_history_backfill_checkpoint)").all() as Array<{
+        name: string;
+      }>).map(({ name }) => name),
+    ).toEqual(expect.arrayContaining(["undated_dropped_count", "gap_evidence_version"]));
+    expect(
+      db
+        .prepare(
+          "SELECT gap_evidence_version FROM training_history_coverage_commit WHERE authority_id = ?",
+        )
+        .get("12345678-1234-4123-8123-123456789abc"),
+    ).toEqual({ gap_evidence_version: 0 });
+    expect(
+      db
+        .prepare(
+          "SELECT gap_evidence_version FROM training_history_backfill_checkpoint WHERE source_cycle = ?",
+        )
+        .get(12345),
+    ).toEqual({ gap_evidence_version: 0 });
+    expect(() =>
+      db!
+        .prepare(
+          `INSERT INTO training_history_coverage_commit (
+  source, lane, authority_kind, authority_id, calendar_timezone,
+  covered_oldest_date_key, covered_newest_date_key, committed_epoch_seconds, gap_state,
+  dropped_local_dates_json, undated_dropped_count
+) VALUES ('intervals-icu', 'activities', 'reference-capture', 'invalid-json', 'UTC',
+  19980413, 19980706, 899712000, 'none', 'not-json', 0)`,
+        )
+        .run(),
+    ).toThrow();
     expect(() =>
       db!
         .prepare("UPDATE training_history_coverage_commit SET gap_state='undated-dropped-rows'")

--- a/packages/kernel/tests/training-history-coverage.test.ts
+++ b/packages/kernel/tests/training-history-coverage.test.ts
@@ -309,4 +309,114 @@ describe("training history coverage", () => {
       }),
     ).rejects.toThrow("invalid training coverage gaps");
   });
+
+  it("accepts a compatible retry over a version-0 commit row", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+    const seedLegacyCommit = (authorityId: string, gapState: string) =>
+      database!
+        .prepare(
+          `INSERT INTO training_history_coverage_commit (
+  source, lane, authority_kind, authority_id, calendar_timezone,
+  covered_oldest_date_key, covered_newest_date_key, committed_epoch_seconds, gap_state
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "intervals-icu",
+          "activities",
+          "reference-capture",
+          authorityId,
+          "Asia/Almaty",
+          19980413,
+          19980706,
+          899_712_000,
+          gapState,
+        );
+    seedLegacyCommit(CAPTURE_ID, "undated-dropped-rows");
+    seedLegacyCommit("legacy-clean-capture", "none");
+
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        gaps: { datedLocalDates: ["1998-07-01"], undatedCount: 0 },
+      }),
+    ).resolves.toEqual({ kind: "already-recorded", commitId: 1 });
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        gaps: { datedLocalDates: [], undatedCount: 0 },
+      }),
+    ).resolves.toEqual({ kind: "already-recorded", commitId: 1 });
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        authorityId: "legacy-clean-capture",
+        gaps: { datedLocalDates: [], undatedCount: 0 },
+      }),
+    ).resolves.toEqual({ kind: "already-recorded", commitId: 2 });
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        authorityId: "legacy-clean-capture",
+        gaps: { datedLocalDates: ["1998-07-01"], undatedCount: 0 },
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        calendarTimeZone: "Europe/Berlin",
+        gaps: { datedLocalDates: [], undatedCount: 1 },
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+  });
+
+  it("accepts a compatible retry over a version-0 checkpoint row", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+    database!
+      .prepare(
+        `INSERT INTO training_history_backfill_checkpoint (
+  authority_id, source_cycle, page_ordinal, requested_oldest_key, requested_newest_key,
+  calendar_timezone, cursor_after, dropped_source_restricted, dropped_other, terminal
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("legacy-backfill-cycle", 9, 0, 19980413, 19980706, "Asia/Almaty", "legacy-cursor", 2, 1, 0);
+    const checkpoint = {
+      authorityId: "legacy-backfill-cycle",
+      sourceCycle: 9,
+      pageOrdinal: 0,
+      requestedOldest: "1998-04-13",
+      requestedNewest: "1998-07-06",
+      calendarTimeZone: "Asia/Almaty",
+      cursorAfter: "legacy-cursor",
+      droppedSourceRestricted: 2,
+      droppedOther: 1,
+      gaps: { datedLocalDates: ["1998-07-01"], undatedCount: 1 },
+      terminal: false,
+    } as const;
+
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, checkpoint),
+    ).resolves.toEqual({ kind: "already-recorded", checkpointId: 1 });
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, {
+        ...checkpoint,
+        droppedOther: 2,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, {
+        ...checkpoint,
+        terminal: true,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+  });
 });

--- a/packages/kernel/tests/training-history-coverage.test.ts
+++ b/packages/kernel/tests/training-history-coverage.test.ts
@@ -366,8 +366,53 @@ describe("training history coverage", () => {
     await expect(
       repository.appendCommitInTransaction(store, {
         ...commit,
-        calendarTimeZone: "Europe/Berlin",
+        authorityId: "legacy-clean-capture",
         gaps: { datedLocalDates: [], undatedCount: 1 },
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        calendarTimeZone: "Europe/Berlin",
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+  });
+
+  it("keeps exact gap comparison for version-1 rows", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+    const checkpoint = {
+      authorityId: "exact-backfill-cycle",
+      sourceCycle: 11,
+      pageOrdinal: 0,
+      requestedOldest: "1998-04-13",
+      requestedNewest: "1998-07-06",
+      calendarTimeZone: "Asia/Almaty",
+      cursorAfter: "exact-cursor",
+      droppedSourceRestricted: 2,
+      droppedOther: 1,
+      gaps: { datedLocalDates: ["1998-07-01"], undatedCount: 1 },
+      terminal: false,
+    } as const;
+    await repository.appendCommitInTransaction(store, commit);
+    await repository.appendBackfillCheckpointInTransaction(store, checkpoint);
+
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        gaps: { datedLocalDates: [], undatedCount: 0 },
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
+    );
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, {
+        ...checkpoint,
+        gaps: { datedLocalDates: [], undatedCount: 0 },
       }),
     ).rejects.toEqual(
       expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),

--- a/packages/kernel/tests/training-history-coverage.test.ts
+++ b/packages/kernel/tests/training-history-coverage.test.ts
@@ -20,7 +20,7 @@ const commit: CoverageCommitInput = {
   coveredOldest: "1998-04-13",
   coveredNewest: "1998-07-06",
   committedEpochSeconds: 899_712_000,
-  gapState: "none",
+  gaps: { datedLocalDates: ["1998-07-01"], undatedCount: 0 },
 };
 
 describe("training history coverage", () => {
@@ -111,6 +111,7 @@ describe("training history coverage", () => {
       cursorAfter,
       droppedSourceRestricted: 2,
       droppedOther: 1,
+      gaps: { datedLocalDates: ["1998-07-01"], undatedCount: 1 },
       terminal: false,
     } as const;
 
@@ -131,6 +132,42 @@ describe("training history coverage", () => {
     ).rejects.toEqual(
       expect.objectContaining({ name: "TrainingCoverageError", code: "authority_conflict" }),
     );
+  });
+
+  it("preserves explicit empty gap evidence across checkpoint retries", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+    const cursorAfter = JSON.stringify({
+      v: 1,
+      cycle: 8,
+      window_start: "1998-01-01",
+      window_end: "1998-07-18",
+      last_key: "1998-07-17T12:00:00Z\u001fsynthetic",
+      complete: false,
+    });
+    const checkpoint = {
+      authorityId: "filtered-gap-backfill-cycle",
+      sourceCycle: 8,
+      pageOrdinal: 0,
+      requestedOldest: "1998-01-01",
+      requestedNewest: "1998-07-18",
+      calendarTimeZone: "Asia/Almaty",
+      cursorAfter,
+      droppedSourceRestricted: 2,
+      droppedOther: 1,
+      gaps: { datedLocalDates: [], undatedCount: 0 },
+      terminal: false,
+    } as const;
+
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, checkpoint),
+    ).resolves.toEqual({ kind: "inserted", checkpointId: 1 });
+    await expect(
+      repository.appendBackfillCheckpointInTransaction(store, checkpoint),
+    ).resolves.toEqual({ kind: "already-recorded", checkpointId: 1 });
+    await expect(
+      repository.readBackfillCheckpoint(store, { sourceCycle: 8, cursorAfter }),
+    ).resolves.toEqual({ checkpointId: 1, ...checkpoint });
   });
 
   it("enforces append-only commit and checkpoint rows", async () => {
@@ -192,5 +229,84 @@ describe("training history coverage", () => {
       "capture-later-12345",
     ]);
     expect(rows.map(({ coverageCommitId }) => coverageCommitId)).toEqual([2, 3, 1]);
+    expect(rows.at(-1)?.gaps).toEqual({
+      datedLocalDates: ["1998-07-01"],
+      undatedCount: 0,
+    });
+  });
+
+  it("maps pre-migration gap rows to conservative undated evidence", async () => {
+    const store = openStore();
+    database!
+      .prepare(
+        `INSERT INTO training_history_coverage_commit (
+  source, lane, authority_kind, authority_id, calendar_timezone,
+  covered_oldest_date_key, covered_newest_date_key, committed_epoch_seconds, gap_state
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "intervals-icu",
+        "activities",
+        "reference-capture",
+        CAPTURE_ID,
+        "Asia/Almaty",
+        19980413,
+        19980706,
+        899_712_000,
+        "undated-dropped-rows",
+      );
+    database!
+      .prepare(
+        `INSERT INTO training_history_backfill_checkpoint (
+  authority_id, source_cycle, page_ordinal, requested_oldest_key, requested_newest_key,
+  calendar_timezone, cursor_after, dropped_source_restricted, dropped_other, terminal
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "legacy-backfill-cycle",
+        9,
+        0,
+        19980413,
+        19980706,
+        "Asia/Almaty",
+        "legacy-cursor",
+        2,
+        1,
+        0,
+      );
+
+    await expect(
+      createTrainingCoverageReader(store).listCommits({
+        source: "intervals-icu",
+        lane: "activities",
+      }),
+    ).resolves.toMatchObject([{ gaps: { datedLocalDates: [], undatedCount: 1 } }]);
+    await expect(
+      createTrainingCoverageRepository().readBackfillCheckpoint(store, {
+        sourceCycle: 9,
+        cursorAfter: "legacy-cursor",
+      }),
+    ).resolves.toMatchObject({ gaps: { datedLocalDates: [], undatedCount: 3 } });
+  });
+
+  it("rejects unsorted or out-of-window dated gap evidence", async () => {
+    const store = openStore();
+    const repository = createTrainingCoverageRepository();
+
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        gaps: {
+          datedLocalDates: ["1998-07-02", "1998-07-01"],
+          undatedCount: 0,
+        },
+      }),
+    ).rejects.toThrow("invalid training coverage gaps");
+    await expect(
+      repository.appendCommitInTransaction(store, {
+        ...commit,
+        gaps: { datedLocalDates: ["1998-07-07"], undatedCount: 0 },
+      }),
+    ).rejects.toThrow("invalid training coverage gaps");
   });
 });

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -18,7 +18,7 @@ import { activityIdentity, mapActivityLanding, mapSettingsLanding, mapWellnessLa
 import { advanceWindow, compactCursor, compareBinary, parseCivilDate, parseCursor, type CursorRange, type RangeCursor } from "./cursor.js";
 import { createRequester, IntervalsHttpError, MIN_CONFIGURED_INTERVAL_MS, SyncBudgetExceededError, type IntervalsRequester } from "./http.js";
 import { BULK_FIT_BATCH_SIZE, BULK_SAFE_ACTIVITY_ID, IncompleteBulkFitBatchError, MAX_FIT_BYTES, MAX_ZIP_BYTES, extractBulkFitZip } from "./zip.js";
-import { INTERVALS_ICU_CAPABILITIES, INTERVALS_ICU_SOURCE_ID, MAX_JSON_BYTES, ZERO_DROPPED_ACTIVITY_ROWS, type DroppedActivityRowCounts, type IntervalsIcuArtifact, type IntervalsIcuCaptureSource, type IntervalsIcuCheckpoint, type IntervalsIcuSourceOptions, type ReferenceCaptureActivityRecord, type ReferenceCaptureBatch, type ReferenceCaptureEndpoint, type ReferenceCaptureSettingsRecord, type ReferenceCaptureStreamRecord, type ReferenceCaptureWellnessRecord } from "./types.js";
+import { INTERVALS_ICU_CAPABILITIES, INTERVALS_ICU_SOURCE_ID, MAX_JSON_BYTES, ZERO_DROPPED_ACTIVITY_ROWS, type DroppedActivityRowEvidence, type IntervalsIcuArtifact, type IntervalsIcuCaptureSource, type IntervalsIcuCheckpoint, type IntervalsIcuSourceOptions, type ReferenceCaptureActivityRecord, type ReferenceCaptureBatch, type ReferenceCaptureEndpoint, type ReferenceCaptureSettingsRecord, type ReferenceCaptureStreamRecord, type ReferenceCaptureWellnessRecord } from "./types.js";
 
 const BASE_URL = "https://intervals.icu";
 const JSON_TYPE = "application/json";
@@ -78,18 +78,36 @@ function isSourceRestrictedRow(entry: unknown): boolean {
 class DropTally {
   private restricted = 0;
   private rest = 0;
+  private readonly dates = new Set<string>();
+  private undated = 0;
   record(entry: unknown): void {
     if (isSourceRestrictedRow(entry)) this.restricted += 1;
     else this.rest += 1;
+    const local =
+      entry !== null && typeof entry === "object" && !Array.isArray(entry)
+        ? (entry as Record<string, unknown>).start_date_local
+        : undefined;
+    if (typeof local === "string") {
+      try {
+        this.dates.add(parseCivilDate(local.slice(0, 10)));
+        return;
+      } catch {}
+    }
+    this.undated += 1;
   }
-  counts(): DroppedActivityRowCounts {
-    return Object.freeze({ sourceRestricted: this.restricted, other: this.rest });
+  evidence(): DroppedActivityRowEvidence {
+    return Object.freeze({
+      sourceRestricted: this.restricted,
+      other: this.rest,
+      datedLocalDates: Object.freeze([...this.dates].sort(compareBinary)),
+      undatedCount: this.undated,
+    });
   }
 }
 
 interface ActivityScan {
   readonly rows: readonly ActivityIndexEntry[];
-  readonly dropped: DroppedActivityRowCounts;
+  readonly dropped: DroppedActivityRowEvidence;
 }
 
 function activityIndex(value: unknown): ActivityScan {
@@ -107,10 +125,10 @@ function activityIndex(value: unknown): ActivityScan {
     rows.push({ ...activityIdentity(row), row });
   }
   rows.sort((a, b) => compareBinary(a.key, b.key));
-  return { rows, dropped: tally.counts() };
+  return { rows, dropped: tally.evidence() };
 }
 
-function checkpoint(lane: SourceLane, cursor: RangeCursor, droppedActivityRows: DroppedActivityRowCounts): IntervalsIcuCheckpoint {
+function checkpoint(lane: SourceLane, cursor: RangeCursor, droppedActivityRows: DroppedActivityRowEvidence): IntervalsIcuCheckpoint {
   return { kind: "checkpoint", watermark: { source: "intervals-icu", lane, value: compactCursor(cursor) }, droppedActivityRows };
 }
 
@@ -203,7 +221,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
       yielded += 1;
     };
     const yieldCheckpoint = async function* (value: RangeCursor,
-      dropped: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS): AsyncGenerator<IntervalsIcuArtifact> {
+      dropped: DroppedActivityRowEvidence = ZERO_DROPPED_ACTIVITY_ROWS): AsyncGenerator<IntervalsIcuArtifact> {
       requester.assertActive();
       yield checkpoint(lane, value, dropped);
     };
@@ -417,7 +435,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
     yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey), droppedRows);
   }
 
-  let capturedActivityDrops: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS;
+  let capturedActivityDrops: DroppedActivityRowEvidence = ZERO_DROPPED_ACTIVITY_ROWS;
 
   const placeholderArchive: ArchiveWriteResult = Object.freeze({
     address: "0".repeat(64),
@@ -488,7 +506,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
         activities.push({ endpoint_ordinal: 1, payload_index: index, external_id: identity.externalId, payload: row });
       } catch { activityDrops.record(activityPayload[index]); }
     }
-    capturedActivityDrops = activityDrops.counts();
+    capturedActivityDrops = activityDrops.evidence();
 
     const wellness: DerivedCaptureMember[] = [];
     const wellnessPayload = endpointPayloads[2]!.payload as unknown[];

--- a/packages/sync-intervals-icu/src/types.ts
+++ b/packages/sync-intervals-icu/src/types.ts
@@ -38,9 +38,16 @@ export interface DroppedActivityRowCounts {
   readonly other: number;
 }
 
-export const ZERO_DROPPED_ACTIVITY_ROWS: DroppedActivityRowCounts = Object.freeze({
+export interface DroppedActivityRowEvidence extends DroppedActivityRowCounts {
+  readonly datedLocalDates: readonly string[];
+  readonly undatedCount: number;
+}
+
+export const ZERO_DROPPED_ACTIVITY_ROWS: DroppedActivityRowEvidence = Object.freeze({
   sourceRestricted: 0,
   other: 0,
+  datedLocalDates: Object.freeze([]),
+  undatedCount: 0,
 });
 
 export type IntervalsHttpFactory = (args: {
@@ -91,7 +98,7 @@ export type IntervalsIcuArtifact =
   | IntervalsIcuCheckpoint;
 
 export type IntervalsIcuCheckpoint = SourceCheckpoint & {
-  readonly droppedActivityRows?: DroppedActivityRowCounts;
+  readonly droppedActivityRows?: DroppedActivityRowEvidence;
 };
 
 export interface IntervalsIcuSource extends SyncSource {
@@ -149,5 +156,5 @@ export interface ReferenceCaptureBatch {
   };
   readonly selected_stream_ids: readonly string[];
   readonly captured_stream_ids: readonly string[];
-  readonly dropped_activity_rows: DroppedActivityRowCounts;
+  readonly dropped_activity_rows: DroppedActivityRowEvidence;
 }

--- a/packages/sync-intervals-icu/tests/capture.test.ts
+++ b/packages/sync-intervals-icu/tests/capture.test.ts
@@ -74,18 +74,28 @@ describe("captureReference", () => {
 
   it("splits the activity rows the capture drops into source-restricted and other", async () => {
     const stub = { id: "9001", icu_athlete_id: "i12345", start_date_local: "1998-07-17T14:08:41", source: "STRAVA" };
-    const foreign = { id: "9002", icu_athlete_id: "i12345", start_date_local: "1998-07-17T14:09:41", source: "GARMIN_CONNECT" };
+    const foreign = { id: "9002", icu_athlete_id: "i12345", source: "GARMIN_CONNECT" };
     const value = fixture({ time: [0, 1], watts: [200, 210] }, [ACTIVITY, stub, foreign]);
 
     const batch = await value.source.captureReference(PLAN, budget());
 
     expect(batch.records.activities).toHaveLength(1);
-    expect(batch.dropped_activity_rows).toEqual({ sourceRestricted: 1, other: 1 });
+    expect(batch.dropped_activity_rows).toEqual({
+      sourceRestricted: 1,
+      other: 1,
+      datedLocalDates: ["1998-07-17"],
+      undatedCount: 1,
+    });
   });
 
   it("reports no dropped activity rows for a clean capture", async () => {
     const batch = await fixture().source.captureReference(PLAN, budget());
-    expect(batch.dropped_activity_rows).toEqual({ sourceRestricted: 0, other: 0 });
+    expect(batch.dropped_activity_rows).toEqual({
+      sourceRestricted: 0,
+      other: 0,
+      datedLocalDates: [],
+      undatedCount: 0,
+    });
   });
 
   it("omits malformed stream responses without omitting required lanes", async () => {


### PR DESCRIPTION
## Why

Training History over-claimed completeness in three cases: one dated dropped row degraded an entire capture window, an open week needed only one covered day, and a morning capture claimed the rest of that local day.

## Scope

- Persist sorted dropped-row local dates separately from the undated dropped-row count.
- Localize dated gaps to intersecting weeks while keeping undated gaps conservative.
- Require an open week to be covered through today before totals and ride counts are exact.
- Commit coverage only through the previous local day while retaining full checkpoint evidence.
- Fold overlapping commits by newest authority and clamp legacy/current-day claims at read time.

## Accepted coverage semantics

Coverage evidence may carry sorted local dates for rejected rows and a separate count for rows without a usable date. Dated gaps degrade only intersecting weeks; undated gaps remain window-wide. A same-day capture proves complete civil days only through the previous local date.

## Tradeoffs

Legacy undated gaps remain intentionally conservative. The migration is additive so existing databases retain their history and old rows map to safe defaults.

## Blast radius

Intervals source diagnostics, Coach capture/backfill and Training History projection, Kernel migrations and coverage repository, plus focused contract tests.

## Verification

- 96 focused projection and repository tests passed.
- 37 focused capture, backfill, and Training History tests passed.
- 82 migration and Coach lifecycle tests passed with every loopback case exercised.
- The planning export round-trip and account-identity upgrade suites pass against migration 31.
- The complete stacked branch passed 558 focused tests before the full repository run.
- Kernel, Sync, and Coach package checks passed.
- Oxlint, whitespace, and changeset user-facing checks passed.
