### PR TITLE
docs(architecture): correct package ownership and wiring

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,38 +1,46 @@
 # Context Map
 
-This repo is a multi-package monorepo for the enduragent AI coaching agent platform — Core publishes the Sport contract, sport packages implement it, binary packages ship them.
+This repo is a multi-package monorepo for the enduragent AI coaching agent platform. Engine defines the Sport contract, sport packages supply domain behavior, and host packages compose them.
 
 ## Contexts
 
-- [Core](./packages/core/CONTEXT.md) — sport-agnostic infrastructure: agent loop, memory, session, secrets, channels (Telegram), LLM transport, intervals.icu client (shared tools), setup wizard, runBinary entry-point, updater. Owns no sport vocabulary. Publishes the `Sport` and `BinaryConfig` contracts.
+- [Core](./packages/core/CONTEXT.md) — shared CLI entry point, setup, memory, secrets, and channels. Defines `BinaryConfig` and re-exports Engine’s sport contract. Depends on Engine and Kernel through transitional edges.
+- [Engine](./packages/engine/src/sport.ts) — defines `Sport`, `SportRuntimePorts`, and the `CoreDeps` alias at `@enduragent/engine/sport`.
+- [Kernel](./packages/kernel/package.json) — declares portable compute, store, planning, and Reference exports. Its dependency rule forbids workspace imports and Node builtins.
+- [Kernel Node](./packages/kernel-node/package.json) — declares Node host adapter exports and depends on Kernel.
+- [Coach](./packages/coach/package.json) — declares runtime, sync, store-runtime, and serve exports; depends on Engine, Kernel, Kernel Node, and transitionally Core.
 - [Cycling](./packages/sport-cycling/CONTEXT.md) — FTP-based zones, power-prescribed workouts, bike equipment, cyclist persona. Implements `Sport`. Bundled into the `cycling-coach` binary.
-- [Running](./packages/sport-running/CONTEXT.md) — VDOT/pace-based zones, impact-aware progression, injury-first intake, runner persona. Stub.
+- [Running](./packages/sport-running/CONTEXT.md) — critical-speed pace zones, schemas, workout serialization, running tools, and a Reference adapter. Implements `Sport`.
 - [Duathlon](./packages/sport-duathlon/CONTEXT.md) — coordinator context. Brick workouts, transitions, dual periodization. Stub.
 - [Cycling Coach](./packages/cycling-coach/CONTEXT.md) — published `cycling-coach` binary; 7-line shim wiring cyclingSport + cyclingBinary into Core's runBinary.
-- [Running Coach](./packages/running-coach/CONTEXT.md) — `running-coach` binary stub; placeholder banner.
+- [Running Coach](./packages/running-coach/CONTEXT.md) — private binary whose entry point calls Core’s `runBinary(runningSport, runningBinary)`.
 - [Duathlon Coach](./packages/duathlon-coach/CONTEXT.md) — `duathlon-coach` binary stub; placeholder banner.
 
 ## Relationships
 
-- **Core → Cycling, Running, Duathlon**: **Open Host Service**. Core publishes the `Sport` interface; each sport conforms. Core changes are coordinated across all sports.
+- **Engine → sport packages**: **Open Host Service**. Engine defines `Sport` at `@enduragent/engine/sport`; Cycling and Running implement it. Coordinate contract changes across consumers. Consult [the dependency checker](./tools/check-package-deps.ts) for allowed and transitional package edges.
 - **Cycling ↔ Running**: **Partnership**. Peer contexts that evolve in lockstep when the `Sport` interface or shared infrastructure changes. Neither is upstream of the other.
-- **Duathlon → Cycling, Running**: **Customer/Supplier (Conformist flavor)**. Duathlon imports `sport-cycling` and `sport-running` as workspace dependencies, reuses their tools/personas/zones verbatim, and adds duathlon-only concepts (brick, transition, dual periodization). Duathlon never redefines cycling or running vocabulary.
+- **Duathlon → Cycling, Running**: intended **Customer/Supplier (Conformist flavor)**. The planned coordinator reuses their tools, personas, and zones and adds brick workouts, transitions, and dual periodization. The current Duathlon source is a stub; this relationship is not implemented.
 
 ## Why Duathlon is a Customer, not a peer
