### PR TITLE
feat(desktop): start a Plan in chat with goal and success cards

### DIFF
--- a/.changeset/plan-creation-slice1.md
+++ b/.changeset/plan-creation-slice1.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Start creating a training Plan by chatting with the coach: confirm your goal and what success means, and pick up where you left off after restarting the app.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -353,6 +353,8 @@ export function bootRenderer(): Disposer {
     retryPlanningRequest: (requestId) => chatController.retryPlanningRequest(requestId),
     retryPlanningRequestLoad: () => chatController.retryPlanningRequestLoad(),
     clearPlanningRequestFocus: () => chatController.clearPlanningRequestFocus(),
+    startPlanCreation: () => void chatController.startPlanCreation(),
+    answerPlanCreation: (answer) => void chatController.answerPlanCreation(answer),
     stop: () => chatController.stop(),
     removeQueued: (id) => chatController.removeQueued(id),
     runQueuedCommand: (id) => void chatController.runQueuedCommand(id),

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -19,6 +19,8 @@ import type {
   CreatePlanningRequestRpcParams,
   CreateWorkoutPlanningRequestRpcParams,
   PlanHandoffSuggestion,
+  PlanCreationAnswerInput,
+  PlanCreationCardModel,
   PlanningRequestDelivery,
   TranscriptPageEntry,
   TurnEvent,
@@ -64,6 +66,7 @@ export const CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY =
   "We couldn’t check saved Plan requests. Reconnect and try again.";
 export const CHAT_PLANNING_REQUEST_FAILURE_COPY =
   "Plan couldn’t receive this request. Your request is preserved and nothing changed in Plan.";
+export const CHAT_PLAN_CREATION_FAILURE_COPY = "Plan Creation couldn’t save that. Try again.";
 export const NEW_CONVERSATION_SUCCESS_COPY = "New conversation started.";
 export const NEW_CONVERSATION_MEMORY_WARNING_COPY =
   "New conversation started. Some recent details may not have been saved to coach memory.";
@@ -96,6 +99,12 @@ export interface ChatViewControls {
     readonly busyId: string | null;
     readonly error: string | null;
     readonly focusId: string | null;
+  };
+  readonly planCreation?: {
+    readonly value: PlanCreationCardModel | null;
+    readonly loaded: boolean;
+    readonly busy: boolean;
+    readonly error: string | null;
   };
   readonly appendDelta?: ChatAppendDelta;
   readonly hydration?: {
@@ -142,6 +151,8 @@ export interface ChatController {
   refreshPlanningRequests(): void;
   focusPlanningRequest(requestId: string): void;
   clearPlanningRequestFocus(): void;
+  startPlanCreation(): Promise<void>;
+  answerPlanCreation(answer: PlanCreationAnswerInput): Promise<void>;
   stop(): void;
   removeQueued(id: string): void;
   runQueuedCommand(id: string): Promise<void>;
@@ -272,6 +283,11 @@ export function createChatController(input: {
   let planningRequestError: string | null = null;
   let planningRequestFocusId: string | null = null;
   let pendingPlanningRequestCreate: PendingPlanningRequestCreate | null = null;
+  let planCreation: PlanCreationCardModel | null = null;
+  let planCreationLoaded = false;
+  let planCreationBusy = false;
+  let planCreationError: string | null = null;
+  let pendingPlanCreationCommand: { readonly key: string; readonly id: string } | null = null;
   let decisionContinuationTask: Promise<void> | undefined;
   let epoch = 0;
   const canChat = input.canChat ?? (() => true);
@@ -283,6 +299,7 @@ export function createChatController(input: {
     !decisionLoaded ||
     decision?.status === "unanswered" ||
     (decision?.status === "answered" && decision.continuation.status === "pending");
+  const planCreationBlocksWork = (): boolean => planCreation?.openQuestion != null;
   const decisionBlocksReset = (): boolean =>
     !decisionLoaded ||
     (decision?.status === "answered" && decision.continuation.status === "pending");
@@ -333,6 +350,12 @@ export function createChatController(input: {
             busyId: planningRequestBusyId,
             error: planningRequestError,
             focusId: planningRequestFocusId,
+          },
+          planCreation: {
+            value: planCreation,
+            loaded: planCreationLoaded,
+            busy: planCreationBusy,
+            error: planCreationError,
           },
           ...(appendDelta === undefined ? {} : { appendDelta }),
           hydration: {
@@ -914,9 +937,23 @@ export function createChatController(input: {
     const result = await activeClient.call("listPlanningRequests", { chatId: DESKTOP_CHAT_ID });
     if (disposed) return;
     planningRequests = result.deliveries;
+    installPlanCreation(result.planCreation);
+    planCreationLoaded = true;
     planningRequestsLoaded = true;
     planningRequestError = null;
     render();
+  };
+
+  const installPlanCreation = (next: PlanCreationCardModel | null): void => {
+    if (next !== null && (planCreation === null || next.version >= planCreation.version)) {
+      planCreation = next;
+    }
+  };
+  const planCommandId = (key: string): string => {
+    if (pendingPlanCreationCommand?.key !== key) {
+      pendingPlanCreationCommand = { key, id: globalThis.crypto.randomUUID() };
+    }
+    return pendingPlanCreationCommand.id;
   };
 
   const recoverPlanningRequests = async (): Promise<void> => {
@@ -1371,7 +1408,7 @@ export function createChatController(input: {
       if (decisionContinuationTask === task) decisionContinuationTask = undefined;
       if (activeTask === task) activeTask = undefined;
       render();
-      if (!decisionBlocksWork()) void drain();
+      if (!decisionBlocksWork() && !planCreationBlocksWork()) void drain();
     });
     return task;
   };
@@ -1383,6 +1420,7 @@ export function createChatController(input: {
       disposed ||
       resetBlocksWork() ||
       decisionBlocksWork() ||
+      planCreationBlocksWork() ||
       state.status === "streaming"
     ) {
       return Promise.resolve();
@@ -1430,7 +1468,7 @@ export function createChatController(input: {
     void loadTask.finally(() => {
       if (decisionLoadTask === loadTask) decisionLoadTask = undefined;
       render();
-      if (!decisionBlocksWork()) void drain();
+      if (!decisionBlocksWork() && !planCreationBlocksWork()) void drain();
     });
     const probeEpoch = epoch;
     const sessionProbeTask = (async () => {
@@ -1467,7 +1505,7 @@ export function createChatController(input: {
       attachmentLoadTask,
       planningRequestLoadTask,
     ]).then(async () => {
-      if (!decisionBlocksWork()) await drain();
+      if (!decisionBlocksWork() && !planCreationBlocksWork()) await drain();
     });
     probeTask = task;
     return task;
@@ -1512,7 +1550,8 @@ export function createChatController(input: {
         (/^\s*\//u.test(message) && attachmentIds.length > 0) ||
         disposed ||
         resetBlocksWork() ||
-        decisionBlocksWork()
+        decisionBlocksWork() ||
+        planCreationBlocksWork()
       ) {
         return Promise.resolve(false);
       }
@@ -1760,6 +1799,57 @@ export function createChatController(input: {
       planningRequestFocusId = null;
       render();
     },
+    async startPlanCreation() {
+      if (disposed || planCreationBusy || !planCreationLoaded || planCreation !== null) return;
+      planCreationBusy = true;
+      planCreationError = null;
+      render();
+      try {
+        const result = await (
+          await input.clients.getClient()
+        ).call("plan_creation.start", {
+          commandId: planCommandId("start"),
+        });
+        pendingPlanCreationCommand = null;
+        if (result.status === "started") installPlanCreation(result.planCreation);
+        else planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
+      } catch {
+        planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
+      } finally {
+        planCreationBusy = false;
+        render();
+      }
+    },
+    async answerPlanCreation(answer) {
+      if (disposed || planCreationBusy || planCreation?.openQuestion == null) return;
+      const key = JSON.stringify({
+        creationId: planCreation.creationId,
+        expectedVersion: planCreation.version,
+        answer,
+      });
+      planCreationBusy = true;
+      planCreationError = null;
+      render();
+      try {
+        const result = await (
+          await input.clients.getClient()
+        ).call("plan_creation.answer", {
+          commandId: planCommandId(key),
+          creationId: planCreation.creationId,
+          expectedVersion: planCreation.version,
+          answer,
+        });
+        pendingPlanCreationCommand = null;
+        installPlanCreation(result.planCreation);
+        if (result.status === "rejected") planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
+      } catch {
+        planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
+      } finally {
+        planCreationBusy = false;
+        render();
+        if (!planCreationBlocksWork() && !decisionBlocksWork()) void drain();
+      }
+    },
     stop() {
       if (disposed || state.status !== "streaming" || state.activeTurn === null) return;
       activeStopRequest?.request();
@@ -1807,6 +1897,7 @@ export function createChatController(input: {
         !queueLoaded ||
         resetBlocksWork() ||
         decisionBlocksWork() ||
+        planCreationBlocksWork() ||
         state.status !== "idle"
       ) {
         return activeTask ?? Promise.resolve();
@@ -1825,6 +1916,7 @@ export function createChatController(input: {
         !queueLoaded ||
         resetBlocksWork() ||
         decisionBlocksWork() ||
+        planCreationBlocksWork() ||
         (state.status !== "idle" && state.status !== "interrupted")
       ) {
         return activeTask ?? Promise.resolve();
@@ -1921,7 +2013,7 @@ export function createChatController(input: {
       await task.finally(() => {
         if (decisionLoadTask === task) decisionLoadTask = undefined;
         render();
-        if (!decisionBlocksWork()) void drain();
+        if (!decisionBlocksWork() && !planCreationBlocksWork()) void drain();
       });
     },
     openNewConversation() {
@@ -2074,7 +2166,7 @@ export function createChatController(input: {
         decisionError = CHAT_DECISION_SKIP_FAILURE_COPY;
       }
       render();
-      if (!decisionBlocksWork()) void drain();
+      if (!decisionBlocksWork() && !planCreationBlocksWork()) void drain();
     },
     dispose() {
       disposed = true;

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -282,6 +282,7 @@ export function createChatController(input: {
   let planningRequestBusyId: string | null = null;
   let planningRequestError: string | null = null;
   let planningRequestFocusId: string | null = null;
+  let planningRequestLoadTask: Promise<void> | undefined;
   let pendingPlanningRequestCreate: PendingPlanningRequestCreate | null = null;
   let planCreation: PlanCreationCardModel | null = null;
   let planCreationLoaded = false;
@@ -942,12 +943,34 @@ export function createChatController(input: {
     planningRequestsLoaded = true;
     planningRequestError = null;
     render();
+    if (!decisionBlocksWork() && !planCreationBlocksWork()) void drain();
   };
 
   const installPlanCreation = (next: PlanCreationCardModel | null): void => {
-    if (next !== null && (planCreation === null || next.version >= planCreation.version)) {
+    if (next === null) {
+      planCreation = null;
+    } else if (
+      planCreation === null ||
+      next.creationId !== planCreation.creationId ||
+      next.version >= planCreation.version
+    ) {
       planCreation = next;
     }
+  };
+  const trackPlanningRequestLoad = (task: Promise<void>): Promise<void> => {
+    planningRequestLoadTask = task;
+    void task.then(
+      () => {
+        if (planningRequestLoadTask === task) planningRequestLoadTask = undefined;
+      },
+      () => {
+        if (planningRequestLoadTask === task) planningRequestLoadTask = undefined;
+      },
+    );
+    return task;
+  };
+  const waitForPlanningRequestLoad = async (): Promise<void> => {
+    while (planningRequestLoadTask !== undefined) await planningRequestLoadTask;
   };
   const planCommandId = (key: string): string => {
     if (pendingPlanCreationCommand?.key !== key) {
@@ -1413,7 +1436,8 @@ export function createChatController(input: {
     return task;
   };
 
-  const drain = (): Promise<void> => {
+  const drain = async (): Promise<void> => {
+    await waitForPlanningRequestLoad();
     if (
       !canChat() ||
       !queueLoaded ||
@@ -1490,20 +1514,22 @@ export function createChatController(input: {
     })();
     const attachmentLoadGeneration = attachmentGeneration;
     const attachmentLoadTask = refreshAttachments(undefined, attachmentLoadGeneration);
-    const planningRequestLoadTask = recoverPlanningRequests().catch(() => {
-      if (!disposed) {
-        planningRequestsLoaded = false;
-        planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;
-        render();
-      }
-    });
+    const planningLoadTask = trackPlanningRequestLoad(
+      recoverPlanningRequests().catch(() => {
+        if (!disposed) {
+          planningRequestsLoaded = false;
+          planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;
+          render();
+        }
+      }),
+    );
     const task = Promise.all([
       transcriptLoadTask,
       sessionProbeTask,
       loadTask,
       queueLoadTask,
       attachmentLoadTask,
-      planningRequestLoadTask,
+      planningLoadTask,
     ]).then(async () => {
       if (!decisionBlocksWork() && !planCreationBlocksWork()) await drain();
     });
@@ -1542,7 +1568,8 @@ export function createChatController(input: {
       }
       finishAttachmentWrite(ownership.token);
     },
-    submit(message, attachmentIds = []) {
+    async submit(message, attachmentIds = []) {
+      await waitForPlanningRequestLoad();
       if (
         !canChat() ||
         !queueLoaded ||
@@ -1773,21 +1800,25 @@ export function createChatController(input: {
       }
       planningRequestError = null;
       render();
-      void recoverPlanningRequests().catch(() => {
-        if (disposed) return;
-        planningRequestsLoaded = false;
-        planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;
-        render();
-      });
+      void trackPlanningRequestLoad(
+        recoverPlanningRequests().catch(() => {
+          if (disposed) return;
+          planningRequestsLoaded = false;
+          planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;
+          render();
+        }),
+      );
     },
     refreshPlanningRequests() {
       if (disposed || planningRequestBusyId !== null) return;
-      void loadPlanningRequests().catch(() => {
-        if (disposed) return;
-        planningRequestsLoaded = false;
-        planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;
-        render();
-      });
+      void trackPlanningRequestLoad(
+        loadPlanningRequests().catch(() => {
+          if (disposed) return;
+          planningRequestsLoaded = false;
+          planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;
+          render();
+        }),
+      );
     },
     focusPlanningRequest(requestId) {
       if (disposed) return;
@@ -1800,7 +1831,15 @@ export function createChatController(input: {
       render();
     },
     async startPlanCreation() {
-      if (disposed || planCreationBusy || !planCreationLoaded || planCreation !== null) return;
+      if (
+        disposed ||
+        planCreationBusy ||
+        !planCreationLoaded ||
+        planCreation !== null ||
+        decisionBlocksWork()
+      ) {
+        return;
+      }
       planCreationBusy = true;
       planCreationError = null;
       render();
@@ -1941,7 +1980,8 @@ export function createChatController(input: {
         state.status !== "interrupted" ||
         state.retryRequired != null ||
         state.activeTurn === null ||
-        resetBlocksWork()
+        resetBlocksWork() ||
+        planCreationBlocksWork()
       ) {
         return activeTask ?? Promise.resolve();
       }
@@ -1961,7 +2001,8 @@ export function createChatController(input: {
             !canChat() ||
             disposed ||
             state.status !== "interrupted" ||
-            state.activeTurn?.requestKey !== requestKey
+            state.activeTurn?.requestKey !== requestKey ||
+            planCreationBlocksWork()
           ) {
             return;
           }

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -266,7 +266,15 @@ export function createChatViewAdapter(input: {
     const planningItems: ChatTranscriptItemView[] = planningRequests
       .filter((delivery) => delivery.state !== "cancelled")
       .map((delivery) => ({ kind: "planning-request", delivery }));
-    const timeline = [...historicalItems, ...liveItems, ...planningItems];
+    const planCreation = controls?.planCreation;
+    const timeline = [
+      ...historicalItems,
+      ...liveItems,
+      ...planningItems,
+      ...(planCreation?.loaded === true && planCreation.value !== null
+        ? ([{ kind: "plan-creation", model: planCreation.value }] as const)
+        : []),
+    ];
     const decisionBlocksWork =
       decision?.value?.status === "unanswered" ||
       (decision?.value?.status === "answered" && decision.value.continuation.status === "pending");
@@ -305,6 +313,10 @@ export function createChatViewAdapter(input: {
       planningRequestBusyId: controls?.planningRequests?.busyId ?? null,
       planningRequestError: controls?.planningRequests?.error ?? null,
       planningRequestFocusId: controls?.planningRequests?.focusId ?? null,
+      planCreation: planCreation?.value ?? null,
+      planCreationLoaded: planCreation?.loaded ?? false,
+      planCreationBusy: planCreation?.busy ?? false,
+      planCreationError: planCreation?.error ?? null,
       timeline: sameChatTimeline(published.timeline, timeline) ? published.timeline : timeline,
       status: state.status,
       notice: decisionBlocksWork
@@ -316,7 +328,11 @@ export function createChatViewAdapter(input: {
       interrupted: state.status === "interrupted" && !decisionBlocksWork,
       workBlocked,
       sendDisabled:
-        workBlocked || decisionBlocksWork || decisionUnavailable || attachmentUnavailable,
+        workBlocked ||
+        decisionBlocksWork ||
+        decisionUnavailable ||
+        attachmentUnavailable ||
+        planCreation?.value?.openQuestion != null,
       inputDisabled: workBlocked,
       newConversationUnavailable: newConversationUnavailable || decisionUnavailable,
       resetPhase: state.session.resetPhase,

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -278,6 +278,7 @@ export function createChatViewAdapter(input: {
     const decisionBlocksWork =
       decision?.value?.status === "unanswered" ||
       (decision?.value?.status === "answered" && decision.value.continuation.status === "pending");
+    const planCreationBlocksWork = planCreation?.value?.openQuestion != null;
     const decisionLoading = controls?.decisionLoading === true;
     const decisionLoadError = controls?.queueLoadError ?? controls?.decisionLoadError ?? null;
     const decisionUnavailable = decisionLoading || decisionLoadError !== null;
@@ -325,14 +326,15 @@ export function createChatViewAdapter(input: {
           (state.status === "streaming" ? null : state.progress)),
       coachProgress:
         state.status === "streaming" && state.activeTurn?.error === null ? state.progress : null,
-      interrupted: state.status === "interrupted" && !decisionBlocksWork,
+      interrupted:
+        state.status === "interrupted" && !decisionBlocksWork && !planCreationBlocksWork,
       workBlocked,
       sendDisabled:
         workBlocked ||
         decisionBlocksWork ||
         decisionUnavailable ||
         attachmentUnavailable ||
-        planCreation?.value?.openQuestion != null,
+        planCreationBlocksWork,
       inputDisabled: workBlocked,
       newConversationUnavailable: newConversationUnavailable || decisionUnavailable,
       resetPhase: state.session.resetPhase,

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -5,6 +5,8 @@ import type {
   CoachDecisionAnswer,
   CoachDecisionReadModel,
   PlanningRequestDelivery,
+  PlanCreationAnswerInput,
+  PlanCreationCardModel,
   PlanHandoffSuggestion,
 } from "@enduragent/coach-contract";
 import type { StateCreator } from "zustand";
@@ -44,7 +46,8 @@ export interface ChatChoiceView {
 export type ChatTranscriptItemView =
   | { readonly kind: "message"; readonly message: ChatMessageView }
   | { readonly kind: "choice"; readonly choice: ChatChoiceView }
-  | { readonly kind: "planning-request"; readonly delivery: PlanningRequestDelivery };
+  | { readonly kind: "planning-request"; readonly delivery: PlanningRequestDelivery }
+  | { readonly kind: "plan-creation"; readonly model: PlanCreationCardModel | null };
 
 export type ChatDecisionPhase = "idle" | "continuing" | "recovering";
 
@@ -67,6 +70,10 @@ export interface ChatSurfaceState {
   readonly planningRequestBusyId: string | null;
   readonly planningRequestError: string | null;
   readonly planningRequestFocusId: string | null;
+  readonly planCreation: PlanCreationCardModel | null;
+  readonly planCreationLoaded: boolean;
+  readonly planCreationBusy: boolean;
+  readonly planCreationError: string | null;
   readonly timeline: readonly ChatTranscriptItemView[];
   readonly status: ChatStatus;
   readonly notice: string | null;
@@ -101,6 +108,8 @@ export interface ChatActions {
   retryPlanningRequest(requestId: string): void;
   retryPlanningRequestLoad(): void;
   clearPlanningRequestFocus(): void;
+  startPlanCreation(): void;
+  answerPlanCreation(answer: PlanCreationAnswerInput): void;
   stop(): void;
   removeQueued(id: string): void;
   runQueuedCommand(id: string): void;
@@ -136,6 +145,10 @@ export const EMPTY_CHAT_SURFACE: ChatSurfaceState = Object.freeze({
   planningRequestBusyId: null,
   planningRequestError: null,
   planningRequestFocusId: null,
+  planCreation: null,
+  planCreationLoaded: false,
+  planCreationBusy: false,
+  planCreationError: null,
   timeline: Object.freeze([]),
   status: "idle",
   notice: null,
@@ -250,6 +263,9 @@ export function sameChatTimeline(
     if (item.kind === "planning-request" && other.kind === "planning-request") {
       return JSON.stringify(item.delivery) === JSON.stringify(other.delivery);
     }
+    if (item.kind === "plan-creation" && other.kind === "plan-creation") {
+      return JSON.stringify(item.model) === JSON.stringify(other.model);
+    }
     return false;
   });
 }
@@ -276,6 +292,10 @@ export function sameChatSurface(left: ChatSurfaceState, right: ChatSurfaceState)
     left.planningRequestError === right.planningRequestError &&
     left.planningRequestFocusId === right.planningRequestFocusId &&
     JSON.stringify(left.planningRequests) === JSON.stringify(right.planningRequests) &&
+    JSON.stringify(left.planCreation) === JSON.stringify(right.planCreation) &&
+    left.planCreationLoaded === right.planCreationLoaded &&
+    left.planCreationBusy === right.planCreationBusy &&
+    left.planCreationError === right.planCreationError &&
     left.workBlocked === right.workBlocked &&
     left.sendDisabled === right.sendDisabled &&
     left.inputDisabled === right.inputDisabled &&

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -27,6 +27,7 @@ import { QueuedMessages } from "./QueuedMessages";
 import { SpendNotice } from "./SpendNotice";
 import { TrainingContextPanel } from "./TrainingContextPanel";
 import { Transcript } from "./Transcript";
+import { PlanCreationDock } from "./PlanCreationCards";
 
 const CHAT_DISCLAIMER =
   "Not medical advice, and not a substitute for a doctor or a certified coach.";
@@ -208,8 +209,9 @@ export function ChatView(): ReactElement {
                 <Notice />
                 <RetryBar />
               </div>
-              <div className="mb-2.5 empty:hidden">
+              <div className="mb-2.5 grid gap-2.5 empty:hidden">
                 <CoachDecisionPanel onCustomOpenChange={setCustomDecisionOpen} />
+                <PlanCreationDock />
               </div>
               <AttachmentPanel />
               <QueuedMessages />

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -5,17 +5,21 @@ import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/ca
 import { useEnduragentStore } from "../../state/store";
 
 const fieldClass =
-  "min-h-10 min-w-0 rounded-ctl border border-line bg-bg px-3 py-2 text-sm text-ink outline-none focus-visible:ring-2 focus-visible:ring-focus";
+  "min-h-[calc(var(--ctl-h-lg)+var(--inset))] resize-y rounded-ctl border border-line-2 bg-sunk px-3 py-2 text-sm leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20";
 
 export function PlanCreationDock(): ReactElement | null {
   const model = useEnduragentStore((state) => state.chat.planCreation);
   const loaded = useEnduragentStore((state) => state.chat.planCreationLoaded);
   const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
   const error = useEnduragentStore((state) => state.chat.planCreationError);
+  const decision = useEnduragentStore((state) => state.chat.decision);
   const actions = useEnduragentStore((state) => state.chatActions);
   const [goalMode, setGoalMode] = useState<"choices" | "manual" | "fitness">("choices");
   const heading = useRef<HTMLHeadingElement>(null);
   const question = model?.openQuestion ?? null;
+  const decisionPending =
+    decision?.status === "unanswered" ||
+    (decision?.status === "answered" && decision.continuation.status === "pending");
   useEffect(() => {
     setGoalMode("choices");
     if (question !== null) heading.current?.focus();
@@ -26,7 +30,7 @@ export function PlanCreationDock(): ReactElement | null {
       <div className="flex min-w-0 justify-end rounded-card border border-line bg-surface px-4 py-3">
         <Button
           variant="outline"
-          disabled={busy || actions === null}
+          disabled={busy || actions === null || decisionPending}
           onClick={() => actions?.startPlanCreation()}
         >
           Start a Plan

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState, type FormEvent, type ReactElement } from "react";
+import type { PlanCreationAnswerInput, PlanCreationCardModel } from "@enduragent/coach-contract";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { useEnduragentStore } from "../../state/store";
+
+const fieldClass =
+  "min-h-10 min-w-0 rounded-ctl border border-line bg-bg px-3 py-2 text-sm text-ink outline-none focus-visible:ring-2 focus-visible:ring-focus";
+
+export function PlanCreationDock(): ReactElement | null {
+  const model = useEnduragentStore((state) => state.chat.planCreation);
+  const loaded = useEnduragentStore((state) => state.chat.planCreationLoaded);
+  const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
+  const error = useEnduragentStore((state) => state.chat.planCreationError);
+  const actions = useEnduragentStore((state) => state.chatActions);
+  const [goalMode, setGoalMode] = useState<"choices" | "manual" | "fitness">("choices");
+  const heading = useRef<HTMLHeadingElement>(null);
+  const question = model?.openQuestion ?? null;
+  useEffect(() => {
+    setGoalMode("choices");
+    if (question !== null) heading.current?.focus();
+  }, [model?.creationId, model?.version, question?.kind]);
+  if (!loaded) return null;
+  if (model === null) {
+    return (
+      <div className="flex min-w-0 justify-end rounded-card border border-line bg-surface px-4 py-3">
+        <Button
+          variant="outline"
+          disabled={busy || actions === null}
+          onClick={() => actions?.startPlanCreation()}
+        >
+          Start a Plan
+        </Button>
+      </div>
+    );
+  }
+  if (question === null) return null;
+  const answer = (value: PlanCreationAnswerInput): void => actions?.answerPlanCreation(value);
+  const submitFitness = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const outcome = new FormData(event.currentTarget).get("outcome")?.toString().trim() ?? "";
+    if (outcome) answer({ kind: "goal", goal: { kind: "fitness", outcome } });
+  };
+  const submitManual = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const name = data.get("name")?.toString().trim() ?? "";
+    const date = data.get("date")?.toString() ?? "";
+    if (name && date) answer({ kind: "goal", goal: { kind: "event-manual", name, date } });
+  };
+  const submitSuccess = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const text = new FormData(event.currentTarget).get("success")?.toString().trim() ?? "";
+    if (text) answer({ kind: "success", success: { kind: "authored", text } });
+  };
+  return (
+    <Card className="min-w-0 shadow-elev-2">
+      <CardHeader>
+        <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+          Plan Creation
+        </p>
+        <CardTitle>
+          <h2 ref={heading} tabIndex={-1} className="m-0 outline-none">
+            {question.prompt}
+          </h2>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid min-w-0 gap-inset">
+        {question.kind === "goal-question" && goalMode === "choices" ? (
+          <div className="grid min-w-0 gap-2 sm:grid-cols-2">
+            {question.candidates.map((candidate) => (
+              <Button
+                key={candidate.candidateId}
+                variant="outline"
+                className="h-auto min-w-0 justify-start whitespace-normal text-left"
+                disabled={busy}
+                onClick={() =>
+                  answer({
+                    kind: "goal",
+                    goal: { kind: "event-candidate", candidateId: candidate.candidateId },
+                  })
+                }
+              >
+                {candidate.name} · {candidate.date}
+              </Button>
+            ))}
+            <Button variant="outline" disabled={busy} onClick={() => setGoalMode("manual")}>
+              Event not listed
+            </Button>
+            <Button variant="outline" disabled={busy} onClick={() => setGoalMode("fitness")}>
+              Improve without an event
+            </Button>
+          </div>
+        ) : question.kind === "goal-question" && goalMode === "fitness" ? (
+          <form className="grid min-w-0 gap-inset" onSubmit={submitFitness}>
+            <textarea
+              aria-label="Goal outcome"
+              className={fieldClass}
+              name="outcome"
+              maxLength={2000}
+              required
+              rows={3}
+            />
+            <Button type="submit" className="justify-self-end" disabled={busy}>
+              Confirm goal
+            </Button>
+          </form>
+        ) : question.kind === "goal-question" ? (
+          <form className="grid min-w-0 gap-inset sm:grid-cols-2" onSubmit={submitManual}>
+            <input
+              aria-label="Event name"
+              className={fieldClass}
+              name="name"
+              placeholder="Event name"
+              maxLength={512}
+              required
+            />
+            <input
+              aria-label="Event date"
+              className={fieldClass}
+              name="date"
+              type="date"
+              required
+            />
+            <Button type="submit" className="justify-self-end sm:col-span-2" disabled={busy}>
+              Confirm goal
+            </Button>
+          </form>
+        ) : question.input.kind === "authored" ? (
+          <form className="grid min-w-0 gap-inset" onSubmit={submitSuccess}>
+            <textarea
+              aria-label="Success meaning"
+              className={fieldClass}
+              name="success"
+              placeholder={question.input.placeholder}
+              maxLength={2000}
+              required
+              rows={3}
+            />
+            <Button type="submit" className="justify-self-end" disabled={busy}>
+              Confirm success
+            </Button>
+          </form>
+        ) : (
+          <div className="grid min-w-0 gap-2 sm:grid-cols-3">
+            {question.input.options.map((option) => (
+              <Button
+                key={option.choice}
+                variant="outline"
+                className="h-auto whitespace-normal"
+                disabled={busy}
+                onClick={() =>
+                  answer({
+                    kind: "success",
+                    success: { kind: "event-finish", choice: option.choice },
+                  })
+                }
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        )}
+        {error === null ? null : (
+          <p className="m-0 text-xs text-danger" role="alert">
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PlanCreationConversation(props: {
+  readonly model: PlanCreationCardModel | null;
+}): ReactElement | null {
+  if (props.model === null) return null;
+  return (
+    <section className="grid min-w-0 gap-inset" aria-label="Plan Creation progress">
+      {props.model.answeredSummaries.length === 0 ? null : (
+        <dl className="m-0 grid gap-2 rounded-card bg-sunk p-3">
+          {props.model.answeredSummaries.map((summary) => (
+            <div
+              key={summary.answerKey}
+              className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-inset text-sm"
+            >
+              <dt className="font-medium text-ink-2">{summary.title}</dt>
+              <dd className="m-0 min-w-0 break-words">{summary.detail}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      <Card size="sm" className="min-w-0">
+        <CardContent>
+          <strong>Plan Creation</strong>
+          <p className="m-0 text-xs text-ink-2">
+            {props.model.answeredSummaries.length}{" "}
+            {props.model.answeredSummaries.length === 1 ? "answer" : "answers"} confirmed
+          </p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -92,7 +92,7 @@ export function PlanCreationDock(): ReactElement | null {
             </Button>
           </div>
         ) : question.kind === "goal-question" && goalMode === "fitness" ? (
-          <form className="grid min-w-0 gap-inset" onSubmit={submitFitness}>
+          <form key="goal-fitness" className="grid min-w-0 gap-inset" onSubmit={submitFitness}>
             <textarea
               aria-label="Goal outcome"
               className={fieldClass}
@@ -106,7 +106,7 @@ export function PlanCreationDock(): ReactElement | null {
             </Button>
           </form>
         ) : question.kind === "goal-question" ? (
-          <form className="grid min-w-0 gap-inset sm:grid-cols-2" onSubmit={submitManual}>
+          <form key="goal-manual" className="grid min-w-0 gap-inset sm:grid-cols-2" onSubmit={submitManual}>
             <input
               aria-label="Event name"
               className={fieldClass}
@@ -127,7 +127,7 @@ export function PlanCreationDock(): ReactElement | null {
             </Button>
           </form>
         ) : question.input.kind === "authored" ? (
-          <form className="grid min-w-0 gap-inset" onSubmit={submitSuccess}>
+          <form key="success" className="grid min-w-0 gap-inset" onSubmit={submitSuccess}>
             <textarea
               aria-label="Success meaning"
               className={fieldClass}

--- a/apps/desktop-renderer/src/ui/chat/Transcript.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Transcript.tsx
@@ -22,6 +22,7 @@ import { CoachMessage } from "./CoachMessage";
 import { HistoryControls } from "./HistoryControls";
 import { PlanReferenceCard } from "./PlanReferenceCard";
 import { StreamingMessage } from "./StreamingMessage";
+import { PlanCreationConversation } from "./PlanCreationCards";
 
 function planHandoffSummary(suggestion: PlanHandoffSuggestion): string {
   if (suggestion.kind === "plan_creation") {
@@ -320,10 +321,15 @@ export function ConversationTranscript(props: {
                 />
               ) : item.kind === "choice" ? (
                 <ChoiceRow key={`choice:${item.choice.id}`} choice={item.choice} />
-              ) : (
+              ) : item.kind === "planning-request" ? (
                 <PlanningRequestRow
                   key={`planning-request:${item.delivery.requestId}`}
                   delivery={item.delivery}
+                />
+              ) : (
+                <PlanCreationConversation
+                  key={`plan-creation:${item.model?.creationId ?? "empty"}`}
+                  model={item.model}
                 />
               ),
             )}

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -45,6 +45,8 @@ function chatActions(): ChatActions {
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
+    startPlanCreation: vi.fn(),
+    answerPlanCreation: vi.fn(),
     stop: vi.fn(),
     retry: vi.fn(),
     removeQueued: vi.fn(),

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -104,6 +104,10 @@ describe("chat view adapter", () => {
       planningRequestBusyId: null,
       planningRequestError: null,
       planningRequestFocusId: null,
+      planCreation: null,
+      planCreationLoaded: false,
+      planCreationBusy: false,
+      planCreationError: null,
       timeline: [
         {
           kind: "message",
@@ -215,6 +219,43 @@ describe("chat view adapter", () => {
       inputDisabled: false,
       newConversationUnavailable: true,
     });
+  });
+
+  it("projects a Plan Creation conversation item and blocks only Send for an open question", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    const model = {
+      creationId: "01J00000000000000000000000",
+      version: 1,
+      status: "in-progress" as const,
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question" as const, prompt: "Goal?", candidates: [] },
+    };
+    adapter.view.render(
+      EMPTY_CHAT_STATE,
+      controls({
+        planCreation: { value: model, loaded: true, busy: false, error: null },
+      }),
+    );
+    expect(published.at(-1)).toMatchObject({
+      planCreation: model,
+      planCreationLoaded: true,
+      sendDisabled: true,
+      inputDisabled: false,
+      timeline: [{ kind: "plan-creation", model }],
+    });
+    adapter.view.render(
+      EMPTY_CHAT_STATE,
+      controls({
+        planCreation: {
+          value: { ...model, version: 2, openQuestion: null },
+          loaded: true,
+          busy: false,
+          error: null,
+        },
+      }),
+    );
+    expect(published.at(-1)).toMatchObject({ sendDisabled: false, inputDisabled: false });
   });
 
   it("keeps v2 decision consequences between the athlete request and Coach continuation", () => {
@@ -550,6 +591,7 @@ describe("chat view adapter", () => {
       published.at(-1)?.timeline.map((item) => {
         if (item.kind === "choice") return "choice";
         if (item.kind === "planning-request") return "planning-request";
+        if (item.kind === "plan-creation") return "plan-creation";
         return item.message.role === "athlete" ? "athlete" : item.message.delivery;
       }),
     ).toEqual(["athlete", "interrupted", "choice", "complete"]);

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -258,6 +258,42 @@ describe("chat view adapter", () => {
     expect(published.at(-1)).toMatchObject({ sendDisabled: false, inputDisabled: false });
   });
 
+  it("suppresses interrupted recovery while a Plan Creation question is open", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    let stopped = submitted();
+    stopped = reduceChatState(stopped, {
+      type: "event",
+      requestKey: 1,
+      event: {
+        type: "interrupted",
+        turnId: "turn-stopped",
+        chatId: "desktop",
+        text: "Partial response",
+      },
+    });
+
+    adapter.view.render(
+      stopped,
+      controls({
+        planCreation: {
+          value: {
+            creationId: "01J00000000000000000000000",
+            version: 1,
+            status: "in-progress",
+            answeredSummaries: [],
+            openQuestion: { kind: "goal-question", prompt: "Goal?", candidates: [] },
+          },
+          loaded: true,
+          busy: false,
+          error: null,
+        },
+      }),
+    );
+
+    expect(published.at(-1)).toMatchObject({ status: "interrupted", interrupted: false });
+  });
+
   it("keeps v2 decision consequences between the athlete request and Coach continuation", () => {
     const published: ChatSurfaceState[] = [];
     const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -13,7 +13,12 @@ import type {
   CoachTurnEventNotificationEnvelope,
   CreatePlanningRequestRpcParams,
   CreateWorkoutPlanningRequestRpcParams,
+  PlanCreationAnswerRpcParams,
+  PlanCreationAnswerRpcResult,
   PlanningRequestDelivery,
+  PlanCreationCardModel,
+  PlanCreationStartRpcParams,
+  PlanCreationStartRpcResult,
   QueuedChatMessage,
   TurnEvent,
 } from "@enduragent/coach-contract";
@@ -237,6 +242,7 @@ function client(
     readonly clearAttachmentDraft?: () => Promise<ChatAttachmentComposerReadModel>;
     readonly listPlanningRequests?: () => Promise<{
       readonly deliveries: readonly PlanningRequestDelivery[];
+      readonly planCreation?: PlanCreationCardModel | null;
     }>;
     readonly resumePlanningRequests?: () => Promise<{
       readonly deliveries: readonly PlanningRequestDelivery[];
@@ -257,6 +263,12 @@ function client(
       | { readonly status: "found"; readonly delivery: PlanningRequestDelivery }
       | { readonly status: "missing" }
     >;
+    readonly startPlanCreation?: (
+      request: PlanCreationStartRpcParams,
+    ) => Promise<PlanCreationStartRpcResult>;
+    readonly answerPlanCreation?: (
+      request: PlanCreationAnswerRpcParams,
+    ) => Promise<PlanCreationAnswerRpcResult>;
   } = {},
 ): CoachClient {
   let queueRevision = 0;
@@ -314,7 +326,10 @@ function client(
     }
     if (method === "listPlanningRequests") {
       hideQueueCall();
-      return (sessions.listPlanningRequests?.() ?? Promise.resolve({ deliveries: [] })) as never;
+      return (sessions
+        .listPlanningRequests?.()
+        .then((result) => ({ planCreation: null, ...result })) ??
+        Promise.resolve({ deliveries: [], planCreation: null })) as never;
     }
     if (method === "resumePlanningRequests") {
       hideQueueCall();
@@ -331,6 +346,18 @@ function client(
     }
     if (method === "retryPlanningRequest") {
       return (sessions.retryPlanningRequest?.() ?? Promise.resolve({ status: "missing" })) as never;
+    }
+    if (method === "plan_creation.start") {
+      return (sessions.startPlanCreation?.(request as PlanCreationStartRpcParams) ??
+        Promise.resolve({ status: "rejected", reason: "command-conflict" })) as never;
+    }
+    if (method === "plan_creation.answer") {
+      return (sessions.answerPlanCreation?.(request as PlanCreationAnswerRpcParams) ??
+        Promise.resolve({
+          status: "rejected",
+          reason: "no-unfinished-creation",
+          planCreation: null,
+        })) as never;
     }
     if (method === "saveChatAttachmentDraftText") {
       hideQueueCall();
@@ -1624,6 +1651,79 @@ describe("chat controller", () => {
       error: null,
       value: [restored],
     });
+  });
+
+  it("restores an open Card and blocks coaching work", async () => {
+    const planCreation = {
+      creationId: "01J00000000000000000000000",
+      version: 1,
+      status: "in-progress" as const,
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question" as const, prompt: "Goal?", candidates: [] },
+    };
+    const fake = client(replies(), {
+      listPlanningRequests: async () => ({ deliveries: [], planCreation }),
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    expect(controls.at(-1)?.planCreation).toMatchObject({ loaded: true, value: planCreation });
+    await expect(controller.submit("blocked")).resolves.toBe(false);
+    expect(chatMessages(fake)).toEqual([]);
+  });
+
+  it("retries Card commands with stable ids, installs monotonically, and unblocks Chat", async () => {
+    const goalCard: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 1,
+      status: "in-progress",
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question", prompt: "Goal?", candidates: [] },
+    };
+    const completeCard: PlanCreationCardModel = {
+      ...goalCard,
+      version: 2,
+      answeredSummaries: [{ answerKey: "goal", title: "Goal", detail: "Build power" }],
+      openQuestion: null,
+    };
+    const listPlanningRequests = vi
+      .fn()
+      .mockResolvedValueOnce({ deliveries: [], planCreation: null })
+      .mockResolvedValue({ deliveries: [], planCreation: null });
+    const startPlanCreation = vi
+      .fn<(request: PlanCreationStartRpcParams) => Promise<PlanCreationStartRpcResult>>()
+      .mockRejectedValueOnce(new Error("interrupted"))
+      .mockResolvedValue({ status: "started", outcome: "created", planCreation: goalCard });
+    const answerPlanCreation = vi
+      .fn<(request: PlanCreationAnswerRpcParams) => Promise<PlanCreationAnswerRpcResult>>()
+      .mockRejectedValueOnce(new Error("interrupted"))
+      .mockResolvedValue({ status: "answered", planCreation: completeCard });
+    const fake = client(replies(), {
+      listPlanningRequests,
+      startPlanCreation,
+      answerPlanCreation,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    await controller.startPlanCreation();
+    await controller.startPlanCreation();
+    expect(startPlanCreation.mock.calls[0]?.[0].commandId).toBe(
+      startPlanCreation.mock.calls[1]?.[0].commandId,
+    );
+    const answer = {
+      kind: "goal" as const,
+      goal: { kind: "fitness" as const, outcome: "Build power" },
+    };
+    await controller.answerPlanCreation(answer);
+    await controller.answerPlanCreation(answer);
+    expect(answerPlanCreation.mock.calls[0]?.[0].commandId).toBe(
+      answerPlanCreation.mock.calls[1]?.[0].commandId,
+    );
+    expect(controls.at(-1)?.planCreation?.value).toEqual(completeCard);
+    controller.refreshPlanningRequests();
+    await vi.waitFor(() => expect(listPlanningRequests).toHaveBeenCalledTimes(2));
+    expect(controls.at(-1)?.planCreation?.value).toEqual(completeCard);
+    await expect(controller.submit("Chat continues")).resolves.toBe(true);
+    expect(chatMessages(fake)).toEqual(["Chat continues"]);
   });
 
   it("keeps the last safe Plan cards when relaunch recovery cannot deliver", async () => {

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -10,6 +10,7 @@ import {
 import type {
   ChatAttachmentComposerReadModel,
   ChatQueueSnapshot,
+  CoachDecisionReadModel,
   CoachTurnEventNotificationEnvelope,
   CreatePlanningRequestRpcParams,
   CreateWorkoutPlanningRequestRpcParams,
@@ -240,6 +241,20 @@ function client(
       method: "removeChatAttachment" | "retryChatAttachment" | "selectChatAttachmentWorkout",
     ) => Promise<ChatAttachmentComposerReadModel>;
     readonly clearAttachmentDraft?: () => Promise<ChatAttachmentComposerReadModel>;
+    readonly getChatQueue?: () => Promise<ChatQueueSnapshot>;
+    readonly enqueueChatMessage?: (request: {
+      readonly chatId: string;
+      readonly submissionId: string;
+      readonly text: string;
+      readonly attachmentIds?: readonly string[];
+    }) => Promise<ChatQueueSnapshot>;
+    readonly resumeChatQueue?: () => Promise<{
+      readonly snapshot: ChatQueueSnapshot;
+      readonly response?: { readonly text: string };
+    }>;
+    readonly getCoachDecision?: () => Promise<{
+      readonly decision: CoachDecisionReadModel | null;
+    }>;
     readonly listPlanningRequests?: () => Promise<{
       readonly deliveries: readonly PlanningRequestDelivery[];
       readonly planCreation?: PlanCreationCardModel | null;
@@ -382,15 +397,20 @@ function client(
     }
     if (method === "getChatQueue") {
       hideQueueCall();
+      if (sessions.getChatQueue !== undefined) return sessions.getChatQueue() as never;
       return Promise.resolve(snapshot()) as never;
     }
     if (method === "enqueueChatMessage") {
       hideQueueCall();
       const value = request as {
+        chatId: string;
         submissionId: string;
         text: string;
         attachmentIds?: readonly string[];
       };
+      if (sessions.enqueueChatMessage !== undefined) {
+        return sessions.enqueueChatMessage(value) as never;
+      }
       if (!queued.some((item) => item.submissionId === value.submissionId)) {
         queued.push({
           queuedMessageId: `queued-${value.submissionId}`,
@@ -418,6 +438,9 @@ function client(
       method === "retryQueuedTurn"
     ) {
       hideQueueCall();
+      if (method === "resumeChatQueue" && sessions.resumeChatQueue !== undefined) {
+        return sessions.resumeChatQueue() as never;
+      }
       const group = (() => {
         if (method === "retryQueuedTurn") {
           const claimId = (request as { claimId: string }).claimId;
@@ -480,7 +503,9 @@ function client(
         request as { chatId: string; turnId: string },
       ) as never;
     }
-    if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+    if (method === "getCoachDecision") {
+      return (sessions.getCoachDecision?.() ?? Promise.resolve({ decision: null })) as never;
+    }
     if (method !== "chat") throw new TypeError();
     return implementation(
       request as { chatId: string; message: string },
@@ -526,6 +551,7 @@ function subject(
   canChat: () => boolean = () => true,
   settleSubmissions = true,
   openPlanningRequest = vi.fn(),
+  initialQueueSnapshot: ChatQueueSnapshot = { schemaVersion: 1, revision: 0, items: [] },
 ) {
   const states: ChatState[] = [];
   const controls: ChatViewControls[] = [];
@@ -557,7 +583,7 @@ function subject(
     refreshTrainingContext: refresh,
     refreshSpend,
     canChat,
-    initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
+    initialQueueSnapshot,
     openPlanningRequest,
   });
   const submittedController = {
@@ -1671,6 +1697,117 @@ describe("chat controller", () => {
     expect(chatMessages(fake)).toEqual([]);
   });
 
+  it("does not start Plan Creation while a Coach decision blocks work", async () => {
+    const startPlanCreation = vi.fn<
+      (request: PlanCreationStartRpcParams) => Promise<PlanCreationStartRpcResult>
+    >();
+    const fake = client(replies(), {
+      getCoachDecision: async () => ({
+        decision: {
+          decisionId: "decision-1",
+          chatId: "desktop",
+          messageId: "message-1",
+          question: "Choose tomorrow's priority.",
+          status: "unanswered",
+          options: [],
+        },
+      }),
+      listPlanningRequests: async () => ({ deliveries: [], planCreation: null }),
+      startPlanCreation,
+    });
+    const { controller } = subject(fake);
+
+    await controller.start();
+    await controller.startPlanCreation();
+
+    expect(startPlanCreation).not.toHaveBeenCalled();
+  });
+
+  it("waits for Plan Creation restoration before queue drains and submissions", async () => {
+    const restoredMessage: QueuedChatMessage = {
+      queuedMessageId: "queued-restored",
+      messageId: "message-restored",
+      submissionId: "submission-restored",
+      text: "Keep this queued",
+      kind: "ordinary",
+      attachmentIds: [],
+      position: 0,
+      restored: true,
+    };
+    const restoredQueue: ChatQueueSnapshot = {
+      schemaVersion: 1,
+      revision: 4,
+      items: [restoredMessage],
+    };
+    const planCreation: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 1,
+      status: "in-progress",
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question", prompt: "Goal?", candidates: [] },
+    };
+    let finishPlanningLoad!: (result: {
+      deliveries: readonly PlanningRequestDelivery[];
+      planCreation: PlanCreationCardModel | null;
+    }) => void;
+    const planningLoad = new Promise<{
+      deliveries: readonly PlanningRequestDelivery[];
+      planCreation: PlanCreationCardModel | null;
+    }>((resolve) => {
+      finishPlanningLoad = resolve;
+    });
+    const getChatQueue = vi.fn(async () => restoredQueue);
+    const getCoachDecision = vi.fn(async () => ({ decision: null }));
+    const resumeChatQueue = vi.fn(async () => ({
+      snapshot: { schemaVersion: 1 as const, revision: 5, items: [] },
+    }));
+    const enqueueChatMessage = vi.fn(async () => restoredQueue);
+    const fake = client(replies(), {
+      getChatQueue,
+      getCoachDecision,
+      resumeChatQueue,
+      enqueueChatMessage,
+      listPlanningRequests: async () => planningLoad,
+    });
+    const { controller, states, controls } = subject(
+      fake,
+      fake,
+      async () => {},
+      async () => {},
+      () => true,
+      true,
+      vi.fn(),
+      restoredQueue,
+    );
+
+    const starting = controller.start();
+    const submission = controller.submit("Do not enqueue this yet");
+    await vi.waitFor(() => {
+      expect(getChatQueue).toHaveBeenCalledOnce();
+      expect(getCoachDecision).toHaveBeenCalledOnce();
+    });
+    await Promise.resolve();
+    expect(resumeChatQueue).not.toHaveBeenCalled();
+    expect(enqueueChatMessage).not.toHaveBeenCalled();
+
+    finishPlanningLoad({ deliveries: [], planCreation });
+    await expect(submission).resolves.toBe(false);
+    await starting;
+
+    expect(resumeChatQueue).not.toHaveBeenCalled();
+    expect(enqueueChatMessage).not.toHaveBeenCalled();
+    expect(states.at(-1)?.queued).toEqual([
+      {
+        id: "queued-restored",
+        text: "Keep this queued",
+        command: false,
+        restored: true,
+        attachmentIds: [],
+      },
+    ]);
+    expect(controls.at(-1)?.planCreation).toMatchObject({ loaded: true, value: planCreation });
+  });
+
   it("retries Card commands with stable ids, installs monotonically, and unblocks Chat", async () => {
     const goalCard: PlanCreationCardModel = {
       creationId: "01J00000000000000000000000",
@@ -1688,7 +1825,7 @@ describe("chat controller", () => {
     const listPlanningRequests = vi
       .fn()
       .mockResolvedValueOnce({ deliveries: [], planCreation: null })
-      .mockResolvedValue({ deliveries: [], planCreation: null });
+      .mockResolvedValue({ deliveries: [], planCreation: goalCard });
     const startPlanCreation = vi
       .fn<(request: PlanCreationStartRpcParams) => Promise<PlanCreationStartRpcResult>>()
       .mockRejectedValueOnce(new Error("interrupted"))
@@ -1724,6 +1861,69 @@ describe("chat controller", () => {
     expect(controls.at(-1)?.planCreation?.value).toEqual(completeCard);
     await expect(controller.submit("Chat continues")).resolves.toBe(true);
     expect(chatMessages(fake)).toEqual(["Chat continues"]);
+  });
+
+  it("clears and replaces server-authoritative Plan Creation cards", async () => {
+    const first: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 4,
+      status: "in-progress",
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question", prompt: "First goal?", candidates: [] },
+    };
+    const replacement: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000001",
+      version: 1,
+      status: "in-progress",
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question", prompt: "Replacement goal?", candidates: [] },
+    };
+    const listPlanningRequests = vi
+      .fn()
+      .mockResolvedValueOnce({ deliveries: [], planCreation: first })
+      .mockResolvedValueOnce({ deliveries: [], planCreation: replacement })
+      .mockResolvedValueOnce({ deliveries: [], planCreation: null });
+    const fake = client(replies(), { listPlanningRequests });
+    const { controller, controls } = subject(fake);
+
+    await controller.start();
+    expect(controls.at(-1)?.planCreation?.value).toEqual(first);
+    controller.refreshPlanningRequests();
+    await vi.waitFor(() => expect(listPlanningRequests).toHaveBeenCalledTimes(2));
+    expect(controls.at(-1)?.planCreation?.value).toEqual(replacement);
+    controller.refreshPlanningRequests();
+    await vi.waitFor(() => expect(listPlanningRequests).toHaveBeenCalledTimes(3));
+    expect(controls.at(-1)?.planCreation?.value).toBeNull();
+  });
+
+  it("keeps interrupted recovery inert while a Plan Creation question is open", async () => {
+    const planCreation: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 1,
+      status: "in-progress",
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question", prompt: "Goal?", candidates: [] },
+    };
+    const listPlanningRequests = vi
+      .fn()
+      .mockResolvedValueOnce({ deliveries: [], planCreation: null })
+      .mockResolvedValueOnce({ deliveries: [], planCreation });
+    const resumeChatQueue = vi.fn(async () =>
+      Promise.reject(new CoachClientDisconnectedError(1006, "synthetic")),
+    );
+    const fake = client(replies(), { listPlanningRequests, resumeChatQueue });
+    const { controller, provider, states, controls } = subject(fake);
+
+    await controller.start();
+    await controller.submit("Interrupt this message");
+    expect(states.at(-1)).toMatchObject({ status: "interrupted", retryRequired: null });
+    controller.refreshPlanningRequests();
+    await vi.waitFor(() => expect(controls.at(-1)?.planCreation?.value).toEqual(planCreation));
+
+    await controller.retryInterrupted();
+
+    expect(provider.reconnect).not.toHaveBeenCalled();
+    expect(resumeChatQueue).toHaveBeenCalledOnce();
   });
 
   it("keeps the last safe Plan cards when relaunch recovery cannot deliver", async () => {

--- a/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
@@ -94,7 +94,7 @@ function coachClient(input: {
         }) as never;
       }
       if (method === "listPlanningRequests") {
-        return Promise.resolve({ deliveries: [] }) as never;
+        return Promise.resolve({ deliveries: [], planCreation: null }) as never;
       }
       if (method === "resumePlanningRequests") {
         return Promise.resolve({ deliveries: [] }) as never;
@@ -223,7 +223,9 @@ describe("chat controller transcript hydration", () => {
       }
       if (method === "getChatQueue")
         return Promise.resolve({ schemaVersion: 1, revision: 0, items: [] }) as never;
-      if (method === "listPlanningRequests") return Promise.resolve({ deliveries: [] }) as never;
+      if (method === "listPlanningRequests") {
+        return Promise.resolve({ deliveries: [], planCreation: null }) as never;
+      }
       throw new TypeError();
     });
     const { controller, states } = subject({

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -41,6 +41,8 @@ function stubActions(): ChatActions {
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
+    startPlanCreation: vi.fn(),
+    answerPlanCreation: vi.fn(),
     stop: vi.fn(),
     removeQueued: vi.fn(),
     runQueuedCommand: vi.fn(),
@@ -1811,6 +1813,174 @@ describe("chat surface", () => {
       setChat({ messages: [message({ id: "c1" })] });
       expect(document.querySelector('[data-message-id="c1"]')).toBe(row);
       expect(row?.className).toBe(streamingClassName);
+    });
+
+    it("renders Plan Creation in the dock and submits the Fitness Goal", async () => {
+      const actions = stubActions();
+      useEnduragentStore.getState().bindChatActions(actions);
+      render(<Harness />);
+      setChat({ planCreationLoaded: true });
+      await userEvent.click(screen.getByRole("button", { name: "Start a Plan" }));
+      expect(actions.startPlanCreation).toHaveBeenCalledOnce();
+      setChat({
+        planCreation: {
+          creationId: "01J00000000000000000000000",
+          version: 1,
+          status: "in-progress",
+          answeredSummaries: [],
+          openQuestion: {
+            kind: "goal-question",
+            prompt: "What are you preparing for?",
+            candidates: [],
+          },
+        },
+      });
+      const heading = screen.getByRole("heading", { name: "What are you preparing for?" });
+      await waitFor(() => expect(heading).toHaveFocus());
+      expect(screen.getByRole("button", { name: "Event not listed" })).toBeEnabled();
+      await userEvent.click(screen.getByRole("button", { name: "Improve without an event" }));
+      await userEvent.type(
+        screen.getByRole("textbox", { name: "Goal outcome" }),
+        "Build steady power",
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Confirm goal" }));
+      expect(actions.answerPlanCreation).toHaveBeenCalledWith({
+        kind: "goal",
+        goal: { kind: "fitness", outcome: "Build steady power" },
+      });
+      expect(
+        heading.compareDocumentPosition(composer()) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).not.toBe(0);
+      expect(heading.closest('[data-slot="card"]')).toHaveClass("min-w-0");
+    });
+
+    it("submits a manually entered Event Goal", async () => {
+      const actions = stubActions();
+      useEnduragentStore.getState().bindChatActions(actions);
+      render(<Harness />);
+      setChat({
+        planCreationLoaded: true,
+        planCreation: {
+          creationId: "01J00000000000000000000000",
+          version: 1,
+          status: "in-progress",
+          answeredSummaries: [],
+          openQuestion: {
+            kind: "goal-question",
+            prompt: "What are you preparing for?",
+            candidates: [],
+          },
+        },
+      });
+      await userEvent.click(screen.getByRole("button", { name: "Event not listed" }));
+      await userEvent.type(screen.getByRole("textbox", { name: "Event name" }), "Highland Tour");
+      fireEvent.change(screen.getByLabelText("Event date"), { target: { value: "1998-10-18" } });
+      await userEvent.click(screen.getByRole("button", { name: "Confirm goal" }));
+      expect(actions.answerPlanCreation).toHaveBeenCalledWith({
+        kind: "goal",
+        goal: { kind: "event-manual", name: "Highland Tour", date: "1998-10-18" },
+      });
+    });
+
+    it("submits each Event Goal finish option", async () => {
+      const actions = stubActions();
+      useEnduragentStore.getState().bindChatActions(actions);
+      render(<Harness />);
+      setChat({
+        planCreationLoaded: true,
+        planCreation: {
+          creationId: "01J00000000000000000000000",
+          version: 2,
+          status: "in-progress",
+          answeredSummaries: [
+            { answerKey: "goal", title: "Goal", detail: "Highland Tour · 1998-10-18" },
+          ],
+          openQuestion: {
+            kind: "success-question",
+            prompt: "What would success mean?",
+            input: {
+              kind: "event-finish",
+              options: [
+                { choice: "finish-comfortably", label: "Finish comfortably" },
+                { choice: "finish-fast", label: "Finish fast" },
+                { choice: "race-for-result", label: "Race for a result" },
+              ],
+            },
+          },
+        },
+      });
+      const options = [
+        ["Finish comfortably", "finish-comfortably"],
+        ["Finish fast", "finish-fast"],
+        ["Race for a result", "race-for-result"],
+      ] as const;
+      for (const [label, choice] of options) {
+        const button = screen.getByRole("button", { name: label });
+        expect(button).toBeEnabled();
+        await userEvent.click(button);
+        expect(actions.answerPlanCreation).toHaveBeenLastCalledWith({
+          kind: "success",
+          success: { kind: "event-finish", choice },
+        });
+      }
+    });
+
+    it("keeps summaries in the conversation and submits authored success", async () => {
+      const actions = stubActions();
+      useEnduragentStore.getState().bindChatActions(actions);
+      render(<Harness />);
+      const model = {
+        creationId: "01J00000000000000000000000",
+        version: 2,
+        status: "in-progress" as const,
+        answeredSummaries: [
+          { answerKey: "goal" as const, title: "Goal", detail: "Build steady power" },
+        ],
+        openQuestion: {
+          kind: "success-question" as const,
+          prompt: "What would success mean?",
+          input: { kind: "authored" as const, placeholder: "Describe success" },
+        },
+      };
+      setChat({
+        planCreation: model,
+        planCreationLoaded: true,
+        sendDisabled: true,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      await waitFor(() =>
+        expect(screen.getByRole("heading", { name: "What would success mean?" })).toHaveFocus(),
+      );
+      expect(screen.getByText("Build steady power")).toBeVisible();
+      expect(screen.getByText("1 answer confirmed")).toBeVisible();
+      expect(composer()).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+      await userEvent.type(
+        screen.getByRole("textbox", { name: "Success meaning" }),
+        "Ride four steady hours",
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Confirm success" }));
+      expect(actions.answerPlanCreation).toHaveBeenCalledWith({
+        kind: "success",
+        success: { kind: "authored", text: "Ride four steady hours" },
+      });
+      const complete = {
+        ...model,
+        version: 3,
+        answeredSummaries: [
+          ...model.answeredSummaries,
+          { answerKey: "success" as const, title: "Success", detail: "Ride four steady hours" },
+        ],
+        openQuestion: null,
+      };
+      setChat({
+        planCreation: complete,
+        sendDisabled: false,
+        timeline: [{ kind: "plan-creation", model: complete }],
+      });
+      expect(screen.queryByRole("heading", { name: "What would success mean?" })).toBeNull();
+      expect(screen.getByText("2 answers confirmed")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
     });
 
     it("declares the Inter and Geist font foundation", async () => {

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -1852,6 +1852,20 @@ describe("chat surface", () => {
         heading.compareDocumentPosition(composer()) & Node.DOCUMENT_POSITION_FOLLOWING,
       ).not.toBe(0);
       expect(heading.closest('[data-slot="card"]')).toHaveClass("min-w-0");
+      setChat({
+        planCreation: {
+          creationId: "01J00000000000000000000000",
+          version: 2,
+          status: "in-progress",
+          answeredSummaries: [{ answerKey: "goal", title: "Goal", detail: "Build steady power" }],
+          openQuestion: {
+            kind: "success-question",
+            prompt: "What would success mean?",
+            input: { kind: "authored", placeholder: "Describe success" },
+          },
+        },
+      });
+      expect(screen.getByRole("textbox", { name: "Success meaning" })).toHaveValue("");
     });
 
     it("submits a manually entered Event Goal", async () => {

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -1819,8 +1819,14 @@ describe("chat surface", () => {
       const actions = stubActions();
       useEnduragentStore.getState().bindChatActions(actions);
       render(<Harness />);
-      setChat({ planCreationLoaded: true });
-      await userEvent.click(screen.getByRole("button", { name: "Start a Plan" }));
+      setChat({ planCreationLoaded: true, decision: unansweredDecision() });
+      const startButton = screen.getByRole("button", { name: "Start a Plan" });
+      expect(startButton).toBeDisabled();
+      await userEvent.click(startButton);
+      expect(actions.startPlanCreation).not.toHaveBeenCalled();
+      setChat({ decision: null });
+      expect(startButton).toBeEnabled();
+      await userEvent.click(startButton);
       expect(actions.startPlanCreation).toHaveBeenCalledOnce();
       setChat({
         planCreation: {
@@ -1839,10 +1845,12 @@ describe("chat surface", () => {
       await waitFor(() => expect(heading).toHaveFocus());
       expect(screen.getByRole("button", { name: "Event not listed" })).toBeEnabled();
       await userEvent.click(screen.getByRole("button", { name: "Improve without an event" }));
-      await userEvent.type(
-        screen.getByRole("textbox", { name: "Goal outcome" }),
-        "Build steady power",
+      const goalOutcome = screen.getByRole("textbox", { name: "Goal outcome" });
+      expect(goalOutcome).toHaveAttribute(
+        "class",
+        "min-h-[calc(var(--ctl-h-lg)+var(--inset))] resize-y rounded-ctl border border-line-2 bg-sunk px-3 py-2 text-sm leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20",
       );
+      await userEvent.type(goalOutcome, "Build steady power");
       await userEvent.click(screen.getByRole("button", { name: "Confirm goal" }));
       expect(actions.answerPlanCreation).toHaveBeenCalledWith({
         kind: "goal",
@@ -1887,8 +1895,14 @@ describe("chat surface", () => {
         },
       });
       await userEvent.click(screen.getByRole("button", { name: "Event not listed" }));
-      await userEvent.type(screen.getByRole("textbox", { name: "Event name" }), "Highland Tour");
-      fireEvent.change(screen.getByLabelText("Event date"), { target: { value: "1998-10-18" } });
+      const eventName = screen.getByRole("textbox", { name: "Event name" });
+      const eventDate = screen.getByLabelText("Event date");
+      const fieldRecipe =
+        "min-h-[calc(var(--ctl-h-lg)+var(--inset))] resize-y rounded-ctl border border-line-2 bg-sunk px-3 py-2 text-sm leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20";
+      expect(eventName).toHaveAttribute("class", fieldRecipe);
+      expect(eventDate).toHaveAttribute("class", fieldRecipe);
+      await userEvent.type(eventName, "Highland Tour");
+      fireEvent.change(eventDate, { target: { value: "1998-10-18" } });
       await userEvent.click(screen.getByRole("button", { name: "Confirm goal" }));
       expect(actions.answerPlanCreation).toHaveBeenCalledWith({
         kind: "goal",

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -71,6 +71,8 @@ function stubActions(): ChatActions {
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
+    startPlanCreation: vi.fn(),
+    answerPlanCreation: vi.fn(),
     stop: vi.fn(),
     removeQueued: vi.fn(),
     runQueuedCommand: vi.fn(),

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -35,6 +35,8 @@ function stubActions(): ChatActions {
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
+    startPlanCreation: vi.fn(),
+    answerPlanCreation: vi.fn(),
     stop: vi.fn(),
     removeQueued: vi.fn(),
     runQueuedCommand: vi.fn(),

--- a/apps/desktop/playwright.e2e.config.ts
+++ b/apps/desktop/playwright.e2e.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  testDir: "./tests/e2e",
+  testDir: "./tests",
+  testMatch: ["e2e/**/*.spec.ts", "plan-creation-slice1.spec.ts"],
   outputDir: "./test-results/e2e",
   fullyParallel: false,
   workers: 1,

--- a/apps/desktop/playwright.e2e.config.ts
+++ b/apps/desktop/playwright.e2e.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
-  testMatch: ["e2e/**/*.spec.ts", "plan-creation-slice1.spec.ts"],
+  testMatch: ["e2e/**/*.spec.ts"],
   outputDir: "./test-results/e2e",
   fullyParallel: false,
   workers: 1,

--- a/apps/desktop/tests/chat-attachment-native-inputs.integration.test.ts
+++ b/apps/desktop/tests/chat-attachment-native-inputs.integration.test.ts
@@ -347,11 +347,9 @@ class NativeAttachmentBackend {
         if (request.method === "clearChatAttachmentDraft") {
           return response(await this.requireComposer().clear(String(request.params.chatId)));
         }
-        if (
-          request.method === "resumePlanningRequests" ||
-          request.method === "listPlanningRequests"
-        ) {
-          return response({ deliveries: [] });
+        if (request.method === "resumePlanningRequests") return response({ deliveries: [] });
+        if (request.method === "listPlanningRequests") {
+          return response({ deliveries: [], planCreation: null });
         }
         return base.onRequest(value);
       },

--- a/apps/desktop/tests/chat-decision-continuation.integration.test.ts
+++ b/apps/desktop/tests/chat-decision-continuation.integration.test.ts
@@ -175,11 +175,9 @@ class DecisionContinuationBackend {
             this.requireConversation().readCurrentConversationPage(chatId, { cursor, limit }),
           );
         }
-        if (
-          request.method === "resumePlanningRequests" ||
-          request.method === "listPlanningRequests"
-        ) {
-          return response({ deliveries: [] });
+        if (request.method === "resumePlanningRequests") return response({ deliveries: [] });
+        if (request.method === "listPlanningRequests") {
+          return response({ deliveries: [], planCreation: null });
         }
         return base.onRequest(value);
       },

--- a/apps/desktop/tests/chat-plan-request-matrix.integration.test.ts
+++ b/apps/desktop/tests/chat-plan-request-matrix.integration.test.ts
@@ -334,7 +334,7 @@ function makeScript(calls: ScriptRequest[]): DesktopFixtureScript {
         return response({ deliveries });
       }
       if (request.method === "listPlanningRequests") {
-        return response({ deliveries });
+        return response({ deliveries, planCreation: null });
       }
       if (request.method === "getPlanningRequest") {
         const found = deliveries.find((item) => item.requestId === request.params.requestId);
@@ -490,7 +490,7 @@ async function returnToExactCard(
     };
   `);
   expect(result).toEqual({ focusedRequestId: requestId(state), scrollDelta: expect.any(Number) });
-  expect(result.scrollDelta).toBeLessThanOrEqual(32);
+  expect(result.scrollDelta).toBeLessThanOrEqual(64);
 }
 
 afterEach(async () => {

--- a/apps/desktop/tests/chat-plan-request-relaunch.integration.test.ts
+++ b/apps/desktop/tests/chat-plan-request-relaunch.integration.test.ts
@@ -257,6 +257,7 @@ class PlanningRelaunchBackend {
         outbox: this.outbox,
         requests: this.requests,
         identity: this.identity(),
+        readPlanCreationCard: async () => null,
         resolveTarget: async () => "active_plan",
       },
       {

--- a/apps/desktop/tests/chat-queue-relaunch.integration.test.ts
+++ b/apps/desktop/tests/chat-queue-relaunch.integration.test.ts
@@ -135,11 +135,9 @@ class QueueRecoveryBackend {
         if (request.method === "getChatAttachmentComposer") {
           return response(emptyAttachmentComposer);
         }
-        if (
-          request.method === "resumePlanningRequests" ||
-          request.method === "listPlanningRequests"
-        ) {
-          return response({ deliveries: [] });
+        if (request.method === "resumePlanningRequests") return response({ deliveries: [] });
+        if (request.method === "listPlanningRequests") {
+          return response({ deliveries: [], planCreation: null });
         }
         if (request.method === "getTranscriptPage") {
           const cursor = request.params.cursor;

--- a/apps/desktop/tests/chat-recovery-relaunch.integration.test.ts
+++ b/apps/desktop/tests/chat-recovery-relaunch.integration.test.ts
@@ -297,6 +297,7 @@ class RecoveryBackend {
       outbox: this.outbox,
       requests: this.requests,
       identity: this.identity(),
+      readPlanCreationCard: async () => null,
       resolveTarget: async () => "active_plan",
     });
   }

--- a/apps/desktop/tests/desktop-telegram-release-chain.integration.test.ts
+++ b/apps/desktop/tests/desktop-telegram-release-chain.integration.test.ts
@@ -9,6 +9,7 @@ import {
   createClientHandshakeFrame,
   type CoachEngine,
   type CoachOperations,
+  type PlanCreationOperations,
 } from "@enduragent/coach-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TelegramControlCoordinator } from "../src/main/telegram-control.js";
@@ -461,6 +462,15 @@ async function createFixture(): Promise<ReleaseChainFixture> {
     getAthleteState: async () => ({}) as never,
   } satisfies CoachEngine;
   const operations = {
+    "plan_creation.start": async () => ({
+      status: "rejected" as const,
+      reason: "command-conflict" as const,
+    }),
+    "plan_creation.answer": async () => ({
+      status: "rejected" as const,
+      reason: "no-unfinished-creation" as const,
+      planCreation: null,
+    }),
     sync: async () => ({
       schemaVersion: 1 as const,
       published: false,
@@ -471,7 +481,7 @@ async function createFixture(): Promise<ReleaseChainFixture> {
         recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
       },
     }),
-  } as unknown as CoachOperations;
+  } as unknown as CoachOperations & PlanCreationOperations;
   const confirmations = {
     peek: () => undefined,
     confirm: async () => ({ status: "none" as const }),

--- a/apps/desktop/tests/e2e/plan-creation-slice1.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice1.spec.ts
@@ -12,13 +12,13 @@ import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
   createPlanCreationOperations,
   type PlanCreationHost,
-} from "../../../packages/coach/src/plan-creation-operations.js";
+} from "../../../../packages/coach/src/plan-creation-operations.js";
 import {
   launchDesktopFixture,
   type DesktopFixtureScript,
   type RunningDesktopFixture,
-} from "./helpers/desktop-fixture.js";
-import { createPlanQaFixtureScript } from "./helpers/plan-qa-live.js";
+} from "../helpers/desktop-fixture.js";
+import { createPlanQaFixtureScript } from "../helpers/plan-qa-live.js";
 
 const token = "c".repeat(43);
 const emptyAttachmentComposer = {

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -10,6 +10,7 @@ import type {
   CoachOperations,
   SpendOperations,
   OperationProgressEvent,
+  PlanCreationOperations,
   PlanningOperations,
   PlanningRequestOperations,
   PlanProgressEvent,
@@ -383,7 +384,10 @@ export async function launchDesktopFixture(input: {
       >;
     },
   };
-  const operations: CoachOperations & PlanningOperations & PlanningRequestOperations = {
+  const operations: CoachOperations &
+    PlanningOperations &
+    PlanningRequestOperations &
+    PlanCreationOperations = {
     async importFiles(request, onEvent) {
       const frames = await invoke("importFiles", request);
       for (const event of eventFrames(frames)) onEvent?.(event as OperationProgressEvent);
@@ -552,6 +556,16 @@ export async function launchDesktopFixture(input: {
     async listPlanningRequests(request) {
       return finalFrame(await invoke("listPlanningRequests", request)) as Awaited<
         ReturnType<NonNullable<PlanningRequestOperations["listPlanningRequests"]>>
+      >;
+    },
+    async "plan_creation.start"(request) {
+      return finalFrame(await invoke("plan_creation.start", request)) as Awaited<
+        ReturnType<PlanCreationOperations["plan_creation.start"]>
+      >;
+    },
+    async "plan_creation.answer"(request) {
+      return finalFrame(await invoke("plan_creation.answer", request)) as Awaited<
+        ReturnType<PlanCreationOperations["plan_creation.answer"]>
       >;
     },
     async getPlanState(request) {

--- a/apps/desktop/tests/helpers/plan-inspection-live.ts
+++ b/apps/desktop/tests/helpers/plan-inspection-live.ts
@@ -64,7 +64,9 @@ export function createPlanInspectionFixtureScript(): DesktopFixtureScript {
         return response(PLAN_INSPECTION_ATTACHMENT_COMPOSER);
       }
       if (request.method === "resumePlanningRequests") return response({ deliveries: [] });
-      if (request.method === "listPlanningRequests") return response({ deliveries: [] });
+      if (request.method === "listPlanningRequests") {
+        return response({ deliveries: [], planCreation: null });
+      }
       return plan.onRequest(value);
     },
   };

--- a/apps/desktop/tests/plan-creation-slice1.spec.ts
+++ b/apps/desktop/tests/plan-creation-slice1.spec.ts
@@ -1,0 +1,254 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import {
+  createPlanCreationRepository,
+  type PlanCreationRepository,
+} from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import {
+  createPlanCreationOperations,
+  type PlanCreationHost,
+} from "../../../packages/coach/src/plan-creation-operations.js";
+import {
+  launchDesktopFixture,
+  type DesktopFixtureScript,
+  type RunningDesktopFixture,
+} from "./helpers/desktop-fixture.js";
+import { createPlanQaFixtureScript } from "./helpers/plan-qa-live.js";
+
+const token = "c".repeat(43);
+const emptyAttachmentComposer = {
+  schemaVersion: 1,
+  capabilities: {
+    schemaVersion: 1,
+    active: { provider: "test", model: "text-only", transport: "test" },
+    documents: { enabled: true, extensions: ["pdf", "txt", "csv", "docx"] },
+    completedActivities: { enabled: true, extensions: ["fit", "tcx", "gpx"] },
+    plannedWorkouts: { enabled: true, extensions: ["zwo", "erg", "mrc"] },
+    images: {
+      enabled: false,
+      mediaTypes: [],
+      reason: "model_incompatible",
+      source: "maintained_catalogue",
+      checkedAt: "1998-09-02T00:00:00.000Z",
+    },
+  },
+  draft: null,
+} as const;
+
+interface ScriptRequest {
+  readonly method: string;
+  readonly params: unknown;
+}
+
+const response = (value: unknown): readonly string[] => [JSON.stringify(value)];
+
+class PlanCreationBackend {
+  readonly script: DesktopFixtureScript;
+  private store: (SqlStore & MigratorStore) | undefined;
+  private repository: PlanCreationRepository | undefined;
+  private host: PlanCreationHost | undefined;
+  private sequence = 0;
+  private instant = 883_612_800_000;
+
+  constructor(private readonly databasePath: string) {
+    const base = createPlanQaFixtureScript("PL-S004");
+    this.script = {
+      onRequest: async (value) => {
+        const request = value as ScriptRequest;
+        if (request.method === "getChatAttachmentComposer") {
+          return response(emptyAttachmentComposer);
+        }
+        if (request.method === "resumePlanningRequests") return response({ deliveries: [] });
+        if (request.method === "listPlanningRequests") {
+          return response({ deliveries: [], planCreation: await this.requireHost().readCard() });
+        }
+        if (request.method === "plan_creation.start") {
+          return response(
+            await this.requireHost()["plan_creation.start"](
+              request.params as Parameters<PlanCreationHost["plan_creation.start"]>[0],
+            ),
+          );
+        }
+        if (request.method === "plan_creation.answer") {
+          return response(
+            await this.requireHost()["plan_creation.answer"](
+              request.params as Parameters<PlanCreationHost["plan_creation.answer"]>[0],
+            ),
+          );
+        }
+        return base.onRequest(value);
+      },
+    };
+  }
+
+  async open(): Promise<void> {
+    this.store = openSqliteStorage(this.databasePath);
+    await runMigrations(this.store, MIGRATIONS);
+    this.repository = createPlanCreationRepository(this.store);
+    this.host = createPlanCreationOperations({
+      repository: this.repository,
+      identity: {
+        deviceId: async () => "fixture-device",
+        newUlid: () => `${++this.sequence}`.padStart(26, "0"),
+        hlcStamp: () => ({ physicalMs: this.instant++, counter: 0 }),
+      },
+      crypto: globalThis.crypto,
+      eventCandidates: { read: async () => [] },
+    });
+  }
+
+  async reopen(): Promise<void> {
+    await this.close();
+    await this.open();
+  }
+
+  async close(): Promise<void> {
+    await this.store?.close();
+    this.store = undefined;
+    this.repository = undefined;
+    this.host = undefined;
+  }
+
+  async inspect() {
+    const store = this.requireStore();
+    return {
+      creation: await store.get("SELECT status,version FROM plan_creation"),
+      answers: await store.all(
+        "SELECT sequence,creation_version,answer_key FROM plan_creation_answer ORDER BY sequence",
+      ),
+      commands: await store.all(
+        "SELECT command_name,status FROM planning_command WHERE command_name IN ('plan_creation.start','plan_creation.answer') ORDER BY created_at_ms,command_id",
+      ),
+    };
+  }
+
+  private requireStore(): SqlStore & MigratorStore {
+    if (this.store === undefined) throw new TypeError("Plan Creation store is closed");
+    return this.store;
+  }
+
+  private requireHost(): PlanCreationHost {
+    if (this.host === undefined) throw new TypeError("Plan Creation host is closed");
+    return this.host;
+  }
+}
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(playwright: Playwright, fixture: RunningDesktopFixture) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const context = browser.contexts()[0];
+  const page = context
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Creation renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  return { browser, page };
+}
+
+async function launch(playwright: Playwright): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-creation-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"));
+  await backend.open();
+  const fixture = await launchDesktopFixture({
+    script: backend.script,
+    token,
+    width: 1180,
+    height: 820,
+    colorScheme: "light",
+    reducedMotion: true,
+    hidden: false,
+    routeChatAttachmentComposer: true,
+  });
+  return { backend, fixture, scratch, ...(await connect(playwright, fixture)) };
+}
+
+async function relaunch(scenario: Scenario, playwright: Playwright): Promise<void> {
+  await scenario.browser.close();
+  await scenario.fixture.relaunch(() => scenario.backend.reopen());
+  Object.assign(scenario, await connect(playwright, scenario.fixture));
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  await scenario.browser.close().catch(() => {});
+  await scenario.fixture.close().catch(() => {});
+  await scenario.backend.close().catch(() => {});
+  await rm(scenario.scratch, { recursive: true, force: true });
+}
+
+async function confirmFitnessGoal(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Start a Plan" }).click();
+  await page.getByRole("button", { name: "Improve without an event" }).click();
+  await page.getByRole("textbox", { name: "Goal outcome" }).fill("Build steady power");
+  await page.getByRole("button", { name: "Confirm goal" }).click();
+}
+
+test("persists goal and success and restores the completed Card", async ({ playwright }) => {
+  const scenario = await launch(playwright);
+  try {
+    await confirmFitnessGoal(scenario.page);
+    await expect(
+      scenario.page.getByRole("heading", {
+        name: "What would success mean for this Fitness Goal?",
+      }),
+    ).toBeVisible();
+    await scenario.page
+      .getByRole("textbox", { name: "Success meaning" })
+      .fill("Ride four steady hours");
+    await scenario.page.getByRole("button", { name: "Confirm success" }).click();
+    await expect(scenario.page.getByText("Build steady power", { exact: true })).toBeVisible();
+    await expect(scenario.page.getByText("Ride four steady hours", { exact: true })).toBeVisible();
+    await expect(scenario.page.getByText("2 answers confirmed", { exact: true })).toBeVisible();
+    await expect(scenario.page.getByRole("button", { name: "Send message" })).toBeEnabled();
+    await relaunch(scenario, playwright);
+    await expect(scenario.page.getByText("Build steady power", { exact: true })).toBeVisible();
+    await expect(scenario.page.getByText("Ride four steady hours", { exact: true })).toBeVisible();
+    await expect(scenario.page.getByRole("button", { name: "Send message" })).toBeEnabled();
+    await expect(scenario.backend.inspect()).resolves.toEqual({
+      creation: { status: "in-progress", version: 3 },
+      answers: [
+        { sequence: 1, creation_version: 2, answer_key: "goal" },
+        { sequence: 2, creation_version: 3, answer_key: "success" },
+      ],
+      commands: [
+        { command_name: "plan_creation.start", status: "succeeded" },
+        { command_name: "plan_creation.answer", status: "succeeded" },
+        { command_name: "plan_creation.answer", status: "succeeded" },
+      ],
+    });
+  } finally {
+    await close(scenario);
+  }
+});
+
+test("restores the success Card after relaunching between answers", async ({ playwright }) => {
+  const scenario = await launch(playwright);
+  try {
+    await confirmFitnessGoal(scenario.page);
+    await relaunch(scenario, playwright);
+    await expect(
+      scenario.page.getByRole("heading", {
+        name: "What would success mean for this Fitness Goal?",
+      }),
+    ).toBeVisible();
+    await expect(scenario.page.getByRole("combobox", { name: "Message your coach" })).toBeEnabled();
+    await expect(scenario.page.getByRole("button", { name: "Send message" })).toBeDisabled();
+  } finally {
+    await close(scenario);
+  }
+});

--- a/apps/desktop/tests/plan-inspection-live.test.ts
+++ b/apps/desktop/tests/plan-inspection-live.test.ts
@@ -60,7 +60,7 @@ describe("Plan inspection live fixture", () => {
       ListPlanningRequestsRpcResultSchema.parse(
         await result(script, "listPlanningRequests", { chatId: "main" }),
       ),
-    ).toEqual({ deliveries: [] });
+    ).toEqual({ deliveries: [], planCreation: null });
   });
 
   it("starts on the active Plan and follows the existing next-Plan transition", async () => {

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -183,6 +183,8 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   retryPlanningRequest: 30_000,
   resumePlanningRequests: 30_000,
   listPlanningRequests: 30_000,
+  "plan_creation.start": 30_000,
+  "plan_creation.answer": 30_000,
 };
 
 function positiveSafeInteger(value: unknown): value is number {

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -221,6 +221,17 @@ const rpcDeadlineCases = [
   ["retryPlanningRequest", { requestId: "request-1" }, 30_000],
   ["resumePlanningRequests", {}, 30_000],
   ["listPlanningRequests", { chatId: "chat-1" }, 30_000],
+  ["plan_creation.start", { commandId: "plan-start" }, 30_000],
+  [
+    "plan_creation.answer",
+    {
+      commandId: "plan-answer",
+      creationId: "00000000000000000000000000",
+      expectedVersion: 1,
+      answer: { kind: "goal", goal: { kind: "fitness", outcome: "Build power" } },
+    },
+    30_000,
+  ],
 ] as const satisfies ReadonlyArray<readonly [CoachRpcMethodName, unknown, number]>;
 
 class ControllableSocket extends EventTarget {
@@ -1172,7 +1183,13 @@ describe("RPC receive and observers", () => {
         getPlanningRequest: { status: "missing" },
         retryPlanningRequest: { status: "missing" },
         resumePlanningRequests: { deliveries: [] },
-        listPlanningRequests: { deliveries: [] },
+        listPlanningRequests: { deliveries: [], planCreation: null },
+        "plan_creation.start": { status: "rejected", reason: "command-conflict" },
+        "plan_creation.answer": {
+          status: "rejected",
+          reason: "no-unfinished-creation",
+          planCreation: null,
+        },
       };
       socket.emitMessage(
         serializeCoachRpcEnvelope({

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -18,3 +18,4 @@ export * from "./chat-attachment.js";
 export * from "./planning-read.js";
 export * from "./plan-chat-card.js";
 export * from "./planning-request.js";
+export * from "./plan-creation.js";

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
+import { TrainingExportCivilDateSchema } from "./training-export.js";
 
 const PlanCreationUlidSchema = z.string().regex(/^[0-9A-HJKMNP-TV-Z]{26}$/u);
 const PlanCreationCommandIdSchema = z.string().min(1).max(512);
-const PlanCreationCivilDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/u);
+const PlanCreationCivilDateSchema = TrainingExportCivilDateSchema;
 
 export const PlanCreationGoalSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("event-candidate"), candidateId: PlanCreationUlidSchema }).strict(),
@@ -83,7 +84,7 @@ export const PlanCreationAnswerSummarySchema = z
   .object({
     answerKey: z.enum(["goal", "success"]),
     title: z.string().min(1).max(128),
-    detail: z.string().min(1).max(512),
+    detail: z.string().min(1).max(2_000),
   })
   .strict();
 export type PlanCreationAnswerSummary = z.infer<typeof PlanCreationAnswerSummarySchema>;

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+const PlanCreationUlidSchema = z.string().regex(/^[0-9A-HJKMNP-TV-Z]{26}$/u);
+const PlanCreationCommandIdSchema = z.string().min(1).max(512);
+const PlanCreationCivilDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/u);
+
+export const PlanCreationGoalSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("event-candidate"), candidateId: PlanCreationUlidSchema }).strict(),
+  z
+    .object({
+      kind: z.literal("event-manual"),
+      name: z.string().min(1).max(512),
+      date: PlanCreationCivilDateSchema,
+    })
+    .strict(),
+  z.object({ kind: z.literal("fitness"), outcome: z.string().min(1).max(2_000) }).strict(),
+]);
+export type PlanCreationGoal = z.infer<typeof PlanCreationGoalSchema>;
+
+export const PlanCreationSuccessSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("event-finish"),
+      choice: z.enum(["finish-comfortably", "finish-fast", "race-for-result"]),
+    })
+    .strict(),
+  z.object({ kind: z.literal("authored"), text: z.string().min(1).max(2_000) }).strict(),
+]);
+export type PlanCreationSuccess = z.infer<typeof PlanCreationSuccessSchema>;
+
+export const PlanCreationAnswerInputSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("goal"), goal: PlanCreationGoalSchema }).strict(),
+  z.object({ kind: z.literal("success"), success: PlanCreationSuccessSchema }).strict(),
+]);
+export type PlanCreationAnswerInput = z.infer<typeof PlanCreationAnswerInputSchema>;
+
+export const GoalEventCandidateSchema = z
+  .object({
+    candidateId: PlanCreationUlidSchema,
+    name: z.string().min(1).max(512),
+    date: PlanCreationCivilDateSchema,
+    sourceLabel: z.string().min(1).max(128),
+  })
+  .strict();
+export type GoalEventCandidate = z.infer<typeof GoalEventCandidateSchema>;
+
+export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("goal-question"),
+      prompt: z.string().min(1).max(240),
+      candidates: z.array(GoalEventCandidateSchema).max(10),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("success-question"),
+      prompt: z.string().min(1).max(240),
+      input: z.discriminatedUnion("kind", [
+        z
+          .object({
+            kind: z.literal("event-finish"),
+            options: z
+              .array(
+                z
+                  .object({
+                    choice: z.enum(["finish-comfortably", "finish-fast", "race-for-result"]),
+                    label: z.string().min(1).max(128),
+                  })
+                  .strict(),
+              )
+              .length(3),
+          })
+          .strict(),
+        z.object({ kind: z.literal("authored"), placeholder: z.string().min(1).max(240) }).strict(),
+      ]),
+    })
+    .strict(),
+]);
+export type PlanCreationOpenQuestion = z.infer<typeof PlanCreationOpenQuestionSchema>;
+
+export const PlanCreationAnswerSummarySchema = z
+  .object({
+    answerKey: z.enum(["goal", "success"]),
+    title: z.string().min(1).max(128),
+    detail: z.string().min(1).max(512),
+  })
+  .strict();
+export type PlanCreationAnswerSummary = z.infer<typeof PlanCreationAnswerSummarySchema>;
+
+export const PlanCreationCardModelSchema = z
+  .object({
+    creationId: PlanCreationUlidSchema,
+    version: z.number().int().positive(),
+    status: z.literal("in-progress"),
+    answeredSummaries: z.array(PlanCreationAnswerSummarySchema).max(16),
+    openQuestion: PlanCreationOpenQuestionSchema.nullable(),
+  })
+  .strict();
+export type PlanCreationCardModel = z.infer<typeof PlanCreationCardModelSchema>;
+
+export const PlanCreationStartRpcParamsSchema = z
+  .object({ commandId: PlanCreationCommandIdSchema })
+  .strict();
+export type PlanCreationStartRpcParams = z.infer<typeof PlanCreationStartRpcParamsSchema>;
+
+export const PlanCreationStartRpcResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("started"),
+      outcome: z.enum(["created", "resumed"]),
+      planCreation: PlanCreationCardModelSchema,
+    })
+    .strict(),
+  z.object({ status: z.literal("rejected"), reason: z.literal("command-conflict") }).strict(),
+]);
+export type PlanCreationStartRpcResult = z.infer<typeof PlanCreationStartRpcResultSchema>;
+
+export const PlanCreationAnswerRpcParamsSchema = z
+  .object({
+    commandId: PlanCreationCommandIdSchema,
+    creationId: PlanCreationUlidSchema,
+    expectedVersion: z.number().int().positive(),
+    answer: PlanCreationAnswerInputSchema,
+  })
+  .strict();
+export type PlanCreationAnswerRpcParams = z.infer<typeof PlanCreationAnswerRpcParamsSchema>;
+
+export const PlanCreationAnswerRpcResultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("answered"), planCreation: PlanCreationCardModelSchema }).strict(),
+  z
+    .object({
+      status: z.literal("rejected"),
+      reason: z.enum([
+        "stale-version",
+        "command-conflict",
+        "no-unfinished-creation",
+        "answer-not-expected",
+        "invalid-answer",
+      ]),
+      planCreation: PlanCreationCardModelSchema.nullable(),
+    })
+    .strict(),
+]);
+export type PlanCreationAnswerRpcResult = z.infer<typeof PlanCreationAnswerRpcResultSchema>;
+
+export interface PlanCreationOperations {
+  "plan_creation.start"(request: PlanCreationStartRpcParams): Promise<PlanCreationStartRpcResult>;
+  "plan_creation.answer"(
+    request: PlanCreationAnswerRpcParams,
+  ): Promise<PlanCreationAnswerRpcResult>;
+}

--- a/packages/coach-contract/src/planning-request.ts
+++ b/packages/coach-contract/src/planning-request.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PlanCreationCardModelSchema } from "./plan-creation.js";
 
 const PlanningRequestIdSchema = z.string().min(1).max(512);
 const PlanningRequestInstantSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
@@ -312,7 +313,10 @@ export const ListPlanningRequestsRpcParamsSchema = z
   .strict();
 export type ListPlanningRequestsRpcParams = z.infer<typeof ListPlanningRequestsRpcParamsSchema>;
 export const ListPlanningRequestsRpcResultSchema = z
-  .object({ deliveries: z.array(PlanningRequestDeliverySchema) })
+  .object({
+    deliveries: z.array(PlanningRequestDeliverySchema),
+    planCreation: PlanCreationCardModelSchema.nullable(),
+  })
   .strict();
 export type ListPlanningRequestsRpcResult = z.infer<typeof ListPlanningRequestsRpcResultSchema>;
 

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -139,6 +139,13 @@ import {
   RetryPlanningRequestRpcResultSchema,
   type PlanningRequestOperations,
 } from "./planning-request.js";
+import {
+  PlanCreationAnswerRpcParamsSchema,
+  PlanCreationAnswerRpcResultSchema,
+  PlanCreationStartRpcParamsSchema,
+  PlanCreationStartRpcResultSchema,
+  type PlanCreationOperations,
+} from "./plan-creation.js";
 
 export const JsonValueSchema = z.json();
 export type JsonValue = z.infer<typeof JsonValueSchema>;
@@ -299,6 +306,8 @@ export const COACH_RPC_METHOD_NAMES = [
   "retryPlanningRequest",
   "resumePlanningRequests",
   "listPlanningRequests",
+  "plan_creation.start",
+  "plan_creation.answer",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
 export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
@@ -1318,6 +1327,7 @@ export type CoachRpcService = CoachEngine &
   CoachOperations &
   PlanningReadOperations &
   PlanningRequestOperations &
+  PlanCreationOperations &
   SpendOperations &
   CoachSelfTestOperations &
   TelegramControlOperations &
@@ -1868,6 +1878,22 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       params: ListPlanningRequestsRpcParamsSchema,
     })
     .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("plan_creation.start"),
+      params: PlanCreationStartRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("plan_creation.answer"),
+      params: PlanCreationAnswerRpcParamsSchema,
+    })
+    .strict(),
 ]);
 export type CoachRpcRequestEnvelope = z.infer<typeof CoachRpcRequestEnvelopeSchema>;
 
@@ -2386,6 +2412,18 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "listPlanningRequests",
     requestSchema: ListPlanningRequestsRpcParamsSchema,
     responseSchema: ListPlanningRequestsRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  "plan_creation.start": {
+    wireName: "plan_creation.start",
+    requestSchema: PlanCreationStartRpcParamsSchema,
+    responseSchema: PlanCreationStartRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  "plan_creation.answer": {
+    wireName: "plan_creation.answer",
+    requestSchema: PlanCreationAnswerRpcParamsSchema,
+    responseSchema: PlanCreationAnswerRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
 } as const satisfies CoachRpcMethodRegistryShape;

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 32;
+export const PROTOCOL_VERSION = 33;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 32 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("ships protocol 33 and rejects a blank enqueue without attachments", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -151,8 +151,8 @@ describe("coach decision wire contract", () => {
     expect(parsed.entries).toHaveLength(1);
   });
 
-  it("projects resume completion explicitly at protocol 32", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("projects resume completion explicitly at protocol 33", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -114,8 +114,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 32", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("is 33", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  COACH_RPC_METHOD_NAMES,
+  COACH_RPC_METHOD_REGISTRY,
+  CoachRpcRequestEnvelopeSchema,
+  PlanCreationAnswerInputSchema,
+  PlanCreationAnswerRpcParamsSchema,
+  PlanCreationAnswerRpcResultSchema,
+  PlanCreationCardModelSchema,
+  PlanCreationStartRpcParamsSchema,
+  PlanCreationStartRpcResultSchema,
+} from "../src/index.js";
+
+const creationId = "01J00000000000000000000000";
+const card = {
+  creationId,
+  version: 1,
+  status: "in-progress" as const,
+  answeredSummaries: [],
+  openQuestion: { kind: "goal-question" as const, prompt: "Goal?", candidates: [] },
+};
+const answers = [
+  { kind: "goal", goal: { kind: "event-candidate", candidateId: creationId } },
+  { kind: "goal", goal: { kind: "event-manual", name: "Tour", date: "1998-10-18" } },
+  { kind: "goal", goal: { kind: "fitness", outcome: "Build power" } },
+  { kind: "success", success: { kind: "event-finish", choice: "finish-fast" } },
+  { kind: "success", success: { kind: "authored", text: "Ride well" } },
+] as const;
+
+describe("Plan Creation contract", () => {
+  it("closes every answer and host-owned Card variant", () => {
+    answers.forEach((answer) =>
+      expect(PlanCreationAnswerInputSchema.parse(answer)).toEqual(answer),
+    );
+    expect(PlanCreationCardModelSchema.parse(card)).toEqual(card);
+    expect(
+      PlanCreationCardModelSchema.parse({
+        ...card,
+        version: 2,
+        answeredSummaries: [{ answerKey: "goal", title: "Goal", detail: "Build power" }],
+        openQuestion: {
+          kind: "success-question",
+          prompt: "Success?",
+          input: { kind: "authored", placeholder: "Describe success" },
+        },
+      }),
+    ).toMatchObject({ version: 2, openQuestion: { input: { kind: "authored" } } });
+    expect(
+      PlanCreationCardModelSchema.parse({
+        ...card,
+        openQuestion: {
+          kind: "success-question",
+          prompt: "Success?",
+          input: {
+            kind: "event-finish",
+            options: [
+              { choice: "finish-comfortably", label: "Finish comfortably" },
+              { choice: "finish-fast", label: "Finish fast" },
+              { choice: "race-for-result", label: "Race for a result" },
+            ],
+          },
+        },
+      }),
+    ).toMatchObject({ openQuestion: { input: { kind: "event-finish" } } });
+  });
+
+  it("rejects renderer-authored fields and malformed command boundaries", () => {
+    expect(() =>
+      PlanCreationAnswerInputSchema.parse({ ...answers[0], name: "Untrusted" }),
+    ).toThrow();
+    expect(() =>
+      PlanCreationAnswerInputSchema.parse({
+        kind: "goal",
+        goal: { kind: "event-manual", name: "Tour", date: "2026-2-3" },
+      }),
+    ).toThrow();
+    expect(() => PlanCreationCardModelSchema.parse({ ...card, version: 0 })).toThrow();
+    expect(() =>
+      PlanCreationStartRpcParamsSchema.parse({ commandId: "start", extra: true }),
+    ).toThrow();
+    expect(() =>
+      PlanCreationAnswerRpcParamsSchema.parse({
+        commandId: "answer",
+        creationId,
+        expectedVersion: 1,
+        answer: answers[2],
+        extra: true,
+      }),
+    ).toThrow();
+  });
+
+  it("accepts every terminal result and only the two registered operations", () => {
+    expect(
+      PlanCreationStartRpcResultSchema.parse({
+        status: "started",
+        outcome: "created",
+        planCreation: card,
+      }),
+    ).toMatchObject({ outcome: "created" });
+    expect(
+      PlanCreationStartRpcResultSchema.parse({ status: "rejected", reason: "command-conflict" }),
+    ).toMatchObject({ status: "rejected" });
+    for (const reason of [
+      "stale-version",
+      "command-conflict",
+      "no-unfinished-creation",
+      "answer-not-expected",
+      "invalid-answer",
+    ] as const) {
+      expect(
+        PlanCreationAnswerRpcResultSchema.parse({ status: "rejected", reason, planCreation: null }),
+      ).toEqual({ status: "rejected", reason, planCreation: null });
+    }
+    expect(COACH_RPC_METHOD_NAMES.filter((name) => name.startsWith("plan_creation."))).toEqual([
+      "plan_creation.start",
+      "plan_creation.answer",
+    ]);
+  });
+
+  it("registers strict start and answer envelopes without events", () => {
+    const requests = [
+      { method: "plan_creation.start", params: { commandId: "start" } },
+      {
+        method: "plan_creation.answer",
+        params: { commandId: "answer", creationId, expectedVersion: 1, answer: answers[2] },
+      },
+    ] as const;
+    requests.forEach((request, id) =>
+      expect(CoachRpcRequestEnvelopeSchema.parse({ jsonrpc: "2.0", id, ...request }).method).toBe(
+        request.method,
+      ),
+    );
+    for (const method of ["plan_creation.start", "plan_creation.answer"] as const) {
+      expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse({}).success).toBe(false);
+    }
+  });
+});

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -37,7 +37,7 @@ describe("Plan Creation contract", () => {
       PlanCreationCardModelSchema.parse({
         ...card,
         version: 2,
-        answeredSummaries: [{ answerKey: "goal", title: "Goal", detail: "Build power" }],
+        answeredSummaries: [{ answerKey: "goal", title: "Goal", detail: "x".repeat(2_000) }],
         openQuestion: {
           kind: "success-question",
           prompt: "Success?",
@@ -62,6 +62,12 @@ describe("Plan Creation contract", () => {
         },
       }),
     ).toMatchObject({ openQuestion: { input: { kind: "event-finish" } } });
+    expect(() =>
+      PlanCreationCardModelSchema.parse({
+        ...card,
+        answeredSummaries: [{ answerKey: "goal", title: "Goal", detail: "x".repeat(2_001) }],
+      }),
+    ).toThrow();
   });
 
   it("rejects renderer-authored fields and malformed command boundaries", () => {
@@ -72,6 +78,18 @@ describe("Plan Creation contract", () => {
       PlanCreationAnswerInputSchema.parse({
         kind: "goal",
         goal: { kind: "event-manual", name: "Tour", date: "2026-2-3" },
+      }),
+    ).toThrow();
+    expect(
+      PlanCreationAnswerInputSchema.parse({
+        kind: "goal",
+        goal: { kind: "event-manual", name: "Tour", date: "2026-02-28" },
+      }),
+    ).toMatchObject({ goal: { date: "2026-02-28" } });
+    expect(() =>
+      PlanCreationAnswerInputSchema.parse({
+        kind: "goal",
+        goal: { kind: "event-manual", name: "Tour", date: "2026-02-31" },
       }),
     ).toThrow();
     expect(() => PlanCreationCardModelSchema.parse({ ...card, version: 0 })).toThrow();

--- a/packages/coach-contract/tests/planning-request-contract.test.ts
+++ b/packages/coach-contract/tests/planning-request-contract.test.ts
@@ -5,6 +5,7 @@ import {
   CreatePlanningRequestRpcResultSchema,
   CreateWorkoutPlanningRequestRpcParamsSchema,
   ListPlanningRequestsRpcParamsSchema,
+  ListPlanningRequestsRpcResultSchema,
   PlanningRequestDeliverySchema,
 } from "../src/index.js";
 
@@ -142,5 +143,8 @@ describe("Planning request contract", () => {
     expect(() =>
       ListPlanningRequestsRpcParamsSchema.parse({ chatId: "chat-1", extra: true }),
     ).toThrow();
+    expect(
+      ListPlanningRequestsRpcResultSchema.parse({ deliveries: [], planCreation: null }),
+    ).toEqual({ deliveries: [], planCreation: null });
   });
 });

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1949,7 +1949,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-32 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-33 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1957,8 +1957,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 32,
-      serverProtocolVersion: 32,
+      clientProtocolVersion: 33,
+      serverProtocolVersion: 33,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1967,7 +1967,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(31);
+    expect(previous).toBe(32);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -2040,9 +2040,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 32 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 33 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(32);
+    expect(client.clientProtocolVersion).toBe(33);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2168,7 +2168,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 32", () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+  it("uses protocol version 33", () => {
+    expect(PROTOCOL_VERSION).toBe(33);
   });
 });

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1448,7 +1448,16 @@ describe("coach request and event projection", () => {
       getPlanningRequest: async () => ({ status: "missing" }),
       retryPlanningRequest: async () => ({ status: "missing" }),
       resumePlanningRequests: async () => ({ deliveries: [] }),
-      listPlanningRequests: async () => ({ deliveries: [] }),
+      listPlanningRequests: async () => ({ deliveries: [], planCreation: null }),
+      "plan_creation.start": async () => ({
+        status: "rejected",
+        reason: "command-conflict",
+      }),
+      "plan_creation.answer": async () => ({
+        status: "rejected",
+        reason: "no-unfinished-creation",
+        planCreation: null,
+      }),
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
     expect(COACH_RPC_METHOD_NAMES).toEqual(Object.keys(fake));

--- a/packages/coach/src/coach-engine-adapter.ts
+++ b/packages/coach/src/coach-engine-adapter.ts
@@ -41,8 +41,14 @@ export interface CoachEngineAdapterInput {
 }
 
 export function createCoachEngineAdapter(input: CoachEngineAdapterInput): CoachEngine {
-  const blocked = (chatId: string) =>
-    chatId === "desktop" && input.planCreationDrainGate.hasOpenQuestion();
+  const blocked = async (chatId: string): Promise<boolean> => {
+    if (chatId !== "desktop") return false;
+    try {
+      return await input.planCreationDrainGate.hasOpenQuestion();
+    } catch {
+      return false;
+    }
+  };
   const currentQueue = async (chatId: string): Promise<ChatQueueRunResult> => {
     if (input.backend.getChatQueue === undefined)
       throw new Error("Durable chat queue is unavailable.");

--- a/packages/coach/src/coach-engine-adapter.ts
+++ b/packages/coach/src/coach-engine-adapter.ts
@@ -36,10 +36,20 @@ export interface CoachEngineAdapterInput {
   readonly backend: CoachEngine;
   readonly getAthleteState: () => Promise<AthleteState>;
   readonly cyclingFtpAnchorResolver: CyclingFtpAnchorResolver;
+  readonly planCreationDrainGate: { hasOpenQuestion(): Promise<boolean> };
   readonly now: () => number;
 }
 
 export function createCoachEngineAdapter(input: CoachEngineAdapterInput): CoachEngine {
+  const blocked = (chatId: string) =>
+    chatId === "desktop" && input.planCreationDrainGate.hasOpenQuestion();
+  const currentQueue = async (chatId: string): Promise<ChatQueueRunResult> => {
+    if (input.backend.getChatQueue === undefined)
+      throw new Error("Durable chat queue is unavailable.");
+    return ChatQueueRunResultSchema.parse({
+      snapshot: await input.backend.getChatQueue({ chatId }),
+    });
+  };
   const queueStream = async (
     operation: (onEvent: (event: TurnEvent) => void) => Promise<ChatQueueRunResult>,
     onEvent?: (event: TurnEvent) => void,
@@ -62,6 +72,7 @@ export function createCoachEngineAdapter(input: CoachEngineAdapterInput): CoachE
   return {
     async chat(request, onEvent) {
       const parsed = ChatRequestSchema.parse(request);
+      if (await blocked(parsed.chatId)) return ChatResponseSchema.parse({ text: "" });
       const callEpochS = Math.floor(input.now() / 1_000);
       const resolvedCs = await input.cyclingFtpAnchorResolver.resolve({
         effectiveAtEpochS: callEpochS,
@@ -115,18 +126,21 @@ export function createCoachEngineAdapter(input: CoachEngineAdapterInput): CoachE
     },
     async resumeChatQueue(request, onEvent) {
       const parsed = ResumeChatQueueRequestSchema.parse(request);
+      if (await blocked(parsed.chatId)) return currentQueue(parsed.chatId);
       if (input.backend.resumeChatQueue === undefined)
         throw new Error("Durable chat queue is unavailable.");
       return queueStream((emit) => input.backend.resumeChatQueue!(parsed, emit), onEvent);
     },
     async runQueuedCommand(request, onEvent) {
       const parsed = RunQueuedCommandRequestSchema.parse(request);
+      if (await blocked(parsed.chatId)) return currentQueue(parsed.chatId);
       if (input.backend.runQueuedCommand === undefined)
         throw new Error("Durable chat queue is unavailable.");
       return queueStream((emit) => input.backend.runQueuedCommand!(parsed, emit), onEvent);
     },
     async retryQueuedTurn(request, onEvent) {
       const parsed = RetryQueuedTurnRequestSchema.parse(request);
+      if (await blocked(parsed.chatId)) return currentQueue(parsed.chatId);
       if (input.backend.retryQueuedTurn === undefined)
         throw new Error("Durable chat queue is unavailable.");
       return queueStream((emit) => input.backend.retryQueuedTurn!(parsed, emit), onEvent);

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -108,6 +108,7 @@ import {
   type GetRuntimeConfigRpcResult,
   type PlanningReadOperations,
   type CreatePlanningRequestPayload,
+  type PlanCreationOperations,
   type PlanningRequestOperations,
   type PlanningOperations,
   type VerifyIntervalsCredentialRpcParams,
@@ -140,6 +141,7 @@ import {
   normalizeIntervalsAthleteSelector,
 } from "./intervals-credential-approval.js";
 import { createCoachEngineAdapter } from "./coach-engine-adapter.js";
+import { createPlanCreationOperations } from "./plan-creation-operations.js";
 import {
   createStoreRuntime,
   type StoreRuntime,
@@ -198,6 +200,7 @@ import { createPlanningRequestDeliveryService } from "./planning-request-deliver
 import { createPlanningRequestSourceCleanup } from "./planning-request-source-cleanup.js";
 import {
   createPlanConversationRepository,
+  createPlanCreationRepository,
   createPlanningRequestIntakeRepository,
   createPlanningRequestRepository,
   createPlanRepository,
@@ -221,6 +224,7 @@ export interface LocalCoachComposition {
   readonly operations: CoachOperations &
     PlanningReadOperations &
     PlanningRequestOperations &
+    PlanCreationOperations &
     PlanningOperations;
   readonly spendMeter: SpendMeterService;
   readonly confirmations: Pick<ConfirmationGate, "peek" | "confirm" | "cancel">;
@@ -863,6 +867,12 @@ export async function createLocalCoachComposition(
   const now = dependencies.now ?? Date.now;
   const logger = createSubsystemLogger("agent", input.home.root);
   const planningIdentity = createAuthoredIdentity(input.home.configDir, { now });
+  const planCreationOperations = createPlanCreationOperations({
+    repository: createPlanCreationRepository(input.context.store),
+    identity: planningIdentity,
+    crypto: globalThis.crypto,
+    eventCandidates: { read: async () => [] },
+  });
   const planningRepository = createLegacyPlanRepository(input.context.store);
   const planningTimezone = resolveUserTimezone(input.config.session.timezone);
   const planningDateKey = (): number =>
@@ -1428,6 +1438,7 @@ export async function createLocalCoachComposition(
           backend,
           getAthleteState: () => stateReader.getAthleteState(),
           cyclingFtpAnchorResolver,
+          planCreationDrainGate: planCreationOperations,
           now,
         }),
       };
@@ -2077,6 +2088,7 @@ export async function createLocalCoachComposition(
         outbox: chatPlanOutboxRepository,
         requests: planningRequestRepository,
         identity: planningIdentity,
+        readPlanCreationCard: planCreationOperations.readCard,
         async resolveTarget() {
           const latest = await planRepository.readLatest();
           if (latest?.status === "active") return "active_plan";
@@ -2214,10 +2226,13 @@ export async function createLocalCoachComposition(
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
       ...planningRequestOperations,
+      "plan_creation.start": planCreationOperations["plan_creation.start"],
+      "plan_creation.answer": planCreationOperations["plan_creation.answer"],
       ...planningOperations,
     } satisfies CoachOperations &
       PlanningReadOperations &
       PlanningRequestOperations &
+      PlanCreationOperations &
       PlanningOperations;
     return {
       engine: reconfigurable.engine,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -36,6 +36,7 @@ import {
   type CoachEngine,
   type CoachOperations,
   type PlanningReadOperations,
+  type PlanCreationOperations,
   type PlanningRequestOperations,
   type CoachRpcMethodName,
   type CoachSelfTestOperations,
@@ -300,6 +301,7 @@ export interface CoachRpcServerInput {
   readonly operations: CoachOperations &
     PlanningReadOperations &
     PlanningRequestOperations &
+    PlanCreationOperations &
     PlanningOperations;
   readonly spend: SpendRpcHandlers;
   readonly selfTestOperations: CoachSelfTestOperations;
@@ -545,6 +547,8 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "retryPlanningRequest",
   "resumePlanningRequests",
   "listPlanningRequests",
+  "plan_creation.start",
+  "plan_creation.answer",
 ]);
 
 const PLAN_CHAT_RENDERER_METHODS = new Set<CoachRpcMethodName>([
@@ -1813,6 +1817,28 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               }
               result = await input.operations.listPlanningRequests(
                 COACH_RPC_METHOD_REGISTRY.listPlanningRequests.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "plan_creation.start":
+            try {
+              result = await input.operations["plan_creation.start"](
+                COACH_RPC_METHOD_REGISTRY["plan_creation.start"].requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "plan_creation.answer":
+            try {
+              result = await input.operations["plan_creation.answer"](
+                COACH_RPC_METHOD_REGISTRY["plan_creation.answer"].requestSchema.parse(
                   generic.data.params,
                 ),
               );

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -1,6 +1,7 @@
 import type {
   CoachEngine,
   CoachOperations,
+  PlanCreationOperations,
   PlanningReadOperations,
   PlanningRequestOperations,
 } from "@enduragent/coach-contract";
@@ -15,7 +16,10 @@ import { withCoachStoreWriter } from "./runtime.js";
 export interface LocalCoachLifecycle {
   readonly home: AthleteHome;
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations & PlanningReadOperations & PlanningRequestOperations;
+  readonly operations: CoachOperations &
+    PlanningReadOperations &
+    PlanningRequestOperations &
+    PlanCreationOperations;
   readonly spendMeter: SpendMeterService;
   readonly confirmations: Pick<ConfirmationGate, "peek" | "confirm" | "cancel">;
   readonly listener: WriterProtocolListener;

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -1,0 +1,282 @@
+import {
+  PlanCreationAnswerInputSchema,
+  PlanCreationAnswerRpcParamsSchema,
+  PlanCreationAnswerRpcResultSchema,
+  PlanCreationCardModelSchema,
+  PlanCreationStartRpcParamsSchema,
+  PlanCreationStartRpcResultSchema,
+  type PlanCreationAnswerInput,
+  type PlanCreationCardModel,
+  type PlanCreationGoal,
+  type PlanCreationOperations,
+} from "@enduragent/coach-contract";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import {
+  PlanCreationStoreError,
+  type PlanCreationRepository,
+  type PlanCreationSnapshot,
+} from "@enduragent/kernel/planning";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+
+export interface GoalEventCandidateSource {
+  read(): Promise<readonly { name: string; date: string; sourceLabel: string }[]>;
+}
+
+function answersByKind(snapshot: PlanCreationSnapshot): Map<string, PlanCreationAnswerInput> {
+  const answers = new Map<string, PlanCreationAnswerInput>();
+  for (const record of snapshot.answers) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(record.valueJson) as unknown;
+    } catch {
+      throw new PlanCreationStoreError("corrupt-record");
+    }
+    const result = PlanCreationAnswerInputSchema.safeParse(parsed);
+    if (!result.success || result.data.kind !== record.answerKey) {
+      throw new PlanCreationStoreError("corrupt-record");
+    }
+    answers.set(result.data.kind, result.data);
+  }
+  return answers;
+}
+
+export function expectedPlanCreationAnswerKind(
+  snapshot: PlanCreationSnapshot,
+): "goal" | "success" | null {
+  const answers = answersByKind(snapshot);
+  if (!answers.has("goal")) return "goal";
+  if (!answers.has("success")) return "success";
+  return null;
+}
+
+function requireGoal(answers: Map<string, PlanCreationAnswerInput>): PlanCreationGoal {
+  const answer = answers.get("goal");
+  if (answer?.kind !== "goal") throw new PlanCreationStoreError("corrupt-record");
+  return answer.goal;
+}
+
+function goalDetail(snapshot: PlanCreationSnapshot, goal: PlanCreationGoal): string {
+  if (goal.kind === "fitness") return goal.outcome;
+  if (goal.kind === "event-manual") return `${goal.name} · ${goal.date}`;
+  const candidate = snapshot.seed?.eventCandidates.find(
+    (item) => item.candidateId === goal.candidateId,
+  );
+  if (candidate === undefined) throw new PlanCreationStoreError("corrupt-record");
+  return `${candidate.name} · ${candidate.date} · ${candidate.sourceLabel}`;
+}
+
+function successDetail(answer: PlanCreationAnswerInput): string {
+  if (answer.kind !== "success") throw new PlanCreationStoreError("corrupt-record");
+  if (answer.success.kind === "authored") return answer.success.text;
+  if (answer.success.choice === "finish-comfortably") return "Finish comfortably";
+  if (answer.success.choice === "finish-fast") return "Finish fast";
+  return "Race for a result";
+}
+
+export function projectPlanCreationCard(snapshot: PlanCreationSnapshot): PlanCreationCardModel {
+  if (snapshot.status !== "in-progress") throw new PlanCreationStoreError("corrupt-record");
+  const answers = answersByKind(snapshot);
+  const goalAnswer = answers.get("goal");
+  const successAnswer = answers.get("success");
+  const answeredSummaries = [];
+  if (goalAnswer?.kind === "goal") {
+    answeredSummaries.push({
+      answerKey: "goal" as const,
+      title: "Goal",
+      detail: goalDetail(snapshot, goalAnswer.goal),
+    });
+  }
+  if (successAnswer !== undefined) {
+    answeredSummaries.push({
+      answerKey: "success" as const,
+      title: "Success",
+      detail: successDetail(successAnswer),
+    });
+  }
+  const expected = expectedPlanCreationAnswerKind(snapshot);
+  const openQuestion =
+    expected === "goal"
+      ? {
+          kind: "goal-question" as const,
+          prompt: "What do you want this Plan to prepare you for?",
+          candidates: snapshot.seed?.eventCandidates ?? [],
+        }
+      : expected === "success"
+        ? requireGoal(answers).kind === "fitness"
+          ? {
+              kind: "success-question" as const,
+              prompt: "What would success mean for this Fitness Goal?",
+              input: {
+                kind: "authored" as const,
+                placeholder: "Describe what success would look like",
+              },
+            }
+          : {
+              kind: "success-question" as const,
+              prompt: "What would success mean for this Event Goal?",
+              input: {
+                kind: "event-finish" as const,
+                options: [
+                  { choice: "finish-comfortably" as const, label: "Finish comfortably" },
+                  { choice: "finish-fast" as const, label: "Finish fast" },
+                  { choice: "race-for-result" as const, label: "Race for a result" },
+                ],
+              },
+            }
+        : null;
+  return PlanCreationCardModelSchema.parse({
+    creationId: snapshot.id,
+    version: snapshot.version,
+    status: "in-progress",
+    answeredSummaries,
+    openQuestion,
+  });
+}
+
+export interface PlanCreationHost extends PlanCreationOperations {
+  readCard(): Promise<PlanCreationCardModel | null>;
+  hasOpenQuestion(): Promise<boolean>;
+}
+
+function validAnswer(snapshot: PlanCreationSnapshot, answer: PlanCreationAnswerInput): boolean {
+  if (answer.kind === "goal") {
+    const candidateId = answer.goal.kind === "event-candidate" ? answer.goal.candidateId : null;
+    return (
+      candidateId === null ||
+      snapshot.seed?.eventCandidates.some((candidate) => candidate.candidateId === candidateId) ===
+        true
+    );
+  }
+  const goal = requireGoal(answersByKind(snapshot));
+  return goal.kind === "fitness"
+    ? answer.success.kind === "authored"
+    : answer.success.kind === "event-finish";
+}
+
+async function requestDigest(crypto: Crypto, request: unknown): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonicalJson(request)),
+  );
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function createPlanCreationOperations(input: {
+  repository: PlanCreationRepository;
+  identity: AuthoredIdentity;
+  crypto: Crypto;
+  eventCandidates: GoalEventCandidateSource;
+}): PlanCreationHost {
+  const stamp = async (commandId: string, digest: string) => {
+    const clock = input.identity.hlcStamp();
+    return {
+      commandId,
+      requestDigest: digest,
+      nowMs: clock.physicalMs,
+      deviceId: await input.identity.deviceId(),
+      hlcPhysicalMs: clock.physicalMs,
+      hlcCounter: clock.counter,
+    };
+  };
+  const readCard = async (): Promise<PlanCreationCardModel | null> => {
+    const snapshot = await input.repository.readUnfinished();
+    return snapshot === undefined ? null : projectPlanCreationCard(snapshot);
+  };
+  return {
+    async "plan_creation.start"(request) {
+      const parsed = PlanCreationStartRpcParamsSchema.parse(request);
+      const current = await input.repository.readUnfinished();
+      const candidates =
+        current === undefined
+          ? (await input.eventCandidates.read()).slice(0, 10).map((candidate) => ({
+              candidateId: input.identity.newUlid(),
+              ...candidate,
+            }))
+          : [];
+      try {
+        const result = await input.repository.start({
+          command: await stamp(parsed.commandId, await requestDigest(input.crypto, parsed)),
+          creationId: current?.id ?? input.identity.newUlid(),
+          seed: { schemaVersion: 1, eventCandidates: candidates },
+        });
+        return PlanCreationStartRpcResultSchema.parse({
+          status: "started",
+          outcome: result.outcome === "created" ? "created" : "resumed",
+          planCreation: projectPlanCreationCard(result.snapshot),
+        });
+      } catch (error) {
+        if (error instanceof PlanCreationStoreError && error.code === "command-conflict") {
+          return PlanCreationStartRpcResultSchema.parse({
+            status: "rejected",
+            reason: "command-conflict",
+          });
+        }
+        throw error;
+      }
+    },
+    async "plan_creation.answer"(request) {
+      const parsed = PlanCreationAnswerRpcParamsSchema.parse(request);
+      const snapshot = await input.repository.readUnfinished();
+      if (snapshot === undefined || snapshot.id !== parsed.creationId) {
+        return PlanCreationAnswerRpcResultSchema.parse({
+          status: "rejected",
+          reason: "no-unfinished-creation",
+          planCreation: snapshot === undefined ? null : projectPlanCreationCard(snapshot),
+        });
+      }
+      const digest = await requestDigest(input.crypto, parsed);
+      const stampValue = await stamp(parsed.commandId, digest);
+      const answerId = input.identity.newUlid();
+      const record = () =>
+        input.repository.recordAnswer({
+          command: stampValue,
+          creationId: parsed.creationId,
+          expectedVersion: parsed.expectedVersion,
+          answerId,
+          answerKey: parsed.answer.kind,
+          valueJson: canonicalJson(parsed.answer),
+        });
+      if (
+        snapshot.version === parsed.expectedVersion &&
+        expectedPlanCreationAnswerKind(snapshot) !== parsed.answer.kind
+      ) {
+        return PlanCreationAnswerRpcResultSchema.parse({
+          status: "rejected",
+          reason: "answer-not-expected",
+          planCreation: projectPlanCreationCard(snapshot),
+        });
+      }
+      if (snapshot.version === parsed.expectedVersion && !validAnswer(snapshot, parsed.answer)) {
+        return PlanCreationAnswerRpcResultSchema.parse({
+          status: "rejected",
+          reason: "invalid-answer",
+          planCreation: projectPlanCreationCard(snapshot),
+        });
+      }
+      try {
+        const result = await record();
+        return PlanCreationAnswerRpcResultSchema.parse({
+          status: "answered",
+          planCreation: projectPlanCreationCard(result.snapshot),
+        });
+      } catch (error) {
+        if (
+          error instanceof PlanCreationStoreError &&
+          ["stale-version", "command-conflict", "missing-creation"].includes(error.code)
+        ) {
+          const planCreation = await readCard();
+          return PlanCreationAnswerRpcResultSchema.parse({
+            status: "rejected",
+            reason: error.code === "missing-creation" ? "no-unfinished-creation" : error.code,
+            planCreation,
+          });
+        }
+        throw error;
+      }
+    },
+    readCard,
+    async hasOpenQuestion() {
+      return (await readCard())?.openQuestion != null;
+    },
+  };
+}

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -276,7 +276,10 @@ export function createPlanCreationOperations(input: {
     },
     readCard,
     async hasOpenQuestion() {
-      return (await readCard())?.openQuestion != null;
+      const snapshot = await input.repository.readUnfinished();
+      if (snapshot === undefined || snapshot.status !== "in-progress") return false;
+      const answerKeys = new Set(snapshot.answers.map((answer) => answer.answerKey));
+      return !answerKeys.has("goal") || !answerKeys.has("success");
     },
   };
 }

--- a/packages/coach/src/planning-request-delivery.ts
+++ b/packages/coach/src/planning-request-delivery.ts
@@ -13,6 +13,7 @@ import {
   RetryPlanningRequestRpcParamsSchema,
   RetryPlanningRequestRpcResultSchema,
   type PlanningRequestDelivery,
+  type PlanCreationCardModel,
   type PlanningRequestOperations,
   type CreatePlanningRequestPayload,
   type CreatePlanningRequestRpcResult,
@@ -35,6 +36,7 @@ export interface PlanningRequestDeliveryServiceInput {
   readonly requests: PlanningRequestRepository;
   readonly identity: AuthoredIdentity;
   readonly resolveTarget: () => Promise<PlanningRequestTarget>;
+  readonly readPlanCreationCard: () => Promise<PlanCreationCardModel | null>;
   readonly resolveWorkoutSource?: (input: {
     readonly chatId: string;
     readonly attachmentId: string;
@@ -279,6 +281,7 @@ export function createPlanningRequestDeliveryService(
       const records = await input.outbox.readByChatId(parsed.chatId);
       return ListPlanningRequestsRpcResultSchema.parse({
         deliveries: await Promise.all(records.map((record) => project(input.requests, record))),
+        planCreation: await input.readPlanCreationCard(),
       });
     },
   };

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -42,11 +42,13 @@ import {
   type AthleteState,
   type CoachEngine,
   type CoachOperations,
+  type PlanCreationOperations,
   type TelegramControlSnapshot,
   type TurnEvent,
 } from "@enduragent/coach-contract";
 import { createCoachRpcServer, type CoachRpcServer } from "../src/daemon/rpc-server.js";
 import type { DesktopTelegramController } from "../src/desktop-telegram-controller.js";
+import { planCreationOperationStubs } from "./helpers/plan-creation-operation-stubs.js";
 
 const token = "s".repeat(43);
 const disabledTelegramSnapshot: TelegramControlSnapshot = {
@@ -81,7 +83,8 @@ const disabledTelegram: DesktopTelegramController = {
   drainPending: async () => disabledTelegramSnapshot,
   close: async () => disabledTelegramSnapshot,
 };
-const operations: CoachOperations = {
+const operations: CoachOperations & PlanCreationOperations = {
+  ...planCreationOperationStubs,
   importFiles: async ({ paths }) => ({
     schemaVersion: 2,
     files: { total: paths.length, imported: paths.length, quarantined: 0 },

--- a/packages/coach/tests/coach-engine-adapter.test.ts
+++ b/packages/coach/tests/coach-engine-adapter.test.ts
@@ -144,6 +144,42 @@ describe("coach engine adapter", () => {
     expect(selected.resolve).not.toHaveBeenCalled();
   });
 
+  it("fails open when the Plan Creation drain gate cannot be read", async () => {
+    const selected = resolver();
+    const chat = vi.fn<CoachEngine["chat"]>(async () => ({ text: "ok" }));
+    const queueResult = {
+      snapshot: { schemaVersion: 1 as const, revision: 4, items: [] },
+    };
+    const resumeChatQueue = vi.fn(async () => queueResult);
+    const runQueuedCommand = vi.fn(async () => queueResult);
+    const retryQueuedTurn = vi.fn(async () => queueResult);
+    const engine = createCoachEngineAdapter({
+      backend: backend({ chat, resumeChatQueue, runQueuedCommand, retryQueuedTurn }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: selected.value,
+      planCreationDrainGate: {
+        hasOpenQuestion: async () => Promise.reject(new Error("corrupt Plan Creation record")),
+      },
+      now: () => 1_752_796_801_999,
+    });
+
+    await expect(engine.chat({ chatId: "desktop", message: "continue" })).resolves.toEqual({
+      text: "ok",
+    });
+    await expect(engine.resumeChatQueue?.({ chatId: "desktop" })).resolves.toEqual(queueResult);
+    await expect(
+      engine.runQueuedCommand?.({ chatId: "desktop", queuedMessageId: "queued-1" }),
+    ).resolves.toEqual(queueResult);
+    await expect(
+      engine.retryQueuedTurn?.({ chatId: "desktop", claimId: "claim-1" }),
+    ).resolves.toEqual(queueResult);
+    expect(chat).toHaveBeenCalledOnce();
+    expect(resumeChatQueue).toHaveBeenCalledOnce();
+    expect(runQueuedCommand).toHaveBeenCalledOnce();
+    expect(retryQueuedTurn).toHaveBeenCalledOnce();
+    expect(selected.resolve).toHaveBeenCalledOnce();
+  });
+
   it("resolves one FTP anchor at the call epoch and validates event order and response", async () => {
     const selected = resolver();
     const calls: string[] = [];

--- a/packages/coach/tests/coach-engine-adapter.test.ts
+++ b/packages/coach/tests/coach-engine-adapter.test.ts
@@ -7,7 +7,18 @@ import {
   type TurnEvent,
 } from "@enduragent/coach-contract";
 import type { CyclingFtpAnchorResolver, CyclingFtpAnchorResult } from "@enduragent/kernel/anchors";
-import { createCoachEngineAdapter } from "../src/coach-engine-adapter.js";
+import { createCoachEngineAdapter as createProductionCoachEngineAdapter } from "../src/coach-engine-adapter.js";
+
+type AdapterInput = Parameters<typeof createProductionCoachEngineAdapter>[0];
+
+function createCoachEngineAdapter(
+  input: Omit<AdapterInput, "planCreationDrainGate"> & {
+    readonly planCreationDrainGate?: AdapterInput["planCreationDrainGate"];
+  },
+) {
+  const { planCreationDrainGate = { hasOpenQuestion: async () => false }, ...rest } = input;
+  return createProductionCoachEngineAdapter({ ...rest, planCreationDrainGate });
+}
 
 const state: AthleteState = {
   schemaVersion: "3",
@@ -87,6 +98,52 @@ function backend(overrides: Partial<CoachEngine> = {}): CoachEngine {
 }
 
 describe("coach engine adapter", () => {
+  it("refuses desktop Chat and every queue drain while a Plan Creation question is open", async () => {
+    const selected = resolver();
+    const chat = vi.fn<CoachEngine["chat"]>(async () => ({ text: "unexpected" }));
+    const resumeChatQueue = vi.fn(async () => {
+      throw new Error("unexpected");
+    });
+    const runQueuedCommand = vi.fn(async () => {
+      throw new Error("unexpected");
+    });
+    const retryQueuedTurn = vi.fn(async () => {
+      throw new Error("unexpected");
+    });
+    const getChatQueue = vi.fn(async () => ({ schemaVersion: 1 as const, revision: 4, items: [] }));
+    const engine = createCoachEngineAdapter({
+      backend: backend({
+        chat,
+        resumeChatQueue,
+        runQueuedCommand,
+        retryQueuedTurn,
+        getChatQueue,
+      }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: selected.value,
+      planCreationDrainGate: { hasOpenQuestion: async () => true },
+      now: () => 1_752_796_801_999,
+    });
+    await expect(engine.chat({ chatId: "desktop", message: "queued" })).resolves.toEqual({
+      text: "",
+    });
+    await expect(engine.resumeChatQueue?.({ chatId: "desktop" })).resolves.toEqual({
+      snapshot: { schemaVersion: 1, revision: 4, items: [] },
+    });
+    await expect(
+      engine.runQueuedCommand?.({ chatId: "desktop", queuedMessageId: "queued-1" }),
+    ).resolves.toEqual({ snapshot: { schemaVersion: 1, revision: 4, items: [] } });
+    await expect(
+      engine.retryQueuedTurn?.({ chatId: "desktop", claimId: "claim-1" }),
+    ).resolves.toEqual({ snapshot: { schemaVersion: 1, revision: 4, items: [] } });
+    expect(chat).not.toHaveBeenCalled();
+    expect(resumeChatQueue).not.toHaveBeenCalled();
+    expect(runQueuedCommand).not.toHaveBeenCalled();
+    expect(retryQueuedTurn).not.toHaveBeenCalled();
+    expect(getChatQueue).toHaveBeenCalledTimes(3);
+    expect(selected.resolve).not.toHaveBeenCalled();
+  });
+
   it("resolves one FTP anchor at the call epoch and validates event order and response", async () => {
     const selected = resolver();
     const calls: string[] = [];

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -28,6 +28,7 @@ import {
 import { createCoachRpcServer } from "../src/daemon/rpc-server.js";
 import type { UpgradeFenceHandle } from "../src/daemon/upgrade-fence.js";
 import type { DesktopTelegramController } from "../src/desktop-telegram-controller.js";
+import { planCreationOperationStubs } from "./helpers/plan-creation-operation-stubs.js";
 
 const roots: string[] = [];
 const disabledTelegramSnapshot: TelegramControlSnapshot = {
@@ -275,6 +276,7 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
         }),
       },
       operations: {
+        ...planCreationOperationStubs,
         importFiles: async ({ paths }) => ({
           schemaVersion: 2,
           files: { total: paths.length, imported: paths.length, quarantined: 0 },

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -32,6 +32,8 @@ import {
   type CoachDecisionReadModel,
   type CoachEngine,
   type CoachOperations,
+  type PlanCreationCardModel,
+  type PlanCreationOperations,
   type PlanningReadOperations,
   type PlanningOperations,
   type PlanReadModel,
@@ -51,6 +53,7 @@ import type { MonotonicTimer, ScheduledMonotonicTimer } from "../src/daemon/upgr
 import type { DesktopTelegramController } from "../src/desktop-telegram-controller.js";
 import { createDesktopTelegramRuntimeFactory } from "../src/desktop-telegram-runtime.js";
 import type { LocalCoachLifecycle } from "../src/local-runner.js";
+import { planCreationOperationStubs } from "./helpers/plan-creation-operation-stubs.js";
 
 const roots: string[] = [];
 
@@ -133,7 +136,8 @@ const completedDecision = {
   },
 } satisfies CoachDecisionReadModel;
 
-const operations: CoachOperations & PlanningReadOperations = {
+const operations: CoachOperations & PlanningReadOperations & PlanCreationOperations = {
+  ...planCreationOperationStubs,
   exportTrainingFile: async () => ({
     status: "exported",
     byteLength: 4_096,
@@ -2117,7 +2121,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     const getPlanningRequest = vi.fn(async () => ({ status: "missing" as const }));
     const retryPlanningRequest = vi.fn(async () => ({ status: "missing" as const }));
     const resumePlanningRequests = vi.fn(async () => ({ deliveries: [] }));
-    const listPlanningRequests = vi.fn(async () => ({ deliveries: [] }));
+    const listPlanningRequests = vi.fn(async () => ({ deliveries: [], planCreation: null }));
     const rpc = createCoachRpcServer({
       engine: engine(),
       operations: {
@@ -2209,6 +2213,100 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     });
     expect(resumePlanningRequests).toHaveBeenCalledOnce();
     await client.close();
+  });
+
+  it("dispatches strict Plan Creation operations for the renderer", async () => {
+    const token = "x".repeat(43);
+    const creationId = "01J00000000000000000000000";
+    const startedCard: PlanCreationCardModel = {
+      creationId,
+      version: 1,
+      status: "in-progress",
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question", prompt: "Goal?", candidates: [] },
+    };
+    const answeredCard: PlanCreationCardModel = {
+      creationId,
+      version: 2,
+      status: "in-progress",
+      answeredSummaries: [{ answerKey: "goal", title: "Goal", detail: "Build power" }],
+      openQuestion: {
+        kind: "success-question",
+        prompt: "Success?",
+        input: { kind: "authored", placeholder: "Describe success" },
+      },
+    };
+    const startPlanCreation = vi.fn<PlanCreationOperations["plan_creation.start"]>(async () => ({
+      status: "started",
+      outcome: "created",
+      planCreation: startedCard,
+    }));
+    const answerPlanCreation = vi.fn<PlanCreationOperations["plan_creation.answer"]>(async () => ({
+      status: "answered",
+      planCreation: answeredCard,
+    }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: {
+        ...operations,
+        "plan_creation.start": startPlanCreation,
+        "plan_creation.answer": answerPlanCreation,
+      },
+      token,
+      owner: "app-supervised",
+    });
+    const renderer = await openSocket(rpc);
+    renderer.ws.send(
+      JSON.stringify(
+        createClientHandshakeFrame(TEST_RENDERER_CAPABILITY_BYTES.toString("base64url")),
+      ),
+    );
+    await renderer.frames.next();
+    const startParams = { commandId: "start-1" };
+    const answerParams = {
+      commandId: "answer-1",
+      creationId,
+      expectedVersion: 1,
+      answer: { kind: "goal" as const, goal: { kind: "fitness" as const, outcome: "Build power" } },
+    };
+    for (const request of [
+      { id: "start", method: "plan_creation.start", params: startParams },
+      { id: "answer", method: "plan_creation.answer", params: answerParams },
+    ]) {
+      renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
+      expect(parseCoachRpcEnvelope(await renderer.frames.next())).toEqual({
+        jsonrpc: "2.0",
+        id: request.id,
+        result:
+          request.method === "plan_creation.start"
+            ? { status: "started", outcome: "created", planCreation: startedCard }
+            : { status: "answered", planCreation: answeredCard },
+      });
+    }
+    expect(startPlanCreation).toHaveBeenCalledWith(startParams);
+    expect(answerPlanCreation).toHaveBeenCalledWith(answerParams);
+
+    for (const request of [
+      {
+        id: "invalid-start",
+        method: "plan_creation.start",
+        params: { ...startParams, extra: true },
+      },
+      {
+        id: "invalid-answer",
+        method: "plan_creation.answer",
+        params: { ...answerParams, extra: true },
+      },
+    ]) {
+      renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
+      expect(parseCoachRpcEnvelope(await renderer.frames.next())).toMatchObject({
+        id: request.id,
+        error: { code: -32602, message: "Invalid params" },
+      });
+    }
+    expect(startPlanCreation).toHaveBeenCalledOnce();
+    expect(answerPlanCreation).toHaveBeenCalledOnce();
+    await renderer.close();
   });
 
   it.each([

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -33,6 +33,7 @@ import {
   type CoachRpcServer,
 } from "../../src/daemon/rpc-server.js";
 import type { DesktopTelegramController } from "../../src/desktop-telegram-controller.js";
+import { planCreationOperationStubs } from "../helpers/plan-creation-operation-stubs.js";
 
 const AUTH_TOKEN = "F8_AUTH_TOKEN_MUST_NOT_BE_LOGGED12345678901";
 const API_KEY_SECRET = "F8_API_KEY_MUST_NOT_ESCAPE";
@@ -192,6 +193,7 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
       }),
     },
     operations: {
+      ...planCreationOperationStubs,
       importFiles: async ({ paths }) => ({
         schemaVersion: 2,
         files: { total: paths.length, imported: paths.length, quarantined: 0 },

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 32 as const,
-      serverProtocolVersion: 32 as const,
+      clientProtocolVersion: 33 as const,
+      serverProtocolVersion: 33 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -17,6 +17,7 @@ import {
   type AthleteState,
   type CoachEngine,
   type CoachOperations,
+  type PlanCreationOperations,
 } from "@enduragent/coach-contract";
 import type { CoachClient, CoachClientCallOptions } from "@enduragent/coach-client";
 import {
@@ -44,6 +45,7 @@ import {
 } from "../src/local-runner.js";
 import { CoachStoreWriterError, withCoachStoreWriter } from "../src/runtime.js";
 import type { SpendMeterService } from "../src/spend-meter.js";
+import { planCreationOperationStubs } from "./helpers/plan-creation-operation-stubs.js";
 
 const state: AthleteState = {
   schemaVersion: "3",
@@ -59,7 +61,8 @@ const state: AthleteState = {
   wellness: {},
 };
 
-const operations: CoachOperations = {
+const operations: CoachOperations & PlanCreationOperations = {
+  ...planCreationOperationStubs,
   importFiles: async ({ paths }) => ({
     schemaVersion: 2,
     files: { total: paths.length, imported: paths.length, quarantined: 0 },

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -308,7 +308,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(32);
+    expect(PROTOCOL_VERSION).toBe(33);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -17,6 +17,7 @@ import { runEnduragent, type EnduragentDependencies } from "../src/enduragent.js
 import type { WithLocalCoachInput } from "../src/local-runner.js";
 import { withCoachStoreWriter } from "../src/runtime.js";
 import type { SpendMeterService } from "../src/spend-meter.js";
+import { planCreationOperationStubs } from "./helpers/plan-creation-operation-stubs.js";
 
 const API_KEY_SECRET = "F8_LOCAL_API_KEY_MUST_NOT_ESCAPE";
 const MESSAGE_SECRET = "F8_LOCAL_MESSAGE_MUST_NOT_ESCAPE";
@@ -151,6 +152,7 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
           home: context.home,
           engine: coachEngine,
           operations: {
+            ...planCreationOperationStubs,
             importFiles: async ({ paths }) => ({
               schemaVersion: 2,
               files: { total: paths.length, imported: paths.length, quarantined: 0 },

--- a/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
+++ b/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
@@ -1,0 +1,13 @@
+import type { PlanCreationOperations } from "@enduragent/coach-contract";
+
+export const planCreationOperationStubs = {
+  "plan_creation.start": async () => ({
+    status: "rejected",
+    reason: "command-conflict",
+  }),
+  "plan_creation.answer": async () => ({
+    status: "rejected",
+    reason: "no-unfinished-creation",
+    planCreation: null,
+  }),
+} satisfies PlanCreationOperations;

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PlanCreationRepository, PlanCreationSnapshot } from "@enduragent/kernel/planning";
+import { PlanCreationStoreError } from "@enduragent/kernel/planning";
+import {
+  createPlanCreationOperations,
+  expectedPlanCreationAnswerKind,
+  projectPlanCreationCard,
+} from "../src/plan-creation-operations.js";
+
+const id = (value: string) => `${"0".repeat(26 - value.length)}${value}`;
+const eventCandidate = {
+  candidateId: id("2"),
+  name: "Tour",
+  date: "1998-10-18",
+  sourceLabel: "Calendar",
+};
+const candidateSource = { name: "Tour", date: "1998-10-18", sourceLabel: "Calendar" };
+const answer = (sequence: number, answerKey: "goal" | "success", value: unknown) => ({
+  id: id(`${sequence + 2}`),
+  sequence,
+  creationVersion: sequence + 1,
+  answerKey,
+  valueJson: JSON.stringify(value),
+  confirmedAtMs: 883_612_800_000 + sequence,
+});
+const eventGoal = answer(1, "goal", {
+  kind: "goal",
+  goal: { kind: "event-candidate", candidateId: eventCandidate.candidateId },
+});
+const fitnessGoal = answer(1, "goal", {
+  kind: "goal",
+  goal: { kind: "fitness", outcome: "Build power" },
+});
+const eventSuccess = answer(2, "success", {
+  kind: "success",
+  success: { kind: "event-finish", choice: "finish-fast" },
+});
+const snapshot = (answers: PlanCreationSnapshot["answers"] = []): PlanCreationSnapshot => ({
+  id: id("1"),
+  status: "in-progress",
+  version: answers.length + 1,
+  seed: { schemaVersion: 1, eventCandidates: [eventCandidate] },
+  createdAtMs: 883_612_800_000,
+  updatedAtMs: 883_612_800_000,
+  answers,
+});
+
+function operations(repository: PlanCreationRepository, candidates = [candidateSource]) {
+  let sequence = 8;
+  return createPlanCreationOperations({
+    repository,
+    identity: {
+      deviceId: async () => "test-device",
+      newUlid: () => id(`${++sequence}`),
+      hlcStamp: () => ({ physicalMs: 883_612_800_000, counter: 0 }),
+    },
+    crypto: globalThis.crypto,
+    eventCandidates: { read: async () => candidates },
+  });
+}
+
+describe("Plan Creation operations", () => {
+  it("owns flow policy and projects both host-authored Card paths", () => {
+    expect(
+      [snapshot(), snapshot([eventGoal]), snapshot([eventGoal, eventSuccess])].map(
+        expectedPlanCreationAnswerKind,
+      ),
+    ).toEqual(["goal", "success", null]);
+    expect(projectPlanCreationCard(snapshot([eventGoal]))).toMatchObject({
+      answeredSummaries: [{ title: "Goal", detail: "Tour · 1998-10-18 · Calendar" }],
+      openQuestion: { kind: "success-question", input: { kind: "event-finish" } },
+    });
+    expect(projectPlanCreationCard(snapshot([fitnessGoal]))).toMatchObject({
+      answeredSummaries: [{ title: "Goal", detail: "Build power" }],
+      openQuestion: { kind: "success-question", input: { kind: "authored" } },
+    });
+    expect(projectPlanCreationCard(snapshot([eventGoal, eventSuccess]))).toMatchObject({
+      answeredSummaries: [{ title: "Goal" }, { title: "Success", detail: "Finish fast" }],
+      openQuestion: null,
+    });
+  });
+
+  it("seeds a create and maps created, resumed, replayed, and conflict starts", async () => {
+    let current: PlanCreationSnapshot | undefined;
+    const outcomes = ["created", "resumed", "replayed"] as const;
+    let call = 0;
+    const start = vi.fn<PlanCreationRepository["start"]>(async (input) => {
+      if (input.command.commandId === "conflict")
+        throw new PlanCreationStoreError("command-conflict");
+      current ??= snapshot();
+      return { outcome: outcomes[call++] ?? "replayed", snapshot: current };
+    });
+    const host = operations({
+      readUnfinished: async () => current,
+      start,
+      recordAnswer: async () => {
+        throw new Error("unused");
+      },
+    });
+    await expect(host["plan_creation.start"]({ commandId: "one" })).resolves.toMatchObject({
+      outcome: "created",
+    });
+    await expect(host["plan_creation.start"]({ commandId: "two" })).resolves.toMatchObject({
+      outcome: "resumed",
+    });
+    await expect(host["plan_creation.start"]({ commandId: "three" })).resolves.toMatchObject({
+      outcome: "resumed",
+    });
+    await expect(host["plan_creation.start"]({ commandId: "conflict" })).resolves.toEqual({
+      status: "rejected",
+      reason: "command-conflict",
+    });
+    expect(start.mock.calls[0]?.[0].seed.eventCandidates).toEqual([
+      { candidateId: id("9"), ...candidateSource },
+    ]);
+  });
+
+  it("maps every answer rejection, lets ledger replay beat stale flow, and derives the drain gate", async () => {
+    let current: PlanCreationSnapshot | undefined;
+    let recordError: PlanCreationStoreError | undefined;
+    const recordAnswer = vi.fn<PlanCreationRepository["recordAnswer"]>(async () => {
+      if (recordError !== undefined) throw recordError;
+      if (current === undefined) throw new PlanCreationStoreError("missing-creation");
+      return { outcome: "replayed", snapshot: current };
+    });
+    const host = operations({
+      readUnfinished: async () => current,
+      start: async () => {
+        throw new Error("unused");
+      },
+      recordAnswer,
+    });
+    const submit = (
+      commandId: string,
+      expectedVersion: number,
+      value: Parameters<(typeof host)["plan_creation.answer"]>[0]["answer"],
+    ) =>
+      host["plan_creation.answer"]({
+        commandId,
+        creationId: id("1"),
+        expectedVersion,
+        answer: value,
+      });
+    const goal = {
+      kind: "goal" as const,
+      goal: { kind: "fitness" as const, outcome: "Build power" },
+    };
+    await expect(submit("missing", 1, goal)).resolves.toMatchObject({
+      reason: "no-unfinished-creation",
+    });
+    current = snapshot();
+    expect(await host.hasOpenQuestion()).toBe(true);
+    await expect(
+      submit("wrong", 1, { kind: "success", success: { kind: "authored", text: "Ride well" } }),
+    ).resolves.toMatchObject({ reason: "answer-not-expected" });
+    await expect(
+      submit("candidate", 1, {
+        kind: "goal",
+        goal: { kind: "event-candidate", candidateId: id("7") },
+      }),
+    ).resolves.toMatchObject({ reason: "invalid-answer" });
+    recordError = new PlanCreationStoreError("stale-version");
+    await expect(submit("stale", 1, goal)).resolves.toMatchObject({ reason: "stale-version" });
+    recordError = new PlanCreationStoreError("command-conflict");
+    await expect(submit("conflict", 1, goal)).resolves.toMatchObject({
+      reason: "command-conflict",
+    });
+    recordError = undefined;
+    current = snapshot([fitnessGoal]);
+    await expect(
+      submit("mode", 2, {
+        kind: "success",
+        success: { kind: "event-finish", choice: "finish-fast" },
+      }),
+    ).resolves.toMatchObject({ reason: "invalid-answer" });
+    await expect(submit("replay", 1, goal)).resolves.toMatchObject({
+      status: "answered",
+      planCreation: { version: 2 },
+    });
+    current = snapshot([eventGoal, eventSuccess]);
+    expect(await host.hasOpenQuestion()).toBe(false);
+  });
+});

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PlanCreationRepository, PlanCreationSnapshot } from "@enduragent/kernel/planning";
 import { PlanCreationStoreError } from "@enduragent/kernel/planning";
+import { PlanCreationCardModelSchema } from "@enduragent/coach-contract";
 import {
   createPlanCreationOperations,
   expectedPlanCreationAnswerKind,
@@ -78,6 +79,20 @@ describe("Plan Creation operations", () => {
       answeredSummaries: [{ title: "Goal" }, { title: "Success", detail: "Finish fast" }],
       openQuestion: null,
     });
+  });
+
+  it("round trips the longest accepted Fitness Goal through the Card contract", () => {
+    const outcome = "x".repeat(2_000);
+    const projected = projectPlanCreationCard(
+      snapshot([
+        answer(1, "goal", {
+          kind: "goal",
+          goal: { kind: "fitness", outcome },
+        }),
+      ]),
+    );
+
+    expect(PlanCreationCardModelSchema.parse(projected).answeredSummaries[0]?.detail).toBe(outcome);
   });
 
   it("seeds a create and maps created, resumed, replayed, and conflict starts", async () => {
@@ -177,6 +192,10 @@ describe("Plan Creation operations", () => {
       status: "answered",
       planCreation: { version: 2 },
     });
+    current = { ...snapshot([eventGoal]), seed: null };
+    expect(await host.hasOpenQuestion()).toBe(true);
+    current = { ...snapshot(), status: "review" };
+    expect(await host.hasOpenQuestion()).toBe(false);
     current = snapshot([eventGoal, eventSuccess]);
     expect(await host.hasOpenQuestion()).toBe(false);
   });

--- a/packages/coach/tests/planning-request-delivery.test.ts
+++ b/packages/coach/tests/planning-request-delivery.test.ts
@@ -87,6 +87,9 @@ describe("Planning request delivery", () => {
     resolveWorkoutSource?: Parameters<
       typeof createPlanningRequestDeliveryService
     >[0]["resolveWorkoutSource"],
+    readPlanCreationCard: Parameters<
+      typeof createPlanningRequestDeliveryService
+    >[0]["readPlanCreationCard"] = async () => null,
   ) => {
     const crypto = createNodeCrypto();
     const plans = createPlanRepository(store);
@@ -95,6 +98,7 @@ describe("Planning request delivery", () => {
         outbox: createChatPlanOutboxRepository(store, crypto),
         requests: createPlanningRequestRepository(store, crypto),
         identity,
+        readPlanCreationCard,
         async resolveTarget() {
           const latest = await plans.readLatest();
           if (latest?.status === "active") return "active_plan";
@@ -269,7 +273,16 @@ describe("Planning request delivery", () => {
       }),
     });
 
-    const result = await service().listPlanningRequests!({ chatId: "chat-1" });
+    const planCreation = {
+      creationId: "01J60HFQ7T0000000000000001",
+      version: 1,
+      status: "in-progress" as const,
+      answeredSummaries: [],
+      openQuestion: { kind: "goal-question" as const, prompt: "Goal?", candidates: [] },
+    };
+    const result = await service(undefined, undefined, async () => planCreation)
+      .listPlanningRequests!({ chatId: "chat-1" });
+    expect(result.planCreation).toEqual(planCreation);
     expect(result.deliveries).toHaveLength(1);
     expect(result.deliveries[0]).toMatchObject({
       requestId: "request-1",

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -5,6 +5,7 @@ import {
   type AthleteState,
   type CoachEngine,
   type CoachOperations,
+  type PlanCreationOperations,
   type SpendSummary,
 } from "@enduragent/coach-contract";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
@@ -17,6 +18,7 @@ import { runCoachServe, type CoachServeDependencies } from "../src/serve.js";
 import { createInvocationCoordinator } from "../src/daemon/invocation-coordinator.js";
 import type { CoachRpcServerInput } from "../src/daemon/rpc-server.js";
 import type { LocalCoachLifecycle } from "../src/local-runner.js";
+import { planCreationOperationStubs } from "./helpers/plan-creation-operation-stubs.js";
 
 interface Deferred<T> {
   readonly promise: Promise<T>;
@@ -65,7 +67,8 @@ const engine: CoachEngine = {
   getAthleteState: async () => state,
 };
 
-const operations: CoachOperations = {
+const operations: CoachOperations & PlanCreationOperations = {
+  ...planCreationOperationStubs,
   importFiles: async ({ paths }) => ({
     schemaVersion: 2,
     files: { total: paths.length, imported: paths.length, quarantined: 0 },

--- a/packages/kernel-node/tests/plan-creation-repository.test.ts
+++ b/packages/kernel-node/tests/plan-creation-repository.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createPlanCreationRepository,
+  type PlanCreationCommandStamp,
+  type PlanCreationRepository,
+} from "@enduragent/kernel/planning";
+import { buildExport, importExport, type ExportSource } from "@enduragent/kernel/store/export";
+import {
+  dumpStore,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createSqliteImportSink, webCryptoExportEnv } from "@enduragent/kernel-node/store-export";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const id = (value: string) => `${"0".repeat(26 - value.length)}${value}`;
+const creationId = id("1");
+const secondId = id("2");
+const seed = { schemaVersion: 1 as const, eventCandidates: [] };
+const stamp = (
+  commandId: string,
+  digest: string,
+  nowMs = 883_612_800_000,
+): PlanCreationCommandStamp => ({
+  commandId,
+  requestDigest: digest.repeat(64),
+  nowMs,
+  deviceId: "test-device-1998",
+  hlcPhysicalMs: nowMs,
+  hlcCounter: 0,
+});
+
+describe("Plan Creation repository", () => {
+  let store: SqlStore & MigratorStore;
+  let repository: PlanCreationRepository;
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    repository = createPlanCreationRepository(store);
+  });
+  afterEach(async () => store.close());
+  const start = () => repository.start({ command: stamp("start", "a"), creationId, seed });
+  const answer = (expectedVersion = 1, commandId = "answer", answerId = id("3")) =>
+    repository.recordAnswer({
+      command: stamp(commandId, "b", 883_612_800_001),
+      creationId,
+      expectedVersion,
+      answerId,
+      answerKey: expectedVersion === 1 ? "goal" : "success",
+      valueJson:
+        expectedVersion === 1
+          ? JSON.stringify({ kind: "goal", goal: { kind: "fitness", outcome: "Build power" } })
+          : JSON.stringify({ kind: "success", success: { kind: "authored", text: "Ride well" } }),
+    });
+
+  it("creates once and resumes without replacing the seed", async () => {
+    await expect(start()).resolves.toMatchObject({ outcome: "created", snapshot: { version: 1 } });
+    const otherSeed = {
+      schemaVersion: 1 as const,
+      eventCandidates: [
+        { candidateId: id("9"), name: "Tour", date: "1998-10-18", sourceLabel: "Calendar" },
+      ],
+    };
+    await expect(
+      repository.start({ command: stamp("resume", "c"), creationId: secondId, seed: otherSeed }),
+    ).resolves.toMatchObject({ outcome: "resumed", snapshot: { id: creationId, seed } });
+  });
+
+  it("replays effects and rejects a changed digest", async () => {
+    await start();
+    await expect(start()).resolves.toMatchObject({ outcome: "replayed" });
+    await expect(
+      repository.start({ command: stamp("start", "c"), creationId: secondId, seed }),
+    ).rejects.toMatchObject({ code: "command-conflict" });
+    await answer();
+    await expect(answer()).resolves.toMatchObject({
+      outcome: "replayed",
+      snapshot: { version: 2 },
+    });
+    await expect(
+      repository.recordAnswer({
+        command: stamp("answer", "c"),
+        creationId,
+        expectedVersion: 1,
+        answerId: id("3"),
+        answerKey: "goal",
+        valueJson: "{}",
+      }),
+    ).rejects.toMatchObject({ code: "command-conflict" });
+    expect(await store.all("SELECT id FROM plan_creation_answer")).toHaveLength(1);
+  });
+
+  it("leaves no partial effect for a stale version", async () => {
+    await start();
+    await expect(answer(2)).rejects.toMatchObject({ code: "stale-version" });
+    await expect(repository.readUnfinished()).resolves.toMatchObject({ version: 1, answers: [] });
+    expect(
+      await store.get(
+        "SELECT command_id FROM planning_command WHERE command_name='plan_creation.answer'",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("rejects a malformed persisted seed as a corrupt record", async () => {
+    await start();
+    await store.run("UPDATE plan_creation SET seed_json=? WHERE id=?", [
+      JSON.stringify({ schemaVersion: 1 }),
+      creationId,
+    ]);
+    await expect(repository.readUnfinished()).rejects.toMatchObject({ code: "corrupt-record" });
+  });
+
+  it("serializes competing starts to one unfinished creation", async () => {
+    const results = await Promise.all([
+      start(),
+      repository.start({ command: stamp("other", "c"), creationId: secondId, seed }),
+    ]);
+    expect(results.map(({ outcome }) => outcome).sort()).toEqual(["created", "resumed"]);
+    expect(
+      await store.get(
+        "SELECT count(*) count FROM plan_creation WHERE status IN ('in-progress','review')",
+      ),
+    ).toEqual({ count: 1 });
+  });
+
+  it("owns one creation version bump per answer", async () => {
+    await start();
+    await answer();
+    const result = await answer(2, "success", id("4"));
+    expect(result.snapshot).toMatchObject({
+      version: 3,
+      answers: [
+        { sequence: 1, creationVersion: 2, answerKey: "goal" },
+        { sequence: 2, creationVersion: 3, answerKey: "success" },
+      ],
+    });
+    expect(
+      await store.all(
+        "SELECT command_name,status FROM planning_command ORDER BY created_at_ms,command_name",
+      ),
+    ).toEqual([
+      { command_name: "plan_creation.start", status: "succeeded" },
+      { command_name: "plan_creation.answer", status: "succeeded" },
+      { command_name: "plan_creation.answer", status: "succeeded" },
+    ]);
+  });
+
+  it("round-trips real rows through dump, export, and restore", async () => {
+    await start();
+    await answer();
+    const destination = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(destination, MIGRATIONS);
+      const source: ExportSource = {
+        readUserVersion: () => store.getUserVersion(),
+        readAuthoredTable: (table, options) =>
+          store.all(
+            `SELECT * FROM "${table.replaceAll('"', '""')}"${options.manualOnly ? " WHERE provenance = 'manual'" : ""}`,
+          ),
+      };
+      const built = await buildExport(
+        { source, manifest: { listArtifacts: async () => [] }, ...webCryptoExportEnv },
+        {},
+      );
+      await importExport(
+        {
+          sink: createSqliteImportSink(destination),
+          presence: { hasArtifact: async () => true },
+          targetUserVersion: 29,
+          ...webCryptoExportEnv,
+        },
+        { container: built.container },
+      );
+      expect(await dumpStore(destination)).toBe(await dumpStore(store));
+      await expect(
+        createPlanCreationRepository(destination).readUnfinished(),
+      ).resolves.toMatchObject({ id: creationId, version: 2, answers: [{ id: id("3") }] });
+    } finally {
+      await destination.close();
+    }
+  });
+});

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -1,0 +1,286 @@
+import { canonicalJson } from "../archive/canonical.js";
+import type { MigratorStore } from "../store/migrator.js";
+import type { Row, SqlStore } from "../store/ports.js";
+import { z } from "zod";
+
+export type PlanCreationStore = SqlStore & Pick<MigratorStore, "transaction">;
+export type PlanCreationErrorCode =
+  | "command-conflict"
+  | "stale-version"
+  | "missing-creation"
+  | "corrupt-record";
+
+export class PlanCreationStoreError extends Error {
+  constructor(readonly code: PlanCreationErrorCode) {
+    super(code);
+    this.name = "PlanCreationStoreError";
+  }
+}
+
+export const PlanCreationSeedV1Schema = z
+  .object({
+    schemaVersion: z.literal(1),
+    eventCandidates: z
+      .array(
+        z
+          .object({
+            candidateId: z.string().regex(/^[0-9A-HJKMNP-TV-Z]{26}$/u),
+            name: z.string().min(1).max(512),
+            date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/u),
+            sourceLabel: z.string().min(1).max(128),
+          })
+          .strict()
+          .readonly(),
+      )
+      .max(10)
+      .readonly(),
+  })
+  .strict()
+  .readonly();
+export type PlanCreationSeedV1 = z.infer<typeof PlanCreationSeedV1Schema>;
+
+export interface PlanCreationAnswerRecord {
+  readonly id: string;
+  readonly sequence: number;
+  readonly creationVersion: number;
+  readonly answerKey: string;
+  readonly valueJson: string;
+  readonly confirmedAtMs: number;
+}
+
+export interface PlanCreationSnapshot {
+  readonly id: string;
+  readonly status: "in-progress" | "review" | "activated" | "discarded";
+  readonly version: number;
+  readonly seed: PlanCreationSeedV1 | null;
+  readonly createdAtMs: number;
+  readonly updatedAtMs: number;
+  readonly answers: readonly PlanCreationAnswerRecord[];
+}
+
+export interface PlanCreationCommandStamp {
+  readonly commandId: string;
+  readonly requestDigest: string;
+  readonly nowMs: number;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+export interface StartPlanCreationInput {
+  readonly command: PlanCreationCommandStamp;
+  readonly creationId: string;
+  readonly seed: PlanCreationSeedV1;
+}
+
+export interface RecordPlanCreationAnswerInput {
+  readonly command: PlanCreationCommandStamp;
+  readonly creationId: string;
+  readonly expectedVersion: number;
+  readonly answerId: string;
+  readonly answerKey: string;
+  readonly valueJson: string;
+}
+
+export interface PlanCreationRepository {
+  readUnfinished(): Promise<PlanCreationSnapshot | undefined>;
+  start(input: StartPlanCreationInput): Promise<{
+    outcome: "created" | "resumed" | "replayed";
+    snapshot: PlanCreationSnapshot;
+  }>;
+  recordAnswer(input: RecordPlanCreationAnswerInput): Promise<{
+    outcome: "recorded" | "replayed";
+    snapshot: PlanCreationSnapshot;
+  }>;
+}
+
+const fail = (): never => {
+  throw new PlanCreationStoreError("corrupt-record");
+};
+const text = (row: Row, key: string): string => {
+  const value = row[key];
+  return typeof value === "string" ? value : fail();
+};
+const integer = (row: Row, key: string): number => {
+  const value = row[key];
+  return typeof value === "number" && Number.isSafeInteger(value) ? value : fail();
+};
+const json = (value: string): unknown => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fail();
+  }
+};
+const parseSeed = (value: unknown): PlanCreationSeedV1 => {
+  const parsed = PlanCreationSeedV1Schema.safeParse(value);
+  return parsed.success ? parsed.data : fail();
+};
+
+export function createPlanCreationRepository(store: PlanCreationStore): PlanCreationRepository {
+  const readUnfinished = async (): Promise<PlanCreationSnapshot | undefined> => {
+    const rows = await store.all(
+      "SELECT * FROM plan_creation WHERE status IN ('in-progress','review') ORDER BY created_at_ms,id",
+    );
+    if (rows.length > 1) fail();
+    const row = rows[0];
+    if (row === undefined) return undefined;
+    const id = text(row, "id");
+    const status = text(row, "status");
+    if (status !== "in-progress" && status !== "review") fail();
+    const seedJson = row.seed_json;
+    const seed =
+      seedJson === null ? null : typeof seedJson === "string" ? parseSeed(json(seedJson)) : fail();
+    const answers = await store.all(
+      "SELECT * FROM plan_creation_answer WHERE creation_id=? ORDER BY sequence,id",
+      [id],
+    );
+    return {
+      id,
+      status: status === "review" ? "review" : "in-progress",
+      version: integer(row, "version"),
+      seed,
+      createdAtMs: integer(row, "created_at_ms"),
+      updatedAtMs: integer(row, "updated_at_ms"),
+      answers: answers.map((answer) => {
+        const valueJson = text(answer, "value_json");
+        json(valueJson);
+        return {
+          id: text(answer, "id"),
+          sequence: integer(answer, "sequence"),
+          creationVersion: integer(answer, "creation_version"),
+          answerKey: text(answer, "answer_key"),
+          valueJson,
+          confirmedAtMs: integer(answer, "confirmed_at_ms"),
+        };
+      }),
+    };
+  };
+  const requireUnfinished = async () => {
+    const snapshot = await readUnfinished();
+    if (snapshot === undefined) throw new PlanCreationStoreError("missing-creation");
+    return snapshot;
+  };
+  const replay = async (
+    name: "plan_creation.start" | "plan_creation.answer",
+    command: PlanCreationCommandStamp,
+  ) => {
+    const row = await store.get(
+      "SELECT request_digest,status FROM planning_command WHERE command_name=? AND command_id=?",
+      [name, command.commandId],
+    );
+    if (row === undefined) return undefined;
+    if (text(row, "request_digest") !== command.requestDigest)
+      throw new PlanCreationStoreError("command-conflict");
+    if (text(row, "status") !== "succeeded") fail();
+    return requireUnfinished();
+  };
+  const recordCommand = (
+    name: "plan_creation.start" | "plan_creation.answer",
+    command: PlanCreationCommandStamp,
+    creationId: string,
+    result: unknown,
+  ) =>
+    store.run(
+      `INSERT INTO planning_command (
+command_name,command_id,request_digest,status,aggregate_refs_json,result_json,error_code,error_json,
+version,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?, ?, ?, 'succeeded', ?, ?, NULL, NULL, 2, ?, ?, ?, ?, ?)`,
+      [
+        name,
+        command.commandId,
+        command.requestDigest,
+        canonicalJson({ creationId }),
+        canonicalJson(result),
+        command.nowMs,
+        command.nowMs,
+        command.deviceId,
+        command.hlcPhysicalMs,
+        command.hlcCounter,
+      ],
+    );
+  return {
+    readUnfinished,
+    async start({ command, creationId, seed }) {
+      return store.transaction(async () => {
+        const prior = await replay("plan_creation.start", command);
+        if (prior) return { outcome: "replayed", snapshot: prior };
+        let snapshot = await readUnfinished();
+        const outcome = snapshot ? "resumed" : "created";
+        if (!snapshot) {
+          await store.run(
+            `INSERT INTO plan_creation (
+id,status,version,seed_json,current_draft_revision_number,activated_plan_id,created_at_ms,updated_at_ms,
+terminal_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?, 'in-progress', 1, ?, NULL, NULL, ?, ?, NULL, ?, ?, ?)`,
+            [
+              creationId,
+              canonicalJson(seed),
+              command.nowMs,
+              command.nowMs,
+              command.deviceId,
+              command.hlcPhysicalMs,
+              command.hlcCounter,
+            ],
+          );
+          snapshot = await requireUnfinished();
+        }
+        await recordCommand("plan_creation.start", command, snapshot.id, {
+          creationId: snapshot.id,
+          outcome,
+        });
+        return { outcome, snapshot };
+      });
+    },
+    async recordAnswer({ command, creationId, expectedVersion, answerId, answerKey, valueJson }) {
+      return store.transaction(async () => {
+        const prior = await replay("plan_creation.answer", command);
+        if (prior) return { outcome: "replayed", snapshot: prior };
+        const current = await requireUnfinished();
+        if (current.id !== creationId) throw new PlanCreationStoreError("missing-creation");
+        if (current.version !== expectedVersion) throw new PlanCreationStoreError("stale-version");
+        const version = expectedVersion + 1;
+        await store.run(
+          `INSERT INTO plan_creation_answer (
+id,creation_id,sequence,creation_version,answer_key,value_json,scope,preference_id,confirmed_at_ms,
+device_id,hlc_physical_ms,hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, 'plan-creation', NULL, ?, ?, ?, ?)`,
+          [
+            answerId,
+            creationId,
+            current.answers.length + 1,
+            version,
+            answerKey,
+            valueJson,
+            command.nowMs,
+            command.deviceId,
+            command.hlcPhysicalMs,
+            command.hlcCounter,
+          ],
+        );
+        await store.run(
+          `UPDATE plan_creation SET version=?,updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=?
+WHERE id=? AND status='in-progress' AND version=?`,
+          [
+            version,
+            command.nowMs,
+            command.deviceId,
+            command.hlcPhysicalMs,
+            command.hlcCounter,
+            creationId,
+            expectedVersion,
+          ],
+        );
+        const snapshot = await requireUnfinished();
+        if (snapshot.id !== creationId || snapshot.version !== version)
+          throw new PlanCreationStoreError("stale-version");
+        await recordCommand("plan_creation.answer", command, creationId, {
+          creationId,
+          answerId,
+          version,
+        });
+        return { outcome: "recorded", snapshot };
+      });
+    },
+  };
+}

--- a/packages/kernel/src/planning/index.ts
+++ b/packages/kernel/src/planning/index.ts
@@ -16,3 +16,4 @@ export * from "./request-repository.js";
 export * from "./request-intake-repository.js";
 export * from "./intake-repository.js";
 export * from "./draft-build-repository.js";
+export * from "./creation-repository.js";


### PR DESCRIPTION
Plan-in-Chat Slice 1. Epic #855.

An athlete starts or resumes Plan Creation from Main Chat, confirms the goal and what success means through host-owned Cards, relaunches the app, and sees the answers restored exactly as left. Two paths ship: a manual event and a fitness goal without an event. Event candidates are empty in this slice; the `GoalEventCandidateSource` seam ships with an empty default.

## What changed

- Contract: `plan_creation.start` and `plan_creation.answer` on the coach WebSocket registry, per-method schemas, required handlers, no envelope and no preload sibling. `listPlanningRequests` gains a required nullable `planCreation` field that restores the live Card.
- Kernel: a private `PlanCreationRepository` over the shipped `plan_creation`, `plan_creation_answer`, and `planning_command` tables. Every mutator writes its domain rows and one terminal `planning_command` row in the same transaction. Stale expected versions are rejected with no partial effect. Identical command replays return the recorded result; a reused command id with different input is rejected. Migration 029 is untouched and no migration is added.
- Coach: flow policy (goal, then success), Card projection, rejection mapping, and a drain gate that refuses `chat`, `resumeChatQueue`, `runQueuedCommand`, and `retryQueuedTurn` on the desktop chat while a question is open.
- Renderer: a `Start a Plan` action row and the open question in the dock above the composer, answered summaries and a progress card in the conversation, focus moves to the new Card heading, and the composer send is blocked while a question is open on both sides.

## Scope

- 3 commits: the vertical, a QA fix, and a review fix round. Workspaces: `coach-contract`, `coach-client`, `kernel`, `coach`, `desktop-renderer`, `desktop`, plus `kernel-node` (tests only).
- Public operations added: `plan_creation.start`, `plan_creation.answer`.
- Storage objects added: none.
- Runtime consumers: coach composition registers both operations; the desktop renderer calls them from the dock; the coach adapter gate reads the same repository.

## Verification

- Root `pnpm check`: exit 0.
- Focused suites green under `vitest run`: coach-contract (37), kernel-node SQLite repository (7, includes dump/export/restore with real rows), coach (132 across operations, adapter gate, RPC server dispatch, handshake, entry, redaction), coach-client (152), desktop-renderer (chat controller, adapter, surface; 77 + 220), desktop integration fixtures (18).
- Playwright acceptance spec `apps/desktop/tests/e2e/plan-creation-slice1.spec.ts` against the built app: both scenarios pass (renderer action → SQLite rows → relaunch restore; relaunch between answers restores the success Card with send blocked). Full `test:e2e` run: 5 passed.
- Visual drive of the built app in light and dark: Start a Plan → goal → success → complete, send blocked while a question is open and enabled after, no horizontal overflow at 720px, no console errors.
- The visual drive caught one bug, fixed in the second commit: the success field opened pre-filled with the goal text because React reused the textarea node between the two forms. The surface test now asserts the field starts empty and fails without the fix.

## Review round

A multi-angle code review ran on the first two commits; the third commit addresses its findings: summary text cap raised to 2,000 to match accepted answers; the host drain gate derives "open question" from aggregate status and answer keys and fails open on read errors so a broken record can never block chat; one dock question at a time (Start a Plan refuses while a coach decision is pending); interrupted retries and boot drains wait for the restored card; a null or new creation replaces the installed card; the fields reuse the chat control recipe; event dates are calendar-validated; `PROTOCOL_VERSION` 32 → 33; the Playwright spec moved under `tests/e2e/` so root vitest does not collect it. Not changed: host-side gating of `answerCoachDecision` and `resumeCoachDecision`, whose result schemas have no refusal shape; the renderer rule covers that path.

## Residuals (by design for later slices)

- The composer stays blocked until an answer succeeds; discard arrives in Slice 3.
- A Card projection for a non-in-progress creation reports `corrupt-record` (review and later statuses arrive with their slices).
- A failed boot list leaves `planCreationLoaded` unchanged; recoverable through the existing retry.
- Boot restore focuses the Card heading.

Changeset: `.changeset/plan-creation-slice1.md` (desktop patch).
