### PR TITLE
fix(desktop): simplify Training page and ride actions

### DIFF
--- a/.agents/skills/verify-enduragent/references/features/training.md
+++ b/.agents/skills/verify-enduragent/references/features/training.md
@@ -2,9 +2,9 @@
 
 ## Sub-features
 
-- Owned user route: **Training** in Main navigation (`activeView: "training"`). Manifest surfaces: `training-setup`, `first-sync`, `training-import`, `training`, `ride-review`, `power-progress`, `wellness`, `training-export`, and `training-sync`.
+- Owned user route: **Training** in Main navigation (`activeView: "training"`). Manifest surfaces: `training-setup`, `first-sync`, `training-import`, `training`, `ride-review`, `wellness`, `training-export`, and `training-sync`.
 - Setup and first sync: [`setup.md`](setup.md) owns the Setup scenarios; Training owns `training.first-sync.provider-backfill` and `training.first-sync.failure-recovery`.
-- Week-first overview and recovery: `training.view.panel-inventory`, `training.view.readiness-states`, `training.view.context-recovery`, `training.view.anchor-load-plan-adherence`, `training.power-progress.comparison`, and `training.wellness.trend`. Weekly summary owns riding time, rides, distance, Load, and the six-week trend; Recent rides owns the scoped callout.
+- Week-first overview and recovery: `training.view.panel-inventory`, `training.view.readiness-states`, `training.view.context-recovery`, `training.view.anchor-load-plan-adherence`, `training.power-progress.hidden`, and `training.wellness.trend`. Weekly summary owns riding time, rides, distance, Load, and the six-week trend; Recent rides owns the scoped callout.
 - Ride review, import, export, and sync: `training.ride-review.navigation`, `training.ride-review.local-analysis`, `training.import.progress-results`, `training.export.activity-formats`, `training.sync.lifecycle`, and `training.sync.protocol-failure`. Ride review opens inline on the Training route. The sidebar owns Sync now, and Plan proves `training.export.workout-formats` beside its WorkoutMatch list.
 
 Fixture/profile: isolated renderer `ready()` state with shifted fixture dates and no athlete profile or credentials. Supported executors: renderer and desktop `vitest`; native Windows scenarios remain `vm-only`.
@@ -14,7 +14,7 @@ Fixture/profile: isolated renderer `ready()` state with shifted fixture dates an
 - Complete Setup, then choose **Training** in Main navigation.
 - Compare **This week** with **Previous week**, read the six-week riding-time trend, and start with the recent ride marked **Worth a look**.
 - Use **Sync now** in the sidebar or **Import ride files** on Training. Open a ride from **Recent rides** for inline **Ride review**, then use **Back to training** to restore focus.
-- Open **Recorded analysis and export** to load recorded analysis or export the ride. Choose **Plan** to export its visible Workouts as a ZWO, MRC, ERG, or FIT archive.
+- Open **Recorded analysis** to load recorded analysis. Choose **Plan** to export its visible Workouts as a ZWO, MRC, ERG, or FIT archive.
 
 ## Driving it with verify-enduragent
 
