### PR TITLE
fix(desktop): resolve Training review follow-ups

### DIFF
--- a/.changeset/sweet-pandas-show.md
+++ b/.changeset/sweet-pandas-show.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Training week labels now show both years when a week crosses New Year. The weekly chart and its data table use the same name for screen readers.

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -92,12 +92,14 @@ function rideCountCopy(value: number): string {
 }
 
 function weekRangeLabel(week: CompletedActivityWeek): string {
+  const year =
+    week.window.start.slice(0, 4) === week.window.end.slice(0, 4) ? undefined : "numeric";
   const startMonth = formatCivilDate(week.window.start, { month: "short" });
   const endMonth = formatCivilDate(week.window.end, { month: "short" });
-  const start = formatCivilDate(week.window.start, { day: "numeric", month: "short" });
+  const start = formatCivilDate(week.window.start, { day: "numeric", month: "short", year });
   const end = formatCivilDate(
     week.window.end,
-    startMonth === endMonth ? { day: "numeric" } : { day: "numeric", month: "short" },
+    startMonth === endMonth ? { day: "numeric", year } : { day: "numeric", month: "short", year },
   );
   return `${start}–${end}`;
 }
@@ -156,7 +158,9 @@ function Trend(props: { readonly week: CompletedActivityWeek }): ReactElement {
         ))}
       </div>
       <table className={styles.srOnly}>
-        <caption>{TRAINING_HISTORY_COPY.trendTitle} data</caption>
+        <caption>
+          {TRAINING_HISTORY_COPY.trendLabel} {TRAINING_HISTORY_COPY.trendPeriod}
+        </caption>
         <thead>
           <tr>
             <th scope="col">Week</th>

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -380,6 +380,22 @@ describe("training landing page", () => {
     expect(screen.queryByRole("region", { name: "Import ride files" })).not.toBeInTheDocument();
   });
 
