### PR TITLE
fix(ci): preserve checked image digest in promotion

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: source
-        name: Derive immutable source tag
+        name: Derive source tag
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
@@ -131,7 +131,9 @@ jobs:
               exit 1
             fi
 
-            if ! run_count=$(jq -er 'arrays | length' <<< "$runs_json"); then
+            if ! runs_json=$(jq -ce --arg sha "$HEAD_SHA" --arg repository "$REPOSITORY" \
+              'map(select(.head_sha == $sha and .event == "push" and .head_branch == "main" and .repository.full_name == $repository and .head_repository.full_name == $repository))' <<< "$runs_json") ||
+              ! run_count=$(jq -er 'arrays | length' <<< "$runs_json"); then
               echo "::error::GitHub Actions API returned an invalid workflow-runs response."
               exit 1
             fi
@@ -142,7 +144,7 @@ jobs:
                 exit 1
               fi
 
-              echo "::notice::No publish-image.yml run exists for ${HEAD_SHA}; the push was skipped by its path filters, so stable remains unchanged."
+              echo "::notice::No matching main-push publish-image.yml run exists for ${HEAD_SHA}; stable remains unchanged."
               echo "ready=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -214,7 +216,7 @@ jobs:
           done
 
       - id: images
-        name: Check immutable images
+        name: Check source image digests
         if: steps.publish.outputs.ready == 'true'
         env:
           SHORT_SHA: ${{ steps.source.outputs.short_sha }}
@@ -225,56 +227,48 @@ jobs:
           expected_digest=""
           for image in "$IMAGE_NAME" "$ALIAS_IMAGE_NAME"; do
             source="${image}:main-${SHORT_SHA}"
-            if ! source_digest=$(docker buildx imagetools inspect "$source" --format '{{json .Manifest}}' | jq -er '.digest'); then
-              echo "::error::publish-image.yml succeeded, but immutable image $source does not exist."
+            if ! source_digest=$(docker buildx imagetools inspect "$source" --format '{{json .Manifest}}' | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))'); then
+              echo "::error::publish-image.yml succeeded, but image $source has no valid digest."
               exit 1
             fi
 
             if [[ -n "$expected_digest" && "$source_digest" != "$expected_digest" ]]; then
-              echo "::error::Immutable image names do not resolve to the same digest"
+              echo "::error::Source image names do not resolve to the same digest"
               exit 1
             fi
             expected_digest="$source_digest"
           done
 
+          echo "digest=$expected_digest" >> "$GITHUB_OUTPUT"
           echo "available=true" >> "$GITHUB_OUTPUT"
 
-      - name: Promote immutable images
+      - name: Promote checked image digest
         if: steps.images.outputs.available == 'true'
         env:
-          SHORT_SHA: ${{ steps.source.outputs.short_sha }}
+          SOURCE_DIGEST: ${{ steps.images.outputs.digest }}
         shell: bash
         run: |
           set -euo pipefail
 
-          docker buildx imagetools create -t "${IMAGE_NAME}:stable" "${IMAGE_NAME}:main-${SHORT_SHA}"
-          docker buildx imagetools create -t "${ALIAS_IMAGE_NAME}:stable" "${ALIAS_IMAGE_NAME}:main-${SHORT_SHA}"
+          docker buildx imagetools create -t "${IMAGE_NAME}:stable" "${IMAGE_NAME}@${SOURCE_DIGEST}"
+          docker buildx imagetools create -t "${ALIAS_IMAGE_NAME}:stable" "${ALIAS_IMAGE_NAME}@${SOURCE_DIGEST}"
 
       - name: Verify stable image digests
         if: steps.images.outputs.available == 'true'
         env:
-          SHORT_SHA: ${{ steps.source.outputs.short_sha }}
+          SOURCE_DIGEST: ${{ steps.images.outputs.digest }}
         shell: bash
         run: |
           set -euo pipefail
 
-          expected_digest=""
           for image in "$IMAGE_NAME" "$ALIAS_IMAGE_NAME"; do
