### PR TITLE
fix(tooling): scan Markdown fences for athlete IDs

### DIFF
--- a/tools/check-fixture-privacy.test.ts
+++ b/tools/check-fixture-privacy.test.ts
@@ -187,6 +187,27 @@ function expectOnlyCode(hits: readonly PrivacyHit[], code: string): void {
 }
 
 describe("Rule A — real intervals.icu id shape", () => {
+  it.each(["", "```json", "~~~text"])("flags Markdown identifiers with fence %j", (fence) => {
+    const id = `i${"9".repeat(8)}`;
+    const opening = fence ? `${fence}\n` : "";
+    const closing = fence ? `\n${fence.slice(0, 3)}` : "";
+    const file = write("sample.md", `${opening}athlete ${id}${closing}\n`);
+    expect(findIdHits([file])).toEqual([
+      expect.objectContaining({ file, line: fence ? 2 : 1, column: 9, rule: "intervals-id" }),
+    ]);
+  });
+
+  it("preserves Markdown placeholder and explicit file exemptions", () => {
+    const placeholder = `i${"1234"}${"5678"}`;
+    const forbidden = `i${"9".repeat(9)}`;
+    expect(findIdHits([write("placeholder.md", `\`\`\`\n${placeholder}\n\`\`\`\n`)])).toEqual([]);
+    expect(
+      findIdHits([
+        write("skip.md", `<!-- fixture-privacy-lint:skip-file -->\n\`\`\`\n${forbidden}\n\`\`\``),
+      ]),
+    ).toEqual([]);
+  });
+
   it("flags an i+9-digit id inside a JSON string", () => {
     const file = write("fixture.json", `{ "id": "i123456789", "type": "Ride" }\n`);
     const hits = findIdHits([file]);

--- a/tools/check-fixture-privacy.ts
+++ b/tools/check-fixture-privacy.ts
@@ -254,10 +254,9 @@ function findIdHitsInJsonFile(file: string): PrivacyHit[] {
 function findIdHitsInMdFile(file: string): PrivacyHit[] {
   const source = readFileSync(file, "utf-8");
   if (isSkippedFile(source)) return [];
-  const stripped = source.replace(/```[\s\S]*?```/g, (block) => block.replace(/[^\n]/g, " "));
-  const lineStarts = buildLineStarts(stripped);
+  const lineStarts = buildLineStarts(source);
   const hits: PrivacyHit[] = [];
-  for (const hit of matchIntervalsId(stripped, 0)) {
+  for (const hit of matchIntervalsId(source, 0)) {
     const { line, column } = offsetToLineCol(lineStarts, hit.offset);
     hits.push({
       file,
@@ -266,7 +265,7 @@ function findIdHitsInMdFile(file: string): PrivacyHit[] {
       path: "$",
       rule: "intervals-id",
       code: "source.intervals_id",
-      detail: `real intervals.icu id shape "${hit.value}" in prose`,
+      detail: `real intervals.icu id shape "${hit.value}" in Markdown`,
     });
   }
   return hits;


### PR DESCRIPTION
Scan Markdown code fences as well as prose for forbidden athlete identifier shapes. Preserve documented placeholders and explicit file exemptions. The regression reproduces the old fence bypass and asserts original line and column reporting. Validation: 177 privacy tests pass; actual CLI fixtures reject prose and fenced violations and accept placeholders; the repository privacy command scans 3,210 source files and 21 golden fixtures cleanly. Required autoreview completed with no actionable findings at the configured P0 threshold. Part of #879.