@@ -23,7 +23,7 @@ pnpm --filter @enduragent/desktop-renderer exec vitest run tests/plan-surface.te
 pnpm --filter @enduragent/desktop exec vitest run tests/verification-feature-selection.test.ts tests/windows-parity-scenarios.test.ts
 ```
 
-Require the renderer run to show **Weekly summary**, **Recent rides**, and **Power progress** in order. Weekly summary must show riding time, rides, distance, Load, and the six-week trend; Recent rides must show recorded facts and at most one **Worth a look** callout. Require truthful partial, zero, stale, sparse, and unavailable states, an import live region that persists through idle and suppressed states, inline Ride review with deferred analysis, recorded evidence, and FIT or GPX export, sidebar sync recovery with a disabled-chip focus fallback, the ride export request, and the Plan WorkoutMatch archive request. The standalone cycling anchor, power zones, Cycling Load, Plan, aggregate Adherence, and Wellness panels must remain absent. Require the desktop run to validate the frozen Training manifest and its deterministic citations; it does not execute the mapped behavior.
+Require the renderer run to show **Weekly summary** and **Recent rides** in order, with **Power progress** absent. Weekly summary must show riding time, rides, distance, Load, and the six-week trend; Recent rides must show recorded facts and at most one **Worth a look** callout. Require truthful partial, zero, stale, sparse, and unavailable states, an import live region that persists through idle and suppressed states, inline Ride review with deferred analysis, recorded evidence without ride-export controls, sidebar sync recovery with a disabled-chip focus fallback, the ride export request, and the Plan WorkoutMatch archive request. The standalone cycling anchor, power zones, Cycling Load, Plan, aggregate Adherence, and Wellness panels must remain absent. Require the desktop run to validate the frozen Training manifest and its deterministic citations; it does not execute the mapped behavior.
 
 ## Gotchas
 

--- a/.changeset/few-spies-buy.md
+++ b/.changeset/few-spies-buy.md
@@ -3,4 +3,4 @@
 "@enduragent/desktop": patch
 ---
 
-User-facing: Training now keeps ride import compact and ends after your recent rides. Ride review shows recorded analysis without the ride-export card.
+User-facing: Training now uses a compact ride-import control without an extra file-selection message and ends after your recent rides. Ride review shows recorded analysis without the ride-export card.

--- a/.changeset/few-spies-buy.md
+++ b/.changeset/few-spies-buy.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Training now uses a compact icon to import ride files. Ride review shows recorded analysis without the ride-export card.

--- a/.changeset/few-spies-buy.md
+++ b/.changeset/few-spies-buy.md
@@ -3,4 +3,4 @@
 "@enduragent/desktop": patch
 ---
 
-User-facing: Training now uses a compact icon to import ride files. Ride review shows recorded analysis without the ride-export card.
+User-facing: Training now keeps ride import compact and ends after your recent rides. Ride review shows recorded analysis without the ride-export card.

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -18,7 +18,6 @@ import { Page } from "../shared/Page";
 import { TRAINING_HISTORY_COPY, analysisRefreshFailureCopy, analysisUnavailableCopy } from "./copy";
 import { RideResponseReview } from "./RideResponseReview";
 import { rideStyles as styles } from "./rideStyles";
-import { ActivityExportControl } from "./TrainingExportControls";
 
 const RIDE_KIND: Readonly<Record<string, string>> = {
   road: "Road ride",
@@ -796,10 +795,6 @@ export function RideDetailView(props: {
       >
         <summary>{TRAINING_HISTORY_COPY.disclosure}</summary>
         <div className={styles.recordedDisclosureBody}>
-          <ActivityExportControl
-            canonicalActivityId={props.ride.id}
-            localDate={props.ride.localDate}
-          />
           <AerobicDriftPanel
             rideId={props.ride.id}
             analysis={props.analysis}

--- a/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
@@ -1,4 +1,4 @@
-import type { ActivityExportFormat, WorkoutArchiveFormat } from "@enduragent/coach-contract";
+import type { WorkoutArchiveFormat } from "@enduragent/coach-contract";
 import { useId, useState, type ReactElement } from "react";
 import { Button } from "../../components/ui/button";
 import {
@@ -14,11 +14,6 @@ import {
   type TrainingExportTarget,
 } from "../../training-export/controller";
 import { overviewStyles as styles } from "./overviewStyles";
-
-const ACTIVITY_FORMATS = [
-  { value: "fit", label: "FIT" },
-  { value: "gpx", label: "GPX" },
-] as const;
 
 const WORKOUT_FORMATS = [
   { value: "zwo", label: "ZWO" },
@@ -41,63 +36,6 @@ function Status(props: { readonly target: TrainingExportTarget }): ReactElement 
     >
       {copy}
     </p>
-  );
-}
-
-export function ActivityExportControl(props: {
-  readonly canonicalActivityId: string;
-  readonly localDate: string;
-}): ReactElement {
-  const id = useId();
-  const [format, setFormat] = useState<ActivityExportFormat>("fit");
-  const state = useEnduragentStore((store) => store.trainingExport);
-  const actions = useEnduragentStore((store) => store.trainingExportActions);
-  const busy = state.status === "running";
-  return (
-    <section className={styles.analysisPanel} aria-labelledby={`${id}-title`}>
-      <h2 id={`${id}-title`} className={styles.analysisTitle}>
-        Export ride
-      </h2>
-      <p className={styles.analysisIntro}>
-        Save a copy to your computer. Exporting does not change this ride or your training account.
-      </p>
-      <div className={styles.exportControls}>
-        <label className="font-medium" htmlFor={`${id}-format`}>
-          File format
-        </label>
-        <Select
-          items={ACTIVITY_FORMATS}
-          value={format}
-          disabled={busy}
-          onValueChange={(value) => {
-            if (value !== null) setFormat(value as ActivityExportFormat);
-          }}
-        >
-          <SelectTrigger id={`${id}-format`} className="min-w-[86px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent align="start">
-            {ACTIVITY_FORMATS.map((entry) => (
-              <SelectItem key={entry.value} value={entry.value}>
-                {entry.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={actions === null || busy}
-          aria-busy={busy ? "true" : undefined}
-          onClick={() => {
-            void actions?.exportActivity({ ...props, format });
-          }}
-        >
-          Export ride
-        </Button>
-      </div>
-      <Status target="activity" />
-    </section>
   );
 }
 

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -465,7 +465,8 @@ function RideImportAction(): ReactElement {
     <Button
       type="button"
       variant="outline"
-      size="icon"
+      size="icon-xs"
+      className={styles.periodButton}
       aria-label="Import ride files"
       title="Import ride files"
       disabled={actions === null || state.status === "running"}
@@ -480,9 +481,10 @@ function RideImportAction(): ReactElement {
 function RideImportStatus(): ReactElement {
   const state = useEnduragentStore((store) => store.rideImport);
   const suppressed = useEnduragentStore(rideImportStatusSuppressed);
-  const visible = state.status !== "idle" && !suppressed;
+  const active = state.status !== "idle" && !suppressed;
+  const visible = active && (state.status !== "running" || state.stage !== "choosing");
   const progress = visible && state.status === "running" ? state.progress : null;
-  const copy = visible ? rideImportStatusCopy(state) : "";
+  const copy = active ? rideImportStatusCopy(state) : "";
   return (
     <>
       {visible ? (
@@ -505,7 +507,7 @@ function RideImportStatus(): ReactElement {
       <p
         id="ride-import-status"
         className={`${styles.srOnly} ride-import-status`}
-        data-state={visible ? state.status : "idle"}
+        data-state={active ? state.status : "idle"}
         role="status"
         aria-live="polite"
         aria-atomic="true"

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -15,7 +15,7 @@ import {
   type ReactNode,
   type Ref,
 } from "react";
-import { ChevronLeft, ChevronRight, FileInput } from "lucide-react";
+import { ChevronLeft, ChevronRight, Upload } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { formatCivilDate } from "../../lib/date";
 import { rideImportStatusCopy } from "../../ride-import";
@@ -473,7 +473,7 @@ function RideImportAction(): ReactElement {
       aria-describedby={state.status === "idle" ? undefined : "ride-import-status"}
       onClick={() => actions?.choose()}
     >
-      <FileInput aria-hidden="true" />
+      <Upload aria-hidden="true" />
     </Button>
   );
 }

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -29,7 +29,6 @@ import {
 import { Page } from "../shared/Page";
 import { TRAINING_DEGRADED_COPY, TRAINING_HISTORY_COPY, trainingStatusCopy } from "./copy";
 import { overviewStyles as styles } from "./overviewStyles";
-import { PowerProgressContent } from "./PowerProgressPanel";
 import { RideDetailView, trainingRideDateTime, trainingRideKind } from "./RideReview";
 
 type Period = "anchor" | "previous";
@@ -385,19 +384,6 @@ function RecentRides(props: {
   );
 }
 
-function PowerProgressStatePanel(props: {
-  readonly panel: Parameters<typeof PowerProgressContent>[0]["panel"];
-}): ReactElement {
-  return (
-    <section className={styles.panel} data-panel="power-progress" aria-label="Power progress">
-      <h2 className={styles.panelTitle}>Power progress</h2>
-      <div className={styles.panelBody}>
-        <PowerProgressContent panel={props.panel} />
-      </div>
-    </section>
-  );
-}
-
 function PeriodNavigation(props: {
   readonly history: TrainingHistoryComputed;
   readonly period: Period;
@@ -705,7 +691,6 @@ export function TrainingView(): ReactElement {
       }
     >
       {historyContent}
-      <PowerProgressStatePanel panel={training.trainingContext.performanceProgress} />
       <RideImportStatus />
     </Page>
   );

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -15,7 +15,7 @@ import {
   type ReactNode,
   type Ref,
 } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, FileInput } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { formatCivilDate } from "../../lib/date";
 import { rideImportStatusCopy } from "../../ride-import";
@@ -479,11 +479,14 @@ function RideImportAction(): ReactElement {
     <Button
       type="button"
       variant="outline"
+      size="icon"
+      aria-label="Import ride files"
+      title="Import ride files"
       disabled={actions === null || state.status === "running"}
       aria-describedby={state.status === "idle" ? undefined : "ride-import-status"}
       onClick={() => actions?.choose()}
     >
-      Import ride files
+      <FileInput aria-hidden="true" />
     </Button>
   );
 }

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -81,7 +81,7 @@ export const TRAINING_HISTORY_COPY = {
   review: "Ride review",
   back: "Back to training",
   keyStats: "Key stats",
-  disclosure: "Recorded analysis and export",
+  disclosure: "Recorded analysis",
 } as const;
 
 export function analysisUnavailableCopy(reason: AnalysisUnavailableReason): string {

--- a/apps/desktop-renderer/tests/ride-interval-evidence.test.tsx
+++ b/apps/desktop-renderer/tests/ride-interval-evidence.test.tsx
@@ -126,7 +126,7 @@ describe("ride interval evidence", () => {
         titleRef={createRef<HTMLHeadingElement>()}
       />,
     );
-    fireEvent.click(screen.getByText("Recorded analysis and export"));
+    fireEvent.click(screen.getByText("Recorded analysis"));
 
     const ordered = screen.getByRole("list", {
       name: "Ordered ride intervals and laps",

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -1558,6 +1558,9 @@ describe("training history states and import status", () => {
     expect(importButton).toBeEnabled();
     expect(importButton.textContent).toBe("");
     expect(importButton).toHaveAttribute("title", "Import ride files");
+    const previousWeek = within(screen.getByRole("group", { name: "Completed riding period" }))
+      .getByRole("button", { name: "Previous week" });
+    expect(importButton.className).toBe(previousWeek.className);
     await user.click(importButton);
     expect(choose).toHaveBeenCalledOnce();
     const status = document.querySelector("#ride-import-status");
@@ -1573,6 +1576,7 @@ describe("training history states and import status", () => {
       result: null,
     });
     expect(status).toHaveTextContent("Waiting for ride file selection…");
+    expect(screen.queryByRole("region", { name: "Import ride files" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Import ride files" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Import ride files" })).toHaveAttribute(
       "aria-describedby",
@@ -1596,6 +1600,7 @@ describe("training history states and import status", () => {
     });
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveTextContent("Importing ride files…");
+    expect(screen.getByRole("region", { name: "Import ride files" })).toBeInTheDocument();
     expect(screen.getByText("2 of 4 files processed")).toBeInTheDocument();
 
     setRideImport({

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -312,7 +312,7 @@ async function openFirstRide(user: ReturnType<typeof userEvent.setup>): Promise<
 
 async function openFirstRideAnalysis(user: ReturnType<typeof userEvent.setup>): Promise<void> {
   await openFirstRide(user);
-  await user.click(screen.getByText("Recorded analysis and export"));
+  await user.click(screen.getByText("Recorded analysis"));
 }
 
 beforeEach(() => {
@@ -829,53 +829,19 @@ describe("ride review", () => {
     expect(document.body).not.toHaveTextContent(FIRST_ID);
     expect(within(keyStats).queryByText("Energy")).not.toBeInTheDocument();
 
-    const disclosure = screen.getByText("Recorded analysis and export").closest("details");
+    const disclosure = screen.getByText("Recorded analysis").closest("details");
     expect(disclosure).not.toHaveAttribute("open");
     expect(start).not.toHaveBeenCalled();
 
-    await user.click(screen.getByText("Recorded analysis and export"));
+    await user.click(screen.getByText("Recorded analysis"));
     expect(disclosure).toHaveAttribute("open");
     expect(start).toHaveBeenCalledTimes(1);
-    await user.click(screen.getByText("Recorded analysis and export"));
-    await user.click(screen.getByText("Recorded analysis and export"));
+    await user.click(screen.getByText("Recorded analysis"));
+    await user.click(screen.getByText("Recorded analysis"));
     expect(start).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("region", { name: "Export ride" })).toBeInTheDocument();
-  });
-
-  it("offers FIT and GPX and exports a ride without rendering its canonical ID", async () => {
-    const user = userEvent.setup();
-    const exportActivity = vi.fn(async () => {});
-    const exportWorkoutArchive = vi.fn(async () => {});
-    useEnduragentStore.setState({
-      trainingExportActions: { exportActivity, exportWorkoutArchive },
-    });
-    render(<TrainingView />);
-
-    await openFirstRideAnalysis(user);
-
-    const panel = screen.getByRole("region", { name: "Export ride" });
-    const formatLabel = within(panel).getByText("File format");
-    expect(formatLabel).toHaveClass("font-medium");
-    await user.click(within(panel).getByRole("combobox", { name: "File format" }));
-    expect((await screen.findAllByRole("option")).map((option) => option.textContent)).toEqual([
-      "FIT",
-      "GPX",
-    ]);
-    await user.click(screen.getByRole("option", { name: "GPX" }));
-    await user.click(within(panel).getByRole("button", { name: "Export ride" }));
-    expect(exportActivity).toHaveBeenCalledWith({
-      canonicalActivityId: FIRST_ID,
-      localDate: "1998-07-09",
-      format: "gpx",
-    });
-    expect(document.body).not.toHaveTextContent(FIRST_ID);
-
-    act(() => {
-      useEnduragentStore.setState({
-        trainingExport: { status: "saved", target: "activity", byteLength: 4_096 },
-      });
-    });
-    expect(within(panel).getByRole("status")).toHaveTextContent("Export saved locally.");
+    expect(screen.queryByRole("region", { name: "Export ride" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Export ride" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "File format" })).not.toBeInTheDocument();
   });
 
   it("uses the prototype label weight for workout archive export", () => {
@@ -1229,7 +1195,7 @@ describe("ride review", () => {
         name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
       }),
     );
-    await user.click(screen.getByText("Recorded analysis and export"));
+    await user.click(screen.getByText("Recorded analysis"));
 
     expect(screen.getByRole("heading", { level: 2, name: "River tempo" })).toBeInTheDocument();
     expect(screen.getAllByText(/could not be (analyzed|loaded)/u).length).toBeGreaterThan(1);
@@ -1642,6 +1608,8 @@ describe("training history states and import status", () => {
     expect(screen.queryByRole("region", { name: "Import ride files" })).not.toBeInTheDocument();
     const importButton = screen.getByRole("button", { name: "Import ride files" });
     expect(importButton).toBeEnabled();
+    expect(importButton.textContent).toBe("");
+    expect(importButton).toHaveAttribute("title", "Import ride files");
     await user.click(importButton);
     expect(choose).toHaveBeenCalledOnce();
     const status = document.querySelector("#ride-import-status");

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -362,7 +362,7 @@ describe("training landing page", () => {
     expect(screen.getByRole("button", { name: "Import ride files" })).toBeInTheDocument();
     expect(
       [...document.querySelectorAll("[data-panel]")].map((node) => node.getAttribute("data-panel")),
-    ).toEqual(["weekly-summary", "recent-rides", "power-progress"]);
+    ).toEqual(["weekly-summary", "recent-rides"]);
     const summary = screen.getByRole("region", { name: "Weekly summary" });
     expect(within(summary).getByRole("heading", { name: "Weekly summary" })).toHaveClass("sr-only");
     expect(within(summary).getByText("2h 25m")).toBeInTheDocument();
@@ -448,9 +448,7 @@ describe("training landing page", () => {
       .find((element) => element.id !== "ride-import-status");
     expect(periodStatus).toHaveTextContent("Previous week. Some rides may be missing.");
     expect(periodStatus?.textContent?.match(/Some rides may be missing\./gu)).toHaveLength(1);
-    expect(
-      screen.getByText("Power progress needs rides with recorded power in both 28-day windows."),
-    ).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Power progress" })).not.toBeInTheDocument();
   });
 
   it("keeps focus inside the period group after chevron navigation", async () => {
@@ -1336,77 +1334,27 @@ describe("ride review", () => {
 });
 
 describe("power progress", () => {
-  it("renders an accessible five-effort Power Progress comparison with secondary context", async () => {
-    const user = userEvent.setup();
-    setTraining(
-      ready(history(), {
-        trainingContext: { ...context(), performanceProgress: computedPowerProgress },
-      }),
-    );
+  it("keeps Power progress hidden for computed, stale, and unavailable data", () => {
     render(<TrainingView />);
 
-    const progress = screen.getByRole("region", { name: "Power progress" });
-    expect(
-      within(progress).getByText("Short efforts changed more favorably than long efforts."),
-    ).toBeInTheDocument();
-    expect(
-      within(progress).getByText("Jun 22, 1998–Jul 19, 1998 · compared with the prior 28 days"),
-    ).toBeInTheDocument();
-    expect(within(progress).getByText("Fresh")).toBeInTheDocument();
-    const powerTable = within(progress).getByRole("table", {
-      name: "Power curve for the current 28 days compared with the previous 28 days",
-    });
-    expect(within(powerTable).getAllByRole("row")).toHaveLength(6);
-    expect(within(powerTable).getByText("1120 W")).toBeInTheDocument();
-    expect(within(powerTable).getByLabelText("Increased, 6.7%")).toHaveTextContent("↑ +6.7%");
-    expect(within(powerTable).getByLabelText("Decreased, 2.5%")).toHaveTextContent("↓ -2.5%");
-    expect(within(powerTable).getAllByLabelText("Unavailable")).toHaveLength(3);
-    await user.click(within(progress).getByText("Heart-rate response · 4 efforts"));
-    expect(
-      within(progress).getByRole("table", {
-        name: "Heart-rate curve for the current 28 days compared with the previous 28 days",
-      }),
-    ).toBeVisible();
-    expect(within(progress).getByText("181 bpm")).toBeInTheDocument();
-    expect(
-      within(progress).getByText(
-        "42-day durability context · 83% curve coverage · indoor and outdoor rides",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("explains unavailable data and clearly labels a stale last-good comparison", () => {
-    setTraining(
-      ready(history(), {
-        trainingContext: {
-          ...context(),
-          performanceProgress: { kind: "unavailable", reason: "invalid-data" },
-        },
-      }),
-    );
-    render(<TrainingView />);
-    expect(
-      screen.getByText("Power progress data could not be verified. Sync again."),
-    ).toBeInTheDocument();
-
-    setTraining(
-      ready(history(), {
-        trainingContext: {
-          ...context(),
-          performanceProgress: {
-            kind: "stale",
-            lastGood: { ...computedPowerProgress, freshness: "stale" },
-            refreshFailure: { code: "timeout", failedAt: "1998-07-20T08:00:00.000Z" },
-          },
-        },
-      }),
-    );
-    const progress = screen.getByRole("region", { name: "Power progress" });
-    expect(within(progress).getByText(/latest refresh timed out/i)).toHaveTextContent(
-      "The latest refresh timed out. Showing the last complete comparison. Failed Jul 20, 1998, 8:00 AM.",
-    );
-    expect(within(progress).getByText("Stale")).toBeInTheDocument();
-    expect(within(progress).getByText("1120 W")).toBeInTheDocument();
+    for (const performanceProgress of [
+      computedPowerProgress,
+      {
+        kind: "stale",
+        lastGood: { ...computedPowerProgress, freshness: "stale" },
+        refreshFailure: { code: "timeout", failedAt: "1998-07-20T08:00:00.000Z" },
+      },
+      { kind: "unavailable", reason: "invalid-data" },
+    ] as const) {
+      setTraining(
+        ready(history(), {
+          trainingContext: { ...context(), performanceProgress },
+        }),
+      );
+      expect(screen.queryByRole("region", { name: "Power progress" })).not.toBeInTheDocument();
+      expect(screen.queryByText(/Power progress/i)).not.toBeInTheDocument();
+      expect(screen.getByRole("region", { name: "Recent rides" })).toBeInTheDocument();
+    }
   });
 });
 

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -2277,7 +2277,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const title = page.querySelector("h1");
       const titleFocused = document.activeElement === title;
       const analysisDisclosure = [...page.querySelectorAll("summary")].find(
-        (entry) => entry.textContent.includes("Recorded analysis and export"),
+        (entry) => entry.textContent.includes("Recorded analysis"),
       );
       analysisDisclosure.click();
       const analysisDeadline = Date.now() + 5000;

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -2224,7 +2224,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     `);
     expect(training).toEqual({
       current: "page",
-      order: ["weekly-summary", "recent-rides", "power-progress"],
+      order: ["weekly-summary", "recent-rides"],
       retiredPanelsAbsent: true,
       pageOverflow: false,
       documentOverflow: false,
@@ -2537,7 +2537,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       surfaceMinWidthZero: true,
       readableWrapping: true,
       trainingOpen: true,
-      panelOrder: ["weekly-summary", "recent-rides", "power-progress"],
+      panelOrder: ["weekly-summary", "recent-rides"],
       retiredPanelsAbsent: true,
       chipResident: true,
       chipAccessibleLabel:
@@ -2783,7 +2783,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     `);
     expect(compact).toEqual({
       trainingOpen: true,
-      panelOrder: ["weekly-summary", "recent-rides", "power-progress"],
+      panelOrder: ["weekly-summary", "recent-rides"],
       retiredPanelsAbsent: true,
       chipResident: true,
       chipReachable: true,

--- a/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
@@ -140,7 +140,7 @@
     {
       "id": "training.view.panel-inventory",
       "surface": "training",
-      "expected": "Training renders Weekly summary, Recent rides, and Power progress in that order, with riding time, rides, distance, Load, a six-week trend, one scoped recent-ride callout, and non-idle import status.",
+      "expected": "Training renders Weekly summary and Recent rides in that order, with riding time, rides, distance, Load, a six-week trend, one scoped recent-ride callout, and non-idle import status.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop-renderer/tests/training-surface.test.tsx > training landing page > renders the week-first section order and ignores the rollback fields",
@@ -217,23 +217,16 @@
       ]
     },
     {
-      "id": "training.power-progress.comparison",
-      "surface": "power-progress",
-      "expected": "Power progress remains the third week-first section and compares five shipped effort durations across the current and prior 28 days with accessible direction labels, unavailable values, optional heart-rate response, freshness, and 42-day durability context.",
+      "id": "training.power-progress.hidden",
+      "surface": "training",
+      "expected": "Training hides Power progress for computed, stale, and unavailable data and preserves Recent rides.",
       "automation": "deterministic",
-      "test": "apps/desktop-renderer/tests/training-surface.test.tsx > power progress > renders an accessible five-effort Power Progress comparison with secondary context"
-    },
-    {
-      "id": "training.power-progress.recovery",
-      "surface": "power-progress",
-      "expected": "Unavailable Power progress explains why it cannot be shown, while a failed refresh labels and timestamps the failure and retains the last complete comparison as stale evidence.",
-      "automation": "deterministic",
-      "test": "apps/desktop-renderer/tests/training-surface.test.tsx > power progress > explains unavailable data and clearly labels a stale last-good comparison"
+      "test": "apps/desktop-renderer/tests/training-surface.test.tsx > power progress > keeps Power progress hidden for computed, stale, and unavailable data"
     },
     {
       "id": "training.wellness.trend",
       "surface": "wellness",
-      "expected": "Training omits the retired standalone Wellness trend and keeps the week-first section order limited to Weekly summary, Recent rides, and Power progress.",
+      "expected": "Training omits the retired standalone Wellness trend and keeps the week-first section order limited to Weekly summary and Recent rides.",
       "automation": "deterministic",
       "test": "apps/desktop-renderer/tests/training-surface.test.tsx > training landing page > renders the week-first section order and ignores the rollback fields"
     },

--- a/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
@@ -250,11 +250,10 @@
     {
       "id": "training.export.activity-formats",
       "surface": "training-export",
-      "expected": "Inline Ride review reveals Export ride only inside Recorded analysis and export, offers FIT and GPX, sends the selected canonical ride without rendering its identifier, reports a saved export, and lets the trusted main process add the destination through the native save dialog.",
+      "expected": "Inline Ride review keeps ride-export controls hidden when Recorded analysis opens. The retained export contract sends a closed ride request, reports a saved export, and lets the trusted main process add the destination through the native save dialog.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop-renderer/tests/training-surface.test.tsx > ride review > shows recorded facts in order, caps key metrics at four, and lazy-starts the disclosure",
-        "apps/desktop-renderer/tests/training-surface.test.tsx > ride review > offers FIT and GPX and exports a ride without rendering its canonical ID",
         "apps/desktop-renderer/tests/training-export.test.ts > sends a closed ride request and publishes a saved result",
         "apps/desktop/tests/training-export-ipc.test.ts > uses the native save dialog and adds the destination only in the trusted main process"
       ]

--- a/apps/desktop/tests/windows-installed-acceptance.test.ts
+++ b/apps/desktop/tests/windows-installed-acceptance.test.ts
@@ -62,7 +62,7 @@ describe("Windows installed acceptance", () => {
 
     expect(plan.manifests).toEqual(collection.manifests);
     expect(plan.totals).toEqual(derivedTotals);
-    expect(plan.totals.total).toBe(139);
+    expect(plan.totals.total).toBe(138);
     expect(plan.automatedEvidence).toHaveLength(derivedTotals.deterministic);
     expect(plan.manualChecklist).toHaveLength(derivedTotals.vmOnly);
     expect(

--- a/apps/desktop/tests/windows-parity-scenarios.test.ts
+++ b/apps/desktop/tests/windows-parity-scenarios.test.ts
@@ -73,7 +73,7 @@ describe("Windows parity scenario manifests", () => {
         (scenario) => scenario.automation === "deterministic",
       ).length,
       vmOnly: collection.scenarios.filter((scenario) => scenario.automation === "vm-only").length,
-    }).toEqual({ total: 139, deterministic: 111, vmOnly: 28 });
+    }).toEqual({ total: 138, deterministic: 110, vmOnly: 28 });
     expect(new Set(collection.scenarios.map((scenario) => scenario.id)).size).toBe(
       collection.scenarios.length,
     );


### PR DESCRIPTION
Training now ends after Recent rides and the applicable Previous week button. It hides the Power progress panel that is absent from the approved prototype. Ride review also hides Export ride and labels its disclosure Recorded analysis. Ride import uses the operator-selected Lucide Upload icon with the same compact button size and styling as the week arrows, without a redundant waiting block while its file chooser is open.

Validation: 51 focused renderer and import tests, 2 affected desktop integration flows, and 39 scenario and installed-acceptance tests pass. Build, type, lint, privacy, dependency, and verification-catalog checks pass. The built app passed both week views and Ride review return at wide and compact widths in light and dark mode. Upload rendering, equal button geometry, file-picker waiting, and cancellation passed at both widths and themes. Codex autoreview reported no actionable findings.
