### PR TITLE
fix(desktop): clarify training data setup

### DIFF
--- a/.changeset/odd-meteors-clap.md
+++ b/.changeset/odd-meteors-clap.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+Clarify the training-data setup subtitle.
+
+User-facing: Setup now says you can connect a service or import ride files.

--- a/apps/desktop-renderer/src/ui/onboarding/copy.ts
+++ b/apps/desktop-renderer/src/ui/onboarding/copy.ts
@@ -158,7 +158,7 @@ export const TRAINING_ROW_TITLE = "Intervals.icu";
 
 export const TRAINING_ROW_SUBTITLES = {
   connected: "Connected · where your rides come from",
-  missing: "Required · where your rides come from",
+  missing: "Connect or import ride files.",
 } as const;
 
 export const TRAINING_ROW_TOOLTIP = {

--- a/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
@@ -1248,7 +1248,7 @@ describe("setup card", () => {
     }));
     const missing = mountWizard({ bridge: missingBridge });
     await missing.open();
-    expect(rowSubtitle("training")).toBe("Required · where your rides come from");
+    expect(rowSubtitle("training")).toBe("Connect or import ride files.");
     expect(trigger("training").textContent).toBe("Connect");
     expect(rowState("training")).toBe("pending");
     expect(useEnduragentStore.getState().onboarding.readiness.trainingData).toBe(true);
@@ -1289,7 +1289,7 @@ describe("setup card", () => {
       expect(useEnduragentStore.getState().onboarding.readiness.trainingData).toBe(true);
     });
     expect(rowState("training")).toBe("pending");
-    expect(rowSubtitle("training")).toBe("Required · where your rides come from");
+    expect(rowSubtitle("training")).toBe("Connect or import ride files.");
     expect(trigger("training").textContent).toBe("Connect");
     wizard.controller.dispose();
   });