+  it.each([
+    ["en-US", "1998-07-06", "1998-07-12", "Jul 6–12"],
+    ["en-US", "1998-06-29", "1998-07-05", "Jun 29–Jul 5"],
+    ["en-US", "1997-12-29", "1998-01-04", "Dec 29, 1997–Jan 4, 1998"],
+    ["en-GB", "1998-07-06", "1998-07-12", "6 Jul–12"],
+    ["en-GB", "1998-06-29", "1998-07-05", "29 Jun–5 Jul"],
+    ["en-GB", "1997-12-29", "1998-01-04", "29 Dec 1997–4 Jan 1998"],
+  ] as const)("formats the %s week subtitle for %s through %s", (locale, start, end, label) => {
+    vi.restoreAllMocks();
+    pinDefaultLocale(locale);
+    setTraining(ready(history({ anchorWeek: week("anchor", { window: { start, end } }) })));
+    render(<TrainingView />);
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
   it("uses adjacent pressed period buttons and announces the selected period with one warning", async () => {
     const user = userEvent.setup();
     setTraining(
@@ -537,7 +553,7 @@ describe("training landing page", () => {
     expect(bars.item(3)).toHaveStyle({ height: "75%" });
     expect(figure.querySelector('[aria-hidden="true"]')).toHaveClass("max-[761px]:min-h-[76px]");
     const table = within(figure).getByRole("table", {
-      name: "Six complete weeks of riding time data",
+      name: "Weekly time 6 weeks",
     });
     expect(within(figure).getByText("6/15")).toBeInTheDocument();
     expect(within(table).getByText("Jun 15, 1998 to Jun 21, 1998")).toBeInTheDocument();
@@ -1618,11 +1634,16 @@ describe("training history states and import status", () => {
     expect(screen.queryByText("9,999")).not.toBeInTheDocument();
   });
 
-  it("reports the picker, progress, success and failure stages", () => {
+  it("reports the picker, progress, success and failure stages", async () => {
+    const user = userEvent.setup();
     const choose = vi.fn();
     useEnduragentStore.setState({ rideImportActions: { choose } });
     render(<TrainingView />);
     expect(screen.queryByRole("region", { name: "Import ride files" })).not.toBeInTheDocument();
+    const importButton = screen.getByRole("button", { name: "Import ride files" });
+    expect(importButton).toBeEnabled();
+    await user.click(importButton);
+    expect(choose).toHaveBeenCalledOnce();
     const status = document.querySelector("#ride-import-status");
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveClass("sr-only");

--- a/apps/desktop/tests/helpers/training-incomplete-athlete-state.ts
+++ b/apps/desktop/tests/helpers/training-incomplete-athlete-state.ts
@@ -1,3 +1,4 @@
+import type { RidingTimeTrend } from "@enduragent/coach-contract";
 import { createInspectionAthleteState } from "./inspection-athlete-states.js";
 import { TRAINING_CURRENT_ATHLETE_STATE } from "./training-current-athlete-state.js";
 
@@ -43,6 +44,27 @@ const recordedRides = [
     energyKilojoules: 1_137,
   },
 ];
+
+const trend = {
+  kind: "computed",
+  buckets: [
+    { start: "1998-07-13", end: "1998-07-19" },
+    { start: "1998-07-20", end: "1998-07-26" },
+    { start: "1998-07-27", end: "1998-08-02" },
+    { start: "1998-08-03", end: "1998-08-09" },
+    { start: "1998-08-10", end: "1998-08-16" },
+    { start: "1998-08-17", end: "1998-08-23" },
+  ].map((window) => {
+    const rides = recordedRides.filter(
+      (ride) => ride.localDate >= window.start && ride.localDate <= window.end,
+    );
+    return {
+      window,
+      rideCount: rides.length,
+      ridingSeconds: rides.reduce((sum, ride) => sum + ride.ridingSeconds, 0),
+    };
+  }),
+} satisfies RidingTimeTrend;
 
 export const TRAINING_INCOMPLETE_ATHLETE_STATE = createInspectionAthleteState(
   {
@@ -96,7 +118,7 @@ export const TRAINING_INCOMPLETE_ATHLETE_STATE = createInspectionAthleteState(
           items: recordedRides,
           truncated: true,
         },
-        trend: { kind: "unavailable", reason: "incomplete-source" },
+        trend,
         callout: null,
       },
       previousWeek: {
@@ -115,7 +137,7 @@ export const TRAINING_INCOMPLETE_ATHLETE_STATE = createInspectionAthleteState(
           items: [],
           truncated: false,
         },
-        trend: { kind: "unavailable", reason: "incomplete-source" },
+        trend,
         callout: null,
       },
     },

--- a/apps/desktop/tests/helpers/training-no-power-athlete-state.ts
+++ b/apps/desktop/tests/helpers/training-no-power-athlete-state.ts
@@ -114,6 +114,41 @@ const previousRides = [
   },
 ];
 
+const comparisonWindow = { start: "1998-08-03", end: "1998-08-30" };
+
+const trendBuckets = [
+  {
+    window: { start: "1998-07-13", end: "1998-07-19" },
+    rideCount: 3,
+    ridingSeconds: 12_480,
+  },
+  {
+    window: { start: "1998-07-20", end: "1998-07-26" },
+    rideCount: 3,
+    ridingSeconds: 11_400,
+  },
+  {
+    window: { start: "1998-07-27", end: "1998-08-02" },
+    rideCount: 3,
+    ridingSeconds: 14_100,
+  },
+  {
+    window: { start: "1998-08-03", end: "1998-08-09" },
+    rideCount: 4,
+    ridingSeconds: 16_800,
+  },
+  {
+    window: { start: "1998-08-10", end: "1998-08-16" },
+    rideCount: 3,
+    ridingSeconds: 14_880,
+  },
+  {
+    window: { start: "1998-08-17", end: "1998-08-23" },
+    rideCount: 2,
+    ridingSeconds: 9_660,
+  },
+];
+
 export const TRAINING_NO_POWER_ATHLETE_STATE = createInspectionAthleteState(
   {
     ...currentTrainingContext,
@@ -162,45 +197,25 @@ export const TRAINING_NO_POWER_ATHLETE_STATE = createInspectionAthleteState(
         },
         trend: {
           kind: "computed",
-          buckets: [
-            {
-              window: { start: "1998-07-13", end: "1998-07-19" },
-              rideCount: 3,
-              ridingSeconds: 12_480,
-            },
-            {
-              window: { start: "1998-07-20", end: "1998-07-26" },
-              rideCount: 3,
-              ridingSeconds: 11_400,
-            },
-            {
-              window: { start: "1998-07-27", end: "1998-08-02" },
-              rideCount: 3,
-              ridingSeconds: 14_100,
-            },
-            {
-              window: { start: "1998-08-03", end: "1998-08-09" },
-              rideCount: 4,
-              ridingSeconds: 16_800,
-            },
-            {
-              window: { start: "1998-08-10", end: "1998-08-16" },
-              rideCount: 3,
-              ridingSeconds: 14_880,
-            },
-            {
-              window: { start: "1998-08-17", end: "1998-08-23" },
-              rideCount: 2,
-              ridingSeconds: 9_660,
-            },
-          ],
+          buckets: trendBuckets,
         },
         callout: {
           kind: "longest-ride-28d",
           rideId: rides[0].id,
           durationSeconds: rides[0].ridingSeconds,
-          window: { start: "1998-08-03", end: "1998-08-30" },
-          comparisonRideCount: 10,
+          window: comparisonWindow,
+          comparisonRideCount:
+            rides.filter(
+              (ride) =>
+                ride.localDate >= comparisonWindow.start && ride.localDate <= comparisonWindow.end,
+            ).length +
+            trendBuckets
+              .filter(
+                (bucket) =>
+                  bucket.window.start >= comparisonWindow.start &&
+                  bucket.window.end <= comparisonWindow.end,
+              )
+              .reduce((sum, bucket) => sum + bucket.rideCount, 0),
         },
       },
       previousWeek: {
@@ -227,31 +242,7 @@ export const TRAINING_NO_POWER_ATHLETE_STATE = createInspectionAthleteState(
               rideCount: 3,
               ridingSeconds: 14_760,
             },
-            {
-              window: { start: "1998-07-13", end: "1998-07-19" },
-              rideCount: 3,
-              ridingSeconds: 12_480,
-            },
-            {
-              window: { start: "1998-07-20", end: "1998-07-26" },
-              rideCount: 3,
-              ridingSeconds: 11_400,
-            },
-            {
-              window: { start: "1998-07-27", end: "1998-08-02" },
-              rideCount: 3,
-              ridingSeconds: 14_100,
-            },
-            {
-              window: { start: "1998-08-03", end: "1998-08-09" },
-              rideCount: 4,
-              ridingSeconds: 16_800,
-            },
-            {
-              window: { start: "1998-08-10", end: "1998-08-16" },
-              rideCount: 3,
-              ridingSeconds: 14_880,
-            },
+            ...trendBuckets.slice(0, -1),
           ],
         },
         callout: null,

--- a/apps/desktop/tests/plan-inspection-live.test.ts
+++ b/apps/desktop/tests/plan-inspection-live.test.ts
@@ -117,16 +117,38 @@ describe("Plan inspection live fixture", () => {
     if (noPowerCallout?.kind !== "longest-ride-28d") {
       throw new TypeError("expected longest ride callout");
     }
-    const longestDuration = Math.max(
-      ...noPower.recentRides.items
-        .filter(
-          (ride) =>
-            ride.localDate >= noPowerCallout.window.start &&
-            ride.localDate <= noPowerCallout.window.end,
-        )
-        .map((ride) => ride.movingSeconds ?? 0),
-    );
-    expect(noPowerCallout.durationSeconds).toBe(longestDuration);
+    const noPowerRideLists = [
+      {
+        name: "recent rides",
+        items: noPower.recentRides.items.map((ride) => ({
+          id: ride.id,
+          localDate: ride.localDate,
+          ridingSeconds: ride.movingSeconds ?? ride.elapsedSeconds,
+        })),
+      },
+      {
+        name: "Training history",
+        items: [
+          ...noPower.trainingHistory.anchorWeek.rides.items,
+          ...(noPower.trainingHistory.previousWeek?.rides.items ?? []),
+        ],
+      },
+    ];
+    for (const rideList of noPowerRideLists) {
+      const comparisonRides = rideList.items.filter(
+        (ride) =>
+          ride.localDate >= noPowerCallout.window.start &&
+          ride.localDate <= noPowerCallout.window.end,
+      );
+      const longestDuration = Math.max(...comparisonRides.map((ride) => ride.ridingSeconds ?? 0));
+      expect(noPowerCallout.durationSeconds, rideList.name).toBe(longestDuration);
+      expect(
+        comparisonRides
+          .filter((ride) => ride.ridingSeconds === longestDuration)
+          .map((ride) => ride.id),
+        rideList.name,
+      ).toEqual([noPowerCallout.rideId]);
+    }
 
     const limited = TRAINING_LIMITED_ATHLETE_STATE.trainingContext?.trainingHistory;
     expect(limited?.kind).toBe("computed");
@@ -182,10 +204,6 @@ describe("Plan inspection live fixture", () => {
       "Park tempo",
       "Country endurance",
     ]);
-    expect(incomplete.anchorWeek.trend).toEqual({
-      kind: "unavailable",
-      reason: "incomplete-source",
-    });
     expect(incomplete.anchorWeek.callout).toBeNull();
     expect(incomplete.previousWeek?.coverage).toEqual({ kind: "complete" });
     expect(incomplete.previousWeek?.totals).toEqual({
@@ -209,6 +227,66 @@ describe("Plan inspection live fixture", () => {
     expect(stale.lastGood.previousWeek).toBeNull();
   });
 
+  it("counts the no-power callout population from its comparison weeks", () => {
+    const history = TRAINING_NO_POWER_ATHLETE_STATE.trainingContext?.trainingHistory;
+    if (history?.kind !== "computed") throw new TypeError("expected history");
+    const { anchorWeek } = history;
+    const { callout, trend } = anchorWeek;
+    if (callout?.kind !== "longest-ride-28d") throw new TypeError("expected longest ride callout");
+    if (trend.kind !== "computed") throw new TypeError("expected computed trend");
+    const comparisonWeeks = [
+      ...trend.buckets,
+      { window: anchorWeek.window, rideCount: anchorWeek.rides.items.length },
+    ].filter(
+      (week) => week.window.start >= callout.window.start && week.window.end <= callout.window.end,
+    );
+
+    expect(comparisonWeeks).toHaveLength(4);
+    expect(comparisonWeeks[0]?.window.start).toBe(callout.window.start);
+    expect(comparisonWeeks.at(-1)?.window.end).toBe(callout.window.end);
+    expect(comparisonWeeks.map((week) => week.rideCount)).toEqual([4, 3, 2, 4]);
+    expect(callout.comparisonRideCount).toBe(13);
+  });
+
+  it("keeps the incomplete fixture's proven closed weeks as zero trend buckets", () => {
+    const context = TRAINING_INCOMPLETE_ATHLETE_STATE.trainingContext;
+    if (context === undefined) throw new TypeError("expected Training context");
+    const history = context.trainingHistory;
+    if (history.kind !== "computed") throw new TypeError("expected history");
+    const { coverage, anchorWeek, previousWeek } = history;
+    if (coverage.kind !== "incomplete") throw new TypeError("expected incomplete coverage");
+    if (coverage.provenStart === null || coverage.provenThrough === null) {
+      throw new TypeError("expected proven coverage");
+    }
+    if (context.recentRides.kind !== "computed") throw new TypeError("expected recent rides");
+    expect(anchorWeek.trend.kind).toBe("computed");
+    if (anchorWeek.trend.kind !== "computed") throw new TypeError("expected computed trend");
+    expect(previousWeek?.trend).toEqual(anchorWeek.trend);
+    expect(anchorWeek.trend.buckets.map((bucket) => bucket.window)).toEqual([
+      { start: "1998-07-13", end: "1998-07-19" },
+      { start: "1998-07-20", end: "1998-07-26" },
+      { start: "1998-07-27", end: "1998-08-02" },
+      { start: "1998-08-03", end: "1998-08-09" },
+      { start: "1998-08-10", end: "1998-08-16" },
+      { start: "1998-08-17", end: "1998-08-23" },
+    ]);
+    const rides = [...anchorWeek.rides.items, ...(previousWeek?.rides.items ?? [])];
+    for (const bucket of anchorWeek.trend.buckets) {
+      expect(bucket.window.start >= coverage.provenStart).toBe(true);
+      expect(bucket.window.end <= coverage.provenThrough).toBe(true);
+      expect(bucket.window.end < anchorWeek.window.start).toBe(true);
+      expect(bucket.rideCount).toBe(0);
+      expect(bucket.ridingSeconds).toBe(0);
+      for (const rideList of [rides, context.recentRides.items]) {
+        expect(
+          rideList.filter(
+            (ride) => ride.localDate >= bucket.window.start && ride.localDate <= bucket.window.end,
+          ),
+        ).toHaveLength(0);
+      }
+    }
+  });
+
   it("keeps Training fixture ride IDs distinct across data states", () => {
     const states = [
       TRAINING_CURRENT_ATHLETE_STATE,
@@ -217,13 +295,32 @@ describe("Plan inspection live fixture", () => {
       TRAINING_INCOMPLETE_ATHLETE_STATE,
       TRAINING_STALE_ATHLETE_STATE,
     ];
-    const rideIds = states.flatMap((state) =>
-      state.trainingContext?.recentRides.kind === "computed"
-        ? state.trainingContext.recentRides.items.map((ride) => ride.id)
-        : [],
-    );
+    const rideLists = [
+      {
+        name: "recent rides",
+        ids: states.flatMap((state) =>
+          state.trainingContext?.recentRides.kind === "computed"
+            ? state.trainingContext.recentRides.items.map((ride) => ride.id)
+            : [],
+        ),
+      },
+      {
+        name: "Training history",
+        ids: states.flatMap((state) => {
+          const panel = state.trainingContext?.trainingHistory;
+          const history =
+            panel?.kind === "computed" ? panel : panel?.kind === "stale" ? panel.lastGood : null;
+          return [
+            ...(history?.anchorWeek.rides.items ?? []),
+            ...(history?.previousWeek?.rides.items ?? []),
+          ].map((ride) => ride.id);
+        }),
+      },
+    ];
 
-    expect(new Set(rideIds).size).toBe(rideIds.length);
+    for (const rideList of rideLists) {
+      expect(new Set(rideList.ids).size, rideList.name).toBe(rideList.ids.length);
+    }
   });
 
   it("uses privacy-safe ordinary Main Chat turns", async () => {


### PR DESCRIPTION
## Why

Training week labels omitted both years across New Year, and the weekly chart and its data table had different accessible names. Inspection fixtures also carried inconsistent ride counts and historical trend states.

## Scope

- Show both years for cross-year weeks using the existing locale formatter, preserving ordinary week labels.
- Give the weekly chart and its data table the same accessible name.
- Click the enabled ride-import control in its existing test and assert that it invokes the chooser.
- Derive the no-power comparison count from its dated fixture data and check longest-ride and unique-ID invariants independently in recent rides and Training history.
- Give the incomplete fixture six computed zero-ride historical buckets where its coverage proves complete weeks.

## Tradeoffs

The incomplete fixture retains its current-week partial totals, known rides, and warning. Both selected periods use the proven historical trend. Changing only an unavailable reason would leave that fixture inconsistent.

## Blast Radius

Production changes stay inside Training date formatting and the chart table caption. The remaining changes affect synthetic inspection data and regression tests. No protocol, storage, release, or workflow changes. No new numeric limits.

## Verification

- `pnpm check` passed, including builds, workspace/root type checks, fixture privacy, dependency and schema checks, and 35 verification-catalog tests. Its first sandboxed attempt stopped at a denied local `tsx` socket; the exact command passed with the required permission.
- `pnpm exec vitest run --project renderer-dom apps/desktop-renderer/tests/training-surface.test.tsx --project workspace apps/desktop/tests/plan-inspection-live.test.ts apps/desktop-renderer/tests/date.test.ts` passed all 65 tests. The new regressions failed before the fix.
- `pnpm --filter @enduragent/desktop-renderer check` passed.
- `pnpm --filter @enduragent/desktop exec vitest run tests/chat-panels.integration.test.ts` passed all 8 tests against the rebuilt desktop. The first run passed 7 tests and failed in fixture onboarding startup; the failure did not reproduce in a rerun with no concurrent desktop sessions, and no source change was needed.
- The project desktop verification driver passed 16 combinations of current, cross-year, no-power, and incomplete states across wide/compact layouts and light/dark themes. Each case exercised current → previous → next navigation, checked focus and overflow, and matched the figure/table names. Cross-year labels show both years; ordinary week labels remain compact. Screenshots and DOM evidence were retained and inspected.
- The existing prototype comparison passed 20 affected state/layout/theme cases with zero unexplained differences. Existing allowances remained in scope.
- Fresh no-comments review found no actionable items.
- Codex autoreview (`gpt-5.6-sol`, high reasoning) passed with no accepted/actionable findings; its secret scan was clean.
