### PR TITLE
fix(ci): reuse locked dependencies for container build

### DIFF
--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -48,7 +48,7 @@ COPY LICENSE NOTICE.md ./
 
 # Only build what cycling-coach needs (`...` = the package + all its deps in
 # topo order). Packages outside the closure aren't even copied into the image.
-RUN pnpm --filter cycling-coach... build
+RUN pnpm --config.verify-deps-before-run=false --filter cycling-coach... build
 
 RUN pnpm --filter cycling-coach --prod deploy /app/runtime-bundle \
     && cp packages/cycling-coach/package.json /app/runtime-bundle/package.json

--- a/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
+++ b/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
@@ -70,7 +70,7 @@ describe("Docker image supply-chain guards", () => {
   it("copies canonical legal inputs before building and preserves runtime copies", () => {
     const dockerfile = readFileSync(resolve(repoRoot, "packages/cycling-coach/Dockerfile"), "utf8");
     const builderCopy = "COPY LICENSE NOTICE.md ./";
-    const build = "RUN pnpm --filter cycling-coach... build";
+    const build = "RUN pnpm --config.verify-deps-before-run=false --filter cycling-coach... build";
     const runtimeCopy = "COPY --chown=root:root LICENSE NOTICE.md ./";
 
     expect(dockerfile.indexOf(builderCopy)).toBeGreaterThan(-1);
@@ -81,7 +81,9 @@ describe("Docker image supply-chain guards", () => {
   it("copies a manifest and a source tree for every workspace package cycling-coach needs", () => {
     const dockerfile = readFileSync(resolve(repoRoot, "packages/cycling-coach/Dockerfile"), "utf8");
     const install = dockerfile.indexOf("RUN pnpm install --filter cycling-coach...");
-    const build = dockerfile.indexOf("RUN pnpm --filter cycling-coach... build");
+    const build = dockerfile.indexOf(
+      "RUN pnpm --config.verify-deps-before-run=false --filter cycling-coach... build",
+    );
     const closure = workspaceClosure("cycling-coach");
 
     expect(closure).toContain("packages/engine");


### PR DESCRIPTION
The main container build fails after its frozen, filtered install. pnpm 11 checks the intentionally partial workspace again before running the build, then launches an unfiltered install that fails with `ERR_PNPM_UNUSED_PATCH` for `fit-file-parser@3.0.2`.

Disable that automatic dependency recheck for the Docker builder's build invocation. Dependencies still come from the existing explicit `pnpm install --filter cycling-coach... --frozen-lockfile`; the lockfile, patch policy, package versions, runtime image and publication workflow are unchanged.

The failure was observed in main image run [33945980299](https://github.com/yerzhansa/enduragent/actions/runs/33945980299). A full local Linux ARM64 Docker build now succeeds with a fresh filtered frozen-lockfile install. Network-disabled runtime checks pass for the documented help command, UID 1000, an unwritable application bundle and a writable ephemeral data directory. No credentials or host data were mounted. The exact Dockerfile build is the focused regression proof for this mechanical invocation change.

The documented `version` command also passes. The existing Dockerfile supply-chain guard suite now matches the updated build invocation; all seven tests and their focused TypeScript check pass. The initial CI run exposed the two stale command matches, which are corrected without changing the production fix.

The full Linux AMD64 build and the same network-disabled actual-entrypoint checks also pass locally. The final permitted isolated Codex review of the complete Dockerfile and test diff is clean with no accepted/actionable findings.

The corrected CI run passes, including root checks, Linux workspace tests and desktop E2E, native macOS packaged acceptance, and Windows NSIS install/test/uninstall.

This is a delivery-tooling prerequisite and must remain unmerged for operator approval. No image is published by this change preparation.