--- a/apps/desktop-renderer/tests/setup-readiness.test.tsx
+++ b/apps/desktop-renderer/tests/setup-readiness.test.tsx
@@ -458,7 +458,7 @@ describe("authoritative setup readiness", () => {
         "data-state",
         "none",
       );
-      expect(document.body.textContent).not.toContain("Required · where your rides come from");
+      expect(document.body.textContent).not.toContain("Connect or import ride files.");
       expect(document.body.textContent).not.toContain("Required — Enduragent doesn't include one");
       expect(readinessBadge()).toHaveTextContent("Checking setup…");
       expect(readinessBadge()).not.toHaveTextContent("0 of 3 required ready");

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -266,37 +266,44 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live", () => {
-  it("finishes file-only onboarding into working Chat and Training pages", async () => {
-    const fixture = await launchDesktopFixture({
-      script: makeScript(),
-      token,
-      width: 1440,
-      height: 900,
-      colorScheme: "light",
-      reducedMotion: false,
-    });
-    fixtures.push(fixture);
-    const observed = await fixture.evaluate<{
-      readonly present: boolean;
-      readonly chatSetup: boolean;
-      readonly scrimAbsent: boolean;
-      readonly modalAbsent: boolean;
-      readonly title: string;
-      readonly escapeStayed: boolean;
-      readonly shellReplaced: boolean;
-      readonly finished: boolean;
-      readonly shellRestored: boolean;
-      readonly chatWorking: boolean;
-      readonly trainingReady: boolean;
-      readonly recentRideVisible: boolean;
-      readonly syncNeedsAttention: boolean;
-    }>(`
+  it.each([
+    { width: 1440, height: 900, colorScheme: "light", reducedMotion: false },
+    { width: 800, height: 700, colorScheme: "dark", reducedMotion: true },
+  ] as const)(
+    "finishes file-only onboarding into working Chat and Training pages at $width in $colorScheme",
+    async (appearance) => {
+      const fixture = await launchDesktopFixture({
+        script: makeScript(),
+        token,
+        ...appearance,
+      });
+      fixtures.push(fixture);
+      const observed = await fixture.evaluate<{
+        readonly trainingSubtitle: string;
+        readonly readiness: string;
+        readonly startEnabled: boolean;
+        readonly completionStored: boolean;
+        readonly present: boolean;
+        readonly chatSetup: boolean;
+        readonly scrimAbsent: boolean;
+        readonly modalAbsent: boolean;
+        readonly title: string;
+        readonly escapeStayed: boolean;
+        readonly shellReplaced: boolean;
+        readonly finished: boolean;
+        readonly shellRestored: boolean;
+        readonly chatWorking: boolean;
+        readonly trainingReady: boolean;
+        readonly recentRideVisible: boolean;
+        readonly syncNeedsAttention: boolean;
+      }>(`
       const deadline = Date.now() + 10000;
       const setupSelector =
         '[data-shell="gate"][data-onboarding="settled"] [data-setup-host="gate"]';
       while (!document.querySelector(setupSelector) && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
+      const trainingSubtitle = document.querySelector('[data-setup-row="training"] [data-setup-row-subtitle]')?.textContent ?? "";
       const page = document.querySelector(setupSelector);
       const present = page !== null;
       const chatSetup = document.querySelector(setupSelector) !== null;
@@ -387,6 +394,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       await waitFor('[data-setup-readiness="2"]');
       await pick("onboarding-injury-status", "No current injury");
       await new Promise((resolve) => setTimeout(resolve, 60));
+      const readiness = document.querySelector("[data-setup-readiness]")?.textContent ?? "";
+      const startEnabled = button("Start coaching")?.disabled === false;
       button("Start coaching")?.click();
       const chatDeadline = Date.now() + 10000;
       const chatReady = () => {
@@ -420,6 +429,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       const recentRides = training?.querySelector('[data-panel="recent-rides"]');
       const syncChip = document.querySelector(".sync-chip");
       return {
+        trainingSubtitle,
+        readiness,
+        startEnabled,
+        completionStored: localStorage.getItem("enduragent.desktop.onboarding") === '{"version":1,"completed":true}',
         present,
         chatSetup,
         scrimAbsent,
@@ -439,20 +452,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
         syncNeedsAttention: syncChip?.getAttribute("data-status") === "attention",
       };
     `);
-    expect(observed).toEqual({
-      present: true,
-      chatSetup: true,
-      scrimAbsent: true,
-      modalAbsent: true,
-      title: "Get your coach running before you can chat",
-      escapeStayed: true,
-      shellReplaced: true,
-      finished: true,
-      shellRestored: true,
-      chatWorking: true,
-      trainingReady: true,
-      recentRideVisible: true,
-      syncNeedsAttention: false,
-    });
-  }, 90_000);
+      expect(observed).toEqual({
+        trainingSubtitle: "Connect or import ride files.",
+        readiness: "3 of 3 required ready",
+        startEnabled: true,
+        completionStored: true,
+        present: true,
+        chatSetup: true,
+        scrimAbsent: true,
+        modalAbsent: true,
+        title: "Get your coach running before you can chat",
+        escapeStayed: true,
+        shellReplaced: true,
+        finished: true,
+        shellRestored: true,
+        chatWorking: true,
+        trainingReady: true,
+        recentRideVisible: true,
+        syncNeedsAttention: false,
+      });
+    },
+    90_000,
+  );
 });


### PR DESCRIPTION
Use the selected training-data setup subtitle: Connect or import ride files.

Connection readiness, connected wording, import behavior, and action order remain unchanged. Validation passed 102 renderer setup tests and two rebuilt native fixture cases at wide/light and compact/dark sizes. Visual review confirmed subtitle fit and completion/navigation. Fixtures used synthetic imported data and scripted RPC; no real service connection was made.

Part of the app reliability and Astra epic. The umbrella requires operator approval.

Required final Codex autoreview reported no findings at its configured P0 threshold. Final affected-flow checks passed on the combined snapshot.