+
+The intended composition follows two rules:
 
 1. **It doesn't redefine upstream vocabulary.** "FTP" means the same thing inside Duathlon as inside Cycling. If a duathlete asks about FTP, Cycling's persona answers verbatim.
 2. **It adds, never overrides.** Brick, transition, dual periodization are _new_ concepts that don't exist in Cycling or Running.
 
-If sport-cycling improves its FTP-test guidance, sport-duathlon inherits the improvement automatically. This is the load-bearing reason for the Customer pattern over Partnership.
+Once that composition is implemented, improvements to sport-cycling’s FTP-test guidance will also reach sport-duathlon. This is the load-bearing reason for the Customer pattern over Partnership.
 
 ## Status
 
 Current state of the Core/Sport seam:
 
-- **Core** — implemented at `packages/core/`. Sport-agnostic; no cycling vocabulary leaks. Three-category tool split per ADR-0004 (Pure-Core memory + intervals tools live in Core; sport-injected config flows in via `BinaryConfig`/`Sport.intervalsActivityTypes`). Private workspace package (`@enduragent/core`); bundled into the `cycling-coach` binary at publish time, not separately published. See ADR-0009.
+- **Core** — implemented private workspace package consumed by CLI binaries. Its `Sport` export forwards Engine’s definition. The dependency checker explicitly marks its Engine and Kernel dependencies transitional; shared infrastructure has not all moved out of Core.
 - **Cycling** — implemented at `packages/sport-cycling/`. SOUL.md + skills/\*.md inlined into the bundle via tsup `.md: text` loader and skills.generated.ts codegen. Private workspace package (`@enduragent/sport-cycling`); bundled into the `cycling-coach` binary at publish time, not separately published.
 - **Cycling Coach** — implemented at `packages/cycling-coach/`. 7-line bin shim. Published as `cycling-coach` on npm (CalVer continues). The published tarball is self-contained — `@enduragent/*` workspace code is inlined via `tsup` `noExternal`.
-- **Running, Duathlon, Running Coach, Duathlon Coach** — empty stubs at `packages/{sport-running,sport-duathlon,running-coach,duathlon-coach}/`. Private workspace packages (SemVer); not published. They graduate to public CalVer-versioned npm binaries once a real implementation lands.
+- **Running and Running Coach** — private workspace packages with implemented sport/tool composition and a CLI entry point. Source inspection establishes this wiring; it does not establish end-to-end coaching behavior or publication readiness.
+- **Duathlon and Duathlon Coach** — private stubs at `packages/sport-duathlon/` and `packages/duathlon-coach/`; the sport exports a status constant and the binary prints a placeholder banner.
+- **Scoped packages** — `check:package-deps` requires `@enduragent/*` packages to remain private. A declared export is a workspace API, not a publication commitment.
 
 ## Release flow
 

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -1,13 +1,13 @@
 # Core
 
-Sport-agnostic infrastructure for AI coaching agents. Provides the agent loop, memory, secrets, channels, LLM transport, and intervals.icu client. Publishes the `Sport` contract that domain packages implement.
+Sport-agnostic CLI infrastructure for AI coaching agents, including setup, memory, secrets, and channels. Engine defines the `Sport` contract at `@enduragent/engine/sport`; Core re-exports it for existing consumers.
 
-> Status: this directory is a planning placeholder. Source still lives at the repo root in `src/agent/`, `src/secrets/`, `src/auth/`, `src/channels/`. The refactor will move that code here.
+> Status: implemented private workspace package. Core depends on Engine and Kernel through explicitly transitional edges. Consult the [context map](../../CONTEXT-MAP.md) and [dependency checker](../../tools/check-package-deps.ts) for current package boundaries.
 
 ## Language
 
 **Sport**:
