### PR TITLE
fix(tooling): enforce relative workspace imports

### DIFF
--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -57,6 +57,113 @@ const rDesktop = ruleForDir("apps/desktop");
 const rCoach = ruleForDir("packages/coach");
 const rBin = ruleForDir("packages/cycling-coach");
 
+describe("relative workspace imports", () => {
+  it.each([
+    'import { value } from "../../engine/src/index.js";',
+    'import "../../engine/src/index.js";',
+    'export { value } from "../../engine/src/index.js";',
+    'export * from "../../engine/src/index.js";',
+    'export const value = import("../../engine/src/index.js");',
+    'export const value = require("../../engine/src/index.js");',
+  ])("rejects a forbidden relative edge: %s", (source) => {
+    writeJson("packages/engine/package.json", { name: "@enduragent/engine", private: true });
+    write("packages/engine/src/index.ts", "export const value = 1;");
+    const file = write("packages/kernel/src/bad.ts", source);
+    expect(runRulesAgainst(tempDir, [r1]).violations).toEqual([
+      expect.objectContaining({ file, specifier: "../../engine/src/index.js", ruleId: "R1" }),
+    ]);
+    expect(main([tempDir])).toBe(1);
+  });
+
+  it("preserves same-package, shared-file, and allowed workspace imports", () => {
+    writeJson("packages/kernel/package.json", { name: "@enduragent/kernel", private: true });
+    write("packages/kernel/src/index.ts", "export const value = 1;");
+    writeJson("packages/kernel-node/package.json", {
+      name: "@enduragent/kernel-node",
+      private: true,
+    });
+    write(
+      "packages/kernel-node/src/ok.ts",
+      [
+        'import "./helper.js";',
+        'import "../test/helper.js";',
+        'import "../../../tools/helper.js";',
+        'import "../../kernel/src/index.js";',
+      ].join("\n"),
+    );
+    expect(violationsFor(r2)).toBe(0);
+  });
+
+  it("preserves transitional warnings for relative imports", () => {
+    writeJson("packages/engine/package.json", { name: "@enduragent/engine", private: true });
+    write("packages/core/src/shim.ts", 'export * from "../../engine/src/index.js";');
+    const result = runRulesAgainst(tempDir, [rCore]);
+    expect(result.violations).toHaveLength(0);
+    expect(result.warnEdges).toEqual([{ dir: "packages/core", target: "@enduragent/engine" }]);
+  });
+
+  it("resolves imports across workspace groups and normalizes parent segments", () => {
+    writeJson("packages/engine/package.json", { name: "@enduragent/engine", private: true });
+    write(
+      "apps/desktop-renderer/src/bad.tsx",
+      'import "../../../packages/core/../engine/src/index.js";',
+    );
+    expect(violationsFor(rRenderer)).toBe(1);
+  });
+
+  it.each(["src/contracts/sport", "src/contracts/sport/index.js", "dist/contracts/sport/index.js"])(
+    "maps declared export targets independently of their file name: %s",
+    (target) => {
+      writeJson("packages/engine/package.json", {
+        name: "@enduragent/engine",
+        private: true,
+        exports: { "./sport": "./dist/contracts/sport/index.js" },
+      });
+      write("packages/sport-x/src/ok.ts", `export * from "../../engine/${target}";`);
+      expect(violationsFor(r4)).toBe(0);
+    },
+  );
+
+  it("does not infer an allowed sport export from a private file's name", () => {
+    writeJson("packages/engine/package.json", {
+      name: "@enduragent/engine",
+      private: true,
+      exports: { "./sport": "./dist/contracts/sport.js" },
+    });
+    write("packages/sport-x/src/bad.ts", 'export * from "../../engine/src/sport.js";');
+    expect(violationsFor(r4)).toBe(1);
+  });
+
+  it.each(["src/sport.ts", "src/sport.js", "dist/sport.js"])(
+    "allows the declared engine sport entry through %s",
+    (target) => {
+      writeJson("packages/engine/package.json", {
+        name: "@enduragent/engine",
+        private: true,
+        exports: { "./sport": { types: "./dist/sport.d.ts", import: "./dist/sport.js" } },
+      });
+      write("packages/sport-x/src/ok.ts", `export * from "../../engine/${target}";`);
+      expect(violationsFor(r4)).toBe(0);
+    },
+  );
+
+  it.each([
+    "src/index.js",
+    "src/runtime.js",
+    "src/sport-internal.js",
+    "src/sport/private.js",
+    "src/sport/index.js",
+  ])("rejects engine imports outside its declared sport entry: %s", (target) => {
+    writeJson("packages/engine/package.json", {
+      name: "@enduragent/engine",
+      private: true,
+      exports: { "./sport": "./dist/sport.js" },
+    });
+    write("packages/sport-x/src/bad.ts", `export * from "../../engine/${target}";`);
+    expect(violationsFor(r4)).toBe(1);
+  });
+});
+
 describe("R1 kernel purity", () => {
   it("R1 flags a node: prefixed import", () => {
     write("packages/kernel/src/bad.ts", `import { readFileSync } from "node:fs";\n`);

--- a/tools/check-package-deps.ts
+++ b/tools/check-package-deps.ts
@@ -36,7 +36,7 @@
 
 import * as ts from "typescript";
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, resolve, relative, sep } from "node:path";
 import { isBuiltin } from "node:module";
 import { TS_EXTS, ext, collectFiles, makeSkipCheck, nonFlagArgs, runGateCli } from "./lint-fs.js";
 
@@ -361,6 +361,69 @@ interface ConcreteDir {
   readonly fsDir: string;
 }
 
+interface WorkspacePackage {
+  readonly fsDir: string;
+  readonly name: string;
+  readonly exports: Record<string, unknown>;
+}
+
+function workspacePackages(root: string): WorkspacePackage[] {
+  const packages: WorkspacePackage[] = [];
+  for (const group of ["packages", "apps"]) {
+    const parent = join(root, group);
+    if (!existsSync(parent)) continue;
+    for (const entry of readdirSync(parent, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const fsDir = resolve(parent, entry.name);
+      const manifest = readManifestDeps(fsDir, "");
+      if (manifest.packageName.startsWith(WORKSPACE_SCOPE)) {
+        packages.push({ fsDir, name: manifest.packageName, exports: manifest.packageExports });
+      }
+    }
+  }
+  return packages;
+}
+
+function modulePath(path: string): string {
+  return path
+    .replaceAll(sep, "/")
+    .replace(/^\.\//, "")
+    .replace(/^(?:src|dist)\//, "")
+    .replace(/(?:\.d)?\.[cm]?[jt]sx?$/, "");
+}
+
+function exportTargets(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (value === null || typeof value !== "object") return [];
+  return Object.values(value).flatMap(exportTargets);
+}
+
+function relativeWorkspaceSpecifier(
+  file: string,
+  specifier: string,
+  ownerDir: string,
+  packages: readonly WorkspacePackage[],
+): string | undefined {
+  const target = resolve(dirname(file), specifier);
+  const owner = packages.find((pkg) => target === pkg.fsDir || target.startsWith(pkg.fsDir + sep));
+  if (!owner || owner.fsDir === resolve(ownerDir)) return undefined;
+  const targetPath = modulePath(relative(owner.fsDir, target));
+  for (const [key, value] of Object.entries(owner.exports)) {
+    if (!key.startsWith("./")) continue;
+    if (
+      exportTargets(value).some((entry) => {
+        const entryPath = modulePath(entry);
+        return (
+          entryPath === targetPath || (ext(target) === "" && entryPath === `${targetPath}/index`)
+        );
+      })
+    ) {
+      return owner.name + key.slice(1);
+    }
+  }
+  return owner.name;
+}
+
 function expandRuleDirs(root: string, rule: PackageDepRule): ConcreteDir[] {
   if (rule.dir.includes("*")) {
     const parent = dirname(rule.dir);
@@ -393,6 +456,7 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
   const warnSet = new Map<string, TransitionalEdge>();
   const notPresent: string[] = [];
   let scannedFileCount = 0;
+  const packages = workspacePackages(root);
 
   const recordWarn = (dir: string, target: string): void => {
     const key = `${dir} -> ${target}`;
@@ -416,7 +480,11 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
         if (!TS_EXTS.has(ext(file))) continue;
         scannedFileCount++;
         for (const ref of collectSpecifiers(file)) {
-          const spec = ref.specifier;
+          const isRelative = ref.specifier.startsWith("./") || ref.specifier.startsWith("../");
+          const spec = isRelative
+            ? relativeWorkspaceSpecifier(file, ref.specifier, fsDir, packages)
+            : ref.specifier;
+          if (spec === undefined) continue;
           if (isNodeSpecifier(spec)) {
             if (rule.forbidNode) {
               violations.push({
@@ -424,7 +492,7 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
                 line: ref.line,
                 column: ref.column,
                 ruleId: rule.ruleId,
-                specifier: spec,
+                specifier: ref.specifier,
                 pkg: dir,
               });
             }
@@ -444,7 +512,7 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
                 line: ref.line,
                 column: ref.column,
                 ruleId: rule.ruleId,
-                specifier: spec,
+                specifier: ref.specifier,
                 pkg: dir,
               });
               continue;
@@ -460,12 +528,11 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
               line: ref.line,
               column: ref.column,
               ruleId: rule.ruleId,
-              specifier: spec,
+              specifier: ref.specifier,
               pkg: dir,
             });
             continue;
           }
-          if (spec.startsWith("./") || spec.startsWith("../")) continue;
           if (
             rule.allowedExternal === undefined ||
             rule.allowedExternal.some((entry) => matchesEntry(spec, entry))


### PR DESCRIPTION
Resolve relative import and export targets to their workspace package, then apply existing dependency and allowed-subpath rules. Declared export targets preserve the Engine sport boundary. Same-package imports and intentional transitional edges retain their behavior. Validation: 74 focused tests pass; actual CLI fixtures reject a forbidden kernel-to-engine path and accept a same-package path; the repository checker passes 803 files with the same three transitional warnings. Required autoreview is clean at the configured P0 threshold. Computed specifiers, aliases, symlinks, and wildcard export mappings remain unsupported. Part of #879.