### PR TITLE
fix(tools): count unique remembered facts

### DIFF
--- a/tools/compaction-gate/checks.test.ts
+++ b/tools/compaction-gate/checks.test.ts
@@ -79,6 +79,20 @@ describe("mustPreserveDiff", () => {
 });
 
 describe("factScore", () => {
+  it("counts a repeated remembered fact once", () => {
+    const verdict = { factsPreserved: Array(10).fill("F01"), factsMissing: [], fabrications: [] };
+    expect(factScore(verdict, INVENTORY)).toBe(0.1);
+    expect(tierJTranscriptVerdict([verdict, verdict, verdict], INVENTORY).pass).toBe(false);
+  });
+
+  it("counts distinct inventory facts and keeps scores bounded", () => {
+    expect(factScore(run(10, 0), [...INVENTORY, "F01"])).toBe(1);
+    expect(factScore(run(10, 0), [])).toBe(0);
+  });
+
+  it("does not credit facts also declared missing", () => {
+    expect(factScore({ ...run(10, 0), factsMissing: ["F01"] }, INVENTORY)).toBe(0.9);
+  });
   it("scores 9 of 10 preserved inventory ids as 0.9", () => {
     expect(factScore(run(9, 0), INVENTORY)).toBeCloseTo(0.9, 10);
   });
@@ -129,21 +143,60 @@ describe("cacheEvidence", () => {
 });
 
 describe("parseJudgeVerdict", () => {
+  it.each([null, 1, {}, ["F01", 2], [""], ["   "]])(
+    "rejects malformed field values: %j",
+    (value) => {
+      for (const field of ["factsPreserved", "factsMissing", "fabrications"]) {
+        expect(() =>
+          parseJudgeVerdict(JSON.stringify({ ...run(1, 0), [field]: value }), INVENTORY),
+        ).toThrow();
+      }
+    },
+  );
+
+  it("rejects contradictory preserved and missing facts", () => {
+    expect(() =>
+      parseJudgeVerdict(JSON.stringify({ ...run(1, 0), factsMissing: ["F01"] }), INVENTORY),
+    ).toThrow(/both preserved and missing/);
+  });
+
+  it.each(["factsPreserved", "factsMissing"])("rejects unknown IDs in %s", (field) => {
+    expect(() =>
+      parseJudgeVerdict(JSON.stringify({ ...run(1, 0), [field]: ["UNKNOWN"] }), INVENTORY),
+    ).toThrow(/unknown fact ID/);
+  });
+
+  it("deduplicates valid declarations", () => {
+    expect(
+      parseJudgeVerdict(
+        JSON.stringify({
+          factsPreserved: ["F01", "F01"],
+          factsMissing: ["F02", "F02"],
+          fabrications: [],
+        }),
+        INVENTORY,
+      ),
+    ).toEqual({ factsPreserved: ["F01"], factsMissing: ["F02"], fabrications: [] });
+  });
   it("parses a clean JSON reply", () => {
-    const v = parseJudgeVerdict('{"factsPreserved":["F01"],"factsMissing":[],"fabrications":[]}');
+    const v = parseJudgeVerdict(
+      '{"factsPreserved":["F01"],"factsMissing":[],"fabrications":[]}',
+      INVENTORY,
+    );
     expect(v.factsPreserved).toEqual(["F01"]);
   });
 
   it("extracts JSON wrapped in prose", () => {
     const v = parseJudgeVerdict(
       'Here is my verdict:\n{"factsPreserved":[],"factsMissing":["F01"],"fabrications":["made up a number"]}\nDone.',
+      INVENTORY,
     );
     expect(v.factsMissing).toEqual(["F01"]);
     expect(v.fabrications).toEqual(["made up a number"]);
   });
 
   it("throws on garbage", () => {
-    expect(() => parseJudgeVerdict("no json here")).toThrow();
+    expect(() => parseJudgeVerdict("no json here", INVENTORY)).toThrow();
   });
 });
 

--- a/tools/compaction-gate/checks.ts
+++ b/tools/compaction-gate/checks.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { UsageLedgerLine } from "../../packages/core/src/usage-ledger.js";
 import { TIER_J_FACT_THRESHOLD, TIER_J_MAX_FABRICATIONS } from "./rubric.js";
 
@@ -20,8 +21,11 @@ export function median(values: number[]): number {
 export function factScore(run: JudgeVerdict, inventoryIds: readonly string[]): number {
   if (inventoryIds.length === 0) return 0;
   const inventory = new Set(inventoryIds);
-  const preserved = run.factsPreserved.filter((id) => inventory.has(id));
-  return preserved.length / inventoryIds.length;
+  const missing = new Set(run.factsMissing);
+  const preserved = new Set(
+    run.factsPreserved.filter((id) => inventory.has(id) && !missing.has(id)),
+  );
+  return preserved.size / inventory.size;
 }
 
 /** Tier-J verdict for one transcript from its 3 judge runs. */
@@ -96,24 +100,28 @@ export function cacheEvidence(lines: UsageLedgerLine[]): { ok: boolean; reason: 
   return { ok: true, reason: "cache written on first call and read on a later call" };
 }
 
-/** Strict-JSON extraction for judge replies: parse the first {...} block; throw on failure. */
-export function parseJudgeVerdict(text: string): JudgeVerdict {
+const judgeVerdictSchema = z.object({
+  factsPreserved: z.array(z.string().trim().min(1)),
+  factsMissing: z.array(z.string().trim().min(1)),
+  fabrications: z.array(z.string().trim().min(1)),
+});
+
+export function parseJudgeVerdict(text: string, inventoryIds: readonly string[]): JudgeVerdict {
   const start = text.indexOf("{");
   const end = text.lastIndexOf("}");
   if (start === -1 || end === -1 || end < start) {
     throw new Error("no JSON object found in judge reply");
   }
-  const parsed = JSON.parse(text.slice(start, end + 1)) as Partial<JudgeVerdict>;
-  if (
-    !Array.isArray(parsed.factsPreserved) ||
-    !Array.isArray(parsed.factsMissing) ||
-    !Array.isArray(parsed.fabrications)
-  ) {
-    throw new Error("judge reply JSON missing required array fields");
+  const parsed = judgeVerdictSchema.parse(JSON.parse(text.slice(start, end + 1)));
+  const inventory = new Set(inventoryIds);
+  const factsPreserved = [...new Set(parsed.factsPreserved)];
+  const factsMissing = [...new Set(parsed.factsMissing)];
+  for (const id of [...factsPreserved, ...factsMissing]) {
+    if (!inventory.has(id)) throw new Error(`judge reply contains unknown fact ID: ${id}`);
   }
-  return {
-    factsPreserved: parsed.factsPreserved,
-    factsMissing: parsed.factsMissing,
-    fabrications: parsed.fabrications,
-  };
+  const missing = new Set(factsMissing);
+  if (factsPreserved.some((id) => missing.has(id))) {
+    throw new Error("judge reply declares a fact both preserved and missing");
+  }
+  return { factsPreserved, factsMissing, fabrications: parsed.fabrications };
 }

--- a/tools/compaction-gate/run.ts
+++ b/tools/compaction-gate/run.ts
@@ -142,7 +142,7 @@ async function judgeOnce(
       maxOutputTokens: JUDGE_MAX_OUTPUT_TOKENS,
     });
     try {
-      return parseJudgeVerdict(text);
+      return parseJudgeVerdict(text, payload.facts.map((fact) => fact.id));
     } catch (err) {
       lastErr = err;
     }


### PR DESCRIPTION
Repeated remembered fact IDs could inflate preservation scores to a perfect result. Count each valid inventory fact once, and reject malformed judge values, unknown IDs, and contradictory preserved/missing declarations.

Validation: 32 scorer/parser tests passed, including repeated-ID score 0.1 and failed quality threshold. No live model evaluation was run.

Part of the app reliability and Astra epic. The umbrella requires operator approval.

Required final Codex autoreview reported no findings at its configured P0 threshold. Final affected-flow checks passed on the combined snapshot.
