### PR TITLE
chore(tooling): strengthen development workflow checks

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,38 +1,46 @@
 # Context Map
 
-This repo is a multi-package monorepo for the enduragent AI coaching agent platform — Core publishes the Sport contract, sport packages implement it, binary packages ship them.
+This repo is a multi-package monorepo for the enduragent AI coaching agent platform. Engine defines the Sport contract, sport packages supply domain behavior, and host packages compose them.
 
 ## Contexts
 
-- [Core](./packages/core/CONTEXT.md) — sport-agnostic infrastructure: agent loop, memory, session, secrets, channels (Telegram), LLM transport, intervals.icu client (shared tools), setup wizard, runBinary entry-point, updater. Owns no sport vocabulary. Publishes the `Sport` and `BinaryConfig` contracts.
+- [Core](./packages/core/CONTEXT.md) — shared CLI entry point, setup, memory, secrets, and channels. Defines `BinaryConfig` and re-exports Engine’s sport contract. Depends on Engine and Kernel through transitional edges.
+- [Engine](./packages/engine/src/sport.ts) — defines `Sport`, `SportRuntimePorts`, and the `CoreDeps` alias at `@enduragent/engine/sport`.
+- [Kernel](./packages/kernel/package.json) — declares portable compute, store, planning, and Reference exports. Its dependency rule forbids workspace imports and Node builtins.
+- [Kernel Node](./packages/kernel-node/package.json) — declares Node host adapter exports and depends on Kernel.
+- [Coach](./packages/coach/package.json) — declares runtime, sync, store-runtime, and serve exports; depends on Engine, Kernel, Kernel Node, and transitionally Core.
 - [Cycling](./packages/sport-cycling/CONTEXT.md) — FTP-based zones, power-prescribed workouts, bike equipment, cyclist persona. Implements `Sport`. Bundled into the `cycling-coach` binary.
-- [Running](./packages/sport-running/CONTEXT.md) — VDOT/pace-based zones, impact-aware progression, injury-first intake, runner persona. Stub.
+- [Running](./packages/sport-running/CONTEXT.md) — critical-speed pace zones, schemas, workout serialization, running tools, and a Reference adapter. Implements `Sport`.
 - [Duathlon](./packages/sport-duathlon/CONTEXT.md) — coordinator context. Brick workouts, transitions, dual periodization. Stub.
 - [Cycling Coach](./packages/cycling-coach/CONTEXT.md) — published `cycling-coach` binary; 7-line shim wiring cyclingSport + cyclingBinary into Core's runBinary.
-- [Running Coach](./packages/running-coach/CONTEXT.md) — `running-coach` binary stub; placeholder banner.
+- [Running Coach](./packages/running-coach/CONTEXT.md) — private binary whose entry point calls Core’s `runBinary(runningSport, runningBinary)`.
 - [Duathlon Coach](./packages/duathlon-coach/CONTEXT.md) — `duathlon-coach` binary stub; placeholder banner.
 
 ## Relationships
 
-- **Core → Cycling, Running, Duathlon**: **Open Host Service**. Core publishes the `Sport` interface; each sport conforms. Core changes are coordinated across all sports.
+- **Engine → sport packages**: **Open Host Service**. Engine defines `Sport` at `@enduragent/engine/sport`; Cycling and Running implement it. Coordinate contract changes across consumers. Consult [the dependency checker](./tools/check-package-deps.ts) for allowed and transitional package edges.
 - **Cycling ↔ Running**: **Partnership**. Peer contexts that evolve in lockstep when the `Sport` interface or shared infrastructure changes. Neither is upstream of the other.
-- **Duathlon → Cycling, Running**: **Customer/Supplier (Conformist flavor)**. Duathlon imports `sport-cycling` and `sport-running` as workspace dependencies, reuses their tools/personas/zones verbatim, and adds duathlon-only concepts (brick, transition, dual periodization). Duathlon never redefines cycling or running vocabulary.
+- **Duathlon → Cycling, Running**: intended **Customer/Supplier (Conformist flavor)**. The planned coordinator reuses their tools, personas, and zones and adds brick workouts, transitions, and dual periodization. The current Duathlon source is a stub; this relationship is not implemented.
 
 ## Why Duathlon is a Customer, not a peer
+
+The intended composition follows two rules:
 
 1. **It doesn't redefine upstream vocabulary.** "FTP" means the same thing inside Duathlon as inside Cycling. If a duathlete asks about FTP, Cycling's persona answers verbatim.
 2. **It adds, never overrides.** Brick, transition, dual periodization are _new_ concepts that don't exist in Cycling or Running.
 
