### PR TITLE
fix(core): redact diagnostic sinks and helper failures

### DIFF
--- a/.changeset/heavy-streets-bake.md
+++ b/.changeset/heavy-streets-bake.md
@@ -1,0 +1,10 @@
+---
+"cycling-coach": patch
+"running-coach": patch
+"@enduragent/coach": patch
+"@enduragent/core": patch
+"@enduragent/desktop": patch
+"duathlon-coach": patch
+---
+
+User-facing: Diagnostic logs now hide sensitive error text and credential-bearing URLs. Secret helper failures show an exit code and setup guidance without exposing helper output.

--- a/apps/desktop/tests/startup-catch.test.ts
+++ b/apps/desktop/tests/startup-catch.test.ts
@@ -103,9 +103,9 @@ describe("desktop startup catch", () => {
       event: "startup_failed",
       err: {
         name: "TypeError",
-        message: mocks.startupError.message,
-        stack: mocks.startupError.stack,
       },
     });
+    expect(JSON.stringify(record)).not.toContain(mocks.startupError.message);
+    expect(record.err).not.toHaveProperty("stack");
   }, 30_000);
 });

--- a/apps/desktop/tests/startup-failure.test.ts
+++ b/apps/desktop/tests/startup-failure.test.ts
@@ -39,10 +39,10 @@ describe("desktop startup failure", () => {
       event: "startup_failed",
       err: {
         name: "TypeError",
-        message: "synthetic startup failure",
-        stack: error.stack,
       },
     });
