### PR TITLE
feat(engine): prepare public API Astra opt-in

### DIFF
--- a/.changeset/tiny-rockets-tan.md
+++ b/.changeset/tiny-rockets-tan.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+"@enduragent/engine": patch
+"@enduragent/core": patch
+---
+
+Prepare explicit Astra selection on the public OpenAI API while retaining existing default models and restricting unverified subscription transports.
+
+User-facing: You can explicitly choose Astra with an OpenAI API key. Existing model choices stay unchanged, and unavailable cost estimates are not shown as known prices.

--- a/packages/core/src/runtime-config.ts
+++ b/packages/core/src/runtime-config.ts
@@ -559,6 +559,9 @@ export function resolveRuntimeConfig(
     : current !== undefined && !providerChanged
       ? current.llm.model
       : DEFAULT_MODELS[provider];
+  if (model === "gpt-6-astra" && (provider === "openai-codex" || provider === "codex-agent")) {
+    throw new TypeError("GPT-6 Astra is not enabled for this connection; use the public OpenAI API.");
+  }
   const selectionChanged = current === undefined || providerChanged || model !== current.llm.model;
   const keyless = isKeylessProvider(provider);
   const apiKey = keyless
@@ -592,25 +595,32 @@ export function resolveRuntimeConfig(
         )
       : undefined;
 
+  const astra = provider === "openai" && model === "gpt-6-astra";
+  const backgroundModel = astra
+    ? current !== undefined && !providerChanged && current.llm.model !== "gpt-6-astra"
+      ? current.llm.model
+      : DEFAULT_MODELS.openai
+    : model;
   const requestedFlushModel = optionalModel(llmPatch, "flushModel");
   const flushModel =
     requestedFlushModel === null
       ? undefined
       : (requestedFlushModel ??
-        (current !== undefined && !providerChanged ? current.llm.flushModel : undefined));
+        (current !== undefined && !providerChanged ? current.llm.flushModel : undefined) ??
+        (astra ? backgroundModel : undefined));
 
   const requestedCompactModel = optionalModel(llmPatch, "compactModel");
   const compactModel =
     provider === "openai-codex"
       ? model
       : requestedCompactModel === null
-        ? (compactModelDefault(provider) ?? model)
+        ? (compactModelDefault(provider) ?? backgroundModel)
         : (requestedCompactModel ??
           (current !== undefined && !providerChanged
             ? model !== current.llm.model && current.llm.compactModel === current.llm.model
-              ? model
+              ? backgroundModel
               : current.llm.compactModel
-            : (compactModelDefault(provider) ?? model)));
+            : (compactModelDefault(provider) ?? backgroundModel)));
 
   let baseUrl: string | undefined;
   if (

--- a/packages/core/tests/runtime-config.test.ts
+++ b/packages/core/tests/runtime-config.test.ts
@@ -177,3 +177,41 @@ describe("runtime configuration authority", () => {
     }
   });
 });
+
+describe("Astra explicit public API selection", () => {
+  it("preserves defaults and background choices when opting in and back out", () => {
+    const initial = resolveRuntimeConfig({
+      llm: {
+        provider: "openai",
+        apiKey: "fake-key",
+        compactModel: "gpt-5.6-luna",
+        flushModel: "gpt-5.6-luna",
+      },
+    });
+    expect(initial.llm.model).toBe("gpt-5.6-sol");
+    const selected = resolveRuntimeConfig({ llm: { model: "gpt-6-astra" } }, initial);
+    expect(selected.llm).toEqual({ ...initial.llm, model: "gpt-6-astra" });
+    expect(selected.contextWindowTokens).toBe(200_000);
+    const restored = resolveRuntimeConfig({ llm: { model: "gpt-5.6-sol" } }, selected);
+    expect(restored.llm).toEqual(initial.llm);
+    expect(restored.contextWindowTokens).toBe(initial.contextWindowTokens);
+  });
+
+  it.each(["openai-codex", "codex-agent"] as const)("refuses unverified %s support", (provider) => {
+    expect(() => resolveRuntimeConfig({ llm: { provider, model: "gpt-6-astra" } })).toThrow(
+      "not enabled for this connection",
+    );
+  });
+});
+
+it("keeps implicit OpenAI background work on its previous model when opting into Astra", () => {
+  const initial = resolveRuntimeConfig({ llm: { provider: "openai", apiKey: "fake-key" } });
+  const selected = resolveRuntimeConfig({ llm: { model: "gpt-6-astra" } }, initial);
+  expect(selected.llm.flushModel).toBe(initial.llm.flushModel ?? initial.llm.model);
+  expect(selected.llm.compactModel).toBe(initial.llm.compactModel ?? initial.llm.model);
+  const fresh = resolveRuntimeConfig({
+    llm: { provider: "openai", model: "gpt-6-astra", apiKey: "fake-key" },
+  });
+  expect(fresh.llm.flushModel).toBe("gpt-5.6-sol");
+  expect(fresh.llm.compactModel).toBe("gpt-5.6-sol");
+});

