### PR TITLE
fix(engine): retain context after failed compaction

### DIFF
--- a/.changeset/late-dingos-remain.md
+++ b/.changeset/late-dingos-remain.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+"@enduragent/engine": patch
+---
+
+Retain unsummarized conversation history after compaction failures and stop when it cannot safely fit.
+
+User-facing: If a conversation summary fails, the coach keeps the original context or asks you to try again instead of silently forgetting earlier goals and corrections.

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -848,6 +848,7 @@ describe("local coach composition", () => {
         undefined,
         {
           ...base,
+          contextWindowTokens: 120_000,
           llm: {
             provider: "openai-codex",
             model: "gpt-5.4",
@@ -2503,16 +2504,22 @@ describe("local coach composition", () => {
         return generation(`reply-${generateCalls}`);
       },
     });
-    const lifecycle = await compose(home, {
-      bootstrap: async () => reference(),
-      createRuntime: () => runtime(),
-      createRepository: () => ({
-        insertIfAbsent: async () => false,
-        readCurrent: async () => undefined,
-      }),
-      createResolver: () => missingResolver(),
-      modelTransportDecorator: decorator,
-    });
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        modelTransportDecorator: decorator,
+      },
+      fakeContext(home),
+      undefined,
+      { ...config(home), contextWindowTokens: 120_000 },
+    );
     const completion: string[] = [];
     const first = lifecycle.engine.chat({ chatId: "same", message: "first" }).then((value) => {
       completion.push("first");

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -970,7 +970,8 @@ export class CoachAgent {
               this.chatStore.overwriteHistory(chatId, [summaryMsg, ...requeued, ...kept]);
             }
           } catch (err) {
-            this.log.warn("Dropped message summarization failed, continuing without summary", err);
+            this.log.warn("Dropped message summarization failed, retaining original messages", err);
+            requeued = dropped;
             if (previousSummary) {
               summaryMsg = makeSummaryMessage(
                 previousSummary,
@@ -1059,6 +1060,17 @@ export class CoachAgent {
             messages,
             ...this.compactionParams(turnBudget),
           });
+          if (
+            shouldCompact({
+              messages: compacted.messages,
+              systemPrompt: this.systemPrompt,
+              contextWindowTokens: this.config.contextWindowTokens,
+            })
+          ) {
+            throw new Error(
+              "Conversation could not be shortened safely to fit the context budget. Please try again.",
+            );
+          }
           messages = compacted.messages;
           if (compacted.summary && compacted.summaryProvenance) {
             this.persistSummaryToDailyNote(compacted.summary, compacted.summaryProvenance);

--- a/packages/engine/src/agent/compaction.ts
+++ b/packages/engine/src/agent/compaction.ts
@@ -518,7 +518,7 @@ export async function summarizeDroppedMessages(params: {
   const unsummarized: ModelMessage[] = [];
   let lastError: unknown;
 
-  for (const chunk of chunks) {
+  for (const [index, chunk] of chunks.entries()) {
     const transcript = formatTranscript(chunk);
     const carriedSummary = summary ?? previousSummary;
 
@@ -534,13 +534,14 @@ export async function summarizeDroppedMessages(params: {
       summaryProvenance = unionProvenance(summaryProvenance, provenanceOfMessages(chunk));
     } catch (err) {
       lastError = err;
-      unsummarized.push(...chunk);
+      unsummarized.push(...chunks.slice(index).flat());
       console.warn("Dropped message summarization LLM call failed, using fallback", err);
+      break;
     }
   }
 
   if (summary === undefined) {
-    throw new Error("Dropped message summarization failed for every chunk", {
+    throw new Error("Dropped message summarization failed before any chunk was summarized", {
       cause: lastError,
     });
   }
@@ -603,7 +604,8 @@ export async function summarizeInStages(params: {
 
   // Thread previousSummary through chunk loop
   let summary = previousSummary;
-  for (const chunk of chunks) {
+  const unsummarized: ModelMessage[] = [];
+  for (const [index, chunk] of chunks.entries()) {
     const transcript = formatTranscript(chunk);
 
     try {
@@ -617,13 +619,21 @@ export async function summarizeInStages(params: {
       summary = text;
       summaryProvenance = unionProvenance(summaryProvenance, provenanceOfMessages(chunk));
     } catch (err) {
-      console.warn("Staged summarization chunk failed; continuing with carried summary", err);
+      unsummarized.push(...chunks.slice(index).flat());
+      console.warn("Staged summarization chunk failed; retaining original messages", err);
+      break;
     }
   }
 
-  if (summary === undefined) {
-    console.warn("Staged summarization produced no summary; dropping oldest messages without one");
-    return { messages: [...recent] };
+  if (summary === undefined || unsummarized.length === toSummarize.length) {
+    return {
+      messages: [
+        ...(previousSummary === undefined
+          ? []
+          : [makeSummaryMessage(previousSummary, previousSummaryProvenance ?? UNKNOWN_PROVENANCE)]),
+        ...messages,
+      ],
+    };
   }
 
   const finalSummary = await finalizeSummary({
@@ -636,7 +646,7 @@ export async function summarizeInStages(params: {
   });
   const durableProvenance = summaryProvenance ?? UNKNOWN_PROVENANCE;
   return {
-    messages: [makeSummaryMessage(finalSummary, durableProvenance), ...recent],
+    messages: [makeSummaryMessage(finalSummary, durableProvenance), ...unsummarized, ...recent],
     summary: finalSummary,
     summaryProvenance: durableProvenance,
   };

--- a/packages/engine/tests/coach-agent-garmin-attribution.test.ts
+++ b/packages/engine/tests/coach-agent-garmin-attribution.test.ts
@@ -293,15 +293,16 @@ describe("CoachAgent selective Garmin attribution", () => {
 
   it("does not count source fields hidden by the result cap", async () => {
     const execute = vi.fn(async () => [
-      { id: "synthetic", source: "GARMIN_CONNECT", samples: "x".repeat(20_000) },
+      { id: "synthetic", source: "GARMIN_CONNECT", samples: "x".repeat(100_000) },
     ]);
     let calls = 0;
     const complete = vi.fn(async () =>
       ++calls === 1 ? toolCall() : assistant("Capped guidance."),
     );
-    const agent = await setupAgent(complete, activitySport(execute), 2_000);
+    const agent = await setupAgent(complete, activitySport(execute), 40_000);
 
     expect(await agent.chat("capped", "Use the activity.")).toBe("Capped guidance.");
+    expect(execute).toHaveBeenCalledOnce();
   });
 
   it("does not carry Garmin evidence across a failed outer attempt", async () => {
@@ -419,7 +420,7 @@ describe("CoachAgent selective Garmin attribution", () => {
     });
   });
 
-  it("does not attribute history dropped before the generation boundary", async () => {
+  it("attributes retained history after dropped-message summarization fails", async () => {
     const complete = vi.fn(async (params: { messages: unknown }) => {
       if (JSON.stringify(params.messages).includes("Incorporate the older conversation")) {
         throw new Error("summary unavailable");
@@ -427,7 +428,7 @@ describe("CoachAgent selective Garmin attribution", () => {
       return assistant("Visible-history guidance.");
     });
     const { agent } = await setupAgentWithStore(complete, syntheticSport, {
-      contextWindowTokens: 8_000,
+      contextWindowTokens: 40_000,
       seed: [
         {
           role: "assistant",
@@ -442,7 +443,15 @@ describe("CoachAgent selective Garmin attribution", () => {
       ],
     });
 
-    expect(await agent.chat("dropped-history", "What now?")).toBe("Visible-history guidance.");
+    expect(await agent.chat("dropped-history", "What now?")).toBe(
+      `Visible-history guidance.\n\n${GARMIN_DATA_ATTRIBUTION}`,
+    );
+    expect(
+      complete.mock.calls.some(([params]) =>
+        JSON.stringify(params.messages).includes("Incorporate the older conversation"),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(complete.mock.calls.at(-1)?.[0].messages)).toContain("x".repeat(30_000));
   });
 
   it("isolates concurrent chats", async () => {

--- a/packages/engine/tests/compaction.test.ts
+++ b/packages/engine/tests/compaction.test.ts
@@ -275,23 +275,23 @@ describe("summarizeDroppedMessages failure containment", () => {
         mustPreserveTokens: [],
         memory: EMPTY_SNAPSHOT,
       }),
-    ).rejects.toThrow("Dropped message summarization failed for every chunk");
+    ).rejects.toThrow("Dropped message summarization failed before any chunk was summarized");
   });
 
-  it("requeues the failed chunk's messages when one chunk fails", async () => {
+  it("requeues the failed chunk and all newer messages in order", async () => {
     const firstMessage: ModelMessage = { role: "user", content: "CHUNK-A " + "a".repeat(20_000) };
     const secondMessage: ModelMessage = { role: "user", content: "CHUNK-B " + "b".repeat(20_000) };
-    const llm = createFakeLLM([{ error: new Error("boom") }, VALID_FIVE_SECTION_SUMMARY]);
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);
 
     const result = await summarizeDroppedMessages({
-      dropped: [firstMessage, secondMessage],
+      dropped: [firstMessage, secondMessage, ...REPRESENTATIVE_CONVERSATION],
       llm,
       mustPreserveTokens: [],
       memory: EMPTY_SNAPSHOT,
       contextWindowTokens: 30_000,
     });
 
-    expect(result.unsummarized).toEqual([firstMessage]);
+    expect(result.unsummarized).toEqual([secondMessage, ...REPRESENTATIVE_CONVERSATION]);
     expect(result.summary).toContain("## Coach Stance");
   });
 
@@ -304,10 +304,10 @@ describe("summarizeDroppedMessages failure containment", () => {
       { role: "user", content: "CHUNK-B " + "b".repeat(20_000) },
       UNKNOWN,
     );
-    const llm = createFakeLLM([{ error: new Error("boom") }, VALID_FIVE_SECTION_SUMMARY]);
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);
 
     const result = await summarizeDroppedMessages({
-      dropped: [failedGarmin, summarizedUnknown],
+      dropped: [summarizedUnknown, failedGarmin],
       llm,
       mustPreserveTokens: [],
       memory: EMPTY_SNAPSHOT,
@@ -386,10 +386,10 @@ describe("staged summary provenance", () => {
       { role: "user", content: "CHUNK-B " + "b".repeat(20_000) },
       UNKNOWN,
     );
-    const llm = createFakeLLM([{ error: new Error("boom") }, VALID_FIVE_SECTION_SUMMARY]);
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);
 
     const result = await summarizeInStages({
-      messages: [failedGarmin, summarizedUnknown],
+      messages: [summarizedUnknown, failedGarmin],
       llm,
       mustPreserveTokens: [],
       memory: EMPTY_SNAPSHOT,
@@ -399,6 +399,80 @@ describe("staged summary provenance", () => {
 
     expect(result.summaryProvenance).toEqual(UNKNOWN);
     expect(getMessageProvenance(result.messages[0])).toEqual(UNKNOWN);
+  });
+});
+
+describe("staged summarization failure containment", () => {
+  const goal: ModelMessage = {
+    role: "user",
+    content: "Goal: finish the mountain ride. " + "a".repeat(20_000),
+  };
+  const correction: ModelMessage = {
+    role: "user",
+    content: "Correction: no Tuesday training. " + "b".repeat(20_000),
+  };
+  const recent: ModelMessage[] = [
+    { role: "assistant", content: "What changed this week?" },
+    { role: "user", content: "Keep Friday easy." },
+  ];
+
+  it.each([false, true])(
+    "retains every message after total failure (prior summary: %s)",
+    async (withSummary) => {
+      const messages = [
+        ...(withSummary ? [makeSummaryMessage("FTP 247W; protect the knee", UNKNOWN)] : []),
+        goal,
+        correction,
+        ...recent,
+      ];
+      const llm = createFakeLLM([{ error: new Error("summary unavailable") }], {
+        repeatLast: true,
+      });
+      const result = await summarizeInStages({
+        messages,
+        llm,
+        mustPreserveTokens: [],
+        memory: EMPTY_SNAPSHOT,
+        recentToKeep: 2,
+        contextWindowTokens: 30_000,
+      });
+
+      expect(result.messages).toEqual(messages);
+      expect(llm.capturedMessages).toHaveLength(1);
+      expect(result.summary).toBeUndefined();
+    },
+  );
+
+  it("retains failed corrections alongside the successful summary and recent messages", async () => {
+    const summary = VALID_FIVE_SECTION_SUMMARY + "\nGoal: finish the mountain ride.";
+    const newerCorrection: ModelMessage = {
+      role: "user",
+      content: "Update: Tuesday training is possible again. " + "c".repeat(20_000),
+    };
+    const llm = createFakeLLM([summary, { error: new Error("summary unavailable") }]);
+    const result = await summarizeInStages({
+      messages: [
+        makeSummaryMessage("FTP 247W; protect the knee", UNKNOWN),
+        goal,
+        correction,
+        newerCorrection,
+        ...recent,
+      ],
+      llm,
+      mustPreserveTokens: [],
+      memory: EMPTY_SNAPSHOT,
+      recentToKeep: 2,
+      contextWindowTokens: 30_000,
+    });
+
+    expect(result.messages).toEqual([
+      makeSummaryMessage(summary, UNKNOWN),
+      correction,
+      newerCorrection,
+      ...recent,
+    ]);
+    expect(llm.capturedMessages).toHaveLength(2);
+    expect(String(llm.capturedMessages[0][0].content)).toContain("FTP 247W; protect the knee");
   });
 });
 
@@ -417,7 +491,9 @@ describe("shared audit post-step (cap-before-audit)", () => {
     });
 
     expect(spy.capturedOpts).toHaveLength(2);
-    expect(String(spy.capturedMessages[1][0].content)).toContain("Restructure the following summary");
+    expect(String(spy.capturedMessages[1][0].content)).toContain(
+      "Restructure the following summary",
+    );
     for (const opts of spy.capturedOpts) {
       expect(opts.maxOutputTokens).toBe(1000);
     }
@@ -518,4 +594,3 @@ describe("shared audit post-step (cap-before-audit)", () => {
     expect(spy.capturedOpts[1].system).toContain("PRESERVE every fact in it");
   });
 });
-

--- a/packages/engine/tests/summarize-stages-guards.test.ts
+++ b/packages/engine/tests/summarize-stages-guards.test.ts
@@ -38,7 +38,7 @@ const EMPTY_SNAPSHOT: MemorySnapshot = {
   read: () => null,
   has: () => false,
   listSections: () => [],
-    provenanceOf: () => ({ garmin: false, nonGarmin: false, unknown: true }),
+  provenanceOf: () => ({ garmin: false, nonGarmin: false, unknown: true }),
 };
 
 const hangingLLM = { generate: () => new Promise<never>(() => {}) } as unknown as LLM;
@@ -49,7 +49,7 @@ afterEach(() => {
 });
 
 describe("summarizeInStages guards", () => {
-  it("times out a hung summarization call after 120 s and degrades to the previous summary", async () => {
+  it("times out a hung summarization call after 120 s and retains the previous summary and history", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -67,16 +67,17 @@ describe("summarizeInStages guards", () => {
     expect(result.messages[0].role).toBe("system");
     expect(String(result.messages[0].content)).toContain("FTP 247W");
     expect(String(result.messages[0].content)).toContain("## Coach Stance");
-    expect(result.messages.length).toBe(5);
+    expect(result.messages.slice(1)).toEqual(REPRESENTATIVE_CONVERSATION);
 
     const chunkWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+      (call) =>
+        typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
     );
     expect(chunkWarn).toBeDefined();
     expect(isTimeoutError(chunkWarn?.[1])).toBe(true);
   }, 10_000);
 
-  it("falls back to the previous summary when the summarization call rejects", async () => {
+  it("retains the previous summary and history when the summarization call rejects", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const spy = createFakeLLM([{ error: new Error("boom") }]);
 
@@ -91,14 +92,16 @@ describe("summarizeInStages guards", () => {
     expect(result.messages[0].role).toBe("system");
     expect(String(result.messages[0].content)).toContain("FTP 247W");
     expect(spy.capturedOpts.length).toBe(1);
+    expect(result.messages.slice(1)).toEqual(REPRESENTATIVE_CONVERSATION);
 
     const chunkWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+      (call) =>
+        typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
     );
     expect(chunkWarn).toBeDefined();
   });
 
-  it("head-drops when every call fails and there is no previous summary", async () => {
+  it("retains every message when summarization fails without a previous summary", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const spy = createFakeLLM([{ error: new Error("boom") }], { repeatLast: true });
 
@@ -109,16 +112,16 @@ describe("summarizeInStages guards", () => {
       memory: EMPTY_SNAPSHOT,
     });
 
-    expect(result.messages).toEqual(REPRESENTATIVE_CONVERSATION.slice(-4));
+    expect(result.messages).toEqual(REPRESENTATIVE_CONVERSATION);
     expect(result.summary).toBeUndefined();
     for (const msg of result.messages) {
       expect(String(msg.content).startsWith(SUMMARY_PREFIX)).toBe(false);
     }
 
-    const dropWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("produced no summary"),
+    const retainedWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("retaining original messages"),
     );
-    expect(dropWarn).toBeDefined();
+    expect(retainedWarn).toBeDefined();
   });
 
   it("returns the input unchanged with no summary when there is nothing to summarize", async () => {
@@ -152,12 +155,14 @@ describe("summarizeInStages guards", () => {
     });
 
     expect(spy.capturedOpts.length).toBe(2);
+    expect(result.messages.slice(1)).toEqual(messages.slice(1));
     expect(result.messages[0].role).toBe("system");
     expect(String(result.messages[0].content)).toContain("## Coach Stance");
     expect(String(result.messages[0].content)).toContain("FTP 247W");
 
     const chunkWarns = warnSpy.mock.calls.filter(
-      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+      (call) =>
+        typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
     );
     expect(chunkWarns.length).toBe(1);
   });
@@ -181,7 +186,8 @@ describe("summarizeInStages guards", () => {
     const guardWarn = warnSpy.mock.calls.find(
       (call) =>
         typeof call[0] === "string" &&
-        (call[0].includes("Staged summarization chunk failed") || call[0].includes("produced no summary")),
+        (call[0].includes("Staged summarization chunk failed") ||
+          call[0].includes("retaining original messages")),
     );
     expect(guardWarn).toBeUndefined();
   });
@@ -207,11 +213,13 @@ describe("summarizeInStages guards", () => {
     await vi.advanceTimersByTimeAsync(120_000);
     const err = await rejection;
 
-    expect(err.message).toContain("failed for every chunk");
+    expect(err.message).toContain("failed before any chunk was summarized");
     expect(isTimeoutError((err as Error & { cause?: unknown }).cause)).toBe(true);
 
     const chunkWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("Dropped message summarization LLM call failed"),
+      (call) =>
+        typeof call[0] === "string" &&
+        call[0].includes("Dropped message summarization LLM call failed"),
     );
     expect(chunkWarn).toBeDefined();
   }, 10_000);

--- a/packages/engine/tests/trim-compaction-guard.test.ts
+++ b/packages/engine/tests/trim-compaction-guard.test.ts
@@ -1,17 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import {
-  mkdtempSync,
-  rmSync,
-  mkdirSync,
-  writeFileSync,
-  readFileSync,
-  readdirSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { baseAgentConfig } from "./helpers/base-agent-config.js";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import type { Sport } from "../src/sport.js";
+import type { CodexResponsesParams } from "../src/agent/codex/responses.js";
+import { SUMMARY_PREFIX } from "../src/agent/history-limit.js";
 
 let tempHome: string;
 let origHome: string | undefined;
@@ -33,7 +28,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+async function setupAgent(
+  complete: ReturnType<typeof vi.fn>,
+  windows: {
+    contextWindowTokens?: number;
+    compactContextWindowTokens?: number;
+    historyTokenBudgetRatio?: number;
+  } = {},
+) {
   vi.doMock("../src/agent/codex/responses.js", () => ({
     codexResponses: complete,
   }));
@@ -52,7 +54,17 @@ async function setupAgent(complete: ReturnType<typeof vi.fn>) {
   const ports = baseAgentConfig(dataDir);
   return new CoachAgent(cyclingSport as unknown as Sport, {
     ...ports,
-    config: { ...ports.config, contextWindowTokens: 120_000 },
+    config: {
+      ...ports.config,
+      session: {
+        ...ports.config.session,
+        historyTokenBudgetRatio:
+          windows.historyTokenBudgetRatio ?? ports.config.session.historyTokenBudgetRatio,
+      },
+      contextWindowTokens: windows.contextWindowTokens ?? 120_000,
+      compactContextWindowTokens:
+        windows.compactContextWindowTokens ?? ports.config.compactContextWindowTokens,
+    },
   });
 }
 
@@ -168,29 +180,183 @@ describe("trim-path compaction guard", () => {
     ).toBe(true);
   });
 
-  it("leaves history untouched when summarization fails entirely", async () => {
-    let n = 0;
-    const complete = vi.fn(async () => {
-      n++;
-      if (n === 1) return mkAssistant("facts noted");
-      if (n === 2) throw new Error("boom");
+  it.each([false, true])(
+    "preserves all history in the next request after total failure (prior summary: %s)",
+    async (withSummary) => {
+      let n = 0;
+      const complete = vi.fn(async () => {
+        n++;
+        if (n === 1) return mkAssistant("facts noted");
+        if (n === 2) throw new Error("boom");
+        return mkAssistant("final-reply");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const agent = await setupAgent(complete);
+      seedSession("trim-summary-fail", [
+        ...(withSummary
+          ? [{ role: "system", content: `${SUMMARY_PREFIX}\nProtect the knee.`, ts: FRESH_TS }]
+          : []),
+        ...seeded.map((message, i) => ({
+          ...message,
+          content:
+            message.content +
+            (i === 0
+              ? " Goal: finish the mountain ride."
+              : i === 10
+                ? " Correction: no Tuesday training."
+                : ""),
+        })),
+      ]);
+
+      const text = await agent.chat("trim-summary-fail", "hello");
+
+      expect(text).toBe("final-reply");
+      expect(listPrecompact("trim-summary-fail")).toHaveLength(0);
+      const request = JSON.stringify(complete.mock.calls.at(-1));
+      expect(request).toContain("TRIM-MARK-0 ");
+      expect(request).toContain("TRIM-MARK-29 ");
+      expect(request).toContain("Goal: finish the mountain ride.");
+      expect(request).toContain("Correction: no Tuesday training.");
+      if (withSummary) expect(request).toContain("Protect the knee.");
+
+      const session = readFileSync(join(dataDir, "sessions", "trim-summary-fail.jsonl"), "utf-8");
+      expect(session).toContain("TRIM-MARK-0 ");
+      expect(session).not.toContain("## Coach Stance");
+
+      expect(
+        warnSpy.mock.calls.some((c) =>
+          String(c[0]).includes("Dropped message summarization failed"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("retains failed chunks in the next request after partial summarization", async () => {
+    let summaries = 0;
+    const complete = vi.fn(async (params: CodexResponsesParams) => {
+      if (String(params.messages[0]?.content).startsWith("Incorporate the older")) {
+        summaries++;
+        if (summaries === 2) throw new Error("summary unavailable");
+        return mkAssistant(
+          FIVE_SECTION_SUMMARY + "\nProtect the knee. Goal: finish the mountain ride.",
+        );
+      }
       return mkAssistant("final-reply");
     });
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const agent = await setupAgent(complete);
-    seedSession("trim-summary-fail", seeded);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, { compactContextWindowTokens: 30_000 });
+    seedSession("trim-partial", [
+      { role: "system", content: `${SUMMARY_PREFIX}\nProtect the knee.`, ts: FRESH_TS },
+      ...seeded.map((message, i) => ({
+        ...message,
+        content:
+          message.content +
+          (i === 0
+            ? " Goal: finish the mountain ride."
+            : i === 10
+              ? " Correction: no Tuesday training."
+              : ""),
+      })),
+    ]);
 
-    const text = await agent.chat("trim-summary-fail", "hello");
+    expect(await agent.chat("trim-partial", "hello")).toBe("final-reply");
 
-    expect(text).toBe("final-reply");
-    expect(listPrecompact("trim-summary-fail")).toHaveLength(0);
+    expect(summaries).toBeGreaterThan(1);
+    const request = JSON.stringify(complete.mock.calls.at(-1)?.[0].messages);
+    expect(request).toContain("Goal: finish the mountain ride.");
+    expect(request).toContain("Correction: no Tuesday training.");
+    expect(request).toContain("Protect the knee.");
+    expect(request).toContain("TRIM-MARK-29 ");
+  });
 
-    const session = readFileSync(join(dataDir, "sessions", "trim-summary-fail.jsonl"), "utf-8");
-    expect(session).toContain("TRIM-MARK-0 ");
-    expect(session).not.toContain("## Coach Stance");
+  it("retains a failed staged correction in the next request after overflow rescue", async () => {
+    let requests = 0;
+    let summaries = 0;
+    const complete = vi.fn(async (params: CodexResponsesParams) => {
+      if (String(params.messages[0]?.content).startsWith("Summarize the conversation")) {
+        summaries++;
+        if (summaries === 2) throw new Error("summary unavailable");
+        return mkAssistant(
+          FIVE_SECTION_SUMMARY + "\nProtect the knee. Goal: finish the mountain ride.",
+        );
+      }
+      if (params.system?.startsWith("You are reviewing a conversation"))
+        return mkAssistant("facts noted");
+      if (
+        params.messages.some(
+          (message) => message.role === "user" && String(message.content).startsWith("hello"),
+        )
+      ) {
+        requests++;
+        if (requests === 1) throw new Error("Request exceeds the maximum context length");
+        return mkAssistant("final-reply");
+      }
+      return mkAssistant("facts noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, {
+      compactContextWindowTokens: 30_000,
+      historyTokenBudgetRatio: 0.95,
+    });
+    seedSession("staged-partial", [
+      { role: "system", content: `${SUMMARY_PREFIX}\nProtect the knee.`, ts: FRESH_TS },
+      ...Array.from({ length: 6 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content:
+          (i === 0
+            ? "Goal: finish the mountain ride."
+            : i === 1
+              ? "Correction: no Tuesday training."
+              : `RECENT-${i}`) + "x".repeat(20_000),
+        ts: FRESH_TS,
+      })),
+    ]);
+
+    expect(await agent.chat("staged-partial", "hello")).toBe("final-reply");
+
+    expect(requests).toBe(2);
+    expect(summaries).toBeGreaterThan(1);
+    const request = JSON.stringify(complete.mock.calls.at(-1)?.[0].messages);
+    expect(request).toContain("Goal: finish the mountain ride.");
+    expect(request).toContain("Correction: no Tuesday training.");
+    expect(request).toContain("Protect the knee.");
+    expect(request).toContain("RECENT-5");
+  });
+
+  it("stops before generating when failed summaries leave history over budget", async () => {
+    const complete = vi.fn(async (params: CodexResponsesParams) => {
+      const content = String(params.messages[0]?.content);
+      if (
+        content.startsWith("Incorporate the older") ||
+        content.startsWith("Summarize the conversation")
+      ) {
+        throw new Error("summary unavailable");
+      }
+      return mkAssistant("facts noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, { contextWindowTokens: 40_000 });
+    seedSession(
+      "trim-over-budget",
+      seeded.map((message) => ({
+        ...message,
+        content: message.content + "x".repeat(8_000),
+      })),
+    );
+
+    await expect(agent.chat("trim-over-budget", "hello")).rejects.toThrow(
+      "Conversation could not be shortened safely to fit the context budget",
+    );
 
     expect(
-      warnSpy.mock.calls.some((c) => String(c[0]).includes("Dropped message summarization failed")),
-    ).toBe(true);
+      complete.mock.calls.some(([params]) =>
+        params.messages.some(
+          (message) => message.role === "user" && String(message.content).startsWith("hello"),
+        ),
+      ),
+    ).toBe(false);
+    expect(listPrecompact("trim-over-budget")).toHaveLength(0);
+    const session = readFileSync(join(dataDir, "sessions", "trim-over-budget.jsonl"), "utf-8");
+    expect(session).toContain("TRIM-MARK-0 ");
   });
 });


### PR DESCRIPTION
When a summary request fails, retain the failed chunk and every newer message in chronological order. Restore the previous summary and dropped history after total failure. Stop before model generation when retained context cannot fit the existing budget.

Deterministic complete/partial failures verify older goals, corrections, previous summaries, recent messages, and the actual next model request. Focused compaction tests passed 35 tests; broader compaction/recovery/retry/deadline/durability coverage passed 56 tests.

Part of the app reliability and Astra epic. The umbrella requires operator approval.

Required final Codex autoreview reported no findings at its configured P0 threshold. Final affected-flow checks passed on the combined snapshot.
