### PR TITLE
fix(ingest): process selected files lazily and traverse XML iteratively

### DIFF
--- a/.changeset/cold-coats-happen.md
+++ b/.changeset/cold-coats-happen.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/kernel-node": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+---
+
+Read selected activity files during processing and traverse XML without recursion.
+
+User-facing: Importing a batch of activity files uses less memory. Deeply nested GPX and TCX files no longer interrupt the import with a stack error.

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -1063,7 +1063,7 @@ describe("coach sync composition", () => {
       const batch = importBatchWithReport.mock.calls[0]![0];
       expect(batch.platform_records).toEqual([]);
       expect(batch.files).toHaveLength(1);
-      expect(batch.files[0]!.bytes).toBe(bytes);
+      expect(batch.files[0]).toMatchObject({ bytes });
       expect(batch.files[0]!.input_path).toBe(artifact.file.input_path);
     } finally {
       await harness.store.close();

--- a/packages/kernel-node/src/ingest/import-files.ts
+++ b/packages/kernel-node/src/ingest/import-files.ts
@@ -15,6 +15,7 @@ import {
   type ConcernValue,
   type DedupCandidateSummary,
   type ImportArtifact,
+  type ImportArtifactSource,
   type ImportReport,
   type ImportReportDeps,
   type LapConcern,
@@ -341,7 +342,7 @@ function createImportReportDeps(options: NodeImportRuntimeOptions): ImportReport
 export async function importFilesWithReport(options: ImportFilesOptions): Promise<ImportReport> {
   if (options.inputPaths.length === 0) throw new TypeError("input path list is empty");
   const seen = new Set<string>();
-  const files: ImportArtifact[] = [];
+  const files: ImportArtifactSource[] = [];
   for (const inputPath of options.inputPaths) {
     if (typeof inputPath !== "string" || inputPath.length === 0 || seen.has(inputPath))
       throw new TypeError("duplicate or invalid input path");
@@ -349,7 +350,7 @@ export async function importFilesWithReport(options: ImportFilesOptions): Promis
     const ext = extname(inputPath).slice(1).toLowerCase();
     if (ext !== "fit" && ext !== "tcx" && ext !== "gpx")
       throw new TypeError("unsupported input extension");
-    files.push({ input_path: inputPath, bytes: new Uint8Array(await readFile(inputPath)), ext });
+    files.push({ input_path: inputPath, readBytes: () => readFile(inputPath), ext });
   }
   return createNodeImportRuntime(options).importBatchWithReport({ files, platform_records: [] });
 }

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -1409,7 +1409,7 @@ describe("coach-dev import --report", () => {
               expect(archived).toBe(3);
               readsAtImport = readCalls;
               for (const file of batch.files) {
-                expect(file.bytes).toEqual(expected.get(file.input_path));
+                expect(file).toMatchObject({ bytes: expected.get(file.input_path) });
               }
               await Promise.all(paths.map((path) => rm(path)));
               return runtime.importBatchWithReport(batch);

--- a/packages/kernel-node/tests/incremental-import.test.ts
+++ b/packages/kernel-node/tests/incremental-import.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -29,6 +29,46 @@ describe("operational incremental Node import", () => {
       expect(await left.store.get("SELECT initialized FROM ingest_incremental_state")).toEqual({ initialized: 1 });
       expect((await left.store.all("SELECT candidate_id FROM ingest_candidate_index")).length).toBeGreaterThan(0);
     } finally { await left.store.close(); await right.store.close(); }
+  });
+
+  it.each([false, true])("reads the next source after archiving the previous file with legacy cache %s", async (legacy) => {
+    const value = await fresh();
+    try {
+      if (legacy) {
+        await value.runtime.importBatchWithReport({ files: [artifact("brick-cycling.fit")], platform_records: [] });
+        await value.store.run("UPDATE ingest_incremental_state SET initialized=0");
+      }
+      const names = ["brick-cycling.fit", "brick-running.fit"];
+      const reads: string[] = [];
+      const files = names.map((name) => ({
+        input_path: name,
+        ext: "fit" as const,
+        async readBytes() {
+          if (reads.length > 0) {
+            const archived = readdirSync(join(value.root, "archive"), { recursive: true });
+            expect(archived.some((path) => String(path).endsWith(".fit"))).toBe(true);
+          }
+          reads.push(name);
+          return new Uint8Array(readFileSync(fixture(name)));
+        },
+      }));
+      const report = await value.runtime.importBatchWithReport({ files: [...files].reverse(), platform_records: [] });
+      expect(reads).toEqual(names);
+      expect(report.files.every((file) => file.outcome === "imported")).toBe(true);
+      expect(report.clusters).toHaveLength(1);
+    } finally { await value.store.close(); }
+  });
+
+  it("rolls back the batch if a later source cannot be read", async () => {
+    const value = await fresh();
+    try {
+      const before = await dumpStore(value.store);
+      await expect(value.runtime.importBatchWithReport({ files: [
+        { ...artifact("brick-cycling.fit"), input_path: "a.fit" },
+        { input_path: "z.fit", ext: "fit", readBytes: async () => { throw new Error("read failed"); } },
+      ], platform_records: [] })).rejects.toThrow("read failed");
+      expect(await dumpStore(value.store)).toBe(before);
+    } finally { await value.store.close(); }
   });
 
   it("commits data and progress together and performs no write after finalizer", async () => {

--- a/packages/kernel/src/ingest/dedup-rekey.ts
+++ b/packages/kernel/src/ingest/dedup-rekey.ts
@@ -1,3 +1,4 @@
+import { readImportArtifact } from "./import-report.js";
 import { assertValidAddress } from "../archive/paths.js";
 import { sortKeys } from "../store/canonical-json.js";
 import { createDedupConfirmationRepository } from "../store/dedup-confirmation-repository.js";
@@ -681,11 +682,11 @@ async function runGlobalReplan(
     incomingPlatforms.set(presentation.row.id, presentation);
   }
 
-  const files = [...batch.files].map((file) => ({ ...file, bytes: new Uint8Array(file.bytes) }))
-    .sort((a, b) => compareText(a.input_path, b.input_path));
+  const files = [...batch.files].sort((a, b) => compareText(a.input_path, b.input_path));
   const fileWork: FileWork[] = [];
   const incomingAddresses = new Map<string, PreparedAddress>();
-  for (const file of files) {
+  for (const input of files) {
+    const file = await readImportArtifact(input);
     const result = await measure("archive-decode", () => deps.prepareFile(file, targetSettings));
     if (result.outcome === "quarantined") {
       const archived = await measure("archive-decode", () =>

--- a/packages/kernel/src/ingest/gpx.ts
+++ b/packages/kernel/src/ingest/gpx.ts
@@ -80,7 +80,8 @@ function validateGpxNamespaces(root: Element, core: string, order: ReturnType<ty
       }
     }
   };
-  const visitCore = (element: Element): void => {
+  const pending: Element[] = [root];
+  for (let element = pending.pop(); element; element = pending.pop()) {
     const allowed = element === root ? ["version", "creator"] : ["trkpt", "wpt", "rtept"].includes(element.localName ?? "") ? ["lat", "lon"] : [];
     attrIssues(element, allowed, order, issues);
     for (const child of childElements(element)) {
@@ -89,10 +90,9 @@ function validateGpxNamespaces(root: Element, core: string, order: ReturnType<ty
         continue;
       }
       if (child.namespaceURI !== core) issues.push({ order: elementOrder(order, child), path: elementPath(child) });
-      else visitCore(child);
+      else pending.push(child);
     }
-  };
-  visitCore(root);
+  }
   throwFirstIssue("xml.namespace", issues);
 }
 

--- a/packages/kernel/src/ingest/import-report.ts
+++ b/packages/kernel/src/ingest/import-report.ts
@@ -18,8 +18,17 @@ export interface ImportArtifact {
   };
 }
 
+export interface ImportArtifactSource extends Omit<ImportArtifact, "bytes"> {
+  readonly readBytes: () => Promise<Uint8Array>;
+}
+
+export async function readImportArtifact(input: ImportArtifact | ImportArtifactSource): Promise<ImportArtifact> {
+  const bytes = "readBytes" in input ? await input.readBytes() : input.bytes;
+  return { ...input, bytes: new Uint8Array(bytes) };
+}
+
 export interface ImportBatch {
-  readonly files: readonly ImportArtifact[];
+  readonly files: readonly (ImportArtifact | ImportArtifactSource)[];
   readonly platform_records: readonly PlatformImportArtifact[];
 }
 

--- a/packages/kernel/src/ingest/incremental-rekey.ts
+++ b/packages/kernel/src/ingest/incremental-rekey.ts
@@ -1,3 +1,4 @@
+import { readImportArtifact } from "./import-report.js";
 import { assertValidAddress } from "../archive/paths.js";
 import { sortKeys } from "../store/canonical-json.js";
 import { createDedupConfirmationRepository } from "../store/dedup-confirmation-repository.js";
@@ -171,7 +172,8 @@ export async function importArtifactsIncrementally(batch: ImportBatch, deps: Imp
   const inputPaths = new Set<string>();
   const incomingAddresses = new Map<string, PreparedAddress>();
   const fileReports: { readonly report: FileReport; readonly address: string }[] = [];
-  for (const file of [...batch.files].sort((a, b) => compareText(a.input_path, b.input_path))) {
+  for (const input of [...batch.files].sort((a, b) => compareText(a.input_path, b.input_path))) {
+    const file = await readImportArtifact(input);
     if (typeof file.input_path !== "string" || file.input_path.length === 0 || inputPaths.has(file.input_path)) throw new TypeError("duplicate or invalid input path");
     inputPaths.add(file.input_path);
     const result = await phase(deps, "archive-decode", () => deps.prepareFile({ ...file, bytes: new Uint8Array(file.bytes) }, settings));

--- a/packages/kernel/src/ingest/tcx.ts
+++ b/packages/kernel/src/ingest/tcx.ts
@@ -91,7 +91,8 @@ function validateTcxNamespaces(root: Element, order: ReturnType<typeof documentO
       }
     }
   };
-  const visitCore = (element: Element): void => {
+  const pending: Element[] = [root];
+  for (let element = pending.pop(); element; element = pending.pop()) {
     const allowed = element.localName === "Activity" ? ["Sport"] : element.localName === "Lap" ? ["StartTime"] : [];
     attrIssues(element, allowed, order, issues);
     for (const child of childElements(element)) {
@@ -102,11 +103,10 @@ function validateTcxNamespaces(root: Element, order: ReturnType<typeof documentO
       if (child.namespaceURI !== TCX) {
         issues.push({ order: elementOrder(order, child), path: elementPath(child) });
       } else {
-        visitCore(child);
+        pending.push(child);
       }
     }
-  };
-  visitCore(root);
+  }
   throwFirstIssue("xml.namespace", issues);
 }
 

--- a/packages/kernel/src/ingest/xml-common.ts
+++ b/packages/kernel/src/ingest/xml-common.ts
@@ -87,15 +87,22 @@ export function runXmlValidationStages(stages: XmlValidationStages): void {
   stages.overlap();
 }
 
+function* descendants(root: Node): Generator<Node> {
+  let node: Node | null = root;
+  while (node) {
+    yield node;
+    if (node.firstChild) {
+      node = node.firstChild;
+      continue;
+    }
+    while (node !== root && !node.nextSibling) node = node.parentNode!;
+    node = node === root ? null : node.nextSibling;
+  }
+}
+
 export function documentOrder(root: Element): ReadonlyMap<Node, number> {
   const result = new Map<Node, number>();
-  let next = 0;
-  const visit = (node: Node): void => {
-    result.set(node, next);
-    next += 1;
-    for (let child = node.firstChild; child; child = child.nextSibling) visit(child);
-  };
-  visit(root);
+  for (const node of descendants(root)) result.set(node, result.size);
   return result;
 }
 
@@ -129,15 +136,12 @@ export function parseXmlDocument(xmlWithoutDeclaration: string): Document {
   }
 }
 
-function walk(node: Node): void {
-  if (node.nodeType === 5 || node.nodeType === 6 || node.nodeType === 7 || node.nodeType === 10) {
-    throw quarantine("xml.parse", "$");
-  }
-  for (let child = node.firstChild; child; child = child.nextSibling) walk(child);
-}
-
 export function validateDocumentShell(document: Document): Element {
-  walk(document);
+  for (const node of descendants(document)) {
+    if (node.nodeType === 5 || node.nodeType === 6 || node.nodeType === 7 || node.nodeType === 10) {
+      throw quarantine("xml.parse", "$");
+    }
+  }
   let element: Element | null = null;
   for (let child = document.firstChild; child; child = child.nextSibling) {
     if (child.nodeType === 1) {
@@ -172,13 +176,18 @@ export function childElements(parent: Element): Element[] {
 }
 
 export function elementPath(element: Element): string {
-  const parent = element.parentNode;
-  if (!parent || parent.nodeType === 9) return "$";
-  let index = 0;
-  for (let sibling = parent.firstChild; sibling && sibling !== element; sibling = sibling.nextSibling) {
-    if (sibling.nodeType === 1 && sibling.localName === element.localName) index += 1;
+  const parts: string[] = [];
+  let node: Node = element;
+  while (node.parentNode && node.parentNode.nodeType !== 9) {
+    const parent = node.parentNode;
+    let index = 0;
+    for (let sibling = parent.firstChild; sibling && sibling !== node; sibling = sibling.nextSibling) {
+      if (sibling.nodeType === 1 && sibling.localName === node.localName) index += 1;
+    }
+    parts.push(`${node.localName}[${index}]`);
+    node = parent;
   }
-  return `${elementPath(parent as Element)}/${element.localName}[${index}]`;
+  return ["$", ...parts.reverse()].join("/");
 }
 
 export function attributePath(element: Element, localName: string): string {
@@ -209,7 +218,11 @@ export function requiredUnqualifiedAttribute(element: Element, localName: string
 }
 
 export function textValue(element: Element): string {
-  return (element.textContent ?? "").trim();
+  const parts: string[] = [];
+  for (const node of descendants(element)) {
+    if (node.nodeType === 3 || node.nodeType === 4) parts.push(node.nodeValue ?? "");
+  }
+  return parts.join("").trim();
 }
 
 function normalizeZero(value: number): number {

--- a/packages/kernel/tests/ingest/xml-depth.test.ts
+++ b/packages/kernel/tests/ingest/xml-depth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseGpx } from "../../src/ingest/gpx.js";
+import { parseTcx } from "../../src/ingest/tcx.js";
+import { childElements, documentOrder, elementPath, parseXmlDocument, textValue, validateDocumentShell } from "../../src/ingest/xml-common.js";
+
+const depth = 10_000;
+const nested = (body: string): string => `${"<x>".repeat(depth)}${body}${"</x>".repeat(depth)}`;
+
+describe("deep XML input", () => {
+  it("walks and numbers every node without a call-stack limit", () => {
+    const root = validateDocumentShell(parseXmlDocument(nested("text")));
+    const order = documentOrder(root);
+    expect(order.size).toBe(depth + 1);
+    expect([...order.values()]).toEqual(Array.from({ length: depth + 1 }, (_, index) => index));
+    expect(textValue(root)).toBe("text");
+    let leaf = root;
+    for (let child = childElements(leaf)[0]; child; child = childElements(leaf)[0]) leaf = child;
+    expect(elementPath(leaf)).toBe(`$${"/x[0]".repeat(depth - 1)}`);
+  });
+
+  it("keeps preorder and sibling path indices", () => {
+    const root = validateDocumentShell(parseXmlDocument("<root><x>A<y>B</y>C</x><x>D</x></root>"));
+    expect([...documentOrder(root).keys()].map((node) => node.nodeName)).toEqual([
+      "root", "x", "#text", "y", "#text", "#text", "x", "#text",
+    ]);
+    expect(elementPath(childElements(root)[1]!)).toBe("$/x[1]");
+    expect(textValue(root)).toBe("ABCD");
+    expect(documentOrder(childElements(root)[0]!).size).toBe(5);
+  });
+
+  it("returns typed quarantine results from both public activity parsers", () => {
+    const body = nested("");
+    expect(parseGpx(body).quarantine?.code).toBe("xml.namespace");
+    expect(parseTcx(body).quarantine?.code).toBe("xml.namespace");
+    expect(parseGpx(`<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">${body}</gpx>`).quarantine?.code).toBe("xml.missing_required");
+    expect(parseTcx(`<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">${body}</TrainingCenterDatabase>`).quarantine?.code).toBe("xml.missing_required");
+  });
+
+  it("reports a deeply nested foreign element without recursive error paths", () => {
+    const report = parseGpx(`<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">${nested('<bad xmlns="urn:foreign"/>')}</gpx>`);
+    expect(report.quarantine).toMatchObject({ code: "xml.namespace", path: `$${"/x[0]".repeat(depth)}/bad[0]` });
+  });
+});


### PR DESCRIPTION
Selecting a deeply nested GPX or TCX file could throw a stack error, and importing multiple files retained the complete batch of raw bytes. XML validation, ordering, paths, and text extraction now use iterative traversal. File-path imports defer reads until each file is processed, including legacy-store rebuilding, while retaining one batch transaction and duplicate detection.

Validation: 97 importer tests and all 40 caller tests passed, including 10,000 nested XML nodes, normal FIT/GPX/TCX imports, lazy reads in incremental and legacy paths, and rollback after a later read failure. Full root typecheck, affected package typechecks, focused lint, fixture privacy, changeset and kernel/dependency checks passed with fresh locked dependencies and rebuilt targets. Initial and final permitted autoreview completed without findings at the skill default P0 reporting threshold.

A freshly built desktop package exercised the real daemon with a mixed four-file batch: two valid files imported and two hostile files quarantined without a stack error. Repeating the valid files inserted no duplicate raw records. The built renderer/main/daemon also passed visible mixed, repeat, and hostile-only import flows with only the native file picker stubbed to synthetic paths. Screenshots were inspected. Published artifacts have not been updated by this PR.

This reduces raw-byte retention for selected file paths. Parsed candidate data and caller-owned in-memory batches remain in memory; this does not establish a 1,000-file memory guarantee or introduce file-size limits. Release remains through the established Changesets workflow.
