### PR TITLE
fix(core): report refused workout confirmations honestly

### DIFF
--- a/.changeset/fiery-yaks-stand.md
+++ b/.changeset/fiery-yaks-stand.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+"@enduragent/core": patch
+---
+
+Distinguish confirmation guard refusals and returned failures from completed changes.
+
+User-facing: When a workout can no longer be changed, the coach explains why instead of saying it is done.

--- a/packages/core/src/agent/confirmation-gate.ts
+++ b/packages/core/src/agent/confirmation-gate.ts
@@ -27,6 +27,7 @@ export interface PendingProposal {
 
 export type ConfirmOutcome =
   | { status: "executed"; summary: string; result: unknown }
+  | { status: "refused"; summary: string; message: string; result: unknown }
   | { status: "failed"; summary: string; message: string }
   | { status: "expired" }
   | { status: "mismatch" }
@@ -34,6 +35,7 @@ export type ConfirmOutcome =
 
 export function formatConfirmOutcome(outcome: ConfirmOutcome): string {
   if (outcome.status === "executed") return `Done — ${outcome.summary}.`;
+  if (outcome.status === "refused") return `Nothing was changed — ${outcome.message}`;
   if (outcome.status === "failed") return `That didn't go through — ${outcome.message}`;
   return "That proposal expired — ask me again and I'll re-propose.";
 }
@@ -77,7 +79,20 @@ export class ConfirmationGate {
     if (proposal.nonce !== nonce) return { status: "mismatch" };
     this.proposals.delete(chatId);
     try {
-      return { status: "executed", summary: proposal.summary, result: await proposal.run() };
+      const result = await proposal.run();
+      const error = stringField(result, "error");
+      if (error !== undefined) {
+        const details = stringField(result, "details");
+        if (details !== undefined) {
+          return { status: "refused", summary: proposal.summary, message: details, result };
+        }
+        return {
+          status: "failed",
+          summary: proposal.summary,
+          message: stringField(result, "message") ?? error,
+        };
+      }
+      return { status: "executed", summary: proposal.summary, result };
     } catch (err) {
       return {
         status: "failed",

--- a/packages/core/tests/confirmation-gate.test.ts
+++ b/packages/core/tests/confirmation-gate.test.ts
@@ -9,6 +9,7 @@ import {
   PROPOSAL_TTL_MS,
   createProposalSummarizers,
   createToolConfirmationPort,
+  formatConfirmOutcome,
 } from "../src/agent/confirmation-gate.js";
 import type { ProposalSummarizer } from "../src/agent/confirmation-gate.js";
 import { READ_ONLY_TOOL_NAMES } from "../../engine/src/agent/read-memoizer.js";
@@ -26,10 +27,7 @@ function turnOptions(chatId: string): unknown {
   return { experimental_context: createTurnContext(null, chatId) };
 }
 
-function port(
-  gate: ConfirmationGate,
-  summarizers: Record<string, ProposalSummarizer>,
-) {
+function port(gate: ConfirmationGate, summarizers: Record<string, ProposalSummarizer>) {
   return createToolConfirmationPort({ gate, summarizers });
 }
 
@@ -56,7 +54,9 @@ function fakeIntervals(initial = event()): {
   const updates = vi.fn(async () => ({ ok: true, value: current }));
   const deletes = vi.fn(async () => ({ ok: true, value: undefined }));
   return {
-    client: { events: { get: gets, update: updates, delete: deletes } } as unknown as IntervalsClient,
+    client: {
+      events: { get: gets, update: updates, delete: deletes },
+    } as unknown as IntervalsClient,
     setEvent: (next) => {
       current = next;
     },
@@ -67,6 +67,19 @@ function fakeIntervals(initial = event()): {
 }
 
 describe("ConfirmationGate", () => {
+  it.each([
+    [{ error: "NotFound", message: "Workout no longer exists." }, "Workout no longer exists."],
+    [{ error: "platform_credentials_required" }, "platform_credentials_required"],
+  ])("reports a returned failure without claiming success", async (result, message) => {
+    const gate = new ConfirmationGate();
+    gate.propose("chat", "Update workout", async () => result);
+    const proposal = gate.peek("chat")!;
+    const outcome = await gate.confirm("chat", proposal.nonce);
+    expect(outcome).toEqual({ status: "failed", summary: "Update workout", message });
+    expect(formatConfirmOutcome(outcome)).not.toContain("Done");
+    expect(await gate.confirm("chat", proposal.nonce)).toEqual({ status: "none" });
+  });
+
   it("stores, replaces, confirms once, and rejects mismatches", async () => {
     const gate = new ConfirmationGate();
     const firstRun = vi.fn(async () => "first");
@@ -310,9 +323,9 @@ describe("proposal summarizers and guard reuse", () => {
     });
 
     fake.setEvent(event({ tags: [] }));
-    await expect(
-      summarize({ eventId: 42, changes: { name: "Blocked" } }),
-    ).resolves.toMatchObject({ block: { error: "not_coach_created" } });
+    await expect(summarize({ eventId: 42, changes: { name: "Blocked" } })).resolves.toMatchObject({
+      block: { error: "not_coach_created" },
+    });
     expect(fake.updates).not.toHaveBeenCalled();
   });
 
@@ -353,9 +366,12 @@ describe("proposal summarizers and guard reuse", () => {
     fake.setEvent(event({ category: "NOTE" }));
     const outcome = await gate.confirm("chat", proposal.nonce);
     expect(outcome).toMatchObject({
-      status: "executed",
+      status: "refused",
       result: { error: "not_a_workout" },
     });
+    expect(formatConfirmOutcome(outcome)).toContain("Nothing was changed");
+    expect(formatConfirmOutcome(outcome)).not.toContain("Done");
+    expect(await gate.confirm("chat", proposal.nonce)).toEqual({ status: "none" });
     expect(fake.gets).toHaveBeenCalledTimes(2);
     expect(fake.deletes).not.toHaveBeenCalled();
   });
@@ -382,9 +398,12 @@ describe("proposal summarizers and guard reuse", () => {
     fake.setEvent(event({ category: "NOTE" }));
     const outcome = await gate.confirm("chat", proposal.nonce);
     expect(outcome).toMatchObject({
-      status: "executed",
+      status: "refused",
       result: { error: "not_a_workout" },
     });
+    expect(formatConfirmOutcome(outcome)).toContain("Nothing was changed");
+    expect(formatConfirmOutcome(outcome)).not.toContain("Done");
+    expect(await gate.confirm("chat", proposal.nonce)).toEqual({ status: "none" });
     expect(fake.gets).toHaveBeenCalledTimes(2);
     expect(fake.updates).not.toHaveBeenCalled();
   });

--- a/packages/core/tests/run-binary.test.ts
+++ b/packages/core/tests/run-binary.test.ts
@@ -228,6 +228,23 @@ describe("formatCliReply", () => {
 });
 
 describe("_promptProposalConfirm", () => {
+  it("prints a refusal from the real gate without claiming success", async () => {
+    const { ConfirmationGate } = await import("../src/agent/confirmation-gate.js");
+    const gate = new ConfirmationGate();
+    gate.propose("cli", "Delete workout", async () => ({
+      error: "not_a_workout",
+      details: "This entry is no longer a workout.",
+    }));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { _promptProposalConfirm } = await import("../src/run-binary.js");
+    await _promptProposalConfirm(
+      { question: (_prompt, answer) => answer("yes") },
+      { confirmations: gate },
+    );
+    expect(log).toHaveBeenCalledWith("Nothing was changed — This entry is no longer a workout.");
+    expect(gate.peek("cli")).toBeUndefined();
+  });
+
   it.each(["y", "yes", " Y ", "YeS\n"])("confirms explicit yes answer %j", async (answer) => {
     const confirm = vi.fn(async () => ({
       status: "executed" as const,

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -6,6 +6,18 @@ import { APICallError } from "@ai-sdk/provider";
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
 import { startTypingHeartbeat, TYPING_HEARTBEAT_MS } from "../src/channels/telegram.js";
 
+import {
+  ConfirmationGate,
+  createProposalSummarizers,
+  createToolConfirmationPort,
+} from "../src/agent/confirmation-gate.js";
+import { createPureCoreIntervalsTools } from "../src/sport.js";
+import { createPlatformCalendarMutations } from "../src/athlete-data.js";
+import { gateMutatingTool } from "../../engine/src/agent/coach-agent.js";
+import { createTurnContext } from "../../engine/src/agent/turn-context.js";
+import { COACH_EVENT_TAG } from "../src/agent/event-provenance.js";
+import type { IntervalsClient } from "intervals-icu-api";
+
 let dataDir: string;
 
 beforeEach(() => {
@@ -395,6 +407,65 @@ describe("confirmation callbacks", () => {
         ],
       },
     });
+  });
+
+  it.each<"intervals_delete_workout" | "intervals_update_workout">([
+    "intervals_delete_workout",
+    "intervals_update_workout",
+  ])("shows the execution-time refusal for %s through the host callback", async (toolName) => {
+    const { bot, agent, drainPending } = await buildBot();
+    let category = "WORKOUT";
+    const write = vi.fn();
+    const client = {
+      events: {
+        get: vi.fn(async () => ({
+          ok: true,
+          value: {
+            id: 42,
+            name: "Synthetic workout",
+            category,
+            startDateLocal: "2999-01-02T00:00:00",
+            tags: [COACH_EVENT_TAG],
+          },
+        })),
+        update: write,
+        delete: write,
+      },
+    } as unknown as IntervalsClient;
+    const gate = new ConfirmationGate();
+    const raw = createPureCoreIntervalsTools(
+      client,
+      "UTC",
+      undefined,
+      createPlatformCalendarMutations(client),
+    )[toolName]!;
+    const wrapped = gateMutatingTool(
+      toolName,
+      raw,
+      createToolConfirmationPort({
+        gate,
+        summarizers: createProposalSummarizers({ intervals: client, tz: "UTC" }),
+      }),
+    );
+    await wrapped.execute!({ eventId: 42, changes: { name: "Revised workout" } }, {
+      experimental_context: createTurnContext(null, "telegram:777"),
+    } as never);
+    const proposal = gate.peek("telegram:777")!;
+    agent.confirmations.confirm.mockImplementation((chatId: string, nonce: string) =>
+      gate.confirm(chatId, nonce),
+    );
+    category = "NOTE";
+    const ctx = callbackCtx(`cg:y:${proposal.nonce}`);
+    await getCallbackQueryData(bot)(ctx);
+    await drainPending();
+    expect(write).not.toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("Nothing was changed"));
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("category NOTE"));
+    expect(ctx.reply).not.toHaveBeenCalledWith(expect.stringContaining("Done"));
+    await getCallbackQueryData(bot)(ctx);
+    await drainPending();
+    expect(write).not.toHaveBeenCalled();
+    expect(client.events.get).toHaveBeenCalledTimes(2);
   });
 
   it("acks then executes a matching confirmation", async () => {


### PR DESCRIPTION
Workout confirmation could say Done after the execution-time guard refused a changed calendar target. The gate now distinguishes guarded refusals and returned service failures from completed changes. Telegram and CLI use the resulting outcome without claiming a write succeeded.

Verified with 108 focused tests, including changed-target update/delete calls through the actual Telegram host callback with synthetic calendar reads and zero external writes. CLI refusal output, expiry, nonce matching, and single consumption remain covered.

Part of the app reliability and Astra epic. The umbrella requires operator approval.

Required final Codex autoreview reported no findings at its configured P0 threshold. Final affected-flow checks passed on the combined snapshot.