-            source="${image}:main-${SHORT_SHA}"
             stable="${image}:stable"
-            source_digest=$(docker buildx imagetools inspect "$source" --format '{{json .Manifest}}' | jq -er '.digest')
             stable_digest=$(docker buildx imagetools inspect "$stable" --format '{{json .Manifest}}' | jq -er '.digest')
 
-            if [[ "$stable_digest" != "$source_digest" ]]; then
-              echo "::error::Digest mismatch for $stable: expected $source_digest, got $stable_digest"
+            if [[ "$stable_digest" != "$SOURCE_DIGEST" ]]; then
+              echo "::error::Digest mismatch for $stable: expected $SOURCE_DIGEST, got $stable_digest"
               exit 1
             fi
-
-            if [[ -n "$expected_digest" && "$stable_digest" != "$expected_digest" ]]; then
-              echo "::error::Stable image names do not resolve to the same digest"
-              exit 1
-            fi
-            expected_digest="$stable_digest"
           done
 
-          echo "Promoted both stable image names at digest $expected_digest"
+          echo "Promoted both stable image names at digest $SOURCE_DIGEST"

--- a/tools/promote-stable.test.ts
+++ b/tools/promote-stable.test.ts
@@ -1,0 +1,253 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { z } from "zod";
+
+const stepSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().optional(),
+  run: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+});
+const workflow = z
+  .object({
+    env: z.record(z.string(), z.string()),
+    jobs: z.object({ promote: z.object({ steps: z.array(stepSchema) }) }),
+  })
+  .parse(
+    parse(
+      readFileSync(new URL("../.github/workflows/promote-stable.yml", import.meta.url), "utf8"),
+    ),
+  );
+const digestA = `sha256:${"a".repeat(64)}`;
+const digestB = `sha256:${"b".repeat(64)}`;
+const headSha = "a".repeat(40);
+const repository = "synthetic/enduragent";
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+});
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), "enduragent-promotion-"));
+  directories.push(directory);
+  const output = join(directory, "output");
+  const stateFile = join(directory, "state.json");
+  const outputs = new Map<string, string>();
+  writeFileSync(join(directory, "timeout"), '#!/bin/sh\nshift\nexec "$@"\n', { mode: 0o700 });
+  writeFileSync(join(directory, "sleep"), "#!/bin/sh\nexit 97\n", { mode: 0o700 });
+  writeFileSync(join(directory, "gh"), '#!/bin/sh\ncat "$CASE_DIR/runs.json"\n', { mode: 0o700 });
+  writeFileSync(
+    join(directory, "docker"),
+    `#!${process.execPath}
+const fs = require("node:fs");
+const file = process.env.CASE_DIR + "/state.json";
+const state = JSON.parse(fs.readFileSync(file, "utf8"));
+const args = process.argv.slice(2);
+if (args[0] !== "buildx" || args[1] !== "imagetools") process.exit(2);
+if (args[2] === "inspect") {
+  state.inspections.push(args[3]);
+  fs.writeFileSync(file, JSON.stringify(state));
+  const digest = state.tags[args[3]];
+  if (digest === undefined) process.exit(1);
+  process.stdout.write(JSON.stringify({ digest }));
+} else if (args[2] === "create" && args[3] === "-t") {
+  const source = args[5];
+  const digest = source.includes("@") ? source.split("@")[1] : state.tags[source];
+  if (digest === undefined) process.exit(1);
+  state.promotions.push({ target: args[4], source, digest });
+  state.tags[args[4]] = digest;
+  fs.writeFileSync(file, JSON.stringify(state));
+} else process.exit(2);
+`,
+    { mode: 0o700 },
+  );
+  const sourceTag = `main-${headSha.slice(0, 12)}`;
+  const tags = {
+    [`${workflow.env.IMAGE_NAME}:${sourceTag}`]: digestA,
+    [`${workflow.env.ALIAS_IMAGE_NAME}:${sourceTag}`]: digestA,
+  };
+  writeFileSync(stateFile, JSON.stringify({ tags, inspections: [], promotions: [] }));
+
+  function execute(name: string) {
+    const step = workflow.jobs.promote.steps.find((candidate) => candidate.name === name);
+    if (!step?.run) throw new Error(`Missing workflow shell step: ${name}`);
+    const expressions = new Map([
+      ["github.event.workflow_run.head_sha", headSha],
+      ["github.repository", repository],
+      ["secrets.GITHUB_TOKEN", "synthetic-test-token"],
+      ...outputs,
+    ]);
+    const env = Object.fromEntries(
+      Object.entries(step.env ?? {}).map(([key, value]) => [
+        key,
+        value.replace(/\$\{\{\s*(.*?)\s*\}\}/g, (_match: string, expression: string) => {
+          const resolved = expressions.get(expression);
+          if (resolved === undefined)
+            throw new Error(`Unresolved workflow expression: ${expression}`);
+          return resolved;
+        }),
+      ]),
+    );
+    writeFileSync(output, "");
+    const result = spawnSync("/bin/bash", ["-c", step.run], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        PATH: `${directory}:${process.env.PATH}`,
+        ...workflow.env,
+        ...env,
+        CASE_DIR: directory,
+        GITHUB_OUTPUT: output,
+      },
+    });
+    for (const line of readFileSync(output, "utf8").trim().split("\n")) {
+      const separator = line.indexOf("=");
+      if (separator > 0 && step.id) {
+        outputs.set(
+          `steps.${step.id}.outputs.${line.slice(0, separator)}`,
+          line.slice(separator + 1),
+        );
+      }
+    }
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      error: result.error,
+    };
+  }
+
+  function setTags(changes: Record<string, string>) {
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    Object.assign(state.tags, changes);
+    writeFileSync(stateFile, JSON.stringify(state));
+  }
+
+  expect(execute("Derive source tag").status).toBe(0);
+  return {
+    execute,
+    setTags,
+    outputs,
+    tags,
+    state: () => JSON.parse(readFileSync(stateFile, "utf8")),
+    runs: (runs: unknown[]) =>
+      writeFileSync(join(directory, "runs.json"), JSON.stringify({ workflow_runs: runs })),
+  };
+}
+
+describe("stable promotion digest binding", () => {
+  it.each([false, true])("promotes the checked digest when source tags change: %s", (race) => {
+    const run = fixture();
+    expect(run.execute("Check source image digests").status).toBe(0);
+    expect(run.outputs.get("steps.images.outputs.digest")).toBe(digestA);
+    if (race) run.setTags(Object.fromEntries(Object.keys(run.tags).map((tag) => [tag, digestB])));
+    expect(run.execute("Promote checked image digest").status).toBe(0);
+    expect(run.execute("Verify stable image digests").status).toBe(0);
+    expect(run.state().promotions).toEqual([
+      {
+        target: `${workflow.env.IMAGE_NAME}:stable`,
+        source: `${workflow.env.IMAGE_NAME}@${digestA}`,
+        digest: digestA,
+      },
+      {
+        target: `${workflow.env.ALIAS_IMAGE_NAME}:stable`,
+        source: `${workflow.env.ALIAS_IMAGE_NAME}@${digestA}`,
+        digest: digestA,
+      },
+    ]);
+    expect(run.state().inspections).toEqual([
+      ...Object.keys(run.tags),
+      `${workflow.env.IMAGE_NAME}:stable`,
+      `${workflow.env.ALIAS_IMAGE_NAME}:stable`,
+    ]);
+  });
+
+  it.each([digestB, "", "sha256:not-a-digest", `sha256:${"b".repeat(64)}\navailable=true`])(
+    "rejects mismatched or malformed source digest %s before enabling writes",
+    (digest) => {
+      const run = fixture();
+      run.setTags({ [`${workflow.env.ALIAS_IMAGE_NAME}:main-${headSha.slice(0, 12)}`]: digest });
+      expect(run.execute("Check source image digests").status).not.toBe(0);
+      expect(run.outputs.has("steps.images.outputs.available")).toBe(false);
+      expect(run.state().promotions).toEqual([]);
+    },
+  );
+
+  it.each([workflow.env.IMAGE_NAME, workflow.env.ALIAS_IMAGE_NAME])(
+    "detects a changed stable digest for %s",
+    (image) => {
+      const run = fixture();
+      expect(run.execute("Check source image digests").status).toBe(0);
+      expect(run.execute("Promote checked image digest").status).toBe(0);
+      run.setTags({ [`${image}:stable`]: digestB });
+      expect(run.execute("Verify stable image digests").status).not.toBe(0);
+    },
+  );
+});
+
+const trustedRun = {
+  id: 101,
+  run_number: 1,
+  created_at: "1998-01-01T00:00:00Z",
+  head_sha: headSha,
+  head_branch: "main",
+  event: "push",
+  repository: { full_name: repository },
+  head_repository: { full_name: repository },
+  status: "completed",
+  conclusion: "success",
+};
+
+describe("stable promotion image-run provenance", () => {
+  it("accepts a successful same-repository main push", () => {
+    const run = fixture();
+    run.runs([trustedRun]);
+    expect(run.execute("Wait for matching image publication").status).toBe(0);
+    expect(run.outputs.get("steps.publish.outputs.ready")).toBe("true");
+  });
+
+  it.each([
+    { event: "workflow_dispatch" },
+    { event: "pull_request" },
+    { head_branch: "feature/other" },
+    { head_sha: "b".repeat(40) },
+    { repository: { full_name: "other/enduragent" } },
+    { head_repository: { full_name: "other/enduragent" } },
+    { head_repository: null },
+  ])("ignores mismatched provenance %j", (changed) => {
+    const run = fixture();
+    run.runs([{ ...trustedRun, ...changed }]);
+    expect(run.execute("Wait for matching image publication").status).toBe(0);
+    expect(run.outputs.get("steps.publish.outputs.ready")).toBe("false");
+  });
+
+  it("does not let a newer manual run replace the successful push", () => {
+    const run = fixture();
+    run.runs([
+      trustedRun,
+      { ...trustedRun, event: "workflow_dispatch", run_number: 2, conclusion: "failure" },
+    ]);
+    expect(run.execute("Wait for matching image publication").status).toBe(0);
+    expect(run.outputs.get("steps.publish.outputs.ready")).toBe("true");
+  });
+
+  it("preserves path-filter skips when no image run exists", () => {
+    const run = fixture();
+    run.runs([]);
+    expect(run.execute("Wait for matching image publication").status).toBe(0);
+    expect(run.outputs.get("steps.publish.outputs.ready")).toBe("false");
+  });
+
+  it("refuses a failed matching run", () => {
+    const run = fixture();
+    run.runs([{ ...trustedRun, conclusion: "failure" }]);
+    expect(run.execute("Wait for matching image publication").status).not.toBe(0);
+    expect(run.outputs.has("steps.publish.outputs.ready")).toBe(false);
+  });
+});


### PR DESCRIPTION
Stable image promotion checked two source tags, copied those mutable tags, and then verified against tags read again. If both source tags changed between the check and the copy, a different image could become stable while verification still passed.

Save the validated SHA-256 digest as a workflow output, copy both image names using that digest, and compare both stable tags with the saved digest. Select the image publication run only when its SHA, push event, main branch and repository identities match the successful CI candidate. Both image names and version-tag recovery remain supported.

Validation: fresh frozen-lockfile install; 19 regression cases execute the actual workflow shell blocks with synthetic GitHub and Docker responses, including mutable-tag races, invalid digests, changed stable tags and wrong image-run provenance. Focused TypeScript and lint checks pass. The required isolated Codex autoreview is clean with no accepted/actionable findings. This is infrastructure-only and does not change an athlete-facing release note or desktop UI flow.

This closes the checked-tag-to-copy race. It does not establish exclusive registry-writer authority, prevent replacement before the initial read or after verification, or change the current promotion staleness policy. No live registry write or deployment was performed.

This PR changes a release workflow and must remain unmerged for operator approval.