--- a/packages/engine/src/agent/codex-agent/bridge.ts
+++ b/packages/engine/src/agent/codex-agent/bridge.ts
@@ -693,6 +693,9 @@ export async function codexAgentGenerateText(
   opts: CodexAgentGenerateOpts,
   ports: CodexAgentBridgePorts,
 ): Promise<GenerateResult> {
+  if (opts.modelId === "gpt-6-astra") {
+    throw new Error("GPT-6 Astra is not enabled for this connection; use the public OpenAI API.");
+  }
   if ((ports.platform ?? process.platform) === "win32") throw unsupportedPlatformError();
   if (ports.runtime.enabled !== true) throw disabledLaneError();
 

--- a/packages/engine/src/agent/codex-agent/cost.ts
+++ b/packages/engine/src/agent/codex-agent/cost.ts
@@ -17,6 +17,7 @@ export const CODEX_AGENT_PRICE_TABLE: Record<string, CodexAgentModelCost> = {
 };
 
 export function resolveCodexAgentPriceId(modelId: string): string {
+  if (modelId === "gpt-6-astra") return modelId;
   if (CODEX_AGENT_PRICE_TABLE[modelId] !== undefined) return modelId;
   const family = modelId.toLowerCase();
   if (family.includes("terra")) return "gpt-5.6-terra";
@@ -24,7 +25,8 @@ export function resolveCodexAgentPriceId(modelId: string): string {
   return CODEX_AGENT_FALLBACK_PRICE_ID;
 }
 
-export function codexAgentRates(modelId: string): CodexAgentModelCost {
+export function codexAgentRates(modelId: string): CodexAgentModelCost | undefined {
+  if (modelId === "gpt-6-astra") return undefined;
   return (
     CODEX_AGENT_PRICE_TABLE[resolveCodexAgentPriceId(modelId)] ??
     CODEX_AGENT_PRICE_TABLE[CODEX_AGENT_FALLBACK_PRICE_ID]
@@ -41,6 +43,7 @@ export function codexAgentCacheReadSavingsUsd(
 ): number | null {
   if (!validTokenCount(cacheReadTokens)) return null;
   const rates = codexAgentRates(modelId);
+  if (rates === undefined) return null;
   const savings = (Math.max(0, rates.input - rates.cacheRead) * cacheReadTokens) / 1_000_000;
   return Number.isFinite(savings) && savings >= 0 ? savings : null;
 }
@@ -58,6 +61,7 @@ export function priceCodexAgentInclusiveUsage(
     return undefined;
   }
   const rates = codexAgentRates(modelId);
+  if (rates === undefined) return undefined;
   const uncachedInputTokens = Math.max(
     0,
     usage.inputTokens - usage.cacheReadTokens - usage.cacheWriteTokens,

--- a/packages/engine/src/agent/codex-bridge.ts
+++ b/packages/engine/src/agent/codex-bridge.ts
@@ -173,6 +173,7 @@ function mapUsage(u: CodexUsage): LanguageModelUsage {
 // upstream falls back to its default-model template for those, so price unknown
 // codex ids at gpt-5.6-sol rates rather than dropping to undefined.
 function resolveCodexPriceId(modelId: string): string {
+  if (modelId === "gpt-6-astra") return modelId;
   return PRICE_TABLE["openai-codex"]?.[modelId] ? modelId : "gpt-5.6-sol";
 }
 
@@ -262,6 +263,9 @@ export async function codexGenerateText(
     classifyFailure: (error: unknown) => FailureReason;
   },
 ): Promise<GenerateResult> {
+  if (opts.modelId === "gpt-6-astra") {
+    throw new Error("GPT-6 Astra is not enabled for this connection; use the public OpenAI API.");
+  }
   const {
     system,
     messages,

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -316,12 +316,16 @@ export class LLM {
       ];
     }
 
+    const astra = this.config.llm.provider === "openai" && this.config.llm.model === "gpt-6-astra";
     const base = {
       model: this.aiSdkModel,
+      ...(astra ? { providerOptions: { openai: { forceReasoning: true } } } : {}),
       system,
       tools: opts.tools,
       stopWhen: opts.stopWhen,
-      maxOutputTokens: opts.maxOutputTokens,
+      maxOutputTokens: astra
+        ? Math.min(opts.maxOutputTokens ?? 128_000, 128_000)
+        : opts.maxOutputTokens,
       maxRetries: 0,
       abortSignal: opts.signal,
       experimental_context: opts.context,
@@ -355,6 +359,7 @@ export class LLM {
             });
             break;
           case "finish":
+            if (astra && part.finishReason === "error") throw new Error("OpenAI response failed.");
             break;
           case "error":
             throw part.error;
@@ -397,6 +402,7 @@ export class LLM {
         ? await generateText({ ...base, prompt: opts.prompt })
         : await generateText({ ...base, messages });
 
+    if (astra && result.finishReason === "error") throw new Error("OpenAI response failed.");
     return {
       text: result.text,
       toolCalls: result.toolCalls as GenerateResult["toolCalls"],

--- a/packages/engine/tests/astra-compatibility.test.ts
+++ b/packages/engine/tests/astra-compatibility.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText, Output, stepCountIs, tool } from "ai";
+import { z } from "zod";
+import { LLM } from "../src/llm.js";
+import type { EngineConfig } from "../src/host-ports.js";
+import { llmTestPorts } from "./helpers/base-agent-config.js";
+import { codexGenerateText } from "../src/agent/codex-bridge.js";
+import { codexAgentGenerateText } from "../src/agent/codex-agent/bridge.js";
+import {
+  codexAgentCacheReadSavingsUsd,
+  priceCodexAgentInclusiveUsage,
+} from "../src/agent/codex-agent/cost.js";
+
+const config: EngineConfig = {
+  llm: { provider: "openai", model: "gpt-6-astra", apiKey: "fake-key" },
+  dataSource: "platform",
+  session: {
+    historyTokenBudgetRatio: 0.3,
+    idleMinutes: 0,
+    dailyResetHour: 4,
+    resetArchiveRetentionDays: 0,
+    timezone: "",
+  },
+  contextWindowTokens: 200_000,
+  compactContextWindowTokens: 200_000,
+};
+
+function response(
+  output: unknown[] = [
+    {
+      type: "message",
+      id: "msg_test",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Ready", annotations: [] }],
+    },
+  ],
+) {
+  return {
+    id: "resp_test",
+    created_at: 0,
+    model: "gpt-6-astra",
+    status: "completed",
+    output,
+    usage: {
+      input_tokens: 120,
+      output_tokens: 8,
+      input_tokens_details: { cached_tokens: 40, cache_creation_tokens: 20 },
+      output_tokens_details: { reasoning_tokens: 2 },
+    },
+  };
+}
+
+function jsonResponse(output?: unknown[]) {
+  return new Response(JSON.stringify(response(output)), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function streamResponse() {
+  const events = [
+    { type: "response.created", response: response([]) },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "msg_test", role: "assistant", content: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: "msg_test",
+      output_index: 0,
+      content_index: 0,
+      delta: "Ready",
+    },
+    { type: "response.output_item.done", output_index: 0, item: response().output[0] },
+    { type: "response.completed", response: response() },
+  ];
+  return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Astra public Responses compatibility", () => {
+  it("serializes developer instructions, bounds output and keeps unmeasured cache cost unavailable", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse());
+    const result = await new LLM(config, llmTestPorts()).generate({
+      caller: "compact",
+      system: "Preserve goals",
+      prompt: "Summarize",
+      maxOutputTokens: 200_000,
+    });
+    const [url, init] = fetch.mock.calls[0];
+    expect(String(url)).toBe("https://api.openai.com/v1/responses");
+    const body = JSON.parse(String(init?.body));
+    expect(body.model).toBe("gpt-6-astra");
+    expect(body.input[0].role).toBe("developer");
+    expect(body.max_output_tokens).toBe(128_000);
+    for (const field of ["temperature", "top_p", "store", "prompt_cache_retention", "reasoning"])
+      expect(body).not.toHaveProperty(field);
+    expect(result.text).toBe("Ready");
+    expect(result.totalUsage?.inputTokenDetails.cacheReadTokens).toBe(40);
+    expect(result.totalUsage?.inputTokenDetails.cacheWriteTokens).toBeUndefined();
+    expect(result.cost).toBeUndefined();
+    expect(result.providerReportedCostUsd).toBeUndefined();
+  });
+
+  it("streams athlete text and measured token usage through LLM", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(streamResponse());
+    const onTextDelta = vi.fn();
+    const result = await new LLM(config, llmTestPorts()).generate({
+      caller: "chat",
+      prompt: "Hi",
+      onTextDelta,
+    });
+    expect(onTextDelta).toHaveBeenCalledWith("Ready");
+    expect(result.text).toBe("Ready");
+    expect(result.totalUsage?.inputTokens).toBe(120);
+    expect(result.cost).toBeUndefined();
+  });
+
+  it("surfaces a terminal stream failure without a success result or retry", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          `data: ${JSON.stringify({ type: "response.failed", response: { error: { code: "blocked", message: "Stopped for review" } } })}\n\n`,
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+    const append = vi.fn();
+    await expect(
+      new LLM(config, { ...llmTestPorts(), usage: { append } }).generate({
+        caller: "chat",
+        prompt: "Hi",
+      }),
+    ).rejects.toBeDefined();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("correlates a tool result with its original call across real SDK requests", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            type: "function_call",
+            id: "fc_test",
+            call_id: "call_test",
+            name: "read_goal",
+            arguments: "{}",
+            status: "completed",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse());
+    const execute = vi.fn(async () => "Finish the training plan");
+    await new LLM(config, llmTestPorts()).generate({
+      caller: "compact",
+      prompt: "Recall my goal",
+      tools: { read_goal: tool({ inputSchema: z.object({}), execute }) },
+      stopWhen: stepCountIs(2),
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const body = JSON.parse(String(fetch.mock.calls[1][1]?.body));
+    expect(body.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "item_reference", id: "fc_test" }),
+        expect.objectContaining({
+          type: "function_call_output",
+          call_id: "call_test",
+          output: "Finish the training plan",
+        }),
+      ]),
+    );
+  });
+
+  it("does not replay a completed tool after a subsequent provider failure", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            type: "function_call",
+            id: "fc_test",
+            call_id: "call_test",
+            name: "save_goal",
+            arguments: "{}",
+            status: "completed",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: "Stopped for review", code: "blocked" } }),
+          { status: 403, headers: { "content-type": "application/json" } },
+        ),
+      );
+    const execute = vi.fn(async () => "Saved");
+    await expect(
+      new LLM(config, llmTestPorts()).generate({
+        caller: "compact",
+        prompt: "Save goal",
+        tools: { save_goal: tool({ inputSchema: z.object({}), execute }) },
+        stopWhen: stepCountIs(2),
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["low", "medium", "high", "xhigh", "max"])(
+    "installed SDK serializes documented %s effort and structured output",
+    async (effort) => {
+      const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        jsonResponse([
+          {
+            type: "message",
+            id: "msg_test",
+            role: "assistant",
+            content: [{ type: "output_text", text: '{"ready":true}', annotations: [] }],
+          },
+        ]),
+      );
+      const result = await generateText({
+        model: createOpenAI({ apiKey: "fake-key" }).responses("gpt-6-astra"),
+        prompt: "Return readiness",
+        providerOptions: { openai: { forceReasoning: true, reasoningEffort: effort } },
+        output: Output.object({ schema: z.object({ ready: z.boolean() }) }),
+        maxRetries: 0,
+      });
+      const body = JSON.parse(String(fetch.mock.calls[0][1]?.body));
+      expect(body.reasoning).toEqual({ effort });
+      expect(body.text.format.type).toBe("json_schema");
+      expect(result.output).toEqual({ ready: true });
+    },
+  );
+
+  it.each([429, 503, 403])(
+    "preserves terminal HTTP %s without an internal retry",
+    async (status) => {
+      const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "Provider refused",
+              code: status === 429 ? "slow_down" : "blocked",
+            },
+          }),
+          { status, headers: { "content-type": "application/json", "retry-after": "3" } },
+        ),
+      );
+      await expect(
+        new LLM(config, llmTestPorts()).generate({ caller: "compact", prompt: "Hi" }),
+      ).rejects.toMatchObject({
+        statusCode: status,
+        responseHeaders: expect.objectContaining({ "retry-after": "3" }),
+      });
+      expect(fetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("cancels a request without retrying", async () => {
+    const controller = new AbortController();
+    const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      controller.abort();
+      throw init?.signal?.reason;
+    });
+    await expect(
+      new LLM(config, llmTestPorts()).generate({
+        caller: "compact",
+        prompt: "Hi",
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unverified Astra subscription transports", () => {
+  it("refuses before accessing credentials or starting app-server", async () => {
+    const getAccessToken = vi.fn();
+    await expect(
+      codexGenerateText(
+        { caller: "chat", modelId: "gpt-6-astra", profileName: "test", prompt: "Hi" },
+        { ...llmTestPorts(), getAccessToken },
+      ),
+    ).rejects.toThrow("not enabled for this connection");
+    expect(getAccessToken).not.toHaveBeenCalled();
+    const ensureReady = vi.fn();
+    await expect(
+      codexAgentGenerateText(
+        { caller: "chat", modelId: "gpt-6-astra", prompt: "Hi" },
+        { runtime: { enabled: true }, ensureReady },
+      ),
+    ).rejects.toThrow("not enabled for this connection");
+    expect(ensureReady).not.toHaveBeenCalled();
+  });
+
+  it("does not infer Sol dollars or cache savings for Astra", () => {
+    expect(
+      priceCodexAgentInclusiveUsage("gpt-6-astra", {
+        inputTokens: 120,
+        outputTokens: 8,
+        cacheReadTokens: 40,
+        cacheWriteTokens: 0,
+      }),
+    ).toBeUndefined();
+    expect(codexAgentCacheReadSavingsUsd("gpt-6-astra", 40)).toBeNull();
+  });
+});


### PR DESCRIPTION
Prepare explicit custom-model Astra selection through the public OpenAI Responses API. Force reasoning-model recognition in the installed SDK, bound output, reject terminal failure responses, preserve existing primary defaults and background models, and keep unavailable costs unpriced.

The subscription bridge and Codex app-server reject Astra before credential access/process startup because their support has not been verified. Astra no longer inherits Sol app-server price estimates.

Validation: real installed SDK with stubbed HTTP covers streaming, structured output, documented reasoning serialization, tool-call correlation, cancellation, retry headers, terminal failure, and no replay after tool execution. Final focused tests passed 28 tests; broader transport/probe/protocol coverage passed 118 tests before the final narrow terminal guard. Defaults and background configuration have dedicated regressions.

Public documentation: https://developers.openai.com/api/docs/models/gpt-6-astra and https://developers.openai.com/codex/app-server.

No paid provider calls occurred. Account entitlement, live compatibility, latency, matched quality, and actual costs remain unresolved. Cache-write usage is unavailable in the installed SDK; token/cache-read counts are measured, not a complete billing estimate.

Part of the app reliability and Astra epic. The umbrella requires operator approval.

Required final Codex autoreview reported no findings at its configured P0 threshold. Final affected-flow checks passed on the combined snapshot.