-If sport-cycling improves its FTP-test guidance, sport-duathlon inherits the improvement automatically. This is the load-bearing reason for the Customer pattern over Partnership.
+Once that composition is implemented, improvements to sport-cycling’s FTP-test guidance will also reach sport-duathlon. This is the load-bearing reason for the Customer pattern over Partnership.
 
 ## Status
 
 Current state of the Core/Sport seam:
 
-- **Core** — implemented at `packages/core/`. Sport-agnostic; no cycling vocabulary leaks. Three-category tool split per ADR-0004 (Pure-Core memory + intervals tools live in Core; sport-injected config flows in via `BinaryConfig`/`Sport.intervalsActivityTypes`). Private workspace package (`@enduragent/core`); bundled into the `cycling-coach` binary at publish time, not separately published. See ADR-0009.
+- **Core** — implemented private workspace package consumed by CLI binaries. Its `Sport` export forwards Engine’s definition. The dependency checker explicitly marks its Engine and Kernel dependencies transitional; shared infrastructure has not all moved out of Core.
 - **Cycling** — implemented at `packages/sport-cycling/`. SOUL.md + skills/\*.md inlined into the bundle via tsup `.md: text` loader and skills.generated.ts codegen. Private workspace package (`@enduragent/sport-cycling`); bundled into the `cycling-coach` binary at publish time, not separately published.
 - **Cycling Coach** — implemented at `packages/cycling-coach/`. 7-line bin shim. Published as `cycling-coach` on npm (CalVer continues). The published tarball is self-contained — `@enduragent/*` workspace code is inlined via `tsup` `noExternal`.
-- **Running, Duathlon, Running Coach, Duathlon Coach** — empty stubs at `packages/{sport-running,sport-duathlon,running-coach,duathlon-coach}/`. Private workspace packages (SemVer); not published. They graduate to public CalVer-versioned npm binaries once a real implementation lands.
+- **Running and Running Coach** — private workspace packages with implemented sport/tool composition and a CLI entry point. Source inspection establishes this wiring; it does not establish end-to-end coaching behavior or publication readiness.
+- **Duathlon and Duathlon Coach** — private stubs at `packages/sport-duathlon/` and `packages/duathlon-coach/`; the sport exports a status constant and the binary prints a placeholder banner.
+- **Scoped packages** — `check:package-deps` requires `@enduragent/*` packages to remain private. A declared export is a workspace API, not a publication commitment.
 
 ## Release flow
 

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -1,13 +1,13 @@
 # Core
 
-Sport-agnostic infrastructure for AI coaching agents. Provides the agent loop, memory, secrets, channels, LLM transport, and intervals.icu client. Publishes the `Sport` contract that domain packages implement.
+Sport-agnostic CLI infrastructure for AI coaching agents, including setup, memory, secrets, and channels. Engine defines the `Sport` contract at `@enduragent/engine/sport`; Core re-exports it for existing consumers.
 
-> Status: this directory is a planning placeholder. Source still lives at the repo root in `src/agent/`, `src/secrets/`, `src/auth/`, `src/channels/`. The refactor will move that code here.
+> Status: implemented private workspace package. Core depends on Engine and Kernel through explicitly transitional edges. Consult the [context map](../../CONTEXT-MAP.md) and [dependency checker](../../tools/check-package-deps.ts) for current package boundaries.
 
 ## Language
 
 **Sport**:
-A pluggable coaching domain (cycling, running, duathlon) that conforms to Core's `Sport` interface — pure domain knowledge, no deployment concerns.
+A pluggable coaching domain (cycling, running, duathlon) that conforms to Engine's `Sport` interface — pure domain knowledge, no deployment concerns.
 _Avoid_: Discipline, modality, mode
 
 **Binary**:
