### PR TITLE
fix(app): preserve context and prepare Astra opt-in

### DIFF
--- a/.changeset/fiery-yaks-stand.md
+++ b/.changeset/fiery-yaks-stand.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+"@enduragent/core": patch
+---
+
+Distinguish confirmation guard refusals and returned failures from completed changes.
+
+User-facing: When a workout can no longer be changed, the coach explains why instead of saying it is done.

--- a/.changeset/late-dingos-remain.md
+++ b/.changeset/late-dingos-remain.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+"@enduragent/engine": patch
+---
+
+Retain unsummarized conversation history after compaction failures and stop when it cannot safely fit.
+
+User-facing: If a conversation summary fails, the coach keeps the original context or asks you to try again instead of silently forgetting earlier goals and corrections.

--- a/.changeset/odd-meteors-clap.md
+++ b/.changeset/odd-meteors-clap.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+Clarify the training-data setup subtitle.
+
+User-facing: Setup now says you can connect a service or import ride files.

--- a/.changeset/tiny-rockets-tan.md
+++ b/.changeset/tiny-rockets-tan.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+"@enduragent/engine": patch
+"@enduragent/core": patch
+---
+
+Prepare explicit Astra selection on the public OpenAI API while retaining existing default models and restricting unverified subscription transports.
+
+User-facing: You can explicitly choose Astra with an OpenAI API key. Existing model choices stay unchanged, and unavailable cost estimates are not shown as known prices.

--- a/apps/desktop-renderer/src/ui/onboarding/copy.ts
+++ b/apps/desktop-renderer/src/ui/onboarding/copy.ts
@@ -158,7 +158,7 @@ export const TRAINING_ROW_TITLE = "Intervals.icu";
 
 export const TRAINING_ROW_SUBTITLES = {
   connected: "Connected · where your rides come from",
-  missing: "Required · where your rides come from",
+  missing: "Connect or import ride files.",
 } as const;
 
 export const TRAINING_ROW_TOOLTIP = {

--- a/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
@@ -1248,7 +1248,7 @@ describe("setup card", () => {
     }));
     const missing = mountWizard({ bridge: missingBridge });
     await missing.open();
-    expect(rowSubtitle("training")).toBe("Required · where your rides come from");
+    expect(rowSubtitle("training")).toBe("Connect or import ride files.");
     expect(trigger("training").textContent).toBe("Connect");
     expect(rowState("training")).toBe("pending");
     expect(useEnduragentStore.getState().onboarding.readiness.trainingData).toBe(true);
@@ -1289,7 +1289,7 @@ describe("setup card", () => {
       expect(useEnduragentStore.getState().onboarding.readiness.trainingData).toBe(true);
     });
     expect(rowState("training")).toBe("pending");
-    expect(rowSubtitle("training")).toBe("Required · where your rides come from");
+    expect(rowSubtitle("training")).toBe("Connect or import ride files.");
     expect(trigger("training").textContent).toBe("Connect");
     wizard.controller.dispose();
   });