+    expect(JSON.stringify(lines)).not.toContain(error.message);
+    expect(lines[0]?.err).not.toHaveProperty("stack");
   });
 
   it("logs before the startup dialog gate without changing its flags", async () => {

--- a/packages/coach/tests/daemon/error-boundary.test.ts
+++ b/packages/coach/tests/daemon/error-boundary.test.ts
@@ -144,21 +144,24 @@ describe("boundary error serialization", () => {
     expect(JsonValueSchema.parse(payload)).toEqual(payload);
   });
 
-  it("never throws for hostile error properties", () => {
+  it("never invokes hostile error properties and preserves safe diagnostics", () => {
+    let callbacks = 0;
     const throwingName = new Error("synthetic");
     Object.defineProperty(throwingName, "name", {
       get() {
+        callbacks++;
         throw new Error("synthetic-name-getter-secret");
       },
     });
     expect(serializeBoundaryError(throwingName)).toEqual({
-      name: "UnserializableError",
+      name: "Error",
     });
 
     const hostile = new Proxy(
       {},
       {
         ownKeys() {
+          callbacks++;
           throw new Error("synthetic-proxy-secret");
         },
       },
@@ -169,9 +172,10 @@ describe("boundary error serialization", () => {
     }
     expect(
       serializeBoundaryError(Object.assign(new Error("synthetic"), { statusCode: hostile })),
-    ).toEqual({ name: "UnserializableError" });
+    ).toEqual({ name: "Error", statusCode: SENTINEL });
     expect(
       serializeBoundaryError(Object.assign(new Error("synthetic"), { diagnostic: hostile })),
-    ).toEqual({ name: "UnserializableError" });
+    ).toEqual({ name: "Error", diagnostic: SENTINEL });
+    expect(callbacks).toBe(0);
   });
 });

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -454,7 +454,7 @@ describe.skipIf(!hasLoopback)("redaction over real RPC and CLI", () => {
         },
         {
           failure: hostileError(),
-          data: { name: "UnserializableError" },
+          data: { name: "Error", statusCode: "[redacted]" },
         },
       ]) {
         failure = variant.failure;

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -315,7 +315,7 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
 
     for (const variant of [
       { failure: NON_ERROR_SECRET, data: { name: "NonError" } },
-      { failure: hostileError(), data: { name: "UnserializableError" } },
+      { failure: hostileError(), data: { name: "Error", statusCode: "[redacted]" } },
     ]) {
       failure = variant.failure;
       const stdout = capture();

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -331,8 +331,11 @@ describe("StoreRuntime", () => {
       level: "warn",
       component: "sync",
       event: "analytics_curve_refresh_failed",
-      err: { name: "Error", message: "curve adapter failed", authorization: "[redacted]" },
+      err: { name: "Error", authorization: "[redacted]" },
     });
+    expect(raw).not.toContain("curve adapter failed");
+    expect(JSON.parse(raw.trim()).err).not.toHaveProperty("message");
+    expect(JSON.parse(raw.trim()).err).not.toHaveProperty("stack");
     expect(raw).not.toContain("SECRET-CURVE-KEY");
     expect(raw).not.toContain("Basic SECRET");
     await runtime.close();
@@ -403,10 +406,12 @@ describe("StoreRuntime", () => {
       event: "scheduled_store_refresh_failed",
       err: {
         name: "Error",
-        message: "capture failed",
         authorization: "[redacted]",
       },
     });
+    expect(raw).not.toContain("capture failed");
+    expect(JSON.parse(lines[0]!).err).not.toHaveProperty("message");
+    expect(JSON.parse(lines[0]!).err).not.toHaveProperty("stack");
     expect(raw).not.toContain("SECRET-API-KEY");
     expect(raw).not.toContain("Bearer SECRET");
     expect(runtime.currentSnapshot()).toBe(produced);

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -1,6 +1,14 @@
-import { appendFileSync, mkdirSync, renameSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
+import { redactObject, REDACTION_SENTINEL } from "./redact.js";
 import { type LogLevel, normalizeLogLevel, isLevelEnabled } from "./levels.js";
 
 export const LOG_FILE = "log.jsonl";
@@ -29,7 +37,7 @@ export interface LogInput {
 }
 
 export interface RootLogger {
-  emit(level: LogLevel, line: LogInput): void;
+  emit(level: LogLevel, line: LogInput, fields?: Record<string, unknown>): void;
 }
 
 export interface RootLoggerOptions {
@@ -112,14 +120,35 @@ export function createRootLogger(dataDir: string, options: RootLoggerOptions = {
   }
 
   return {
-    emit(level, line) {
-      const record: LogLine = {
-        ...line,
-        ts: new Date(now()).toISOString(),
-        level,
-        component: line.component,
-        event: line.event,
-      };
+    emit(level, line, fields) {
+      let record: LogLine;
+      try {
+        const sanitized = redactObject(line);
+        const extra = redactObject(fields);
+        const safeLine = sanitized !== null && typeof sanitized === "object" ? sanitized : {};
+        const safeFields = extra !== null && typeof extra === "object" ? extra : {};
+        const component =
+          "component" in safeLine && typeof safeLine.component === "string"
+            ? safeLine.component
+            : REDACTION_SENTINEL;
+        const event =
+          "event" in safeLine && typeof safeLine.event === "string"
+            ? safeLine.event
+            : REDACTION_SENTINEL;
+        record = {
+          ...safeFields,
+          ...safeLine,
+          ts: new Date(now()).toISOString(),
+          level,
+          component,
+          event,
+        };
+        delete record.err;
+        const error = Object.getOwnPropertyDescriptor(safeLine, "err");
+        if (error && "value" in error) record.err = error.value;
+      } catch {
+        return;
+      }
 
       if (isLevelEnabled(level, threshold)) {
         const sink = consoleSink(level);

--- a/packages/core/src/logging/redact.ts
+++ b/packages/core/src/logging/redact.ts
@@ -1,9 +1,37 @@
+import { isNativeError, isProxy } from "node:util/types";
+
 export const REDACTION_SENTINEL = "[redacted]";
 
-// Substring, case-insensitive: a key like `x-api-key` or `Authorization` matches.
-const DENYLIST_KEY_SUBSTRINGS = ["authorization", "api_key", "apikey", "token", "cookie"];
-
-// Bounded so a hostile or cyclic object can never hang the logger.
+const DENYLIST_KEY_SUBSTRINGS = [
+  "authorization",
+  "api_key",
+  "api-key",
+  "apikey",
+  "token",
+  "cookie",
+  "password",
+  "secret",
+];
+const DROP_FIELDS = new Set(["requestBodyValues", "responseBody", "payload", "body", "data"]);
+const FREE_TEXT_FIELD = /(?:message|stack|url|uri)$/i;
+const ERROR_NAMES = new Set([
+  "Error",
+  "TypeError",
+  "RangeError",
+  "SyntaxError",
+  "ReferenceError",
+  "URIError",
+  "EvalError",
+  "AggregateError",
+  "AbortError",
+  "APICallError",
+  "SecretResolutionError",
+]);
+const ERROR_CODES = new Set([
+  "ENOENT", "EACCES", "EPERM", "EEXIST", "EROFS", "ENOSPC", "EIO", "EINVAL", "ENOTDIR",
+  "ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "ENOTFOUND", "EAI_AGAIN", "ABORT_ERR",
+  "EMPTY", "EXIT_NONZERO", "TIMEOUT", "OVERFLOW",
+]);
 const MAX_REDACT_DEPTH = 6;
 
 export function keyIsDenied(key: string): boolean {
@@ -11,28 +39,67 @@ export function keyIsDenied(key: string): boolean {
   return DENYLIST_KEY_SUBSTRINGS.some((needle) => lower.includes(needle));
 }
 
-// Walks an object/array, replacing the value of any denylisted key with a
-// sentinel (kept, not deleted, so the shape stays legible). Cycles are tracked
-// via a seen-set and depth is capped; both yield a sentinel rather than recurse
-// forever. Primitives pass through untouched — the key denylist is the contract,
-// not a value-shape scanner.
-export function redactObject(value: unknown): unknown {
-  return redactAt(value, 0, new WeakSet<object>());
+function redactText(value: string): string {
+  return value
+    .replace(/\b[a-z][a-z\d+.-]*:\/\/[^\s"'<>]+/gi, REDACTION_SENTINEL)
+    .replace(/\b(?:Bearer|Basic)\s+[^\s,;]+/gi, REDACTION_SENTINEL)
+    .replace(/\b(?:sk-|gh[pousr]_|github_pat_)[a-z\d_-]+/gi, REDACTION_SENTINEL);
 }
 
-function redactAt(value: unknown, depth: number, seen: WeakSet<object>): unknown {
-  if (value === null || typeof value !== "object") return value;
-  if (depth >= MAX_REDACT_DEPTH) return REDACTION_SENTINEL;
-  if (seen.has(value)) return REDACTION_SENTINEL;
+export function redactObject(value: unknown): unknown {
+  try {
+    return redactAt(value, 0, new WeakSet<object>());
+  } catch {
+    return REDACTION_SENTINEL;
+  }
+}
+
+function redactAt(value: unknown, depth: number, seen: WeakSet<object>, errorText = false): unknown {
+  if (typeof value === "string") return errorText ? REDACTION_SENTINEL : redactText(value);
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : REDACTION_SENTINEL;
+  if (typeof value !== "object") return REDACTION_SENTINEL;
+  if (isProxy(value) || depth >= MAX_REDACT_DEPTH || seen.has(value)) return REDACTION_SENTINEL;
   seen.add(value);
 
+  const descriptors = Object.getOwnPropertyDescriptors(value);
   if (Array.isArray(value)) {
-    return value.map((item) => redactAt(item, depth + 1, seen));
+    const out: unknown[] = [];
+    for (let index = 0; index < Math.min(value.length, 64); index++) {
+      const descriptor = descriptors[String(index)];
+      out.push(
+        descriptor && "value" in descriptor
+          ? redactAt(descriptor.value, depth + 1, seen, errorText)
+          : REDACTION_SENTINEL,
+      );
+    }
+    if (value.length > 64) out.push(REDACTION_SENTINEL);
+    return out;
   }
 
-  const out: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    out[key] = keyIsDenied(key) ? REDACTION_SENTINEL : redactAt(child, depth + 1, seen);
+  const out: Record<string, unknown> = Object.create(null);
+  const isError = isNativeError(value);
+  if (isError) out.name = "Error";
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    if (DROP_FIELDS.has(key) || key === "toJSON") continue;
+    if (!descriptor.enumerable && !(isError && ["name", "code", "statusCode"].includes(key)))
+      continue;
+    if (isError && key === "name") {
+      out.name =
+        "value" in descriptor && ERROR_NAMES.has(descriptor.value) ? descriptor.value : "Error";
+      continue;
+    }
+    if (isError && key === "code" && "value" in descriptor && ERROR_CODES.has(descriptor.value)) {
+      out.code = descriptor.value;
+      continue;
+    }
+    out[key] =
+      keyIsDenied(key) ||
+      FREE_TEXT_FIELD.test(key) ||
+      (key === "err" && !isNativeError(descriptor.value)) ||
+      !("value" in descriptor)
+        ? REDACTION_SENTINEL
+        : redactAt(descriptor.value, depth + 1, seen, errorText || isError);
   }
   return out;
 }

--- a/packages/core/src/logging/redact.ts
+++ b/packages/core/src/logging/redact.ts
@@ -79,16 +79,17 @@ function redactAt(value: unknown, depth: number, seen: WeakSet<object>, errorTex
 
   const out: Record<string, unknown> = Object.create(null);
   const isError = isNativeError(value);
-  if (isError) out.name = "Error";
+  if (isError) {
+    const prototype = Object.getPrototypeOf(value);
+    const name = descriptors.name ?? (prototype !== null && !isProxy(prototype)
+      ? Object.getOwnPropertyDescriptor(prototype, "name") : undefined);
+    out.name = name && "value" in name && ERROR_NAMES.has(name.value) ? name.value : "Error";
+  }
   for (const [key, descriptor] of Object.entries(descriptors)) {
     if (DROP_FIELDS.has(key) || key === "toJSON") continue;
     if (!descriptor.enumerable && !(isError && ["name", "code", "statusCode"].includes(key)))
       continue;
-    if (isError && key === "name") {
-      out.name =
-        "value" in descriptor && ERROR_NAMES.has(descriptor.value) ? descriptor.value : "Error";
-      continue;
-    }
+    if (isError && key === "name") continue;
     if (isError && key === "code" && "value" in descriptor && ERROR_CODES.has(descriptor.value)) {
       out.code = descriptor.value;
       continue;

--- a/packages/core/src/logging/serialize-error.ts
+++ b/packages/core/src/logging/serialize-error.ts
@@ -1,64 +1,15 @@
-import { redactObject, REDACTION_SENTINEL, keyIsDenied } from "./redact.js";
-
-// Fields on a provider/SDK error that carry the outbound prompt or response
-// body — the conversation, the memory-bearing system prompt, the athlete's
-// reply text. They are NEVER copied onto the serialized output; this is what
-// makes the log file born redacted rather than redacted by a later follow-up.
-const DROP_FIELDS = new Set([
-  "requestBodyValues",
-  "responseBody",
-  "payload",
-  "body",
-  "data",
-]);
-
-// Provider/SDK error fields that are safe to keep for diagnosis.
-const KEEP_FIELDS = ["statusCode", "url", "provider"] as const;
-
-const MAX_STACK_CHARS = 1000;
-
-function trimStack(stack: unknown): string | undefined {
-  if (typeof stack !== "string") return undefined;
-  return stack.length > MAX_STACK_CHARS ? stack.slice(0, MAX_STACK_CHARS) : stack;
-}
+import { isNativeError, isProxy } from "node:util/types";
+import { redactObject } from "./redact.js";
 
 export function serializeError(err: unknown): Record<string, unknown> {
-  // Never throw: a circular or exotic error must yield a sentinel object, not
-  // crash the logger and so break a chat turn, a sync tick, or startup.
   try {
-    if (!(err instanceof Error)) {
-      return { value: String(err) };
+    if (isProxy(err)) return { name: "UnserializableError" };
+    if (!isNativeError(err)) return { name: "NonError" };
+    const out = redactObject(err);
+    if (out !== null && typeof out === "object" && !Array.isArray(out)) {
+      return { ...out };
     }
-
-    const out: Record<string, unknown> = {
-      name: err.name,
-      message: err.message,
-    };
-
-    const stack = trimStack(err.stack);
-    if (stack !== undefined) out.stack = stack;
-
-    const record = err as unknown as Record<string, unknown>;
-    for (const field of KEEP_FIELDS) {
-      const v = record[field];
-      if (v !== undefined) out[field] = v;
-    }
-
-    // Surviving own-enumerable fields (not the dropped payload class) are run
-    // through the recursive key denylist so a nested authorization/token/cookie
-    // never lands in the file.
-    for (const [key, value] of Object.entries(record)) {
-      if (DROP_FIELDS.has(key)) continue;
-      if (key === "name" || key === "message" || key === "stack") continue;
-      if ((KEEP_FIELDS as readonly string[]).includes(key)) continue;
-      if (keyIsDenied(key)) {
-        out[key] = REDACTION_SENTINEL;
-        continue;
-      }
-      out[key] = redactObject(value);
-    }
-
-    return out;
+    return { name: "UnserializableError" };
   } catch {
     return { name: "UnserializableError" };
   }

--- a/packages/core/src/logging/subsystem.ts
+++ b/packages/core/src/logging/subsystem.ts
@@ -1,6 +1,5 @@
 import { type LogLevel } from "./levels.js";
 import { createRootLogger, type RootLogger, type RootLoggerOptions } from "./logger.js";
-import { serializeError } from "./serialize-error.js";
 
 type Fields = Record<string, unknown>;
 
@@ -23,8 +22,7 @@ function emitErrBearing(
   err?: unknown,
   fields?: Fields,
 ): void {
-  const errFields = err === undefined ? {} : { err: serializeError(err) };
-  root.emit(level, { component, event, ...errFields, ...fields });
+  root.emit(level, err === undefined ? { component, event } : { component, event, err }, fields);
 }
 
 export function createSubsystemLogger(
@@ -35,10 +33,10 @@ export function createSubsystemLogger(
   const root = createRootLogger(dataDir, options);
   return {
     debug(event, fields) {
-      root.emit("debug", { component, event, ...fields });
+      root.emit("debug", { component, event }, fields);
     },
     info(event, fields) {
-      root.emit("info", { component, event, ...fields });
+      root.emit("info", { component, event }, fields);
     },
     warn(event, err, fields) {
       emitErrBearing(root, "warn", component, event, err, fields);

--- a/packages/core/src/process-guard.ts
+++ b/packages/core/src/process-guard.ts
@@ -2,7 +2,7 @@ import { writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 import { getCoachHome } from "./coach-home.js";
-import { createSubsystemLogger, serializeError } from "./logging/index.js";
+import { createSubsystemLogger } from "./logging/index.js";
 
 const BREADCRUMB_FILE = "last-run.json";
 
@@ -55,9 +55,7 @@ function markUnclean(dataDir: string): void {
 function writeLastGaspLine(dataDir: string, event: string, err: unknown): void {
   try {
     const log = createSubsystemLogger("agent", dataDir);
-    // Delegate redaction to the substrate's serializeError (the single
-    // redaction surface) rather than naming any payload field here.
-    log.error(event, undefined, { err: serializeError(err) });
+    log.error(event, err);
   } catch {
     // The logger never throws by contract, but the handler stays defensive.
   }

--- a/packages/core/src/reference/audit/writer.ts
+++ b/packages/core/src/reference/audit/writer.ts
@@ -8,6 +8,7 @@
  * session. Ports from the Reference layer's upstream protocol. See `NOTICE.md`
  * for license attribution.
  */
+import { serializeError } from "../../logging/serialize-error.js";
 import { open, mkdir } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
@@ -20,10 +21,7 @@ import {
 let auditWriteFailureCount = 0;
 let escalated = false;
 
-export async function writeAuditEntry(
-  binaryName: string,
-  entry: AuditLogEntry,
-): Promise<void> {
+export async function writeAuditEntry(binaryName: string, entry: AuditLogEntry): Promise<void> {
   const path = join(referenceDataDir(binaryName), ".audit.jsonl");
   const line = JSON.stringify(entry) + "\n";
 
@@ -41,7 +39,7 @@ export async function writeAuditEntry(
 }
 
 function handleFailure(err: unknown): void {
-  console.warn(`Reference: audit log write failed: ${formatError(err)}`);
+  console.warn(`Reference: audit log write failed: ${JSON.stringify(serializeError(err))}`);
   auditWriteFailureCount++;
   if (auditWriteFailureCount >= 10 && !escalated) {
     escalated = true;
@@ -64,9 +62,4 @@ export function computeResponseHash(
 export function __resetAuditFailureState(): void {
   auditWriteFailureCount = 0;
   escalated = false;
-}
-
-function formatError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
 }

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -22,6 +22,7 @@ import {
   type DroppedActivities,
 } from "@enduragent/coach-contract";
 import { serializeError } from "../../logging/serialize-error.js";
+import { redactObject } from "../../logging/redact.js";
 import {
   REFERENCE_CAPTURE_STREAM_LIMIT,
   REFERENCE_CAPTURE_STREAM_TYPES,
@@ -179,11 +180,9 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
 }
 
 function renderEndpointError(error: unknown): string {
-  const serializable =
-    error !== null && typeof error === "object" && !(error instanceof Error)
-      ? Object.assign(new Error("Reference endpoint failed"), error)
-      : error;
-  return JSON.stringify(serializeError(serializable));
+  return JSON.stringify(
+    error !== null && typeof error === "object" ? redactObject(error) : serializeError(error),
+  );
 }
 
 function shiftedDate(value: string, days: number): string {
@@ -270,9 +269,9 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
         continue;
       }
       if (
-        !isPlanningEventCategory(parsed.data.category)
-        || (parsed.data.category === "WORKOUT"
-          && (parsed.data.type == null || !cyclingSportTypes.has(parsed.data.type)))
+        !isPlanningEventCategory(parsed.data.category) ||
+        (parsed.data.category === "WORKOUT" &&
+          (parsed.data.type == null || !cyclingSportTypes.has(parsed.data.type)))
       ) {
         continue;
       }
@@ -315,9 +314,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
       );
     }
   }
-  const restrictionsFor = (
-    rows: readonly Record<string, unknown>[],
-  ): ActivityRestriction[] => {
+  const restrictionsFor = (rows: readonly Record<string, unknown>[]): ActivityRestriction[] => {
     const counts = new Map<string, number>();
     for (const row of rows) {
       if (row.source !== SOURCE_RESTRICTED_PROVIDER) continue;
@@ -420,9 +417,10 @@ async function fetchStreams(
     try {
       normalized = normalizeStreams(result.value);
     } catch (error) {
-      const reason = error instanceof StreamNormalizationError
-        ? "duplicate descriptor types"
-        : "normalization rejected input";
+      const reason =
+        error instanceof StreamNormalizationError
+          ? "duplicate descriptor types"
+          : "normalization rejected input";
       log(`Reference: streams shape rejected for an activity: ${reason}`);
       continue;
     }

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -1,3 +1,4 @@
+import { serializeError } from "./logging/serialize-error.js";
 import { parseArgs } from "node:util";
 import { createInterface as createReadlineInterface } from "node:readline";
 import { writeSync } from "node:fs";
@@ -304,9 +305,7 @@ export function makeBotShutdown(deps: BotShutdownDeps): () => Promise<void> {
       await deps.closePrepared?.();
       deps.markCleanShutdown({ dataDir: deps.dataDir });
     } catch (err) {
-      console.error(
-        `Shutdown encountered an error: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      console.error(`Shutdown encountered an error: ${JSON.stringify(serializeError(err))}`);
     } finally {
       deps.exit(0);
     }
@@ -322,7 +321,7 @@ export async function runStartupHook(
     await hook(memory);
   } catch (err) {
     console.warn(
-      `Startup hook failed: ${err instanceof Error ? err.message : String(err)}. Continuing with binary startup.`,
+      `Startup hook failed: ${JSON.stringify(serializeError(err))}. Continuing with binary startup.`,
     );
   }
 }

--- a/packages/core/src/secrets/resolve.ts
+++ b/packages/core/src/secrets/resolve.ts
@@ -14,16 +14,10 @@ export async function resolveSecretRef(ref: SecretRef): Promise<string> {
 function resolveEnvRef(name: string): string {
   const value = process.env[name];
   if (value === undefined) {
-    throw new SecretResolutionError(
-      "ENOENT",
-      `Secret env var '${name}' is not set.`,
-    );
+    throw new SecretResolutionError("ENOENT", `Secret env var '${name}' is not set.`);
   }
   if (value === "") {
-    throw new SecretResolutionError(
-      "EMPTY",
-      `Secret env var '${name}' is set but empty.`,
-    );
+    throw new SecretResolutionError("EMPTY", `Secret env var '${name}' is set but empty.`);
   }
   return value;
 }
@@ -47,7 +41,6 @@ export async function _resolveSecretRefWithOverrides(
 
     let settled = false;
     let stdout = "";
-    let stderr = "";
     let stdoutBytes = 0;
     let stderrBytes = 0;
     let timedOut = false;
@@ -80,7 +73,6 @@ export async function _resolveSecretRefWithOverrides(
           }
           return;
         }
-        stderr += text;
       }
     };
 
@@ -99,7 +91,7 @@ export async function _resolveSecretRefWithOverrides(
         reject(
           new SecretResolutionError(
             "EXIT_NONZERO",
-            `Secret resolver command '${cmd}' failed to spawn: ${err.message}`,
+            `Secret resolver command '${cmd}' failed to spawn. Check its executable path and access permissions.`,
           ),
         );
       }
@@ -132,11 +124,10 @@ export async function _resolveSecretRefWithOverrides(
         return;
       }
       if (code !== 0) {
-        const tail = stderr.slice(-200).trim();
         reject(
           new SecretResolutionError(
             "EXIT_NONZERO",
-            `Secret resolver '${cmd}' exited with code ${code}${tail ? `: ${tail}` : "."}`,
+            `Secret resolver '${cmd}' exited with code ${code}. Check the secret helper configuration and access permissions.`,
           ),
         );
         return;
@@ -145,10 +136,7 @@ export async function _resolveSecretRefWithOverrides(
       const trimmed = stdout.replace(/\r?\n$/, "");
       if (trimmed.length === 0) {
         reject(
-          new SecretResolutionError(
-            "EMPTY",
-            `Secret resolver '${cmd}' produced empty output.`,
-          ),
+          new SecretResolutionError("EMPTY", `Secret resolver '${cmd}' produced empty output.`),
         );
         return;
       }

--- a/packages/core/tests/logging.test.ts
+++ b/packages/core/tests/logging.test.ts
@@ -183,6 +183,19 @@ describe("never throws on an unwritable target", () => {
 });
 
 describe("serializeError unit cases", () => {
+  it.each([TypeError, RangeError, SyntaxError])("keeps the safe built-in error name", (ErrorType) => {
+    expect(serializeError(new ErrorType("marker"))).toEqual({ name: ErrorType.name });
+  });
+
+  it("does not inspect a proxied error prototype", () => {
+    const callback = vi.fn(() => { throw new Error("marker"); });
+    const error = Object.setPrototypeOf(new Error("marker"), new Proxy(TypeError.prototype, {
+      get: callback,
+      getOwnPropertyDescriptor: callback,
+    }));
+    expect(serializeError(error)).toEqual({ name: "Error" });
+    expect(callback).not.toHaveBeenCalled();
+  });
   it("keeps name without message or stack for a plain Error", () => {
     const out = serializeError(new Error("plain failure"));
     expect(out.name).toBe("Error");

--- a/packages/core/tests/logging.test.ts
+++ b/packages/core/tests/logging.test.ts
@@ -72,7 +72,7 @@ describe("subsystem logger — file sink", () => {
 });
 
 describe("born-redacted invariant", () => {
-  it("redacts payload/requestBodyValues/responseBody and denylisted keys while keeping name/message/statusCode", () => {
+  it("redacts payload/requestBodyValues/responseBody and denylisted keys while keeping name/statusCode", () => {
     const err = Object.assign(new Error("upstream blew up"), {
       name: "APICallError",
       statusCode: 429,
@@ -98,7 +98,7 @@ describe("born-redacted invariant", () => {
     expect(raw).not.toContain("sk-SECRET");
 
     expect(raw).toContain("APICallError");
-    expect(raw).toContain("upstream blew up");
+    expect(raw).not.toContain("upstream blew up");
     expect(raw).toContain("429");
   });
 });
@@ -183,15 +183,16 @@ describe("never throws on an unwritable target", () => {
 });
 
 describe("serializeError unit cases", () => {
-  it("keeps name and message for a plain Error", () => {
+  it("keeps name without message or stack for a plain Error", () => {
     const out = serializeError(new Error("plain failure"));
     expect(out.name).toBe("Error");
-    expect(out.message).toBe("plain failure");
+    expect(out).not.toHaveProperty("message");
+    expect(out).not.toHaveProperty("stack");
   });
 
-  it("returns { value } for a non-Error without deep inspection", () => {
+  it("returns a fixed name for a non-Error without deep inspection", () => {
     const out = serializeError({ not: "an error" });
-    expect(out).toEqual({ value: "[object Object]" });
+    expect(out).toEqual({ name: "NonError" });
   });
 
   it("does not throw and yields a sentinel for a circular error", () => {
@@ -202,7 +203,7 @@ describe("serializeError unit cases", () => {
       out = serializeError(err);
     }).not.toThrow();
     expect(out.name).toBe("Error");
-    expect(out.message).toBe("cyclic");
+    expect(out).not.toHaveProperty("message");
     // The circular field is replaced by a sentinel, never recursed into.
     expect(JSON.stringify(out)).toContain("[redacted]");
   });
@@ -221,5 +222,83 @@ describe("serializeError unit cases", () => {
     expect(out).not.toHaveProperty("requestBodyValues");
     expect(out).not.toHaveProperty("responseBody");
     expect(out).not.toHaveProperty("payload");
+  });
+});
+
+describe("final diagnostic sinks", () => {
+  it("sanitizes raw root fields, nested errors and URL text before persistence and console output", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const root = createRootLogger(dir);
+    root.emit("error", {
+      component: "agent",
+      event: "request_failed https://marker@example.invalid/marker?token=marker#marker",
+      err: Object.assign(new Error("marker"), { statusCode: 503, code: "ECONNRESET", path: "marker", cause: new Error("marker") }),
+      nested: [{ apiKey: "marker", message: "marker", url: "marker" }],
+      note: "Bearer marker",
+      requestUrl: "marker",
+    });
+    const raw = readLines(dir).join("\n");
+    expect(raw).not.toContain("marker");
+    expect(JSON.stringify(consoleSpy.mock.calls)).not.toContain("marker");
+    expect(JSON.parse(raw).err).toMatchObject({
+      name: "Error",
+      statusCode: 503,
+      code: "ECONNRESET",
+    });
+  });
+
+  it.each(["debug", "info", "warn", "error"] as const)("protects canonical %s fields", (level) => {
+    const log = createSubsystemLogger("agent", dir, { threshold: "error" });
+    const fields = {
+      component: "marker",
+      event: "marker",
+      err: { token: "marker" },
+      ts: "marker",
+      level: "marker",
+    };
+    if (level === "warn" || level === "error")
+      log[level]("request_failed", new Error("marker"), fields);
+    else log[level]("request_failed", fields);
+    const raw = readLines(dir).join("\n");
+    expect(raw).not.toContain("marker");
+    expect(JSON.parse(raw)).toMatchObject({ component: "agent", event: "request_failed", level });
+  });
+
+  it("never invokes field getters, proxy traps, toJSON or error coercion", () => {
+    const callback = vi.fn(() => {
+      throw new Error("marker");
+    });
+    const hostile = new Proxy({}, { ownKeys: callback, get: callback });
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    const fields = Object.defineProperty(
+      { hostile, revoked: revoked.proxy, toJSON: callback, bigint: 1n },
+      "getter",
+      { enumerable: true, get: callback },
+    );
+    const log = createSubsystemLogger("agent", dir);
+    expect(() => log.error("request_failed", { toString: callback }, fields)).not.toThrow();
+    expect(() => log.info("request_failed", hostile)).not.toThrow();
+    expect(() =>
+      createRootLogger(dir).emit(
+        "info",
+        Object.defineProperty({ component: "agent", event: "request_failed" }, "getter", {
+          enumerable: true,
+          get: callback,
+        }),
+      ),
+    ).not.toThrow();
+    expect(callback).not.toHaveBeenCalled();
+    expect(readLines(dir)).toHaveLength(3);
+    expect(readLines(dir).join("\n")).not.toContain("marker");
+  });
+
+  it("does not throw if timestamp generation fails", () => {
+    const root = createRootLogger(dir, {
+      now: () => {
+        throw new Error("marker");
+      },
+    });
+    expect(() => root.emit("info", { component: "agent", event: "request_failed" })).not.toThrow();
   });
 });

--- a/packages/core/tests/process-guard.test.ts
+++ b/packages/core/tests/process-guard.test.ts
@@ -100,8 +100,8 @@ describe("installCrashHandlers", () => {
     expect(line.event).toBe("uncaught_exception");
     const err = line.err as Record<string, unknown>;
     expect(err.name).toBe("Error");
-    expect(err.message).toBe("boom");
-    expect(err.stack).toBeDefined();
+    expect(err).not.toHaveProperty("message");
+    expect(err).not.toHaveProperty("stack");
     expect("requestBodyValues" in err).toBe(false);
     expect("responseBody" in err).toBe(false);
     expect("payload" in err).toBe(false);

--- a/packages/core/tests/reference-audit-writer.test.ts
+++ b/packages/core/tests/reference-audit-writer.test.ts
@@ -136,6 +136,8 @@ describe("writeAuditEntry — best-effort failure handling", () => {
 
     await expect(writeAuditEntry(BINARY, makeEntry())).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(tempDir);
+    expect(JSON.stringify(warnSpy.mock.calls)).toContain("EEXIST");
   });
 
   it("fires console.error EXACTLY ONCE after 10 cumulative failures", async () => {

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -546,8 +546,9 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       throttleMs: 0,
       log: (message) => logs.push(message),
     });
-    expect(logs[0]).toContain('"message":"synthetic unauthorized"');
-    expect(logs[0]).toContain('"stack":');
+    expect(logs[0]).not.toContain("synthetic unauthorized");
+    expect(logs[0]).not.toContain('"stack":');
+    expect(logs[0]).toContain('"status":401');
     expect(logs[0]).toContain('"kind":"Http"');
     expect(logs[0]).not.toContain("[object Object]");
     expect(result.fetchErrors?.[0]?.detail).toBe(

--- a/packages/core/tests/run-binary-shutdown.test.ts
+++ b/packages/core/tests/run-binary-shutdown.test.ts
@@ -89,14 +89,17 @@ describe("makeBotShutdown — graceful shutdown ordering", () => {
   it("a throw in stop() still reaches process.exit (shutdown never hangs)", async () => {
     const { shutdown, rec } = makeDeps({
       stop: async () => {
-        throw new Error("stop failed");
+        throw Object.assign(new Error("synthetic-stop-secret"), { code: "EIO" });
       },
     });
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await shutdown();
 
     expect(rec.exit).toHaveBeenCalledWith(0);
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("synthetic-stop-secret");
+    expect(JSON.stringify(errorSpy.mock.calls)).toContain("EIO");
+    errorSpy.mockRestore();
   });
 
   it("stops the selected timer, closes Reference, then closes prepared composition exactly once", async () => {

--- a/packages/core/tests/run-startup-hook.test.ts
+++ b/packages/core/tests/run-startup-hook.test.ts
@@ -32,7 +32,8 @@ describe("runStartupHook", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const hook = vi.fn().mockRejectedValue(new Error("boom"));
     await expect(runStartupHook(stubMemory, hook)).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("boom"));
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("boom");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"name":"Error"'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Continuing"));
     warnSpy.mockRestore();
   });
@@ -41,7 +42,8 @@ describe("runStartupHook", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const hook = vi.fn().mockRejectedValue("string error");
     await expect(runStartupHook(stubMemory, hook)).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("string error"));
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("string error");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("NonError"));
     warnSpy.mockRestore();
   });
 });

--- a/packages/core/tests/secrets/resolve.test.ts
+++ b/packages/core/tests/secrets/resolve.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import {
-  _resolveSecretRefWithOverrides,
-  resolveSecretRef,
-} from "../../src/secrets/resolve.js";
+import { _resolveSecretRefWithOverrides, resolveSecretRef } from "../../src/secrets/resolve.js";
 import { SecretResolutionError } from "../../src/secrets/types.js";
 
 function expectRejection(p: Promise<unknown>): Promise<SecretResolutionError> {
@@ -66,7 +63,7 @@ describe("resolveSecretRef", () => {
     expect(err.code).toBe("EMPTY");
   });
 
-  it("throws EXIT_NONZERO with stderr tail in message", async () => {
+  it("keeps the exit code and guidance without helper stderr", async () => {
     const err = await expectRejection(
       resolveSecretRef({
         source: "exec",
@@ -76,7 +73,8 @@ describe("resolveSecretRef", () => {
     );
     expect(err).toBeInstanceOf(SecretResolutionError);
     expect(err.code).toBe("EXIT_NONZERO");
-    expect(err.message).toContain("boom");
+    expect(err.message).not.toContain("boom");
+    expect(err.message).toContain("Check the secret helper configuration");
     expect(err.message).toContain("2");
   });
 


### PR DESCRIPTION
Diagnostics could persist raw error text and credential-bearing URLs, caller fields could replace protected log fields, and failing secret helpers printed their stderr during CLI startup. Sanitize both log sinks, read data properties without invoking getters or proxy traps, preserve safe error codes and statuses, and show fixed helper failure guidance. Startup, shutdown and Reference diagnostics use the same safe error serialization.

User-facing: Diagnostic logs hide sensitive error text and credential-bearing URLs. Secret helper failures retain their exit code and setup guidance without exposing helper output.

Validation:
- Fresh frozen-lockfile install; rebuilt Core, desktop dependencies, renderer, desktop and cycling CLI.
- 148 tests passed across logging, secret resolution, crash handling, startup/shutdown, Reference, daemon serialization, real isolated RPC/CLI transport and desktop startup.
- Core TypeScript check, focused lint, fixture privacy and changeset validation passed.
- Required isolated autoreviews passed with no blocking findings, including the operator-authorized additional test-only correction for StoreRuntime expectations.
- Packed and installed the CLI in a separate temporary directory. Version/help passed; synthetic helper stderr was absent from startup output; an injected synthetic uncaught exception wrote a 0600 log with EIO and redacted credentials, with no marker in console or log bytes.

This is prospective redaction. The packed verification used a local build with the unchanged manifest version; no release was published. Opaque secrets under ordinary non-error fields remain a caller responsibility.