@@ -15,7 +15,7 @@ A deployed CLI executable wrapping a `Sport` with deployment-shell config (npm n
 _Avoid_: Build, distro, app
 
 **Agent**:
-The Core-owned conversation loop that runs LLM calls with tool dispatch, compaction, and memory flush; sport-agnostic.
+The sport-agnostic conversation loop that runs LLM calls with tool dispatch, compaction, and memory flush. Core supplies a compatibility host around Engine’s runtime.
 
 **Memory**:
 A file-backed sectioned store of long-lived athlete information at `~/.enduragent/<binary>/memory/MEMORY.md` (or legacy `~/.cycling-coach/memory/MEMORY.md` for grandfathered cycling-coach users).
@@ -42,7 +42,7 @@ The ephemeral compaction path (`summarizeInStages`). Reshapes only the in-memory
 Every freshly generated compaction summary (all four sites: trim, preemptive, overflow recovery, timeout recovery) is also mirrored into the day's note under the fixed marker `### Compaction summary`, heading-demoted, with an exact-block duplicate-skip. This makes the summary recoverable via `memory_read` after a session reset destroys the live JSONL and its archives.
 
 **CoreDeps**:
-The runtime services Core supplies to a Sport's tool factory: `LLM`, `IntervalsClient`, `MemoryStore`, `SecretsResolver`.
+An alias for Engine’s `SportRuntimePorts`, the runtime services received by a Sport’s tool factory. The [contract definition](../engine/src/sport.ts) specifies the required services and optional capabilities.
 
 **BinaryConfig**:
 Deployment-shell config injected into `runBinary` and `runSetup`. Fields: `binaryName` (npm name + CLI invocation), `displayName` (human-readable for prompts), `dataSubdir` (under `~/.enduragent/`), `keychainPrefix` (Apple Keychain entry prefix), `homeEnvVar` (env override variable name). Each binary package declares one and passes it through.
@@ -147,4 +147,4 @@ Golden fixtures (sanitized real intervals.icu responses) live at
 
 ## Flagged ambiguities
 
-- "Coach" was used to mean both **Sport** (coaching domain) and **Binary** (CLI executable). Resolved: code uses **Sport** for domain, **Binary** for deployment shell. "Coach" remains in product surfaces (display names, READMEs) but is not a code-level term.
+- Distinguish **Sport** for coaching domain, **Binary** for deployment shell, and `@enduragent/coach` for the Node composition package.

--- a/packages/running-coach/CONTEXT.md
+++ b/packages/running-coach/CONTEXT.md
@@ -4,15 +4,15 @@ A small shim that wires the running sport (`@enduragent/sport-running`) and the 
 
 ## Status: wired, private (unpublished)
 
-Runs locally from the workspace. Unlike the published `cycling-coach`, this package **externalizes** `@enduragent/*` (tsup default) rather than bundling them: Core compiles to a single self-contained `dist/index.js`, so a private workspace package resolves Core and sport-running through pnpm's symlinks at runtime — no bundled tarball is built.
+The [entry point](./src/index.ts) calls `runBinary(runningSport, runningBinary)` and reports fatal errors using the binary’s data directory. The [build configuration](./tsup.config.ts) explicitly externalizes `@enduragent/*`, so the output requires workspace dependencies at runtime.
 
-When it flips `private: false` to publish, it must switch to bundling (`noExternal`) to match cycling-coach — an externalized tarball would `import` the private, unpublished `@enduragent/core` and 404 on a fresh `npm install`. That transition is **mechanically enforced, not left to memory**: the release smoke job (`.github/workflows/release.yml`) packs the tarball and installs it into a fresh consumer, so a public flip without `noExternal` fails the smoke gate before publish. See ADR-0009/0010.
+This establishes source wiring and build intent, not a verified end-to-end coaching session. The package remains private. Publication would require a separate packaging decision and verification that installation works without private workspace packages.
 
 ## What lives here
 
 - `src/index.ts` — the bin shim (`runBinary(runningSport, runningBinary)`).
 - `src/binary.ts` — `runningBinary: BinaryConfig` (binaryName: "running-coach", displayName: "Running Coach", dataSubdir: "running", keychainPrefix: "running-coach", homeEnvVar: "RUNNING_COACH_HOME").
-- `tests/binary.test.ts` — asserts the BinaryConfig shape and that the running sport wires into `runBinary`.
+- `tests/binary.test.ts` — asserts the `BinaryConfig` shape, the running sport ID, and that `runBinary` is a function; it does not invoke the binary.
 
 ## Not here (intentionally)
 

--- a/packages/sport-running/CONTEXT.md
+++ b/packages/sport-running/CONTEXT.md
@@ -1,10 +1,12 @@
 # Sport-Running
 
-Implements the `Sport` contract from `@enduragent/core` for running. This wave ships **critical-speed-anchored pace zones** — the rest of the Sport surface (plan builder, periodization, workout serializer) is deferred.
+Implements Engine’s `Sport` contract at `@enduragent/engine/sport` for running. The [public index](./src/index.ts) exports critical-speed pace zones, schemas, workout serialization, sport/tools, and a Reference adapter.
 
 ## Status: alpha — zones vertical only
 
-Private workspace package, not published to npm. Becomes a published `@enduragent/sport-running` (SemVer) when a real consumer needs it. See ADR-0009.
+Private workspace package. The heading records the initial zones scope; the implemented surface now includes workout serialization and sport/tool composition. [runningSport](./src/sport.ts) composes memory, intervals.icu, and running tools and supplies the Reference adapter. [Running Coach](../running-coach/CONTEXT.md) consumes it. This source wiring does not establish end-to-end coaching behavior or planning completeness.
+
+`check:package-deps` requires `@enduragent/*` packages to remain private. Publication requires a separate policy decision.
 
 ## Pace zones (the shipped surface)
 
@@ -19,7 +21,7 @@ Primary = **intervals.icu-supplied** value (`threshold_pace`, stored in SI m/s; 
 
 ## Validation gate
 
-`checkCsSource` lives in **core** (`packages/core/src/reference/validation/checks/step5-cs-source.ts`, registered in `sync-gate.ts` as `step5_cs_source`), not here — core owns sync-time validation gates uniformly, following the step1 FTP-source gate precedent (ADR-0021 §4). It refuses to emit zones when a running row carries no sane CS anchor (manual `critical_speed` > platform `threshold_pace`), resolve-or-skip for non-runners. This is the first live instance of the CS-family gate pattern the swim CSS gate (ADR-0021) will follow.
+[checkCsSource](../core/src/reference/validation/checks/step5-cs-source.ts) remains in Core and is called by its [sync gate](../core/src/reference/validation/sync-gate.ts) as `step5_cs_source`. It rejects collected CS values outside the sanity range and gives manual `critical_speed` values precedence over platform `threshold_pace`. It returns no failure when no values are collected. The running `calculate_zones` tool separately returns `no_cs_anchor` when no anchor is available.
 
 ## Monitoring/analyze copy discipline
 

--- a/tools/check-changeset-user-facing.test.ts
+++ b/tools/check-changeset-user-facing.test.ts
@@ -58,6 +58,55 @@ function writeRealisticPackages(): string {
   return join(tempDir, "packages");
 }
 
+describe("User-facing content", () => {
+  it.each([
+    "",
+    " \t\r",
+    "\n\n",
+    "\n# Internal notes",
+    "\n---",
+    "\n```text\nInternal notes\n```",
+    "\n- Internal work",
+    "\n<!-- Internal notes -->",
+    "\n| Package | Change |",
+    " ** ** ",
+  ])("rejects empty or structural content %j", (text) => {
+    const packages = writeRealisticPackages();
+    const file = write(
+      ".changeset/empty.md",
+      `---\n"@enduragent/desktop": patch\n---\n\nUser-facing:${text}\n`,
+    );
+    expect(findChangesetHits([file], packages)).toEqual([
+      expect.objectContaining({ file, line: 5, reason: "empty-user-facing" }),
+    ]);
+  });
+
+  it.each([
+    " Your rides now sync.",
+    "\nYour rides now sync.\nYou can see them in Training.",
+    "\r\n  Your rides now sync.",
+    " **Your rides now sync.**",
+  ])("accepts substantive content %j", (text) => {
+    const packages = writeRealisticPackages();
+    const file = write(
+      ".changeset/valid.md",
+      `---\n"@enduragent/desktop": patch\n---\n\nUser-facing:${text}\n`,
+    );
+    expect(findChangesetHits([file], packages)).toEqual([]);
+  });
+
+  it("checks an empty marker after a valid marker", () => {
+    const packages = writeRealisticPackages();
+    const file = write(
+      ".changeset/multiple.md",
+      `---\n"@enduragent/desktop": patch\n---\n\nUser-facing: Your rides now sync.\nUser-facing:\n`,
+    );
+    expect(findChangesetHits([file], packages)).toEqual([
+      expect.objectContaining({ file, line: 6, reason: "empty-user-facing" }),
+    ]);
+  });
+});
+
 describe("discoverPublishedBinaries", () => {
   it("returns only bin+public packages, keyed by npm name", () => {
     const pkgsDir = writeRealisticPackages();

--- a/tools/check-changeset-user-facing.ts
+++ b/tools/check-changeset-user-facing.ts
@@ -45,6 +45,7 @@ export interface ChangesetHit {
   readonly line: number;
   readonly column: number;
   readonly namedPackages: readonly string[];
+  readonly reason: "missing-release-target" | "empty-user-facing";
 }
 
 const MD_EXTS = new Set([".md", ".mdx"]);
@@ -164,16 +165,6 @@ export function discoverUserFacingReleaseTargets(packagesDir: string): Set<strin
   return new Set([...discoverPublishedBinaries(packagesDir), ...INDEPENDENT_RELEASE_TARGETS]);
 }
 
-/**
- * Lint a single changeset file. Returns a hit when the body carries a
- * `User-facing:` line but no named frontmatter package is a user-facing release target.
- * Returns `[]` when there is no `User-facing:` line, when the file is skipped,
- * when it is a non-changeset (README/config), or when the routing is correct.
- *
- * The hit's line/column point at the first `User-facing:` line (the offending
- * surface), so the report tells the author exactly which line provoked the
- * routing requirement.
- */
 function findHitsInChangesetFile(file: string, published: ReadonlySet<string>): ChangesetHit[] {
   if (NON_CHANGESET_BASENAMES.has(basenameOf(file))) return [];
   const source = readFileSync(file, "utf-8");
@@ -181,30 +172,35 @@ function findHitsInChangesetFile(file: string, published: ReadonlySet<string>): 
 
   const { frontmatter, body, bodyStartLine } = splitFrontmatter(source);
 
-  // Find the first `User-facing:` marker in the BODY only — the frontmatter is
-  // the package list, not prose, so a stray match there must not count. Scanning
-  // per body line yields both the existence check and an accurate location.
   const bodyLines = body.split("\n");
-  let markerBodyIdx = -1;
-  let column = 1;
+  const named = parseFrontmatterPackages(frontmatter);
+  const hasReleaseTarget = named.some((name) => published.has(name));
+  const hits: ChangesetHit[] = [];
+  let reportedRouting = false;
   for (let i = 0; i < bodyLines.length; i++) {
-    const m = USER_FACING_RE.exec(bodyLines[i]);
-    if (m !== null) {
-      markerBodyIdx = i;
-      column = m.index + 1;
-      break;
+    const marker = USER_FACING_RE.exec(bodyLines[i]);
+    if (marker === null) continue;
+    let content = bodyLines[i].slice(marker.index + marker[0].length).trim();
+    if (content === "") content = bodyLines[i + 1]?.trim() ?? "";
+    const structural =
+      /^(?:#{1,6}(?:\s|$)|`{3,}|~{3,}|[-*+]\s|\d+[.)]\s|>|\||<!--|(?:-\s*){3,}$|(?:_\s*){3,}$|(?:\*\s*){3,}$)/.test(
+        content,
+      );
+    const substantive =
+      !structural && !USER_FACING_RE.test(content) && /[\p{L}\p{N}]/u.test(content);
+    const location = {
+      file,
+      line: bodyStartLine + i,
+      column: marker.index + 1,
+      namedPackages: named,
+    };
+    if (!substantive) hits.push({ ...location, reason: "empty-user-facing" });
+    if (!hasReleaseTarget && !reportedRouting) {
+      hits.push({ ...location, reason: "missing-release-target" });
+      reportedRouting = true;
     }
   }
-  if (markerBodyIdx === -1) return [];
-
-  const named = parseFrontmatterPackages(frontmatter);
-  if (named.some((name) => published.has(name))) return [];
-
-  // Translate the body-relative line back to the original source line so the
-  // report points at the offending line, not an offset into the stripped body.
-  const line = bodyStartLine + markerBodyIdx;
-
-  return [{ file, line, column, namedPackages: named }];
+  return hits;
 }
 
 /**
@@ -230,6 +226,9 @@ const DEFAULT_SCAN_PATHS: readonly string[] = [".changeset"];
 const DEFAULT_PACKAGES_DIR = "packages";
 
 function formatHit(hit: ChangesetHit): string {
+  if (hit.reason === "empty-user-facing") {
+    return `${hit.file}:${hit.line}:${hit.column}  User-facing: requires substantive release-note text`;
+  }
   const named =
     hit.namedPackages.length > 0
       ? hit.namedPackages.map((n) => `"${n}"`).join(", ")
@@ -262,12 +261,10 @@ export function main(argv: readonly string[]): number {
     );
     return 0;
   }
-  console.error(
-    `check-changeset-userfacing: ${hits.length} misfiled User-facing changeset(s) found:`,
-  );
+  console.error(`check-changeset-userfacing: ${hits.length} User-facing violation(s) found:`);
   for (const hit of hits) console.error("  " + formatHit(hit));
   console.error(
-    "\nA `User-facing:` line must name a user-facing release target: an npm binary " +
+    "\nA `User-facing:` line needs substantive text and a user-facing release target: an npm binary " +
       "or the independently released @enduragent/desktop app. " +
       `Currently: ${[...releaseTargets].sort().join(", ") || "none"}. ` +
       "Add it to the changeset frontmatter, or drop the User-facing line if the change " +

--- a/tools/check-fixture-privacy.test.ts
+++ b/tools/check-fixture-privacy.test.ts
@@ -187,6 +187,27 @@ function expectOnlyCode(hits: readonly PrivacyHit[], code: string): void {
 }
 
 describe("Rule A — real intervals.icu id shape", () => {
+  it.each(["", "```json", "~~~text"])("flags Markdown identifiers with fence %j", (fence) => {
+    const id = `i${"9".repeat(8)}`;
+    const opening = fence ? `${fence}\n` : "";
+    const closing = fence ? `\n${fence.slice(0, 3)}` : "";
+    const file = write("sample.md", `${opening}athlete ${id}${closing}\n`);
+    expect(findIdHits([file])).toEqual([
+      expect.objectContaining({ file, line: fence ? 2 : 1, column: 9, rule: "intervals-id" }),
+    ]);
+  });
+
+  it("preserves Markdown placeholder and explicit file exemptions", () => {
+    const placeholder = `i${"1234"}${"5678"}`;
+    const forbidden = `i${"9".repeat(9)}`;
+    expect(findIdHits([write("placeholder.md", `\`\`\`\n${placeholder}\n\`\`\`\n`)])).toEqual([]);
+    expect(
+      findIdHits([
+        write("skip.md", `<!-- fixture-privacy-lint:skip-file -->\n\`\`\`\n${forbidden}\n\`\`\``),
+      ]),
+    ).toEqual([]);
+  });
+
   it("flags an i+9-digit id inside a JSON string", () => {
     const file = write("fixture.json", `{ "id": "i123456789", "type": "Ride" }\n`);
     const hits = findIdHits([file]);

--- a/tools/check-fixture-privacy.ts
+++ b/tools/check-fixture-privacy.ts
@@ -254,10 +254,9 @@ function findIdHitsInJsonFile(file: string): PrivacyHit[] {
 function findIdHitsInMdFile(file: string): PrivacyHit[] {
   const source = readFileSync(file, "utf-8");
   if (isSkippedFile(source)) return [];
-  const stripped = source.replace(/```[\s\S]*?```/g, (block) => block.replace(/[^\n]/g, " "));
-  const lineStarts = buildLineStarts(stripped);
+  const lineStarts = buildLineStarts(source);
   const hits: PrivacyHit[] = [];
-  for (const hit of matchIntervalsId(stripped, 0)) {
+  for (const hit of matchIntervalsId(source, 0)) {
     const { line, column } = offsetToLineCol(lineStarts, hit.offset);
     hits.push({
       file,
@@ -266,7 +265,7 @@ function findIdHitsInMdFile(file: string): PrivacyHit[] {
       path: "$",
       rule: "intervals-id",
       code: "source.intervals_id",
-      detail: `real intervals.icu id shape "${hit.value}" in prose`,
+      detail: `real intervals.icu id shape "${hit.value}" in Markdown`,
     });
   }
   return hits;

--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -57,6 +57,113 @@ const rDesktop = ruleForDir("apps/desktop");
 const rCoach = ruleForDir("packages/coach");
 const rBin = ruleForDir("packages/cycling-coach");
 
+describe("relative workspace imports", () => {
+  it.each([
+    'import { value } from "../../engine/src/index.js";',
+    'import "../../engine/src/index.js";',
+    'export { value } from "../../engine/src/index.js";',
+    'export * from "../../engine/src/index.js";',
+    'export const value = import("../../engine/src/index.js");',
+    'export const value = require("../../engine/src/index.js");',
+  ])("rejects a forbidden relative edge: %s", (source) => {
+    writeJson("packages/engine/package.json", { name: "@enduragent/engine", private: true });
+    write("packages/engine/src/index.ts", "export const value = 1;");
+    const file = write("packages/kernel/src/bad.ts", source);
+    expect(runRulesAgainst(tempDir, [r1]).violations).toEqual([
+      expect.objectContaining({ file, specifier: "../../engine/src/index.js", ruleId: "R1" }),
+    ]);
+    expect(main([tempDir])).toBe(1);
+  });
+
+  it("preserves same-package, shared-file, and allowed workspace imports", () => {
+    writeJson("packages/kernel/package.json", { name: "@enduragent/kernel", private: true });
+    write("packages/kernel/src/index.ts", "export const value = 1;");
+    writeJson("packages/kernel-node/package.json", {
+      name: "@enduragent/kernel-node",
+      private: true,
+    });
+    write(
+      "packages/kernel-node/src/ok.ts",
+      [
+        'import "./helper.js";',
+        'import "../test/helper.js";',
+        'import "../../../tools/helper.js";',
+        'import "../../kernel/src/index.js";',
+      ].join("\n"),
+    );
+    expect(violationsFor(r2)).toBe(0);
+  });
+
+  it("preserves transitional warnings for relative imports", () => {
+    writeJson("packages/engine/package.json", { name: "@enduragent/engine", private: true });
+    write("packages/core/src/shim.ts", 'export * from "../../engine/src/index.js";');
+    const result = runRulesAgainst(tempDir, [rCore]);
+    expect(result.violations).toHaveLength(0);
+    expect(result.warnEdges).toEqual([{ dir: "packages/core", target: "@enduragent/engine" }]);
+  });
+
+  it("resolves imports across workspace groups and normalizes parent segments", () => {
+    writeJson("packages/engine/package.json", { name: "@enduragent/engine", private: true });
+    write(
+      "apps/desktop-renderer/src/bad.tsx",
+      'import "../../../packages/core/../engine/src/index.js";',
+    );
+    expect(violationsFor(rRenderer)).toBe(1);
+  });
+
+  it.each(["src/contracts/sport", "src/contracts/sport/index.js", "dist/contracts/sport/index.js"])(
+    "maps declared export targets independently of their file name: %s",
+    (target) => {
+      writeJson("packages/engine/package.json", {
+        name: "@enduragent/engine",
+        private: true,
+        exports: { "./sport": "./dist/contracts/sport/index.js" },
+      });
+      write("packages/sport-x/src/ok.ts", `export * from "../../engine/${target}";`);
+      expect(violationsFor(r4)).toBe(0);
+    },
+  );
+
+  it("does not infer an allowed sport export from a private file's name", () => {
+    writeJson("packages/engine/package.json", {
+      name: "@enduragent/engine",
+      private: true,
+      exports: { "./sport": "./dist/contracts/sport.js" },
+    });
+    write("packages/sport-x/src/bad.ts", 'export * from "../../engine/src/sport.js";');
+    expect(violationsFor(r4)).toBe(1);
+  });
+
+  it.each(["src/sport.ts", "src/sport.js", "dist/sport.js"])(
+    "allows the declared engine sport entry through %s",
+    (target) => {
+      writeJson("packages/engine/package.json", {
+        name: "@enduragent/engine",
+        private: true,
+        exports: { "./sport": { types: "./dist/sport.d.ts", import: "./dist/sport.js" } },
+      });
+      write("packages/sport-x/src/ok.ts", `export * from "../../engine/${target}";`);
+      expect(violationsFor(r4)).toBe(0);
+    },
+  );
+
+  it.each([
+    "src/index.js",
+    "src/runtime.js",
+    "src/sport-internal.js",
+    "src/sport/private.js",
+    "src/sport/index.js",
+  ])("rejects engine imports outside its declared sport entry: %s", (target) => {
+    writeJson("packages/engine/package.json", {
+      name: "@enduragent/engine",
+      private: true,
+      exports: { "./sport": "./dist/sport.js" },
+    });
+    write("packages/sport-x/src/bad.ts", `export * from "../../engine/${target}";`);
+    expect(violationsFor(r4)).toBe(1);
+  });
+});
+
 describe("R1 kernel purity", () => {
   it("R1 flags a node: prefixed import", () => {
     write("packages/kernel/src/bad.ts", `import { readFileSync } from "node:fs";\n`);

--- a/tools/check-package-deps.ts
+++ b/tools/check-package-deps.ts
@@ -36,7 +36,7 @@
 
 import * as ts from "typescript";
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, resolve, relative, sep } from "node:path";
 import { isBuiltin } from "node:module";
 import { TS_EXTS, ext, collectFiles, makeSkipCheck, nonFlagArgs, runGateCli } from "./lint-fs.js";
 
@@ -361,6 +361,69 @@ interface ConcreteDir {
   readonly fsDir: string;
 }
 
+interface WorkspacePackage {
+  readonly fsDir: string;
+  readonly name: string;
+  readonly exports: Record<string, unknown>;
+}
+
+function workspacePackages(root: string): WorkspacePackage[] {
+  const packages: WorkspacePackage[] = [];
+  for (const group of ["packages", "apps"]) {
+    const parent = join(root, group);
+    if (!existsSync(parent)) continue;
+    for (const entry of readdirSync(parent, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const fsDir = resolve(parent, entry.name);
+      const manifest = readManifestDeps(fsDir, "");
+      if (manifest.packageName.startsWith(WORKSPACE_SCOPE)) {
+        packages.push({ fsDir, name: manifest.packageName, exports: manifest.packageExports });
+      }
+    }
+  }
+  return packages;
+}
+
+function modulePath(path: string): string {
+  return path
+    .replaceAll(sep, "/")
+    .replace(/^\.\//, "")
+    .replace(/^(?:src|dist)\//, "")
+    .replace(/(?:\.d)?\.[cm]?[jt]sx?$/, "");
+}
+
+function exportTargets(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (value === null || typeof value !== "object") return [];
+  return Object.values(value).flatMap(exportTargets);
+}
+
+function relativeWorkspaceSpecifier(
+  file: string,
+  specifier: string,
+  ownerDir: string,
+  packages: readonly WorkspacePackage[],
+): string | undefined {
+  const target = resolve(dirname(file), specifier);
+  const owner = packages.find((pkg) => target === pkg.fsDir || target.startsWith(pkg.fsDir + sep));
+  if (!owner || owner.fsDir === resolve(ownerDir)) return undefined;
+  const targetPath = modulePath(relative(owner.fsDir, target));
+  for (const [key, value] of Object.entries(owner.exports)) {
+    if (!key.startsWith("./")) continue;
+    if (
+      exportTargets(value).some((entry) => {
+        const entryPath = modulePath(entry);
+        return (
+          entryPath === targetPath || (ext(target) === "" && entryPath === `${targetPath}/index`)
+        );
+      })
+    ) {
+      return owner.name + key.slice(1);
+    }
+  }
+  return owner.name;
+}
+
 function expandRuleDirs(root: string, rule: PackageDepRule): ConcreteDir[] {
   if (rule.dir.includes("*")) {
     const parent = dirname(rule.dir);
@@ -393,6 +456,7 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
   const warnSet = new Map<string, TransitionalEdge>();
   const notPresent: string[] = [];
   let scannedFileCount = 0;
+  const packages = workspacePackages(root);
 
   const recordWarn = (dir: string, target: string): void => {
     const key = `${dir} -> ${target}`;
@@ -416,7 +480,11 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
         if (!TS_EXTS.has(ext(file))) continue;
         scannedFileCount++;
         for (const ref of collectSpecifiers(file)) {
-          const spec = ref.specifier;
+          const isRelative = ref.specifier.startsWith("./") || ref.specifier.startsWith("../");
+          const spec = isRelative
+            ? relativeWorkspaceSpecifier(file, ref.specifier, fsDir, packages)
+            : ref.specifier;
+          if (spec === undefined) continue;
           if (isNodeSpecifier(spec)) {
             if (rule.forbidNode) {
               violations.push({
@@ -424,7 +492,7 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
                 line: ref.line,
                 column: ref.column,
                 ruleId: rule.ruleId,
-                specifier: spec,
+                specifier: ref.specifier,
                 pkg: dir,
               });
             }
@@ -444,7 +512,7 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
                 line: ref.line,
                 column: ref.column,
                 ruleId: rule.ruleId,
-                specifier: spec,
+                specifier: ref.specifier,
                 pkg: dir,
               });
               continue;
@@ -460,12 +528,11 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
               line: ref.line,
               column: ref.column,
               ruleId: rule.ruleId,
-              specifier: spec,
+              specifier: ref.specifier,
               pkg: dir,
             });
             continue;
           }
-          if (spec.startsWith("./") || spec.startsWith("../")) continue;
           if (
             rule.allowedExternal === undefined ||
             rule.allowedExternal.some((entry) => matchesEntry(spec, entry))


### PR DESCRIPTION
This change closes three development-check bypasses and corrects package ownership documentation.

- Scan Markdown fences for forbidden athlete identifiers while preserving existing placeholder and file exemptions.
- Resolve relative workspace imports and exports before applying the existing dependency and subpath rules.
- Reject empty or structural `User-facing:` content while retaining infra exemptions and valid multiline prose.
- Describe Engine’s Sport contract, Core’s transitional dependencies, Running’s implemented composition, and Running Coach’s actual entry point without claiming unverified end-to-end behavior or publication readiness.

The three child PRs are squash-merged: privacy #883, dependency boundaries #887, and context documentation #888. The release-note checker is the initial epic commit.

Validation: 177 privacy tests, 74 dependency tests, and 45 changeset tests pass. Nine actual CLI scenarios pass. All three repository checker commands and full root `pnpm check` pass. All 22 context-document links resolve. Both scoped required autoreview runs are clean at the configured P0 threshold; no correction pass was needed. Full-suite verification passed with two workers: 752 files and 11,126 tests passed; 5 files and 17 tests skipped. The integrated branch includes current main. All CI checks pass, including Linux desktop E2E, native desktop, Windows package, secrets, smoke, and test jobs.

This umbrella includes release tooling. It was merged by `yerzhansa` after CI passed. No athlete-facing runtime behavior or reviewer model defaults change.