-A pluggable coaching domain (cycling, running, duathlon) that conforms to Core's `Sport` interface — pure domain knowledge, no deployment concerns.
+A pluggable coaching domain (cycling, running, duathlon) that conforms to Engine's `Sport` interface — pure domain knowledge, no deployment concerns.
 _Avoid_: Discipline, modality, mode
 
 **Binary**:
@@ -15,7 +15,7 @@ A deployed CLI executable wrapping a `Sport` with deployment-shell config (npm n
 _Avoid_: Build, distro, app
 
 **Agent**:
-The Core-owned conversation loop that runs LLM calls with tool dispatch, compaction, and memory flush; sport-agnostic.
+The sport-agnostic conversation loop that runs LLM calls with tool dispatch, compaction, and memory flush. Core supplies a compatibility host around Engine’s runtime.
 
 **Memory**:
 A file-backed sectioned store of long-lived athlete information at `~/.enduragent/<binary>/memory/MEMORY.md` (or legacy `~/.cycling-coach/memory/MEMORY.md` for grandfathered cycling-coach users).
@@ -42,7 +42,7 @@ The ephemeral compaction path (`summarizeInStages`). Reshapes only the in-memory
 Every freshly generated compaction summary (all four sites: trim, preemptive, overflow recovery, timeout recovery) is also mirrored into the day's note under the fixed marker `### Compaction summary`, heading-demoted, with an exact-block duplicate-skip. This makes the summary recoverable via `memory_read` after a session reset destroys the live JSONL and its archives.
 
 **CoreDeps**:
-The runtime services Core supplies to a Sport's tool factory: `LLM`, `IntervalsClient`, `MemoryStore`, `SecretsResolver`.
+An alias for Engine’s `SportRuntimePorts`, the runtime services received by a Sport’s tool factory. The [contract definition](../engine/src/sport.ts) specifies the required services and optional capabilities.
 
 **BinaryConfig**:
 Deployment-shell config injected into `runBinary` and `runSetup`. Fields: `binaryName` (npm name + CLI invocation), `displayName` (human-readable for prompts), `dataSubdir` (under `~/.enduragent/`), `keychainPrefix` (Apple Keychain entry prefix), `homeEnvVar` (env override variable name). Each binary package declares one and passes it through.
@@ -147,4 +147,4 @@ Golden fixtures (sanitized real intervals.icu responses) live at
 
 ## Flagged ambiguities
 
-- "Coach" was used to mean both **Sport** (coaching domain) and **Binary** (CLI executable). Resolved: code uses **Sport** for domain, **Binary** for deployment shell. "Coach" remains in product surfaces (display names, READMEs) but is not a code-level term.
+- Distinguish **Sport** for coaching domain, **Binary** for deployment shell, and `@enduragent/coach` for the Node composition package.

--- a/packages/running-coach/CONTEXT.md
+++ b/packages/running-coach/CONTEXT.md
@@ -4,15 +4,15 @@ A small shim that wires the running sport (`@enduragent/sport-running`) and the 
 
 ## Status: wired, private (unpublished)
 
-Runs locally from the workspace. Unlike the published `cycling-coach`, this package **externalizes** `@enduragent/*` (tsup default) rather than bundling them: Core compiles to a single self-contained `dist/index.js`, so a private workspace package resolves Core and sport-running through pnpm's symlinks at runtime — no bundled tarball is built.
+The [entry point](./src/index.ts) calls `runBinary(runningSport, runningBinary)` and reports fatal errors using the binary’s data directory. The [build configuration](./tsup.config.ts) explicitly externalizes `@enduragent/*`, so the output requires workspace dependencies at runtime.
 
-When it flips `private: false` to publish, it must switch to bundling (`noExternal`) to match cycling-coach — an externalized tarball would `import` the private, unpublished `@enduragent/core` and 404 on a fresh `npm install`. That transition is **mechanically enforced, not left to memory**: the release smoke job (`.github/workflows/release.yml`) packs the tarball and installs it into a fresh consumer, so a public flip without `noExternal` fails the smoke gate before publish. See ADR-0009/0010.
+This establishes source wiring and build intent, not a verified end-to-end coaching session. The package remains private. Publication would require a separate packaging decision and verification that installation works without private workspace packages.
 
 ## What lives here
 
 - `src/index.ts` — the bin shim (`runBinary(runningSport, runningBinary)`).
 - `src/binary.ts` — `runningBinary: BinaryConfig` (binaryName: "running-coach", displayName: "Running Coach", dataSubdir: "running", keychainPrefix: "running-coach", homeEnvVar: "RUNNING_COACH_HOME").
-- `tests/binary.test.ts` — asserts the BinaryConfig shape and that the running sport wires into `runBinary`.
+- `tests/binary.test.ts` — asserts the `BinaryConfig` shape, the running sport ID, and that `runBinary` is a function; it does not invoke the binary.
 
 ## Not here (intentionally)
 

--- a/packages/sport-running/CONTEXT.md
+++ b/packages/sport-running/CONTEXT.md
@@ -1,10 +1,12 @@
 # Sport-Running
 
-Implements the `Sport` contract from `@enduragent/core` for running. This wave ships **critical-speed-anchored pace zones** — the rest of the Sport surface (plan builder, periodization, workout serializer) is deferred.
+Implements Engine’s `Sport` contract at `@enduragent/engine/sport` for running. The [public index](./src/index.ts) exports critical-speed pace zones, schemas, workout serialization, sport/tools, and a Reference adapter.
 
 ## Status: alpha — zones vertical only
 
-Private workspace package, not published to npm. Becomes a published `@enduragent/sport-running` (SemVer) when a real consumer needs it. See ADR-0009.
+Private workspace package. The heading records the initial zones scope; the implemented surface now includes workout serialization and sport/tool composition. [runningSport](./src/sport.ts) composes memory, intervals.icu, and running tools and supplies the Reference adapter. [Running Coach](../running-coach/CONTEXT.md) consumes it. This source wiring does not establish end-to-end coaching behavior or planning completeness.
+
+`check:package-deps` requires `@enduragent/*` packages to remain private. Publication requires a separate policy decision.
 
 ## Pace zones (the shipped surface)
 
@@ -19,7 +21,7 @@ Primary = **intervals.icu-supplied** value (`threshold_pace`, stored in SI m/s; 
 
 ## Validation gate
 
-`checkCsSource` lives in **core** (`packages/core/src/reference/validation/checks/step5-cs-source.ts`, registered in `sync-gate.ts` as `step5_cs_source`), not here — core owns sync-time validation gates uniformly, following the step1 FTP-source gate precedent (ADR-0021 §4). It refuses to emit zones when a running row carries no sane CS anchor (manual `critical_speed` > platform `threshold_pace`), resolve-or-skip for non-runners. This is the first live instance of the CS-family gate pattern the swim CSS gate (ADR-0021) will follow.
+[checkCsSource](../core/src/reference/validation/checks/step5-cs-source.ts) remains in Core and is called by its [sync gate](../core/src/reference/validation/sync-gate.ts) as `step5_cs_source`. It rejects collected CS values outside the sanity range and gives manual `critical_speed` values precedence over platform `threshold_pace`. It returns no failure when no values are collected. The running `calculate_zones` tool separately returns `no_cs_anchor` when no anchor is available.
 
 ## Monitoring/analyze copy discipline
 


### PR DESCRIPTION
Correct Sport ownership to Engine and describe Core as a compatibility host with transitional dependencies. Replace stale Running stub and packaging claims with the actual sport composition and runBinary call, and distinguish declared exports and source wiring from unverified coaching and publication behavior. Validation: definitions, exports, consumers, configuration, and test assertions inspected; all 22 local Markdown links resolve; git diff --check and full root pnpm check pass. Required autoreview is clean at the configured P0 threshold. No runtime behavior changes. Part of #879.