### PR TITLE
fix(training): retain safe stale state

### DIFF
--- a/.changeset/training-stale-cache.md
+++ b/.changeset/training-stale-cache.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/coach": patch
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+Keep last-recorded Training history during temporary storage failures, preserve selected rides unless refreshed history proves they were removed, and fence ride analysis cache invalidation against late results.
+
+User-facing: Training now keeps your last recorded history during temporary refresh problems. Ride review no longer closes or reuses out-of-date analysis when refreshed data cannot prove a ride was removed.

--- a/apps/desktop-renderer/src/activity-analysis/controller.ts
+++ b/apps/desktop-renderer/src/activity-analysis/controller.ts
@@ -201,7 +201,12 @@ export function createRideAnalysisController(input: {
     },
     load,
     invalidate() {
+      const reloadSelectedActivity = state.activityId !== null && state.status !== "idle";
+      generation += 1;
+      operation?.abort();
+      operation = undefined;
       cache.clear();
+      if (reloadSelectedActivity) void load(DEFAULT_RIDE_ANALYSIS_SECTIONS);
     },
     dispose() {
       if (disposed) return;

--- a/apps/desktop-renderer/src/state/training-slice.ts
+++ b/apps/desktop-renderer/src/state/training-slice.ts
@@ -1,5 +1,6 @@
 import {
   UNKNOWN_CYCLING_TRAINING_CONTEXT,
+  type CompletedActivityWeek,
   type TrainingHistoryRide,
 } from "@enduragent/coach-contract";
 import type { StateCreator } from "zustand";
@@ -25,19 +26,35 @@ export interface TrainingSlice {
   closeRide: () => void;
 }
 
+function provesRideAbsent(
+  week: CompletedActivityWeek | null,
+  localDate: string,
+): boolean {
+  return (
+    week !== null &&
+    localDate >= week.window.start &&
+    localDate <= week.window.end &&
+    week.coverage.kind === "complete" &&
+    week.rides.count.kind === "exact" &&
+    !week.rides.truncated
+  );
+}
+
 function reconciledRide(
   current: TrainingHistoryRide | null,
   next: TrainingContextViewState,
 ): TrainingHistoryRide | null {
   if (current === null) return null;
   const panel = next.trainingContext.trainingHistory;
-  if (panel.kind === "unavailable") return null;
-  const history = panel.kind === "stale" ? panel.lastGood : panel;
-  return (
-    history.anchorWeek.rides.items.find((ride) => ride.id === current.id) ??
-    history.previousWeek?.rides.items.find((ride) => ride.id === current.id) ??
-    null
-  );
+  if (panel.kind !== "computed") return current;
+  const refreshed =
+    panel.anchorWeek.rides.items.find((ride) => ride.id === current.id) ??
+    panel.previousWeek?.rides.items.find((ride) => ride.id === current.id);
+  if (refreshed !== undefined) return refreshed;
+  return provesRideAbsent(panel.anchorWeek, current.localDate) ||
+    provesRideAbsent(panel.previousWeek, current.localDate)
+    ? null
+    : current;
 }
 
 export const createTrainingSlice: StateCreator<EnduragentState, [], [], TrainingSlice> = (

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -416,18 +416,6 @@ function UnavailableHistory(): ReactElement {
   );
 }
 
-function historyRide(
-  history: TrainingHistoryComputed | null,
-  rideId: string | null,
-): TrainingHistoryRide | null {
-  if (history === null || rideId === null) return null;
-  return (
-    history.anchorWeek.rides.items.find((ride) => ride.id === rideId) ??
-    history.previousWeek?.rides.items.find((ride) => ride.id === rideId) ??
-    null
-  );
-}
-
 function reviewCalloutReason(history: TrainingHistoryComputed, rideId: string): string | null {
   const anchor = calloutReason(history.anchorWeek, rideId);
   if (anchor !== null) return anchor;
@@ -448,15 +436,11 @@ export function TrainingView(): ReactElement {
   const panel = training.trainingContext.trainingHistory;
   const history = effectiveHistory(panel);
   const retained = panel.kind === "stale";
-  const resolvedRide = historyRide(history, selectedRide?.id ?? null);
+  const resolvedRide = selectedRide;
 
   useEffect(() => {
     if (period === "previous" && history?.previousWeek === null) setPeriod("anchor");
   }, [history?.previousWeek, period]);
-
-  useEffect(() => {
-    if (selectedRide !== null && resolvedRide === null) closeRide();
-  }, [closeRide, resolvedRide, selectedRide]);
 
   useLayoutEffect(() => {
     const currentRideId = resolvedRide?.id ?? null;
@@ -486,14 +470,14 @@ export function TrainingView(): ReactElement {
     [label, warning],
   );
 
-  if (resolvedRide !== null && history !== null) {
+  if (resolvedRide !== null) {
     return (
       <RideDetailView
         key={resolvedRide.id}
         ride={resolvedRide}
         units={training.unitsPreference.value}
         analysis={rideAnalysis}
-        calloutReason={reviewCalloutReason(history, resolvedRide.id)}
+        calloutReason={history === null ? null : reviewCalloutReason(history, resolvedRide.id)}
         onStartAnalysis={rideAnalysisActions === null ? null : () => rideAnalysisActions.start()}
         onRefreshAnalysis={
           rideAnalysisActions === null ? null : (sections) => rideAnalysisActions.refresh(sections)

--- a/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
+++ b/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
@@ -248,4 +248,34 @@ describe("ride analysis controller", () => {
     await controller.start();
     expect(call).toHaveBeenCalledTimes(2);
   });
+
+  it("restarts in-flight analysis after cache invalidation", async () => {
+    let resolveFirst!: (value: ActivityAnalysisResult) => void;
+    let callCount = 0;
+    const refreshedRevision = "e".repeat(64);
+    const call = vi.fn(() => {
+      callCount += 1;
+      if (callCount > 1) return Promise.resolve({ ...result(), revision: refreshedRevision });
+      return new Promise<ActivityAnalysisResult>((resolve) => {
+        resolveFirst = resolve;
+      });
+    }) as unknown as CoachClient["call"];
+    const { controller, states } = setup(call);
+
+    await controller.select(FIRST);
+    const pending = controller.start();
+    await vi.waitFor(() => expect(call).toHaveBeenCalledTimes(1));
+    controller.invalidate();
+    await vi.waitFor(() => expect(call).toHaveBeenCalledTimes(2));
+    resolveFirst(result());
+    await pending;
+
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        activityId: FIRST,
+        status: "ready",
+        revision: refreshedRevision,
+      }),
+    );
+  });
 });

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -1093,6 +1093,110 @@ describe("ride review", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Training" })).toHaveFocus();
     expect(useEnduragentStore.getState().selectedRide).toBeNull();
   });
+
+  it("retains a selected ride outside the authoritative returned weeks", () => {
+    const selected = ride({
+      id: PREVIOUS_ID,
+      title: "Earlier endurance",
+      localDate: "1998-07-02",
+    });
+    act(() => useEnduragentStore.getState().openRide(selected));
+    const emptyWeek = (
+      id: "anchor" | "previous",
+      window: { readonly start: string; readonly end: string },
+    ): CompletedActivityWeek =>
+      week(id, {
+        window,
+        totals: {
+          rideCount: { kind: "computed", value: 0 },
+          ridingSeconds: { kind: "computed", value: 0 },
+          distanceMeters: { kind: "computed", value: 0 },
+          load: { kind: "computed", value: 0 },
+        },
+        rides: { count: { kind: "exact", value: 0 }, items: [], truncated: false },
+        callout: null,
+      });
+
+    setTraining(
+      ready(
+        history({
+          anchorWeek: emptyWeek("anchor", {
+            start: "1998-07-13",
+            end: "1998-07-19",
+          }),
+          previousWeek: emptyWeek("previous", {
+            start: "1998-07-06",
+            end: "1998-07-12",
+          }),
+        }),
+      ),
+    );
+    render(<TrainingView />);
+
+    expect(useEnduragentStore.getState().selectedRide).toEqual(selected);
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Earlier endurance" }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["unavailable", { kind: "unavailable", reason: "temporary-failure" }],
+    [
+      "stale",
+      {
+        kind: "stale",
+        failedAt: "1998-07-12T08:15:00.000Z",
+        reason: "temporary-failure",
+        lastGood: history(),
+      },
+    ],
+    [
+      "incomplete",
+      history({
+        anchorWeek: week("anchor", {
+          coverage: {
+            kind: "incomplete",
+            recordedThrough: "1998-07-08",
+            reason: "coverage-lag",
+          },
+          totals: {
+            rideCount: { kind: "partial", value: 1, reason: "incomplete-coverage" },
+            ridingSeconds: { kind: "partial", value: 3_600, reason: "incomplete-coverage" },
+            distanceMeters: { kind: "partial", value: 24_500, reason: "incomplete-coverage" },
+            load: { kind: "partial", value: 28, reason: "incomplete-coverage" },
+          },
+          rides: {
+            count: { kind: "at-least", value: 1 },
+            items: [ride({ id: SECOND_ID })],
+            truncated: true,
+          },
+          callout: null,
+        }),
+      }),
+    ],
+    [
+      "truncated",
+      history({
+        anchorWeek: week("anchor", {
+          rides: {
+            count: { kind: "at-least", value: 1 },
+            items: [ride({ id: SECOND_ID })],
+            truncated: true,
+          },
+          callout: null,
+        }),
+      }),
+    ],
+  ] as const)("retains a selected ride when history is %s", (_label, panel) => {
+    const selected = ride();
+    act(() => useEnduragentStore.getState().openRide(selected));
+
+    setTraining(ready(panel));
+    render(<TrainingView />);
+
+    expect(useEnduragentStore.getState().selectedRide).toEqual(selected);
+    expect(screen.getByRole("heading", { level: 2, name: "River tempo" })).toBeInTheDocument();
+  });
 });
 
 describe("power progress", () => {

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -161,6 +161,21 @@ export function createPersistedAthleteStateSource(
   const errorPath = join(input.dataDir, "data", "error_state.json");
   const schedulerPath = join(input.dataDir, "data", ".scheduler.json");
   let lastGoodTrainingHistory: TrainingHistoryLastGood | null = null;
+  const temporaryFailureHistory = (
+    identity: TrainingHistoryCacheIdentity,
+    failedAt: string,
+  ): TrainingHistoryPanel => {
+    const cached = lastGoodTrainingHistory;
+    if (cached === null || !sameTrainingHistoryIdentity(cached.identity, identity)) {
+      return { kind: "unavailable", reason: "temporary-failure" };
+    }
+    return TrainingHistoryPanelSchema.parse({
+      kind: "stale",
+      failedAt,
+      reason: "temporary-failure",
+      lastGood: withoutTrainingHistoryCallouts(cached.panel),
+    });
+  };
   const readTrainingHistory = async (
     identity: TrainingHistoryCacheIdentity | null,
     request: Parameters<TrainingHistorySource["readTrainingHistory"]>[0],
@@ -174,19 +189,14 @@ export function createPersistedAthleteStateSource(
       if (!parsed.success) throw new TypeError("training history projection is invalid");
       if (parsed.data.kind === "computed") {
         lastGoodTrainingHistory = { identity, panel: parsed.data };
+        return parsed.data;
+      }
+      if (parsed.data.reason === "temporary-failure") {
+        return temporaryFailureHistory(identity, request.asOf);
       }
       return parsed.data;
     } catch {
-      const cached = lastGoodTrainingHistory;
-      if (cached === null || !sameTrainingHistoryIdentity(cached.identity, identity)) {
-        return { kind: "unavailable", reason: "temporary-failure" };
-      }
-      return TrainingHistoryPanelSchema.parse({
-        kind: "stale",
-        failedAt: request.asOf,
-        reason: "temporary-failure",
-        lastGood: withoutTrainingHistoryCallouts(cached.panel),
-      });
+      return temporaryFailureHistory(identity, request.asOf);
     }
   };
   return {

--- a/packages/coach/tests/athlete-state-reader.test.ts
+++ b/packages/coach/tests/athlete-state-reader.test.ts
@@ -236,7 +236,7 @@ describe("persisted athlete state source", () => {
       cyclingFtpAnchorResolver: resolver,
       trainingHistorySource: {
         readTrainingHistory: async () => {
-          if (fail) throw new Error("synthetic");
+          if (fail) return { kind: "unavailable", reason: "temporary-failure" };
           return computedTrainingHistory();
         },
       },
@@ -272,7 +272,7 @@ describe("persisted athlete state source", () => {
     });
   });
 
-  it("passes domain unavailable projections through without consuming last-good history", async () => {
+  it("uses last-good history for returned temporary failures only", async () => {
     const root = await home();
     await writeJson(root, "latest.json", latest("fresh", T1));
     let response: TrainingHistoryProjection | "throw" = computedTrainingHistory();
@@ -287,19 +287,23 @@ describe("persisted athlete state source", () => {
       },
       sourceOwner: () => "synthetic-athlete",
       calendarTimeZone: () => "UTC",
+      now: () => new Date(T1),
     });
 
     await reader.getAthleteState();
-    for (const reason of [
-      "coverage-unavailable",
-      "temporary-failure",
-      "invalid-data",
-    ] as const) {
+    for (const reason of ["coverage-unavailable", "invalid-data"] as const) {
       response = { kind: "unavailable", reason };
       expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toEqual(
         response,
       );
     }
+    response = { kind: "unavailable", reason: "temporary-failure" };
+    expect((await reader.getAthleteState()).trainingContext?.trainingHistory).toMatchObject({
+      kind: "stale",
+      failedAt: T1,
+      reason: "temporary-failure",
+      lastGood: { anchorWeek: { callout: null }, previousWeek: { callout: null } },
+    });
     response = "throw";
     expect((await reader.getAthleteState()).trainingContext?.trainingHistory.kind).toBe(
       "stale",


### PR DESCRIPTION
## Why

Temporary Training History failures returned an unavailable panel instead of the retained last-good result. The renderer then discarded an open ride review, including when a refresh crossed a Monday boundary. Activity-analysis invalidation could also admit an older in-flight result back into an emptied cache.

## Scope

- Convert returned temporary failures to an identity-matched stale panel with callouts removed.
- Keep a selected ride unless a complete, exact, untruncated returned week proves it absent.
- Render the selected ride directly while the store owns reconciliation.
- Advance activity-analysis generation whenever the cache is invalidated.

## Tradeoffs

Stale and incomplete evidence remains conservative. A ride review stays open when absence is unproven, and closes only after authoritative coverage excludes it.

## Blast radius

Coach athlete-state reads, renderer Training state reconciliation, ride-review rendering, and activity-analysis cache lifecycle.

## Verification

- 64 focused Coach and renderer tests passed.
- Renderer typecheck, Oxlint, and whitespace checks passed.
- Isolated built-desktop QA kept “Earlier endurance” open across a completed refresh whose returned weeks did not cover its date.
- Changeset user-facing validation passed.