--- a/apps/desktop-renderer/tests/setup-readiness.test.tsx
+++ b/apps/desktop-renderer/tests/setup-readiness.test.tsx
@@ -458,7 +458,7 @@ describe("authoritative setup readiness", () => {
         "data-state",
         "none",
       );
-      expect(document.body.textContent).not.toContain("Required · where your rides come from");
+      expect(document.body.textContent).not.toContain("Connect or import ride files.");
       expect(document.body.textContent).not.toContain("Required — Enduragent doesn't include one");
       expect(readinessBadge()).toHaveTextContent("Checking setup…");
       expect(readinessBadge()).not.toHaveTextContent("0 of 3 required ready");

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -266,37 +266,44 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live", () => {
-  it("finishes file-only onboarding into working Chat and Training pages", async () => {
-    const fixture = await launchDesktopFixture({
-      script: makeScript(),
-      token,
-      width: 1440,
-      height: 900,
-      colorScheme: "light",
-      reducedMotion: false,
-    });
-    fixtures.push(fixture);
-    const observed = await fixture.evaluate<{
-      readonly present: boolean;
-      readonly chatSetup: boolean;
-      readonly scrimAbsent: boolean;
-      readonly modalAbsent: boolean;
-      readonly title: string;
-      readonly escapeStayed: boolean;
-      readonly shellReplaced: boolean;
-      readonly finished: boolean;
-      readonly shellRestored: boolean;
-      readonly chatWorking: boolean;
-      readonly trainingReady: boolean;
-      readonly recentRideVisible: boolean;
-      readonly syncNeedsAttention: boolean;
-    }>(`
+  it.each([
+    { width: 1440, height: 900, colorScheme: "light", reducedMotion: false },
+    { width: 800, height: 700, colorScheme: "dark", reducedMotion: true },
+  ] as const)(
+    "finishes file-only onboarding into working Chat and Training pages at $width in $colorScheme",
+    async (appearance) => {
+      const fixture = await launchDesktopFixture({
+        script: makeScript(),
+        token,
+        ...appearance,
+      });
+      fixtures.push(fixture);
+      const observed = await fixture.evaluate<{
+        readonly trainingSubtitle: string;
+        readonly readiness: string;
+        readonly startEnabled: boolean;
+        readonly completionStored: boolean;
+        readonly present: boolean;
+        readonly chatSetup: boolean;
+        readonly scrimAbsent: boolean;
+        readonly modalAbsent: boolean;
+        readonly title: string;
+        readonly escapeStayed: boolean;
+        readonly shellReplaced: boolean;
+        readonly finished: boolean;
+        readonly shellRestored: boolean;
+        readonly chatWorking: boolean;
+        readonly trainingReady: boolean;
+        readonly recentRideVisible: boolean;
+        readonly syncNeedsAttention: boolean;
+      }>(`
       const deadline = Date.now() + 10000;
       const setupSelector =
         '[data-shell="gate"][data-onboarding="settled"] [data-setup-host="gate"]';
       while (!document.querySelector(setupSelector) && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
+      const trainingSubtitle = document.querySelector('[data-setup-row="training"] [data-setup-row-subtitle]')?.textContent ?? "";
       const page = document.querySelector(setupSelector);
       const present = page !== null;
       const chatSetup = document.querySelector(setupSelector) !== null;
@@ -387,6 +394,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       await waitFor('[data-setup-readiness="2"]');
       await pick("onboarding-injury-status", "No current injury");
       await new Promise((resolve) => setTimeout(resolve, 60));
+      const readiness = document.querySelector("[data-setup-readiness]")?.textContent ?? "";
+      const startEnabled = button("Start coaching")?.disabled === false;
       button("Start coaching")?.click();
       const chatDeadline = Date.now() + 10000;
       const chatReady = () => {
@@ -420,6 +429,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       const recentRides = training?.querySelector('[data-panel="recent-rides"]');
       const syncChip = document.querySelector(".sync-chip");
       return {
+        trainingSubtitle,
+        readiness,
+        startEnabled,
+        completionStored: localStorage.getItem("enduragent.desktop.onboarding") === '{"version":1,"completed":true}',
         present,
         chatSetup,
         scrimAbsent,
@@ -439,20 +452,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
         syncNeedsAttention: syncChip?.getAttribute("data-status") === "attention",
       };
     `);
-    expect(observed).toEqual({
-      present: true,
-      chatSetup: true,
-      scrimAbsent: true,
-      modalAbsent: true,
-      title: "Get your coach running before you can chat",
-      escapeStayed: true,
-      shellReplaced: true,
-      finished: true,
-      shellRestored: true,
-      chatWorking: true,
-      trainingReady: true,
-      recentRideVisible: true,
-      syncNeedsAttention: false,
-    });
-  }, 90_000);
+      expect(observed).toEqual({
+        trainingSubtitle: "Connect or import ride files.",
+        readiness: "3 of 3 required ready",
+        startEnabled: true,
+        completionStored: true,
+        present: true,
+        chatSetup: true,
+        scrimAbsent: true,
+        modalAbsent: true,
+        title: "Get your coach running before you can chat",
+        escapeStayed: true,
+        shellReplaced: true,
+        finished: true,
+        shellRestored: true,
+        chatWorking: true,
+        trainingReady: true,
+        recentRideVisible: true,
+        syncNeedsAttention: false,
+      });
+    },
+    90_000,
+  );
 });

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -848,6 +848,7 @@ describe("local coach composition", () => {
         undefined,
         {
           ...base,
+          contextWindowTokens: 120_000,
           llm: {
             provider: "openai-codex",
             model: "gpt-5.4",
@@ -2503,16 +2504,22 @@ describe("local coach composition", () => {
         return generation(`reply-${generateCalls}`);
       },
     });
-    const lifecycle = await compose(home, {
-      bootstrap: async () => reference(),
-      createRuntime: () => runtime(),
-      createRepository: () => ({
-        insertIfAbsent: async () => false,
-        readCurrent: async () => undefined,
-      }),
-      createResolver: () => missingResolver(),
-      modelTransportDecorator: decorator,
-    });
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        modelTransportDecorator: decorator,
+      },
+      fakeContext(home),
+      undefined,
+      { ...config(home), contextWindowTokens: 120_000 },
+    );
     const completion: string[] = [];
     const first = lifecycle.engine.chat({ chatId: "same", message: "first" }).then((value) => {
       completion.push("first");

--- a/packages/core/src/agent/confirmation-gate.ts
+++ b/packages/core/src/agent/confirmation-gate.ts
@@ -27,6 +27,7 @@ export interface PendingProposal {
 
 export type ConfirmOutcome =
   | { status: "executed"; summary: string; result: unknown }
+  | { status: "refused"; summary: string; message: string; result: unknown }
   | { status: "failed"; summary: string; message: string }
   | { status: "expired" }
   | { status: "mismatch" }
@@ -34,6 +35,7 @@ export type ConfirmOutcome =
 
 export function formatConfirmOutcome(outcome: ConfirmOutcome): string {
   if (outcome.status === "executed") return `Done — ${outcome.summary}.`;
+  if (outcome.status === "refused") return `Nothing was changed — ${outcome.message}`;
   if (outcome.status === "failed") return `That didn't go through — ${outcome.message}`;
   return "That proposal expired — ask me again and I'll re-propose.";
 }
@@ -77,7 +79,20 @@ export class ConfirmationGate {
     if (proposal.nonce !== nonce) return { status: "mismatch" };
     this.proposals.delete(chatId);
     try {
-      return { status: "executed", summary: proposal.summary, result: await proposal.run() };
+      const result = await proposal.run();
+      const error = stringField(result, "error");
+      if (error !== undefined) {
+        const details = stringField(result, "details");
+        if (details !== undefined) {
+          return { status: "refused", summary: proposal.summary, message: details, result };
+        }
+        return {
+          status: "failed",
+          summary: proposal.summary,
+          message: stringField(result, "message") ?? error,
+        };
+      }
+      return { status: "executed", summary: proposal.summary, result };
     } catch (err) {
       return {
         status: "failed",

--- a/packages/core/src/runtime-config.ts
+++ b/packages/core/src/runtime-config.ts
@@ -559,6 +559,9 @@ export function resolveRuntimeConfig(
     : current !== undefined && !providerChanged
       ? current.llm.model
       : DEFAULT_MODELS[provider];
+  if (model === "gpt-6-astra" && (provider === "openai-codex" || provider === "codex-agent")) {
+    throw new TypeError("GPT-6 Astra is not enabled for this connection; use the public OpenAI API.");
+  }
   const selectionChanged = current === undefined || providerChanged || model !== current.llm.model;
   const keyless = isKeylessProvider(provider);
   const apiKey = keyless
@@ -592,25 +595,32 @@ export function resolveRuntimeConfig(
         )
       : undefined;
 
+  const astra = provider === "openai" && model === "gpt-6-astra";
+  const backgroundModel = astra
+    ? current !== undefined && !providerChanged && current.llm.model !== "gpt-6-astra"
+      ? current.llm.model
+      : DEFAULT_MODELS.openai
+    : model;
   const requestedFlushModel = optionalModel(llmPatch, "flushModel");
   const flushModel =
     requestedFlushModel === null
       ? undefined
       : (requestedFlushModel ??
-        (current !== undefined && !providerChanged ? current.llm.flushModel : undefined));
+        (current !== undefined && !providerChanged ? current.llm.flushModel : undefined) ??
+        (astra ? backgroundModel : undefined));
 
   const requestedCompactModel = optionalModel(llmPatch, "compactModel");
   const compactModel =
     provider === "openai-codex"
       ? model
       : requestedCompactModel === null
-        ? (compactModelDefault(provider) ?? model)
+        ? (compactModelDefault(provider) ?? backgroundModel)
         : (requestedCompactModel ??
           (current !== undefined && !providerChanged
             ? model !== current.llm.model && current.llm.compactModel === current.llm.model
-              ? model
+              ? backgroundModel
               : current.llm.compactModel
-            : (compactModelDefault(provider) ?? model)));
+            : (compactModelDefault(provider) ?? backgroundModel)));
 
   let baseUrl: string | undefined;
   if (

--- a/packages/core/tests/confirmation-gate.test.ts
+++ b/packages/core/tests/confirmation-gate.test.ts
@@ -9,6 +9,7 @@ import {
   PROPOSAL_TTL_MS,
   createProposalSummarizers,
   createToolConfirmationPort,
+  formatConfirmOutcome,
 } from "../src/agent/confirmation-gate.js";
 import type { ProposalSummarizer } from "../src/agent/confirmation-gate.js";
 import { READ_ONLY_TOOL_NAMES } from "../../engine/src/agent/read-memoizer.js";
@@ -26,10 +27,7 @@ function turnOptions(chatId: string): unknown {
   return { experimental_context: createTurnContext(null, chatId) };
 }
 
-function port(
-  gate: ConfirmationGate,
-  summarizers: Record<string, ProposalSummarizer>,
-) {
+function port(gate: ConfirmationGate, summarizers: Record<string, ProposalSummarizer>) {
   return createToolConfirmationPort({ gate, summarizers });
 }
 
@@ -56,7 +54,9 @@ function fakeIntervals(initial = event()): {
   const updates = vi.fn(async () => ({ ok: true, value: current }));
   const deletes = vi.fn(async () => ({ ok: true, value: undefined }));
   return {
-    client: { events: { get: gets, update: updates, delete: deletes } } as unknown as IntervalsClient,
+    client: {
+      events: { get: gets, update: updates, delete: deletes },
+    } as unknown as IntervalsClient,
     setEvent: (next) => {
       current = next;
     },
@@ -67,6 +67,19 @@ function fakeIntervals(initial = event()): {
 }
 
 describe("ConfirmationGate", () => {
+  it.each([
+    [{ error: "NotFound", message: "Workout no longer exists." }, "Workout no longer exists."],
+    [{ error: "platform_credentials_required" }, "platform_credentials_required"],
+  ])("reports a returned failure without claiming success", async (result, message) => {
+    const gate = new ConfirmationGate();
+    gate.propose("chat", "Update workout", async () => result);
+    const proposal = gate.peek("chat")!;
+    const outcome = await gate.confirm("chat", proposal.nonce);
+    expect(outcome).toEqual({ status: "failed", summary: "Update workout", message });
+    expect(formatConfirmOutcome(outcome)).not.toContain("Done");
+    expect(await gate.confirm("chat", proposal.nonce)).toEqual({ status: "none" });
+  });
+
   it("stores, replaces, confirms once, and rejects mismatches", async () => {
     const gate = new ConfirmationGate();
     const firstRun = vi.fn(async () => "first");
@@ -310,9 +323,9 @@ describe("proposal summarizers and guard reuse", () => {
     });
 
     fake.setEvent(event({ tags: [] }));
-    await expect(
-      summarize({ eventId: 42, changes: { name: "Blocked" } }),
-    ).resolves.toMatchObject({ block: { error: "not_coach_created" } });
+    await expect(summarize({ eventId: 42, changes: { name: "Blocked" } })).resolves.toMatchObject({
+      block: { error: "not_coach_created" },
+    });
     expect(fake.updates).not.toHaveBeenCalled();
   });
 
@@ -353,9 +366,12 @@ describe("proposal summarizers and guard reuse", () => {
     fake.setEvent(event({ category: "NOTE" }));
     const outcome = await gate.confirm("chat", proposal.nonce);
     expect(outcome).toMatchObject({
-      status: "executed",
+      status: "refused",
       result: { error: "not_a_workout" },
     });
+    expect(formatConfirmOutcome(outcome)).toContain("Nothing was changed");
+    expect(formatConfirmOutcome(outcome)).not.toContain("Done");
+    expect(await gate.confirm("chat", proposal.nonce)).toEqual({ status: "none" });
     expect(fake.gets).toHaveBeenCalledTimes(2);
     expect(fake.deletes).not.toHaveBeenCalled();
   });
@@ -382,9 +398,12 @@ describe("proposal summarizers and guard reuse", () => {
     fake.setEvent(event({ category: "NOTE" }));
     const outcome = await gate.confirm("chat", proposal.nonce);
     expect(outcome).toMatchObject({
-      status: "executed",
+      status: "refused",
       result: { error: "not_a_workout" },
     });
+    expect(formatConfirmOutcome(outcome)).toContain("Nothing was changed");
+    expect(formatConfirmOutcome(outcome)).not.toContain("Done");
+    expect(await gate.confirm("chat", proposal.nonce)).toEqual({ status: "none" });
     expect(fake.gets).toHaveBeenCalledTimes(2);
     expect(fake.updates).not.toHaveBeenCalled();
   });

--- a/packages/core/tests/run-binary.test.ts
+++ b/packages/core/tests/run-binary.test.ts
@@ -228,6 +228,23 @@ describe("formatCliReply", () => {
 });
 
 describe("_promptProposalConfirm", () => {
+  it("prints a refusal from the real gate without claiming success", async () => {
+    const { ConfirmationGate } = await import("../src/agent/confirmation-gate.js");
+    const gate = new ConfirmationGate();
+    gate.propose("cli", "Delete workout", async () => ({
+      error: "not_a_workout",
+      details: "This entry is no longer a workout.",
+    }));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { _promptProposalConfirm } = await import("../src/run-binary.js");
+    await _promptProposalConfirm(
+      { question: (_prompt, answer) => answer("yes") },
+      { confirmations: gate },
+    );
+    expect(log).toHaveBeenCalledWith("Nothing was changed — This entry is no longer a workout.");
+    expect(gate.peek("cli")).toBeUndefined();
+  });
+
   it.each(["y", "yes", " Y ", "YeS\n"])("confirms explicit yes answer %j", async (answer) => {
     const confirm = vi.fn(async () => ({
       status: "executed" as const,

--- a/packages/core/tests/runtime-config.test.ts
+++ b/packages/core/tests/runtime-config.test.ts
@@ -177,3 +177,41 @@ describe("runtime configuration authority", () => {
     }
   });
 });
+
+describe("Astra explicit public API selection", () => {
+  it("preserves defaults and background choices when opting in and back out", () => {
+    const initial = resolveRuntimeConfig({
+      llm: {
+        provider: "openai",
+        apiKey: "fake-key",
+        compactModel: "gpt-5.6-luna",
+        flushModel: "gpt-5.6-luna",
+      },
+    });
+    expect(initial.llm.model).toBe("gpt-5.6-sol");
+    const selected = resolveRuntimeConfig({ llm: { model: "gpt-6-astra" } }, initial);
+    expect(selected.llm).toEqual({ ...initial.llm, model: "gpt-6-astra" });
+    expect(selected.contextWindowTokens).toBe(200_000);
+    const restored = resolveRuntimeConfig({ llm: { model: "gpt-5.6-sol" } }, selected);
+    expect(restored.llm).toEqual(initial.llm);
+    expect(restored.contextWindowTokens).toBe(initial.contextWindowTokens);
+  });
+
+  it.each(["openai-codex", "codex-agent"] as const)("refuses unverified %s support", (provider) => {
+    expect(() => resolveRuntimeConfig({ llm: { provider, model: "gpt-6-astra" } })).toThrow(
+      "not enabled for this connection",
+    );
+  });
+});
+
+it("keeps implicit OpenAI background work on its previous model when opting into Astra", () => {
+  const initial = resolveRuntimeConfig({ llm: { provider: "openai", apiKey: "fake-key" } });
+  const selected = resolveRuntimeConfig({ llm: { model: "gpt-6-astra" } }, initial);
+  expect(selected.llm.flushModel).toBe(initial.llm.flushModel ?? initial.llm.model);
+  expect(selected.llm.compactModel).toBe(initial.llm.compactModel ?? initial.llm.model);
+  const fresh = resolveRuntimeConfig({
+    llm: { provider: "openai", model: "gpt-6-astra", apiKey: "fake-key" },
+  });
+  expect(fresh.llm.flushModel).toBe("gpt-5.6-sol");
+  expect(fresh.llm.compactModel).toBe("gpt-5.6-sol");
+});

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -6,6 +6,18 @@ import { APICallError } from "@ai-sdk/provider";
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
 import { startTypingHeartbeat, TYPING_HEARTBEAT_MS } from "../src/channels/telegram.js";
 
+import {
+  ConfirmationGate,
+  createProposalSummarizers,
+  createToolConfirmationPort,
+} from "../src/agent/confirmation-gate.js";
+import { createPureCoreIntervalsTools } from "../src/sport.js";
+import { createPlatformCalendarMutations } from "../src/athlete-data.js";
+import { gateMutatingTool } from "../../engine/src/agent/coach-agent.js";
+import { createTurnContext } from "../../engine/src/agent/turn-context.js";
+import { COACH_EVENT_TAG } from "../src/agent/event-provenance.js";
+import type { IntervalsClient } from "intervals-icu-api";
+
 let dataDir: string;
 
 beforeEach(() => {
@@ -395,6 +407,65 @@ describe("confirmation callbacks", () => {
         ],
       },
     });
+  });
+
+  it.each<"intervals_delete_workout" | "intervals_update_workout">([
+    "intervals_delete_workout",
+    "intervals_update_workout",
+  ])("shows the execution-time refusal for %s through the host callback", async (toolName) => {
+    const { bot, agent, drainPending } = await buildBot();
+    let category = "WORKOUT";
+    const write = vi.fn();
+    const client = {
+      events: {
+        get: vi.fn(async () => ({
+          ok: true,
+          value: {
+            id: 42,
+            name: "Synthetic workout",
+            category,
+            startDateLocal: "2999-01-02T00:00:00",
+            tags: [COACH_EVENT_TAG],
+          },
+        })),
+        update: write,
+        delete: write,
+      },
+    } as unknown as IntervalsClient;
+    const gate = new ConfirmationGate();
+    const raw = createPureCoreIntervalsTools(
+      client,
+      "UTC",
+      undefined,
+      createPlatformCalendarMutations(client),
+    )[toolName]!;
+    const wrapped = gateMutatingTool(
+      toolName,
+      raw,
+      createToolConfirmationPort({
+        gate,
+        summarizers: createProposalSummarizers({ intervals: client, tz: "UTC" }),
+      }),
+    );
+    await wrapped.execute!({ eventId: 42, changes: { name: "Revised workout" } }, {
+      experimental_context: createTurnContext(null, "telegram:777"),
+    } as never);
+    const proposal = gate.peek("telegram:777")!;
+    agent.confirmations.confirm.mockImplementation((chatId: string, nonce: string) =>
+      gate.confirm(chatId, nonce),
+    );
+    category = "NOTE";
+    const ctx = callbackCtx(`cg:y:${proposal.nonce}`);
+    await getCallbackQueryData(bot)(ctx);
+    await drainPending();
+    expect(write).not.toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("Nothing was changed"));
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("category NOTE"));
+    expect(ctx.reply).not.toHaveBeenCalledWith(expect.stringContaining("Done"));
+    await getCallbackQueryData(bot)(ctx);
+    await drainPending();
+    expect(write).not.toHaveBeenCalled();
+    expect(client.events.get).toHaveBeenCalledTimes(2);
   });
 
   it("acks then executes a matching confirmation", async () => {

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -271,15 +271,18 @@ function transcriptWriteFailureReason(
 // resolves. All scheduling (jitter, retry-after floor, onRetry) stays in opts.
 function backoffWithSentinelError(
   err: unknown,
-  opts: Parameters<typeof retryWithBackoff>[1],
+  opts: Omit<Parameters<typeof retryWithBackoff>[1], "attempts" | "shouldRetry">,
 ): Promise<void> {
   let retried = false;
-  return retryWithBackoff(async () => {
-    if (!retried) {
-      retried = true;
-      throw err;
-    }
-  }, opts);
+  return retryWithBackoff(
+    async () => {
+      if (!retried) {
+        retried = true;
+        throw err;
+      }
+    },
+    { ...opts, attempts: 2, shouldRetry: () => true },
+  );
 }
 
 function committedWriteSummary(name: string, result: unknown): string | undefined {
@@ -1438,10 +1441,8 @@ export class CoachAgent {
                     ? ` (provider requested ${requestedMs}ms, clamped to ${RATE_LIMIT_MAX_WAIT_MS}ms)`
                     : "";
                 await backoffWithSentinelError(err, {
-                  attempts: 2,
                   baseMs: requestedMs,
                   capMs: RATE_LIMIT_MAX_WAIT_MS,
-                  shouldRetry: () => true,
                   retryAfterMs: () => requestedMs,
                   signal: abortController.signal,
                   random: () => 0,
@@ -1478,10 +1479,8 @@ export class CoachAgent {
                 serverErrorAttempts++;
                 const retryAfterFloor = retryAfterFloorMs(err, this.ports.extractRetryAfterMs);
                 await backoffWithSentinelError(err, {
-                  attempts: 2,
                   baseMs: retryAfterFloor ?? SERVER_ERROR_BACKOFF_BASE_MS,
                   capMs: SERVER_ERROR_BACKOFF_MAX_MS,
-                  shouldRetry: () => true,
                   retryAfterMs: () => retryAfterFloor,
                   signal: abortController.signal,
                 });

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -973,7 +973,8 @@ export class CoachAgent {
               this.chatStore.overwriteHistory(chatId, [summaryMsg, ...requeued, ...kept]);
             }
           } catch (err) {
-            this.log.warn("Dropped message summarization failed, continuing without summary", err);
+            this.log.warn("Dropped message summarization failed, retaining original messages", err);
+            requeued = dropped;
             if (previousSummary) {
               summaryMsg = makeSummaryMessage(
                 previousSummary,
@@ -1062,6 +1063,17 @@ export class CoachAgent {
             messages,
             ...this.compactionParams(turnBudget),
           });
+          if (
+            shouldCompact({
+              messages: compacted.messages,
+              systemPrompt: this.systemPrompt,
+              contextWindowTokens: this.config.contextWindowTokens,
+            })
+          ) {
+            throw new Error(
+              "Conversation could not be shortened safely to fit the context budget. Please try again.",
+            );
+          }
           messages = compacted.messages;
           if (compacted.summary && compacted.summaryProvenance) {
             this.persistSummaryToDailyNote(compacted.summary, compacted.summaryProvenance);

--- a/packages/engine/src/agent/codex-agent/bridge.ts
+++ b/packages/engine/src/agent/codex-agent/bridge.ts
@@ -693,6 +693,9 @@ export async function codexAgentGenerateText(
   opts: CodexAgentGenerateOpts,
   ports: CodexAgentBridgePorts,
 ): Promise<GenerateResult> {
+  if (opts.modelId === "gpt-6-astra") {
+    throw new Error("GPT-6 Astra is not enabled for this connection; use the public OpenAI API.");
+  }
   if ((ports.platform ?? process.platform) === "win32") throw unsupportedPlatformError();
   if (ports.runtime.enabled !== true) throw disabledLaneError();
 

--- a/packages/engine/src/agent/codex-agent/cost.ts
+++ b/packages/engine/src/agent/codex-agent/cost.ts
@@ -17,6 +17,7 @@ export const CODEX_AGENT_PRICE_TABLE: Record<string, CodexAgentModelCost> = {
 };
 
 export function resolveCodexAgentPriceId(modelId: string): string {
+  if (modelId === "gpt-6-astra") return modelId;
   if (CODEX_AGENT_PRICE_TABLE[modelId] !== undefined) return modelId;
   const family = modelId.toLowerCase();
   if (family.includes("terra")) return "gpt-5.6-terra";
@@ -24,7 +25,8 @@ export function resolveCodexAgentPriceId(modelId: string): string {
   return CODEX_AGENT_FALLBACK_PRICE_ID;
 }
 
-export function codexAgentRates(modelId: string): CodexAgentModelCost {
+export function codexAgentRates(modelId: string): CodexAgentModelCost | undefined {
+  if (modelId === "gpt-6-astra") return undefined;
   return (
     CODEX_AGENT_PRICE_TABLE[resolveCodexAgentPriceId(modelId)] ??
     CODEX_AGENT_PRICE_TABLE[CODEX_AGENT_FALLBACK_PRICE_ID]
@@ -41,6 +43,7 @@ export function codexAgentCacheReadSavingsUsd(
 ): number | null {
   if (!validTokenCount(cacheReadTokens)) return null;
   const rates = codexAgentRates(modelId);
+  if (rates === undefined) return null;
   const savings = (Math.max(0, rates.input - rates.cacheRead) * cacheReadTokens) / 1_000_000;
   return Number.isFinite(savings) && savings >= 0 ? savings : null;
 }
@@ -58,6 +61,7 @@ export function priceCodexAgentInclusiveUsage(
     return undefined;
   }
   const rates = codexAgentRates(modelId);
+  if (rates === undefined) return undefined;
   const uncachedInputTokens = Math.max(
     0,
     usage.inputTokens - usage.cacheReadTokens - usage.cacheWriteTokens,

--- a/packages/engine/src/agent/codex-bridge.ts
+++ b/packages/engine/src/agent/codex-bridge.ts
@@ -173,6 +173,7 @@ function mapUsage(u: CodexUsage): LanguageModelUsage {
 // upstream falls back to its default-model template for those, so price unknown
 // codex ids at gpt-5.6-sol rates rather than dropping to undefined.
 function resolveCodexPriceId(modelId: string): string {
+  if (modelId === "gpt-6-astra") return modelId;
   return PRICE_TABLE["openai-codex"]?.[modelId] ? modelId : "gpt-5.6-sol";
 }
 
@@ -262,6 +263,9 @@ export async function codexGenerateText(
     classifyFailure: (error: unknown) => FailureReason;
   },
 ): Promise<GenerateResult> {
+  if (opts.modelId === "gpt-6-astra") {
+    throw new Error("GPT-6 Astra is not enabled for this connection; use the public OpenAI API.");
+  }
   const {
     system,
     messages,

--- a/packages/engine/src/agent/compaction.ts
+++ b/packages/engine/src/agent/compaction.ts
@@ -518,7 +518,7 @@ export async function summarizeDroppedMessages(params: {
   const unsummarized: ModelMessage[] = [];
   let lastError: unknown;
 
-  for (const chunk of chunks) {
+  for (const [index, chunk] of chunks.entries()) {
     const transcript = formatTranscript(chunk);
     const carriedSummary = summary ?? previousSummary;
 
@@ -534,13 +534,14 @@ export async function summarizeDroppedMessages(params: {
       summaryProvenance = unionProvenance(summaryProvenance, provenanceOfMessages(chunk));
     } catch (err) {
       lastError = err;
-      unsummarized.push(...chunk);
+      unsummarized.push(...chunks.slice(index).flat());
       console.warn("Dropped message summarization LLM call failed, using fallback", err);
+      break;
     }
   }
 
   if (summary === undefined) {
-    throw new Error("Dropped message summarization failed for every chunk", {
+    throw new Error("Dropped message summarization failed before any chunk was summarized", {
       cause: lastError,
     });
   }
@@ -603,7 +604,8 @@ export async function summarizeInStages(params: {
 
   // Thread previousSummary through chunk loop
   let summary = previousSummary;
-  for (const chunk of chunks) {
+  const unsummarized: ModelMessage[] = [];
+  for (const [index, chunk] of chunks.entries()) {
     const transcript = formatTranscript(chunk);
 
     try {
@@ -617,13 +619,21 @@ export async function summarizeInStages(params: {
       summary = text;
       summaryProvenance = unionProvenance(summaryProvenance, provenanceOfMessages(chunk));
     } catch (err) {
-      console.warn("Staged summarization chunk failed; continuing with carried summary", err);
+      unsummarized.push(...chunks.slice(index).flat());
+      console.warn("Staged summarization chunk failed; retaining original messages", err);
+      break;
     }
   }
 
-  if (summary === undefined) {
-    console.warn("Staged summarization produced no summary; dropping oldest messages without one");
-    return { messages: [...recent] };
+  if (summary === undefined || unsummarized.length === toSummarize.length) {
+    return {
+      messages: [
+        ...(previousSummary === undefined
+          ? []
+          : [makeSummaryMessage(previousSummary, previousSummaryProvenance ?? UNKNOWN_PROVENANCE)]),
+        ...messages,
+      ],
+    };
   }
 
   const finalSummary = await finalizeSummary({
@@ -636,7 +646,7 @@ export async function summarizeInStages(params: {
   });
   const durableProvenance = summaryProvenance ?? UNKNOWN_PROVENANCE;
   return {
-    messages: [makeSummaryMessage(finalSummary, durableProvenance), ...recent],
+    messages: [makeSummaryMessage(finalSummary, durableProvenance), ...unsummarized, ...recent],
     summary: finalSummary,
     summaryProvenance: durableProvenance,
   };

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -316,12 +316,16 @@ export class LLM {
       ];
     }
 
+    const astra = this.config.llm.provider === "openai" && this.config.llm.model === "gpt-6-astra";
     const base = {
       model: this.aiSdkModel,
+      ...(astra ? { providerOptions: { openai: { forceReasoning: true } } } : {}),
       system,
       tools: opts.tools,
       stopWhen: opts.stopWhen,
-      maxOutputTokens: opts.maxOutputTokens,
+      maxOutputTokens: astra
+        ? Math.min(opts.maxOutputTokens ?? 128_000, 128_000)
+        : opts.maxOutputTokens,
       maxRetries: 0,
       abortSignal: opts.signal,
       experimental_context: opts.context,
@@ -355,6 +359,7 @@ export class LLM {
             });
             break;
           case "finish":
+            if (astra && part.finishReason === "error") throw new Error("OpenAI response failed.");
             break;
           case "error":
             throw part.error;
@@ -397,6 +402,7 @@ export class LLM {
         ? await generateText({ ...base, prompt: opts.prompt })
         : await generateText({ ...base, messages });
 
+    if (astra && result.finishReason === "error") throw new Error("OpenAI response failed.");
     return {
       text: result.text,
       toolCalls: result.toolCalls as GenerateResult["toolCalls"],

--- a/packages/engine/tests/astra-compatibility.test.ts
+++ b/packages/engine/tests/astra-compatibility.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText, Output, stepCountIs, tool } from "ai";
+import { z } from "zod";
+import { LLM } from "../src/llm.js";
+import type { EngineConfig } from "../src/host-ports.js";
+import { llmTestPorts } from "./helpers/base-agent-config.js";
+import { codexGenerateText } from "../src/agent/codex-bridge.js";
+import { codexAgentGenerateText } from "../src/agent/codex-agent/bridge.js";
+import {
+  codexAgentCacheReadSavingsUsd,
+  priceCodexAgentInclusiveUsage,
+} from "../src/agent/codex-agent/cost.js";
+
+const config: EngineConfig = {
+  llm: { provider: "openai", model: "gpt-6-astra", apiKey: "fake-key" },
+  dataSource: "platform",
+  session: {
+    historyTokenBudgetRatio: 0.3,
+    idleMinutes: 0,
+    dailyResetHour: 4,
+    resetArchiveRetentionDays: 0,
+    timezone: "",
+  },
+  contextWindowTokens: 200_000,
+  compactContextWindowTokens: 200_000,
+};
+
+function response(
+  output: unknown[] = [
+    {
+      type: "message",
+      id: "msg_test",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Ready", annotations: [] }],
+    },
+  ],
+) {
+  return {
+    id: "resp_test",
+    created_at: 0,
+    model: "gpt-6-astra",
+    status: "completed",
+    output,
+    usage: {
+      input_tokens: 120,
+      output_tokens: 8,
+      input_tokens_details: { cached_tokens: 40, cache_creation_tokens: 20 },
+      output_tokens_details: { reasoning_tokens: 2 },
+    },
+  };
+}
+
+function jsonResponse(output?: unknown[]) {
+  return new Response(JSON.stringify(response(output)), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function streamResponse() {
+  const events = [
+    { type: "response.created", response: response([]) },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "message", id: "msg_test", role: "assistant", content: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: "msg_test",
+      output_index: 0,
+      content_index: 0,
+      delta: "Ready",
+    },
+    { type: "response.output_item.done", output_index: 0, item: response().output[0] },
+    { type: "response.completed", response: response() },
+  ];
+  return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Astra public Responses compatibility", () => {
+  it("serializes developer instructions, bounds output and keeps unmeasured cache cost unavailable", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse());
+    const result = await new LLM(config, llmTestPorts()).generate({
+      caller: "compact",
+      system: "Preserve goals",
+      prompt: "Summarize",
+      maxOutputTokens: 200_000,
+    });
+    const [url, init] = fetch.mock.calls[0];
+    expect(String(url)).toBe("https://api.openai.com/v1/responses");
+    const body = JSON.parse(String(init?.body));
+    expect(body.model).toBe("gpt-6-astra");
+    expect(body.input[0].role).toBe("developer");
+    expect(body.max_output_tokens).toBe(128_000);
+    for (const field of ["temperature", "top_p", "store", "prompt_cache_retention", "reasoning"])
+      expect(body).not.toHaveProperty(field);
+    expect(result.text).toBe("Ready");
+    expect(result.totalUsage?.inputTokenDetails.cacheReadTokens).toBe(40);
+    expect(result.totalUsage?.inputTokenDetails.cacheWriteTokens).toBeUndefined();
+    expect(result.cost).toBeUndefined();
+    expect(result.providerReportedCostUsd).toBeUndefined();
+  });
+
+  it("streams athlete text and measured token usage through LLM", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(streamResponse());
+    const onTextDelta = vi.fn();
+    const result = await new LLM(config, llmTestPorts()).generate({
+      caller: "chat",
+      prompt: "Hi",
+      onTextDelta,
+    });
+    expect(onTextDelta).toHaveBeenCalledWith("Ready");
+    expect(result.text).toBe("Ready");
+    expect(result.totalUsage?.inputTokens).toBe(120);
+    expect(result.cost).toBeUndefined();
+  });
+
+  it("surfaces a terminal stream failure without a success result or retry", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          `data: ${JSON.stringify({ type: "response.failed", response: { error: { code: "blocked", message: "Stopped for review" } } })}\n\n`,
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+    const append = vi.fn();
+    await expect(
+      new LLM(config, { ...llmTestPorts(), usage: { append } }).generate({
+        caller: "chat",
+        prompt: "Hi",
+      }),
+    ).rejects.toBeDefined();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("correlates a tool result with its original call across real SDK requests", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            type: "function_call",
+            id: "fc_test",
+            call_id: "call_test",
+            name: "read_goal",
+            arguments: "{}",
+            status: "completed",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse());
+    const execute = vi.fn(async () => "Finish the training plan");
+    await new LLM(config, llmTestPorts()).generate({
+      caller: "compact",
+      prompt: "Recall my goal",
+      tools: { read_goal: tool({ inputSchema: z.object({}), execute }) },
+      stopWhen: stepCountIs(2),
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const body = JSON.parse(String(fetch.mock.calls[1][1]?.body));
+    expect(body.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "item_reference", id: "fc_test" }),
+        expect.objectContaining({
+          type: "function_call_output",
+          call_id: "call_test",
+          output: "Finish the training plan",
+        }),
+      ]),
+    );
+  });
+
+  it("does not replay a completed tool after a subsequent provider failure", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            type: "function_call",
+            id: "fc_test",
+            call_id: "call_test",
+            name: "save_goal",
+            arguments: "{}",
+            status: "completed",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: "Stopped for review", code: "blocked" } }),
+          { status: 403, headers: { "content-type": "application/json" } },
+        ),
+      );
+    const execute = vi.fn(async () => "Saved");
+    await expect(
+      new LLM(config, llmTestPorts()).generate({
+        caller: "compact",
+        prompt: "Save goal",
+        tools: { save_goal: tool({ inputSchema: z.object({}), execute }) },
+        stopWhen: stepCountIs(2),
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["low", "medium", "high", "xhigh", "max"])(
+    "installed SDK serializes documented %s effort and structured output",
+    async (effort) => {
+      const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        jsonResponse([
+          {
+            type: "message",
+            id: "msg_test",
+            role: "assistant",
+            content: [{ type: "output_text", text: '{"ready":true}', annotations: [] }],
+          },
+        ]),
+      );
+      const result = await generateText({
+        model: createOpenAI({ apiKey: "fake-key" }).responses("gpt-6-astra"),
+        prompt: "Return readiness",
+        providerOptions: { openai: { forceReasoning: true, reasoningEffort: effort } },
+        output: Output.object({ schema: z.object({ ready: z.boolean() }) }),
+        maxRetries: 0,
+      });
+      const body = JSON.parse(String(fetch.mock.calls[0][1]?.body));
+      expect(body.reasoning).toEqual({ effort });
+      expect(body.text.format.type).toBe("json_schema");
+      expect(result.output).toEqual({ ready: true });
+    },
+  );
+
+  it.each([429, 503, 403])(
+    "preserves terminal HTTP %s without an internal retry",
+    async (status) => {
+      const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "Provider refused",
+              code: status === 429 ? "slow_down" : "blocked",
+            },
+          }),
+          { status, headers: { "content-type": "application/json", "retry-after": "3" } },
+        ),
+      );
+      await expect(
+        new LLM(config, llmTestPorts()).generate({ caller: "compact", prompt: "Hi" }),
+      ).rejects.toMatchObject({
+        statusCode: status,
+        responseHeaders: expect.objectContaining({ "retry-after": "3" }),
+      });
+      expect(fetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("cancels a request without retrying", async () => {
+    const controller = new AbortController();
+    const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      controller.abort();
+      throw init?.signal?.reason;
+    });
+    await expect(
+      new LLM(config, llmTestPorts()).generate({
+        caller: "compact",
+        prompt: "Hi",
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unverified Astra subscription transports", () => {
+  it("refuses before accessing credentials or starting app-server", async () => {
+    const getAccessToken = vi.fn();
+    await expect(
+      codexGenerateText(
+        { caller: "chat", modelId: "gpt-6-astra", profileName: "test", prompt: "Hi" },
+        { ...llmTestPorts(), getAccessToken },
+      ),
+    ).rejects.toThrow("not enabled for this connection");
+    expect(getAccessToken).not.toHaveBeenCalled();
+    const ensureReady = vi.fn();
+    await expect(
+      codexAgentGenerateText(
+        { caller: "chat", modelId: "gpt-6-astra", prompt: "Hi" },
+        { runtime: { enabled: true }, ensureReady },
+      ),
+    ).rejects.toThrow("not enabled for this connection");
+    expect(ensureReady).not.toHaveBeenCalled();
+  });
+
+  it("does not infer Sol dollars or cache savings for Astra", () => {
+    expect(
+      priceCodexAgentInclusiveUsage("gpt-6-astra", {
+        inputTokens: 120,
+        outputTokens: 8,
+        cacheReadTokens: 40,
+        cacheWriteTokens: 0,
+      }),
+    ).toBeUndefined();
+    expect(codexAgentCacheReadSavingsUsd("gpt-6-astra", 40)).toBeNull();
+  });
+});

--- a/packages/engine/tests/coach-agent-garmin-attribution.test.ts
+++ b/packages/engine/tests/coach-agent-garmin-attribution.test.ts
@@ -293,15 +293,16 @@ describe("CoachAgent selective Garmin attribution", () => {
 
   it("does not count source fields hidden by the result cap", async () => {
     const execute = vi.fn(async () => [
-      { id: "synthetic", source: "GARMIN_CONNECT", samples: "x".repeat(20_000) },
+      { id: "synthetic", source: "GARMIN_CONNECT", samples: "x".repeat(100_000) },
     ]);
     let calls = 0;
     const complete = vi.fn(async () =>
       ++calls === 1 ? toolCall() : assistant("Capped guidance."),
     );
-    const agent = await setupAgent(complete, activitySport(execute), 2_000);
+    const agent = await setupAgent(complete, activitySport(execute), 40_000);
 
     expect(await agent.chat("capped", "Use the activity.")).toBe("Capped guidance.");
+    expect(execute).toHaveBeenCalledOnce();
   });
 
   it("does not carry Garmin evidence across a failed outer attempt", async () => {
@@ -419,7 +420,7 @@ describe("CoachAgent selective Garmin attribution", () => {
     });
   });
 
-  it("does not attribute history dropped before the generation boundary", async () => {
+  it("attributes retained history after dropped-message summarization fails", async () => {
     const complete = vi.fn(async (params: { messages: unknown }) => {
       if (JSON.stringify(params.messages).includes("Incorporate the older conversation")) {
         throw new Error("summary unavailable");
@@ -427,7 +428,7 @@ describe("CoachAgent selective Garmin attribution", () => {
       return assistant("Visible-history guidance.");
     });
     const { agent } = await setupAgentWithStore(complete, syntheticSport, {
-      contextWindowTokens: 8_000,
+      contextWindowTokens: 40_000,
       seed: [
         {
           role: "assistant",
@@ -442,7 +443,15 @@ describe("CoachAgent selective Garmin attribution", () => {
       ],
     });
 
-    expect(await agent.chat("dropped-history", "What now?")).toBe("Visible-history guidance.");
+    expect(await agent.chat("dropped-history", "What now?")).toBe(
+      `Visible-history guidance.\n\n${GARMIN_DATA_ATTRIBUTION}`,
+    );
+    expect(
+      complete.mock.calls.some(([params]) =>
+        JSON.stringify(params.messages).includes("Incorporate the older conversation"),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(complete.mock.calls.at(-1)?.[0].messages)).toContain("x".repeat(30_000));
   });
 
   it("isolates concurrent chats", async () => {

--- a/packages/engine/tests/compaction.test.ts
+++ b/packages/engine/tests/compaction.test.ts
@@ -275,23 +275,23 @@ describe("summarizeDroppedMessages failure containment", () => {
         mustPreserveTokens: [],
         memory: EMPTY_SNAPSHOT,
       }),
-    ).rejects.toThrow("Dropped message summarization failed for every chunk");
+    ).rejects.toThrow("Dropped message summarization failed before any chunk was summarized");
   });
 
-  it("requeues the failed chunk's messages when one chunk fails", async () => {
+  it("requeues the failed chunk and all newer messages in order", async () => {
     const firstMessage: ModelMessage = { role: "user", content: "CHUNK-A " + "a".repeat(20_000) };
     const secondMessage: ModelMessage = { role: "user", content: "CHUNK-B " + "b".repeat(20_000) };
-    const llm = createFakeLLM([{ error: new Error("boom") }, VALID_FIVE_SECTION_SUMMARY]);
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);
 
     const result = await summarizeDroppedMessages({
-      dropped: [firstMessage, secondMessage],
+      dropped: [firstMessage, secondMessage, ...REPRESENTATIVE_CONVERSATION],
       llm,
       mustPreserveTokens: [],
       memory: EMPTY_SNAPSHOT,
       contextWindowTokens: 30_000,
     });
 
-    expect(result.unsummarized).toEqual([firstMessage]);
+    expect(result.unsummarized).toEqual([secondMessage, ...REPRESENTATIVE_CONVERSATION]);
     expect(result.summary).toContain("## Coach Stance");
   });
 
@@ -304,10 +304,10 @@ describe("summarizeDroppedMessages failure containment", () => {
       { role: "user", content: "CHUNK-B " + "b".repeat(20_000) },
       UNKNOWN,
     );
-    const llm = createFakeLLM([{ error: new Error("boom") }, VALID_FIVE_SECTION_SUMMARY]);
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);
 
     const result = await summarizeDroppedMessages({
-      dropped: [failedGarmin, summarizedUnknown],
+      dropped: [summarizedUnknown, failedGarmin],
       llm,
       mustPreserveTokens: [],
       memory: EMPTY_SNAPSHOT,
@@ -386,10 +386,10 @@ describe("staged summary provenance", () => {
       { role: "user", content: "CHUNK-B " + "b".repeat(20_000) },
       UNKNOWN,
     );
-    const llm = createFakeLLM([{ error: new Error("boom") }, VALID_FIVE_SECTION_SUMMARY]);
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);
 
     const result = await summarizeInStages({
-      messages: [failedGarmin, summarizedUnknown],
+      messages: [summarizedUnknown, failedGarmin],
       llm,
       mustPreserveTokens: [],
       memory: EMPTY_SNAPSHOT,
@@ -399,6 +399,80 @@ describe("staged summary provenance", () => {
 
     expect(result.summaryProvenance).toEqual(UNKNOWN);
     expect(getMessageProvenance(result.messages[0])).toEqual(UNKNOWN);
+  });
+});
+
+describe("staged summarization failure containment", () => {
+  const goal: ModelMessage = {
+    role: "user",
+    content: "Goal: finish the mountain ride. " + "a".repeat(20_000),
+  };
+  const correction: ModelMessage = {
+    role: "user",
+    content: "Correction: no Tuesday training. " + "b".repeat(20_000),
+  };
+  const recent: ModelMessage[] = [
+    { role: "assistant", content: "What changed this week?" },
+    { role: "user", content: "Keep Friday easy." },
+  ];
+
+  it.each([false, true])(
+    "retains every message after total failure (prior summary: %s)",
+    async (withSummary) => {
+      const messages = [
+        ...(withSummary ? [makeSummaryMessage("FTP 247W; protect the knee", UNKNOWN)] : []),
+        goal,
+        correction,
+        ...recent,
+      ];
+      const llm = createFakeLLM([{ error: new Error("summary unavailable") }], {
+        repeatLast: true,
+      });
+      const result = await summarizeInStages({
+        messages,
+        llm,
+        mustPreserveTokens: [],
+        memory: EMPTY_SNAPSHOT,
+        recentToKeep: 2,
+        contextWindowTokens: 30_000,
+      });
+
+      expect(result.messages).toEqual(messages);
+      expect(llm.capturedMessages).toHaveLength(1);
+      expect(result.summary).toBeUndefined();
+    },
+  );
+
+  it("retains failed corrections alongside the successful summary and recent messages", async () => {
+    const summary = VALID_FIVE_SECTION_SUMMARY + "\nGoal: finish the mountain ride.";
+    const newerCorrection: ModelMessage = {
+      role: "user",
+      content: "Update: Tuesday training is possible again. " + "c".repeat(20_000),
+    };
+    const llm = createFakeLLM([summary, { error: new Error("summary unavailable") }]);
+    const result = await summarizeInStages({
+      messages: [
+        makeSummaryMessage("FTP 247W; protect the knee", UNKNOWN),
+        goal,
+        correction,
+        newerCorrection,
+        ...recent,
+      ],
+      llm,
+      mustPreserveTokens: [],
+      memory: EMPTY_SNAPSHOT,
+      recentToKeep: 2,
+      contextWindowTokens: 30_000,
+    });
+
+    expect(result.messages).toEqual([
+      makeSummaryMessage(summary, UNKNOWN),
+      correction,
+      newerCorrection,
+      ...recent,
+    ]);
+    expect(llm.capturedMessages).toHaveLength(2);
+    expect(String(llm.capturedMessages[0][0].content)).toContain("FTP 247W; protect the knee");
   });
 });
 
@@ -417,7 +491,9 @@ describe("shared audit post-step (cap-before-audit)", () => {
     });
 
     expect(spy.capturedOpts).toHaveLength(2);
-    expect(String(spy.capturedMessages[1][0].content)).toContain("Restructure the following summary");
+    expect(String(spy.capturedMessages[1][0].content)).toContain(
+      "Restructure the following summary",
+    );
     for (const opts of spy.capturedOpts) {
       expect(opts.maxOutputTokens).toBe(1000);
     }
@@ -518,4 +594,3 @@ describe("shared audit post-step (cap-before-audit)", () => {
     expect(spy.capturedOpts[1].system).toContain("PRESERVE every fact in it");
   });
 });
-

--- a/packages/engine/tests/summarize-stages-guards.test.ts
+++ b/packages/engine/tests/summarize-stages-guards.test.ts
@@ -38,7 +38,7 @@ const EMPTY_SNAPSHOT: MemorySnapshot = {
   read: () => null,
   has: () => false,
   listSections: () => [],
-    provenanceOf: () => ({ garmin: false, nonGarmin: false, unknown: true }),
+  provenanceOf: () => ({ garmin: false, nonGarmin: false, unknown: true }),
 };
 
 const hangingLLM = { generate: () => new Promise<never>(() => {}) } as unknown as LLM;
@@ -49,7 +49,7 @@ afterEach(() => {
 });
 
 describe("summarizeInStages guards", () => {
-  it("times out a hung summarization call after 120 s and degrades to the previous summary", async () => {
+  it("times out a hung summarization call after 120 s and retains the previous summary and history", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -67,16 +67,17 @@ describe("summarizeInStages guards", () => {
     expect(result.messages[0].role).toBe("system");
     expect(String(result.messages[0].content)).toContain("FTP 247W");
     expect(String(result.messages[0].content)).toContain("## Coach Stance");
-    expect(result.messages.length).toBe(5);
+    expect(result.messages.slice(1)).toEqual(REPRESENTATIVE_CONVERSATION);
 
     const chunkWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+      (call) =>
+        typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
     );
     expect(chunkWarn).toBeDefined();
     expect(isTimeoutError(chunkWarn?.[1])).toBe(true);
   }, 10_000);
 
-  it("falls back to the previous summary when the summarization call rejects", async () => {
+  it("retains the previous summary and history when the summarization call rejects", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const spy = createFakeLLM([{ error: new Error("boom") }]);
 
@@ -91,14 +92,16 @@ describe("summarizeInStages guards", () => {
     expect(result.messages[0].role).toBe("system");
     expect(String(result.messages[0].content)).toContain("FTP 247W");
     expect(spy.capturedOpts.length).toBe(1);
+    expect(result.messages.slice(1)).toEqual(REPRESENTATIVE_CONVERSATION);
 
     const chunkWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+      (call) =>
+        typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
     );
     expect(chunkWarn).toBeDefined();
   });
 
-  it("head-drops when every call fails and there is no previous summary", async () => {
+  it("retains every message when summarization fails without a previous summary", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const spy = createFakeLLM([{ error: new Error("boom") }], { repeatLast: true });
 
@@ -109,16 +112,16 @@ describe("summarizeInStages guards", () => {
       memory: EMPTY_SNAPSHOT,
     });
 
-    expect(result.messages).toEqual(REPRESENTATIVE_CONVERSATION.slice(-4));
+    expect(result.messages).toEqual(REPRESENTATIVE_CONVERSATION);
     expect(result.summary).toBeUndefined();
     for (const msg of result.messages) {
       expect(String(msg.content).startsWith(SUMMARY_PREFIX)).toBe(false);
     }
 
-    const dropWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("produced no summary"),
+    const retainedWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("retaining original messages"),
     );
-    expect(dropWarn).toBeDefined();
+    expect(retainedWarn).toBeDefined();
   });
 
   it("returns the input unchanged with no summary when there is nothing to summarize", async () => {
@@ -152,12 +155,14 @@ describe("summarizeInStages guards", () => {
     });
 
     expect(spy.capturedOpts.length).toBe(2);
+    expect(result.messages.slice(1)).toEqual(messages.slice(1));
     expect(result.messages[0].role).toBe("system");
     expect(String(result.messages[0].content)).toContain("## Coach Stance");
     expect(String(result.messages[0].content)).toContain("FTP 247W");
 
     const chunkWarns = warnSpy.mock.calls.filter(
-      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+      (call) =>
+        typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
     );
     expect(chunkWarns.length).toBe(1);
   });
@@ -181,7 +186,8 @@ describe("summarizeInStages guards", () => {
     const guardWarn = warnSpy.mock.calls.find(
       (call) =>
         typeof call[0] === "string" &&
-        (call[0].includes("Staged summarization chunk failed") || call[0].includes("produced no summary")),
+        (call[0].includes("Staged summarization chunk failed") ||
+          call[0].includes("retaining original messages")),
     );
     expect(guardWarn).toBeUndefined();
   });
@@ -207,11 +213,13 @@ describe("summarizeInStages guards", () => {
     await vi.advanceTimersByTimeAsync(120_000);
     const err = await rejection;
 
-    expect(err.message).toContain("failed for every chunk");
+    expect(err.message).toContain("failed before any chunk was summarized");
     expect(isTimeoutError((err as Error & { cause?: unknown }).cause)).toBe(true);
 
     const chunkWarn = warnSpy.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("Dropped message summarization LLM call failed"),
+      (call) =>
+        typeof call[0] === "string" &&
+        call[0].includes("Dropped message summarization LLM call failed"),
     );
     expect(chunkWarn).toBeDefined();
   }, 10_000);

--- a/packages/engine/tests/trim-compaction-guard.test.ts
+++ b/packages/engine/tests/trim-compaction-guard.test.ts
@@ -1,17 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import {
-  mkdtempSync,
-  rmSync,
-  mkdirSync,
-  writeFileSync,
-  readFileSync,
-  readdirSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { baseAgentConfig } from "./helpers/base-agent-config.js";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import type { Sport } from "../src/sport.js";
+import type { CodexResponsesParams } from "../src/agent/codex/responses.js";
+import { SUMMARY_PREFIX } from "../src/agent/history-limit.js";
 
 let tempHome: string;
 let origHome: string | undefined;
@@ -33,7 +28,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+async function setupAgent(
+  complete: ReturnType<typeof vi.fn>,
+  windows: {
+    contextWindowTokens?: number;
+    compactContextWindowTokens?: number;
+    historyTokenBudgetRatio?: number;
+  } = {},
+) {
   vi.doMock("../src/agent/codex/responses.js", () => ({
     codexResponses: complete,
   }));
@@ -52,7 +54,17 @@ async function setupAgent(complete: ReturnType<typeof vi.fn>) {
   const ports = baseAgentConfig(dataDir);
   return new CoachAgent(cyclingSport as unknown as Sport, {
     ...ports,
-    config: { ...ports.config, contextWindowTokens: 120_000 },
+    config: {
+      ...ports.config,
+      session: {
+        ...ports.config.session,
+        historyTokenBudgetRatio:
+          windows.historyTokenBudgetRatio ?? ports.config.session.historyTokenBudgetRatio,
+      },
+      contextWindowTokens: windows.contextWindowTokens ?? 120_000,
+      compactContextWindowTokens:
+        windows.compactContextWindowTokens ?? ports.config.compactContextWindowTokens,
+    },
   });
 }
 
@@ -168,29 +180,183 @@ describe("trim-path compaction guard", () => {
     ).toBe(true);
   });
 
-  it("leaves history untouched when summarization fails entirely", async () => {
-    let n = 0;
-    const complete = vi.fn(async () => {
-      n++;
-      if (n === 1) return mkAssistant("facts noted");
-      if (n === 2) throw new Error("boom");
+  it.each([false, true])(
+    "preserves all history in the next request after total failure (prior summary: %s)",
+    async (withSummary) => {
+      let n = 0;
+      const complete = vi.fn(async () => {
+        n++;
+        if (n === 1) return mkAssistant("facts noted");
+        if (n === 2) throw new Error("boom");
+        return mkAssistant("final-reply");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const agent = await setupAgent(complete);
+      seedSession("trim-summary-fail", [
+        ...(withSummary
+          ? [{ role: "system", content: `${SUMMARY_PREFIX}\nProtect the knee.`, ts: FRESH_TS }]
+          : []),
+        ...seeded.map((message, i) => ({
+          ...message,
+          content:
+            message.content +
+            (i === 0
+              ? " Goal: finish the mountain ride."
+              : i === 10
+                ? " Correction: no Tuesday training."
+                : ""),
+        })),
+      ]);
+
+      const text = await agent.chat("trim-summary-fail", "hello");
+
+      expect(text).toBe("final-reply");
+      expect(listPrecompact("trim-summary-fail")).toHaveLength(0);
+      const request = JSON.stringify(complete.mock.calls.at(-1));
+      expect(request).toContain("TRIM-MARK-0 ");
+      expect(request).toContain("TRIM-MARK-29 ");
+      expect(request).toContain("Goal: finish the mountain ride.");
+      expect(request).toContain("Correction: no Tuesday training.");
+      if (withSummary) expect(request).toContain("Protect the knee.");
+
+      const session = readFileSync(join(dataDir, "sessions", "trim-summary-fail.jsonl"), "utf-8");
+      expect(session).toContain("TRIM-MARK-0 ");
+      expect(session).not.toContain("## Coach Stance");
+
+      expect(
+        warnSpy.mock.calls.some((c) =>
+          String(c[0]).includes("Dropped message summarization failed"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("retains failed chunks in the next request after partial summarization", async () => {
+    let summaries = 0;
+    const complete = vi.fn(async (params: CodexResponsesParams) => {
+      if (String(params.messages[0]?.content).startsWith("Incorporate the older")) {
+        summaries++;
+        if (summaries === 2) throw new Error("summary unavailable");
+        return mkAssistant(
+          FIVE_SECTION_SUMMARY + "\nProtect the knee. Goal: finish the mountain ride.",
+        );
+      }
       return mkAssistant("final-reply");
     });
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const agent = await setupAgent(complete);
-    seedSession("trim-summary-fail", seeded);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, { compactContextWindowTokens: 30_000 });
+    seedSession("trim-partial", [
+      { role: "system", content: `${SUMMARY_PREFIX}\nProtect the knee.`, ts: FRESH_TS },
+      ...seeded.map((message, i) => ({
+        ...message,
+        content:
+          message.content +
+          (i === 0
+            ? " Goal: finish the mountain ride."
+            : i === 10
+              ? " Correction: no Tuesday training."
+              : ""),
+      })),
+    ]);
 
-    const text = await agent.chat("trim-summary-fail", "hello");
+    expect(await agent.chat("trim-partial", "hello")).toBe("final-reply");
 
-    expect(text).toBe("final-reply");
-    expect(listPrecompact("trim-summary-fail")).toHaveLength(0);
+    expect(summaries).toBeGreaterThan(1);
+    const request = JSON.stringify(complete.mock.calls.at(-1)?.[0].messages);
+    expect(request).toContain("Goal: finish the mountain ride.");
+    expect(request).toContain("Correction: no Tuesday training.");
+    expect(request).toContain("Protect the knee.");
+    expect(request).toContain("TRIM-MARK-29 ");
+  });
 
-    const session = readFileSync(join(dataDir, "sessions", "trim-summary-fail.jsonl"), "utf-8");
-    expect(session).toContain("TRIM-MARK-0 ");
-    expect(session).not.toContain("## Coach Stance");
+  it("retains a failed staged correction in the next request after overflow rescue", async () => {
+    let requests = 0;
+    let summaries = 0;
+    const complete = vi.fn(async (params: CodexResponsesParams) => {
+      if (String(params.messages[0]?.content).startsWith("Summarize the conversation")) {
+        summaries++;
+        if (summaries === 2) throw new Error("summary unavailable");
+        return mkAssistant(
+          FIVE_SECTION_SUMMARY + "\nProtect the knee. Goal: finish the mountain ride.",
+        );
+      }
+      if (params.system?.startsWith("You are reviewing a conversation"))
+        return mkAssistant("facts noted");
+      if (
+        params.messages.some(
+          (message) => message.role === "user" && String(message.content).startsWith("hello"),
+        )
+      ) {
+        requests++;
+        if (requests === 1) throw new Error("Request exceeds the maximum context length");
+        return mkAssistant("final-reply");
+      }
+      return mkAssistant("facts noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, {
+      compactContextWindowTokens: 30_000,
+      historyTokenBudgetRatio: 0.95,
+    });
+    seedSession("staged-partial", [
+      { role: "system", content: `${SUMMARY_PREFIX}\nProtect the knee.`, ts: FRESH_TS },
+      ...Array.from({ length: 6 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content:
+          (i === 0
+            ? "Goal: finish the mountain ride."
+            : i === 1
+              ? "Correction: no Tuesday training."
+              : `RECENT-${i}`) + "x".repeat(20_000),
+        ts: FRESH_TS,
+      })),
+    ]);
+
+    expect(await agent.chat("staged-partial", "hello")).toBe("final-reply");
+
+    expect(requests).toBe(2);
+    expect(summaries).toBeGreaterThan(1);
+    const request = JSON.stringify(complete.mock.calls.at(-1)?.[0].messages);
+    expect(request).toContain("Goal: finish the mountain ride.");
+    expect(request).toContain("Correction: no Tuesday training.");
+    expect(request).toContain("Protect the knee.");
+    expect(request).toContain("RECENT-5");
+  });
+
+  it("stops before generating when failed summaries leave history over budget", async () => {
+    const complete = vi.fn(async (params: CodexResponsesParams) => {
+      const content = String(params.messages[0]?.content);
+      if (
+        content.startsWith("Incorporate the older") ||
+        content.startsWith("Summarize the conversation")
+      ) {
+        throw new Error("summary unavailable");
+      }
+      return mkAssistant("facts noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, { contextWindowTokens: 40_000 });
+    seedSession(
+      "trim-over-budget",
+      seeded.map((message) => ({
+        ...message,
+        content: message.content + "x".repeat(8_000),
+      })),
+    );
+
+    await expect(agent.chat("trim-over-budget", "hello")).rejects.toThrow(
+      "Conversation could not be shortened safely to fit the context budget",
+    );
 
     expect(
-      warnSpy.mock.calls.some((c) => String(c[0]).includes("Dropped message summarization failed")),
-    ).toBe(true);
+      complete.mock.calls.some(([params]) =>
+        params.messages.some(
+          (message) => message.role === "user" && String(message.content).startsWith("hello"),
+        ),
+      ),
+    ).toBe(false);
+    expect(listPrecompact("trim-over-budget")).toHaveLength(0);
+    const session = readFileSync(join(dataDir, "sessions", "trim-over-budget.jsonl"), "utf-8");
+    expect(session).toContain("TRIM-MARK-0 ");
   });
 });

--- a/tools/compaction-gate/checks.test.ts
+++ b/tools/compaction-gate/checks.test.ts
@@ -79,6 +79,20 @@ describe("mustPreserveDiff", () => {
 });
 
 describe("factScore", () => {
+  it("counts a repeated remembered fact once", () => {
+    const verdict = { factsPreserved: Array(10).fill("F01"), factsMissing: [], fabrications: [] };
+    expect(factScore(verdict, INVENTORY)).toBe(0.1);
+    expect(tierJTranscriptVerdict([verdict, verdict, verdict], INVENTORY).pass).toBe(false);
+  });
+
+  it("counts distinct inventory facts and keeps scores bounded", () => {
+    expect(factScore(run(10, 0), [...INVENTORY, "F01"])).toBe(1);
+    expect(factScore(run(10, 0), [])).toBe(0);
+  });
+
+  it("does not credit facts also declared missing", () => {
+    expect(factScore({ ...run(10, 0), factsMissing: ["F01"] }, INVENTORY)).toBe(0.9);
+  });
   it("scores 9 of 10 preserved inventory ids as 0.9", () => {
     expect(factScore(run(9, 0), INVENTORY)).toBeCloseTo(0.9, 10);
   });
@@ -129,21 +143,60 @@ describe("cacheEvidence", () => {
 });
 
 describe("parseJudgeVerdict", () => {
+  it.each([null, 1, {}, ["F01", 2], [""], ["   "]])(
+    "rejects malformed field values: %j",
+    (value) => {
+      for (const field of ["factsPreserved", "factsMissing", "fabrications"]) {
+        expect(() =>
+          parseJudgeVerdict(JSON.stringify({ ...run(1, 0), [field]: value }), INVENTORY),
+        ).toThrow();
+      }
+    },
+  );
+
+  it("rejects contradictory preserved and missing facts", () => {
+    expect(() =>
+      parseJudgeVerdict(JSON.stringify({ ...run(1, 0), factsMissing: ["F01"] }), INVENTORY),
+    ).toThrow(/both preserved and missing/);
+  });
+
+  it.each(["factsPreserved", "factsMissing"])("rejects unknown IDs in %s", (field) => {
+    expect(() =>
+      parseJudgeVerdict(JSON.stringify({ ...run(1, 0), [field]: ["UNKNOWN"] }), INVENTORY),
+    ).toThrow(/unknown fact ID/);
+  });
+
+  it("deduplicates valid declarations", () => {
+    expect(
+      parseJudgeVerdict(
+        JSON.stringify({
+          factsPreserved: ["F01", "F01"],
+          factsMissing: ["F02", "F02"],
+          fabrications: [],
+        }),
+        INVENTORY,
+      ),
+    ).toEqual({ factsPreserved: ["F01"], factsMissing: ["F02"], fabrications: [] });
+  });
   it("parses a clean JSON reply", () => {
-    const v = parseJudgeVerdict('{"factsPreserved":["F01"],"factsMissing":[],"fabrications":[]}');
+    const v = parseJudgeVerdict(
+      '{"factsPreserved":["F01"],"factsMissing":[],"fabrications":[]}',
+      INVENTORY,
+    );
     expect(v.factsPreserved).toEqual(["F01"]);
   });
 
   it("extracts JSON wrapped in prose", () => {
     const v = parseJudgeVerdict(
       'Here is my verdict:\n{"factsPreserved":[],"factsMissing":["F01"],"fabrications":["made up a number"]}\nDone.',
+      INVENTORY,
     );
     expect(v.factsMissing).toEqual(["F01"]);
     expect(v.fabrications).toEqual(["made up a number"]);
   });
 
   it("throws on garbage", () => {
-    expect(() => parseJudgeVerdict("no json here")).toThrow();
+    expect(() => parseJudgeVerdict("no json here", INVENTORY)).toThrow();
   });
 });
 

--- a/tools/compaction-gate/checks.ts
+++ b/tools/compaction-gate/checks.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { UsageLedgerLine } from "../../packages/core/src/usage-ledger.js";
 import { TIER_J_FACT_THRESHOLD, TIER_J_MAX_FABRICATIONS } from "./rubric.js";
 
@@ -20,8 +21,11 @@ export function median(values: number[]): number {
 export function factScore(run: JudgeVerdict, inventoryIds: readonly string[]): number {
   if (inventoryIds.length === 0) return 0;
   const inventory = new Set(inventoryIds);
-  const preserved = run.factsPreserved.filter((id) => inventory.has(id));
-  return preserved.length / inventoryIds.length;
+  const missing = new Set(run.factsMissing);
+  const preserved = new Set(
+    run.factsPreserved.filter((id) => inventory.has(id) && !missing.has(id)),
+  );
+  return preserved.size / inventory.size;
 }
 
 /** Tier-J verdict for one transcript from its 3 judge runs. */
@@ -96,24 +100,28 @@ export function cacheEvidence(lines: UsageLedgerLine[]): { ok: boolean; reason: 
   return { ok: true, reason: "cache written on first call and read on a later call" };
 }
 
-/** Strict-JSON extraction for judge replies: parse the first {...} block; throw on failure. */
-export function parseJudgeVerdict(text: string): JudgeVerdict {
+const judgeVerdictSchema = z.object({
+  factsPreserved: z.array(z.string().trim().min(1)),
+  factsMissing: z.array(z.string().trim().min(1)),
+  fabrications: z.array(z.string().trim().min(1)),
+});
+
+export function parseJudgeVerdict(text: string, inventoryIds: readonly string[]): JudgeVerdict {
   const start = text.indexOf("{");
   const end = text.lastIndexOf("}");
   if (start === -1 || end === -1 || end < start) {
     throw new Error("no JSON object found in judge reply");
   }
-  const parsed = JSON.parse(text.slice(start, end + 1)) as Partial<JudgeVerdict>;
-  if (
-    !Array.isArray(parsed.factsPreserved) ||
-    !Array.isArray(parsed.factsMissing) ||
-    !Array.isArray(parsed.fabrications)
-  ) {
-    throw new Error("judge reply JSON missing required array fields");
+  const parsed = judgeVerdictSchema.parse(JSON.parse(text.slice(start, end + 1)));
+  const inventory = new Set(inventoryIds);
+  const factsPreserved = [...new Set(parsed.factsPreserved)];
+  const factsMissing = [...new Set(parsed.factsMissing)];
+  for (const id of [...factsPreserved, ...factsMissing]) {
+    if (!inventory.has(id)) throw new Error(`judge reply contains unknown fact ID: ${id}`);
   }
-  return {
-    factsPreserved: parsed.factsPreserved,
-    factsMissing: parsed.factsMissing,
-    fabrications: parsed.fabrications,
-  };
+  const missing = new Set(factsMissing);
+  if (factsPreserved.some((id) => missing.has(id))) {
+    throw new Error("judge reply declares a fact both preserved and missing");
+  }
+  return { factsPreserved, factsMissing, fabrications: parsed.fabrications };
 }

--- a/tools/compaction-gate/run.ts
+++ b/tools/compaction-gate/run.ts
@@ -142,7 +142,7 @@ async function judgeOnce(
       maxOutputTokens: JUDGE_MAX_OUTPUT_TOKENS,
     });
     try {
-      return parseJudgeVerdict(text);
+      return parseJudgeVerdict(text, payload.facts.map((fact) => fact.id));
     } catch (err) {
       lastErr = err;
     }


### PR DESCRIPTION
All six child PRs are merged into this epic after passing their required CI. Final umbrella CI also passed, including Linux E2E and macOS/Windows packaged checks. Latest main is integrated without changing the reviewed app diff. This umbrella remains unmerged for operator approval.

- #880: truthful guarded confirmation outcomes through Telegram and CLI.
- #881: preserve failed-summary context and correction order; stop if retained history cannot fit.
- #882: count unique valid remembered facts and reject invalid judge output.
- #884: use the selected setup subtitle, Connect or import ride files.
- #885: public API Astra opt-in, transport-specific restrictions, terminal failure handling, and unavailable pricing.
- #886: private sentinel retry settings owned by the helper.

Revalidation confirmed the false-success outcome, summary-loss paths, duplicate-ID score inflation, and misleading setup subtitle. The public OpenAI path already used Responses, so no endpoint migration was needed. The optional retry cleanup stayed behavior-preserving.

Validation on the final integration:

- Complete root pnpm check passed after latest-main integration.
- Full suite: 11,168 passed, 17 skipped, and four transient failures across three files. All three files then passed serially, 107 tests, without source changes.
- Final affected host/compaction/Astra tests: 171 passed.
- Final renderer setup: 102 passed; native setup: two cases passed after rebuilding dependencies, renderer, and desktop.
- Required final Codex autoreview reported no findings at its configured P0 threshold.
- Worktree clean; 29 changed files include four user-facing changesets. Protected instruction files and the frozen audit checkout were not edited by this task.

No real athlete writes or paid provider calls occurred. Live Astra entitlement, provider compatibility, latency, complete billing, and matched quality evaluations remain unresolved. The installed SDK does not expose cache-write usage. Exact native Astra save/reload/return-to-Sol is unverified; generic custom-model renderer and Astra configuration/protocol tests cover their respective boundaries. Unverified subscription transports remain disabled for Astra, and current model defaults and background choices remain unchanged.
