### PR TITLE
ci(release): stage npm publications from protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,27 @@
 name: Release
 
-# Tag-triggered, per-binary release. Each binary published from this monorepo
-# has its own tag namespace (cycling-coach@<v>, running-coach@<v>, etc.).
-# Pushing a tag — via `git push --tags` or via the GitHub UI's "Draft a new
-# release" page — fires this workflow against the exact tagged commit.
-# Workflow_dispatch is kept as a fallback for re-running after a failed publish
-# without recreating the tag.
-#
-# Today only `cycling-coach` is publishable (per ADR-0009). The trigger globs
-# include the stub binaries' patterns so when running-coach / duathlon-coach
-# graduate to real npm-published binaries no workflow change is needed —
-# just flip `private: false` and tag.
-
 on:
-  push:
-    tags:
-      - 'cycling-coach@*'
-      - 'running-coach@*'
-      - 'duathlon-coach@*'
   workflow_dispatch:
     inputs:
-      package:
-        description: 'Package to release'
+      phase:
+        description: Prepare once, resume exact staged archives, or verify approved publication
         type: choice
-        default: cycling-coach
-        options:
-          - cycling-coach
-          - running-coach
-          - duathlon-coach
+        options: [prepare, resume, finalize]
+        default: prepare
       tag:
-        description: 'Exact release tag; a main-ref dispatch can only resume versions already present on npm'
-        required: false
-        default: ''
+        description: Exact cycling-coach release tag
+        required: true
+        type: string
+      commit:
+        description: Exact source commit, required for preparation
+        type: string
+      coordinator_run_id:
+        description: Successful Version PR package-coordinator run, required for preparation
+        type: string
+      coordinator_run_attempt:
+        description: Exact coordinator attempt, required for preparation
+        type: string
 
-# PG-16: per-job least-privilege; id-token only on publish.
 permissions:
   contents: read
 
@@ -44,79 +32,47 @@ concurrency:
 
 jobs:
   parse-tag:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
       ref: ${{ steps.parse.outputs.ref }}
       commit: ${{ steps.parse.outputs.commit }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      REPOSITORY_ID: ${{ github.repository_id }}
+      REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+      RELEASE_COMMIT: ${{ inputs.commit }}
+      COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
+      COORDINATOR_RUN_ATTEMPT: ${{ inputs.coordinator_run_attempt }}
     steps:
-      # Needed only when workflow_dispatch is invoked with an empty tag input —
-      # we resolve the version from packages/<package>/package.json on the
-      # dispatched ref. Cheap enough to always run; keeps the resolver simple.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
-      - id: parse
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Validate protected-main source preparation
+        id: parse
         env:
-          DISPATCH_TAG_INPUT: ${{ github.event.inputs.tag }}
-          DISPATCH_PACKAGE_INPUT: ${{ github.event.inputs.package }}
-          WORKFLOW_EVENT_NAME: ${{ github.event_name }}
-          WORKFLOW_REF: ${{ github.ref }}
-          WORKFLOW_REF_NAME: ${{ github.ref_name }}
-          WORKFLOW_SHA: ${{ github.sha }}
-        # Three trigger paths produce a tag string:
-        #   push:tags          -> github.ref_name is the tag (cycling-coach@2026.5.2)
-        #   workflow_dispatch  -> if inputs.tag is non-empty, use it verbatim;
-        #                         otherwise build <inputs.package>@<package.json version>
-        #                         so the operator can dispatch with a single click
-        #                         after a Version-PR merge without typing the tag.
+          PHASE: ${{ inputs.phase }}
         run: |
           set -euo pipefail
-          INPUT_TAG="$DISPATCH_TAG_INPUT"
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [ "$WORKFLOW_EVENT_NAME" = "workflow_dispatch" ]; then
-            PKG="$DISPATCH_PACKAGE_INPUT"
-            if [ ! -f "packages/$PKG/package.json" ]; then
-              echo "::error::packages/$PKG/package.json not found on this ref"
-              exit 1
-            fi
-            VERSION=$(node -p "require('./packages/$PKG/package.json').version")
-            TAG="$PKG@$VERSION"
-            echo "::notice::Empty tag input — resolved to $TAG via packages/$PKG/package.json"
-          else
-            TAG="$WORKFLOW_REF_NAME"
-          fi
-          PACKAGE="${TAG%@*}"
-          VERSION="${TAG#*@}"
-          if ! printf '%s' "$PACKAGE" | grep -Eq '^(cycling-coach|running-coach|duathlon-coach)$' || \
-             ! printf '%s' "$VERSION" | grep -Eq '^[1-9][0-9]{3}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$'; then
-            echo "::error::Tag '$TAG' is not in <package>@<version> format"
-            exit 1
-          fi
-          git fetch --force --no-tags origin "refs/tags/$TAG:refs/tags/$TAG"
-          if ! git show-ref --verify --quiet "refs/tags/$TAG"; then
-            echo "::error::Tag '$TAG' does not exist"
-            exit 1
-          fi
-          COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
-          if [ "$WORKFLOW_EVENT_NAME" = "workflow_dispatch" ] && \
-             [ "$WORKFLOW_REF" != "refs/heads/main" ] && [ "$WORKFLOW_REF" != "refs/tags/$TAG" ]; then
-            echo "::error::Manual release dispatch must run from main or the exact release tag"
-            exit 1
-          fi
-          if [ "$WORKFLOW_EVENT_NAME" = "push" ] && [ "$COMMIT" != "$WORKFLOW_SHA" ]; then
-            echo "::error::Tag commit does not match the triggering commit"
-            exit 1
-          fi
-          echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "ref=$TAG" >> "$GITHUB_OUTPUT"
-          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
-          echo "::notice::Releasing $PACKAGE @ $VERSION (ref: $TAG)"
+          case "$PHASE" in
+            prepare) node tools/npm-release.ts validate-input "$RUNNER_TEMP/npm-release" ;;
+            resume|finalize) node tools/npm-release.ts restore "$RUNNER_TEMP/npm-release" ;;
+            *) exit 1 ;;
+          esac
 
   build:
+    if: inputs.phase == 'prepare'
     runs-on: ubuntu-latest
     needs: parse-tag
     permissions:
@@ -135,6 +91,7 @@ jobs:
       - run: pnpm -r build
 
   test:
+    if: inputs.phase == 'prepare'
     runs-on: ubuntu-latest
     needs: [parse-tag, build]
     permissions:
@@ -154,6 +111,7 @@ jobs:
       - run: pnpm test
 
   smoke:
+    if: inputs.phase == 'prepare'
     runs-on: ubuntu-latest
     needs: [parse-tag, build, test]
     outputs:
@@ -171,6 +129,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.parse-tag.outputs.commit }}
+          persist-credentials: false
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.sha }}
+          path: .release-control
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -232,12 +195,22 @@ jobs:
           echo "alias_filename=$ALIAS_FILENAME" >> "$GITHUB_OUTPUT"
           echo "alias_sha512=$ALIAS_SHA512" >> "$GITHUB_OUTPUT"
           echo "pack_dir=$PACK_DIR" >> "$GITHUB_OUTPUT"
+      - name: Seal source and workflow identities with archive hashes
+        env:
+          RELEASE_VERSION: ${{ needs.parse-tag.outputs.version }}
+          RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
+          COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
+          COORDINATOR_RUN_ATTEMPT: ${{ inputs.coordinator_run_attempt }}
+          PACK_DIR: ${{ steps.pack.outputs.pack_dir }}
+        run: node .release-control/tools/npm-release.ts seal "$PACK_DIR"
       - name: Upload immutable npm release artifacts
         id: npm-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-release-${{ github.run_id }}-${{ github.run_attempt }}-${{ needs.parse-tag.outputs.package }}
-          path: ${{ steps.pack.outputs.pack_dir }}/*.tgz
+          path: |
+            ${{ steps.pack.outputs.pack_dir }}/*.tgz
+            ${{ steps.pack.outputs.pack_dir }}/release-manifest.json
           if-no-files-found: error
           compression-level: 0
           retention-days: 30
@@ -246,12 +219,6 @@ jobs:
           RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
           PACK_DIR: ${{ steps.pack.outputs.pack_dir }}
           PRIMARY_FILENAME: ${{ steps.pack.outputs.primary_filename }}
-        # Install the sealed tarball as a dependency of a fresh consumer
-        # project — what end users actually do. Installing in-place via
-        # `npm install --omit=dev` doesn't work: npm resolves the full
-        # dep graph (incl. devDeps) before applying --omit, hits 404 on
-        # private workspace devDeps.
-        # --ignore-scripts skips the full dependency tree, so this smoke no longer proves postinstall behavior.
         run: |
           set -euo pipefail
           PACKAGE="$RELEASE_PACKAGE"
@@ -263,393 +230,291 @@ jobs:
           npm install "$TARBALL" --ignore-scripts
           timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
 
-  publish-npm:
-    runs-on: ubuntu-latest
+  reserve:
+    if: inputs.phase == 'prepare'
     needs: [parse-tag, smoke]
-    environment: npm-production
-    # Per-package serialization. Two cycling-coach releases on the same day
-    # never run in parallel (avoids any same-tag publish race), but cycling
-    # and running can publish at the same time once both are real binaries.
-    concurrency:
-      group: release-publish-${{ needs.parse-tag.outputs.package }}
-      cancel-in-progress: false
-      queue: max
+    runs-on: ubuntu-latest
+    environment: npm-stage
     permissions:
+      contents: write
       actions: read
-      contents: read
-      id-token: write   # PG-16: OIDC, scoped to publish job only
-    outputs:
-      published_new: ${{ steps.npm-publish.outputs.published_new }}
-      publication_run_id: ${{ steps.npm-publish.outputs.publication_run_id }}
-      publication_run_attempt: ${{ steps.npm-publish.outputs.publication_run_attempt }}
-      publication_ref: ${{ steps.npm-publish.outputs.publication_ref }}
-      publication_event_name: ${{ steps.npm-publish.outputs.publication_event_name }}
-      publication_commit: ${{ steps.npm-publish.outputs.publication_commit }}
+    env:
+      RESERVATION_RULESET_ID: ${{ vars.RESERVATION_RULESET_ID }}
+      RESERVATION_RULESET_UPDATED_AT: ${{ vars.RESERVATION_RULESET_UPDATED_AT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      REPOSITORY_ID: ${{ github.repository_id }}
+      REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+      ARTIFACT_ID: ${{ needs.smoke.outputs.artifact_id }}
+      ARTIFACT_DIGEST: ${{ needs.smoke.outputs.artifact_digest }}
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          # Node 24 ships npm 11.x natively. npm 11.5.1+ is required for the
-          # OIDC trusted-publisher handshake; Node 22's bundled npm 10.x doesn't
-          # support it, and self-upgrading via `npm install -g npm@latest` is
-          # flaky (`Cannot find module 'promise-retry'` mid-swap).
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           artifact-ids: ${{ needs.smoke.outputs.artifact_id }}
           path: ${{ runner.temp }}/npm-release
           digest-mismatch: error
-      - name: Bind immutable npm artifact evidence
-        env:
-          ARTIFACT_ID: ${{ needs.smoke.outputs.artifact_id }}
-          ARTIFACT_DIGEST: ${{ needs.smoke.outputs.artifact_digest }}
-          ARTIFACT_NAME: ${{ needs.smoke.outputs.artifact_name }}
-          PREPARE_RUN_ATTEMPT: ${{ needs.smoke.outputs.workflow_run_attempt }}
-          RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
-        run: |
-          set -euo pipefail
-          printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
-          printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "npm-release-$GITHUB_RUN_ID-$PREPARE_RUN_ATTEMPT-$RELEASE_PACKAGE"
+      - name: Reserve immutable release identity
+        run: node tools/npm-release.ts reserve "$RUNNER_TEMP/npm-release"
 
-      - name: Publish immutable primary tarball to npm via OIDC
-        id: npm-publish
-        env:
-          RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
-          RELEASE_VERSION: ${{ needs.parse-tag.outputs.version }}
-          RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
-          RELEASE_TAG: ${{ needs.parse-tag.outputs.ref }}
-          PRIMARY_FILENAME: ${{ needs.smoke.outputs.primary_filename }}
-          PRIMARY_SHA512: ${{ needs.smoke.outputs.primary_sha512 }}
-        # Publish the exact tarball accepted by the legal-artifact gate.
-        # OIDC is negotiated automatically by npm 11+ when id-token: write
-        # is granted (no NPM_TOKEN secret needed). The trusted publisher
-        # must be configured per-package on npmjs.com (one-time operator
-        # action; matches repo `yerzhansa/enduragent` + workflow
-        # `release.yml`). The `npm-production` environment is the package
-        # publication boundary; desktop tags cannot enter it.
+  publisher-tools:
+    if: inputs.phase != 'finalize'
+    needs: parse-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      artifact_id: ${{ steps.tools.outputs.artifact-id }}
+    steps:
+      - name: Fetch pinned npm without publishing credentials
         run: |
           set -euo pipefail
-          PACKAGE="$RELEASE_PACKAGE"
-          TARBALL="$RUNNER_TEMP/npm-release/$PRIMARY_FILENAME"
-          printf '%s' "$PRIMARY_FILENAME" | grep -Eq '^[a-z0-9-]+-[1-9][0-9]{3}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)\.tgz$'
-          printf '%s' "$PRIMARY_SHA512" | grep -Eq '^[0-9a-f]{128}$'
-          test -f "$TARBALL"
-          test "$(shasum -a 512 "$TARBALL" | awk '{print $1}')" = "$PRIMARY_SHA512"
-          PACKAGE_JSON="$RUNNER_TEMP/$PACKAGE-package.json"
-          tar -xOf "$TARBALL" package/package.json > "$PACKAGE_JSON"
-          CANONICAL_REPOSITORY="git+https://github.com/yerzhansa/enduragent.git"
-          CANONICAL_DIRECTORY="packages/$PACKAGE"
-          jq -e --arg name "$PACKAGE" --arg version "$RELEASE_VERSION" \
-            --arg repository "$CANONICAL_REPOSITORY" --arg directory "$CANONICAL_DIRECTORY" \
-            '.name == $name and .version == $version and .repository == {"type":"git","url":$repository,"directory":$directory} and .publishConfig == null' \
-            "$PACKAGE_JSON" >/dev/null
-          EXPECTED_INTEGRITY="sha512-$(printf '%s' "$PRIMARY_SHA512" | xxd -r -p | base64 | tr -d '\n')"
-          EXPECTED_COMMIT="$RELEASE_COMMIT"
-          SPEC="$PACKAGE@$RELEASE_VERSION"
-          VIEW_JSON="$RUNNER_TEMP/$PACKAGE-view.json"
-          VIEW_ERROR="$RUNNER_TEMP/$PACKAGE-view.error"
-          if npm view "$SPEC" --registry=https://registry.npmjs.org/ --json > "$VIEW_JSON" 2> "$VIEW_ERROR"; then
-            jq -e --arg version "$RELEASE_VERSION" --arg integrity "$EXPECTED_INTEGRITY" \
-              --arg repository "$CANONICAL_REPOSITORY" \
-              '.version == $version and .dist.integrity == $integrity and .repository.url == $repository' \
-              "$VIEW_JSON" >/dev/null || {
-                echo "::error::$SPEC exists but does not match the prepared primary bytes and repository"
-                exit 1
-              }
-            echo "::notice::$SPEC already exists; the no-OIDC verification job will require exact bytes and provenance"
-            echo "published_new=false" >> "$GITHUB_OUTPUT"
-          elif grep -Eq '(^|[[:space:]])E404([[:space:]]|$)|404 Not Found' "$VIEW_ERROR"; then
-            if [ "$GITHUB_REF" != "refs/tags/$RELEASE_TAG" ] || [ "$GITHUB_SHA" != "$EXPECTED_COMMIT" ]; then
-              echo "::error::First npm publication requires the exact release tag ref and commit"
-              exit 1
-            fi
-            npm publish "$TARBALL" --access public --ignore-scripts \
-              --registry=https://registry.npmjs.org/ --provenance
-            echo "published_new=true" >> "$GITHUB_OUTPUT"
-          else
-            cat "$VIEW_ERROR" >&2
-            echo "::error::npm registry lookup failed without a confirmed 404; refusing publish"
-            exit 1
-          fi
-          echo "publication_run_id=$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "publication_run_attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
-          echo "publication_ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
-          echo "publication_event_name=$GITHUB_EVENT_NAME" >> "$GITHUB_OUTPUT"
-          echo "publication_commit=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          mkdir -p "$RUNNER_TEMP/publisher"
+          cd "$RUNNER_TEMP/publisher"
+          curl --fail --silent --show-error --proto '=https' --max-time 60 \
+            https://registry.npmjs.org/npm/-/npm-11.19.1.tgz -o npm-11.19.1.tgz
+          printf '%s  %s\n' 'cedb312b1b7f92421a02cfb68b4194e88f8346651dacd6acc5364a25ef5309d4a32b19616a1ff8aff865e7280c0fa5c0835a99f5cd93368991e2a80ec9da75d2' npm-11.19.1.tgz | sha512sum --check
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        id: tools
+        with:
+          name: npm-publisher-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/publisher/npm-11.19.1.tgz
+          if-no-files-found: error
 
-      - name: Publish enduragent alias to npm via OIDC
-        env:
-          RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
-          RELEASE_VERSION: ${{ needs.parse-tag.outputs.version }}
-          RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
-          RELEASE_TAG: ${{ needs.parse-tag.outputs.ref }}
-          ALIAS_FILENAME: ${{ needs.smoke.outputs.alias_filename }}
-          ALIAS_SHA512: ${{ needs.smoke.outputs.alias_sha512 }}
+  primary-intent:
+    needs: [parse-tag, reserve]
+    if: ${{ always() && github.ref == 'refs/heads/main' && inputs.phase != 'finalize' && needs.parse-tag.result == 'success' && (needs.reserve.result == 'success' || needs.reserve.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    environment: npm-stage
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      stage: ${{ steps.intent.outputs.stage }}
+      receipt_name: ${{ steps.intent.outputs.receipt_name }}
+    env:
+      RESERVATION_RULESET_ID: ${{ vars.RESERVATION_RULESET_ID }}
+      RESERVATION_RULESET_UPDATED_AT: ${{ vars.RESERVATION_RULESET_UPDATED_AT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      REPOSITORY_ID: ${{ github.repository_id }}
+      REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+      RELEASE_PACKAGE: cycling-coach
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Reserve a single stage attempt
+        id: intent
+        run: node tools/npm-release.ts begin "$RUNNER_TEMP/npm-release"
+
+  primary-stage:
+    needs: [primary-intent, publisher-tools]
+    if: needs.primary-intent.outputs.stage == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-production
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      RESERVATION_RULESET_ID: ${{ vars.RESERVATION_RULESET_ID }}
+      RESERVATION_RULESET_UPDATED_AT: ${{ vars.RESERVATION_RULESET_UPDATED_AT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      REPOSITORY_ID: ${{ github.repository_id }}
+      REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+      RELEASE_PACKAGE: cycling-coach
+      PUBLISHER_NODE: node
+      PUBLISHER_NPM: ${{ runner.temp }}/publisher/package/bin/npm-cli.js
+      RECEIPT_PATH: ${{ runner.temp }}/receipt/receipt.json
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          artifact-ids: ${{ needs.publisher-tools.outputs.artifact_id }}
+          path: ${{ runner.temp }}/publisher
+          digest-mismatch: error
+      - name: Verify pinned npm executable
         run: |
           set -euo pipefail
-          PACKAGE="$RELEASE_PACKAGE"
-          if [ "$PACKAGE" != "cycling-coach" ]; then
-            echo "::notice::No enduragent alias for $PACKAGE — skipping"
-            exit 0
-          fi
-          VERSION="$RELEASE_VERSION"
-          test "$ALIAS_FILENAME" = "enduragent-$VERSION.tgz"
-          printf '%s' "$ALIAS_SHA512" | grep -Eq '^[0-9a-f]{128}$'
-          ALIAS_TARBALL="$RUNNER_TEMP/npm-release/$ALIAS_FILENAME"
-          test -f "$ALIAS_TARBALL"
-          test "$(shasum -a 512 "$ALIAS_TARBALL" | awk '{print $1}')" = "$ALIAS_SHA512"
-          ALIAS_PACKAGE_JSON="$RUNNER_TEMP/enduragent-package.json"
-          tar -xOf "$ALIAS_TARBALL" package/package.json > "$ALIAS_PACKAGE_JSON"
-          CANONICAL_REPOSITORY="git+https://github.com/yerzhansa/enduragent.git"
-          CANONICAL_DIRECTORY="packages/$PACKAGE"
-          jq -e --arg version "$VERSION" \
-            --arg repository "$CANONICAL_REPOSITORY" --arg directory "$CANONICAL_DIRECTORY" \
-            '.name == "enduragent" and .version == $version and .bin == {"enduragent":"dist/index.js"} and .repository == {"type":"git","url":$repository,"directory":$directory} and .publishConfig == null' \
-            "$ALIAS_PACKAGE_JSON" >/dev/null
-          EXPECTED_REPO="$CANONICAL_REPOSITORY"
-          EXPECTED_INTEGRITY="sha512-$(printf '%s' "$ALIAS_SHA512" | xxd -r -p | base64 | tr -d '\n')"
-          SPEC="enduragent@$VERSION"
-          VIEW_JSON="$RUNNER_TEMP/enduragent-view.json"
-          VIEW_ERROR="$RUNNER_TEMP/enduragent-view.error"
-          if npm view "$SPEC" --registry=https://registry.npmjs.org/ --json > "$VIEW_JSON" 2> "$VIEW_ERROR"; then
-            PUBLISHED_REPO=$(jq -r '.repository.url // empty' "$VIEW_JSON")
-            PUBLISHED_INTEGRITY=$(jq -r '.dist.integrity // empty' "$VIEW_JSON")
-            if [ "$PUBLISHED_REPO" = "$EXPECTED_REPO" ] && [ "$PUBLISHED_INTEGRITY" = "$EXPECTED_INTEGRITY" ]; then
-              echo "::notice::$SPEC already published from $EXPECTED_REPO — skipping publish"
-            else
-              echo "::error::$SPEC exists on npm but does not match the prepared alias bytes and repository"
-              exit 1
-            fi
-          elif grep -Eq '(^|[[:space:]])E404([[:space:]]|$)|404 Not Found' "$VIEW_ERROR"; then
-            if [ "$GITHUB_REF" != "refs/tags/$RELEASE_TAG" ] || [ "$GITHUB_SHA" != "$RELEASE_COMMIT" ]; then
-              echo "::error::First alias publication requires the exact release tag ref and commit"
-              exit 1
-            fi
-            npm publish "$ALIAS_TARBALL" --access public --ignore-scripts \
-              --registry=https://registry.npmjs.org/ --provenance
-          else
-            cat "$VIEW_ERROR" >&2
-            echo "::error::npm registry lookup failed without a confirmed 404; refusing alias publish"
-            exit 1
-          fi
+          cd "$RUNNER_TEMP/publisher"
+          printf '%s  %s\n' 'cedb312b1b7f92421a02cfb68b4194e88f8346651dacd6acc5364a25ef5309d4a32b19616a1ff8aff865e7280c0fa5c0835a99f5cd93368991e2a80ec9da75d2' npm-11.19.1.tgz | sha512sum --check
+          tar -xzf npm-11.19.1.tgz
+          test "$(node package/bin/npm-cli.js --version)" = 11.19.1
+          mkdir -p "$RUNNER_TEMP/receipt"
+      - name: Restore the exact prepared archives
+        run: node tools/npm-release.ts restore "$RUNNER_TEMP/npm-release"
+      - name: Stage exact archive for human approval
+        run: node tools/npm-release.ts stage "$RUNNER_TEMP/npm-release"
+      - name: Retain accepted or uncertain stage outcome
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ needs.primary-intent.outputs.receipt_name }}
+          path: ${{ runner.temp }}/receipt/receipt.json
+          if-no-files-found: error
+          retention-days: 90
+
+  alias-intent:
+    needs: [primary-intent, primary-stage]
+    if: ${{ always() && github.ref == 'refs/heads/main' && inputs.phase != 'finalize' && needs.primary-intent.result == 'success' && (needs.primary-stage.result == 'success' || needs.primary-stage.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    environment: npm-stage
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      stage: ${{ steps.intent.outputs.stage }}
+      receipt_name: ${{ steps.intent.outputs.receipt_name }}
+    env:
+      RESERVATION_RULESET_ID: ${{ vars.RESERVATION_RULESET_ID }}
+      RESERVATION_RULESET_UPDATED_AT: ${{ vars.RESERVATION_RULESET_UPDATED_AT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      REPOSITORY_ID: ${{ github.repository_id }}
+      REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+      RELEASE_PACKAGE: enduragent
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Reserve a single stage attempt
+        id: intent
+        run: node tools/npm-release.ts begin "$RUNNER_TEMP/npm-release"
+
+  alias-stage:
+    needs: [alias-intent, publisher-tools]
+    if: needs.alias-intent.outputs.stage == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-production
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      RESERVATION_RULESET_ID: ${{ vars.RESERVATION_RULESET_ID }}
+      RESERVATION_RULESET_UPDATED_AT: ${{ vars.RESERVATION_RULESET_UPDATED_AT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      REPOSITORY_ID: ${{ github.repository_id }}
+      REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+      RELEASE_PACKAGE: enduragent
+      PUBLISHER_NODE: node
+      PUBLISHER_NPM: ${{ runner.temp }}/publisher/package/bin/npm-cli.js
+      RECEIPT_PATH: ${{ runner.temp }}/receipt/receipt.json
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          artifact-ids: ${{ needs.publisher-tools.outputs.artifact_id }}
+          path: ${{ runner.temp }}/publisher
+          digest-mismatch: error
+      - name: Verify pinned npm executable
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/publisher"
+          printf '%s  %s\n' 'cedb312b1b7f92421a02cfb68b4194e88f8346651dacd6acc5364a25ef5309d4a32b19616a1ff8aff865e7280c0fa5c0835a99f5cd93368991e2a80ec9da75d2' npm-11.19.1.tgz | sha512sum --check
+          tar -xzf npm-11.19.1.tgz
+          test "$(node package/bin/npm-cli.js --version)" = 11.19.1
+          mkdir -p "$RUNNER_TEMP/receipt"
+      - name: Restore the exact prepared archives
+        run: node tools/npm-release.ts restore "$RUNNER_TEMP/npm-release"
+      - name: Stage exact archive for human approval
+        run: node tools/npm-release.ts stage "$RUNNER_TEMP/npm-release"
+      - name: Retain accepted or uncertain stage outcome
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ needs.alias-intent.outputs.receipt_name }}
+          path: ${{ runner.temp }}/receipt/receipt.json
+          if-no-files-found: error
+          retention-days: 90
 
   verify-npm-publication:
+    if: inputs.phase == 'finalize'
+    needs: parse-tag
     runs-on: ubuntu-latest
-    needs: [parse-tag, smoke, publish-npm]
     permissions:
-      actions: read
       contents: read
-    outputs:
-      npm_integrity: ${{ steps.verify.outputs.npm_integrity }}
-      npm_attestation_url: ${{ steps.verify.outputs.npm_attestation_url }}
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      REPOSITORY_ID: ${{ github.repository_id }}
+      REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          ref: ${{ needs.parse-tag.outputs.commit }}
+          ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
-          cache: pnpm
-          registry-url: https://registry.npmjs.org
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          artifact-ids: ${{ needs.smoke.outputs.artifact_id }}
-          path: ${{ runner.temp }}/npm-release
-          digest-mismatch: error
-      - name: Verify public npm bytes and signed provenance
-        id: verify
-        env:
-          ARTIFACT_ID: ${{ needs.smoke.outputs.artifact_id }}
-          ARTIFACT_DIGEST: ${{ needs.smoke.outputs.artifact_digest }}
-          ARTIFACT_NAME: ${{ needs.smoke.outputs.artifact_name }}
-          PREPARE_RUN_ATTEMPT: ${{ needs.smoke.outputs.workflow_run_attempt }}
-          PRIMARY_FILENAME: ${{ needs.smoke.outputs.primary_filename }}
-          PRIMARY_SHA512: ${{ needs.smoke.outputs.primary_sha512 }}
-          PUBLISHED_NEW: ${{ needs.publish-npm.outputs.published_new }}
-          PUBLICATION_RUN_ID: ${{ needs.publish-npm.outputs.publication_run_id }}
-          PUBLICATION_RUN_ATTEMPT: ${{ needs.publish-npm.outputs.publication_run_attempt }}
-          PUBLICATION_REF: ${{ needs.publish-npm.outputs.publication_ref }}
-          PUBLICATION_EVENT_NAME: ${{ needs.publish-npm.outputs.publication_event_name }}
-          PUBLICATION_COMMIT: ${{ needs.publish-npm.outputs.publication_commit }}
-          RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
-          RELEASE_VERSION: ${{ needs.parse-tag.outputs.version }}
-          RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
-          RELEASE_TAG: ${{ needs.parse-tag.outputs.ref }}
-          WORKFLOW_REPOSITORY: ${{ github.repository }}
-          WORKFLOW_REPOSITORY_ID: ${{ github.repository_id }}
-          WORKFLOW_REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
-        run: |
-          set -euo pipefail
-          printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
-          printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "npm-release-$GITHUB_RUN_ID-$PREPARE_RUN_ATTEMPT-$RELEASE_PACKAGE"
-          test "$PUBLISHED_NEW" = "true" || test "$PUBLISHED_NEW" = "false"
-          printf '%s' "$PUBLICATION_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
-          printf '%s' "$PUBLICATION_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
-          if [ "$PUBLISHED_NEW" = "true" ]; then
-            test "$PUBLICATION_REF" = "refs/tags/$RELEASE_TAG"
-            test "$PUBLICATION_COMMIT" = "$RELEASE_COMMIT"
-          fi
-          printf '%s' "$PRIMARY_SHA512" | grep -Eq '^[0-9a-f]{128}$'
-          TARBALL="$RUNNER_TEMP/npm-release/$PRIMARY_FILENAME"
-          test -f "$TARBALL"
-          test "$(shasum -a 512 "$TARBALL" | awk '{print $1}')" = "$PRIMARY_SHA512"
-          CANONICAL_REPOSITORY="git+https://github.com/yerzhansa/enduragent.git"
-          CANONICAL_DIRECTORY="packages/$RELEASE_PACKAGE"
-          PACKAGE_JSON="$RUNNER_TEMP/verified-package.json"
-          tar -xOf "$TARBALL" package/package.json > "$PACKAGE_JSON"
-          jq -e --arg name "$RELEASE_PACKAGE" --arg version "$RELEASE_VERSION" \
-            --arg repository "$CANONICAL_REPOSITORY" --arg directory "$CANONICAL_DIRECTORY" \
-            '.name == $name and .version == $version and .repository == {"type":"git","url":$repository,"directory":$directory} and .publishConfig == null' \
-            "$PACKAGE_JSON" >/dev/null
-          EXPECTED_INTEGRITY="sha512-$(printf '%s' "$PRIMARY_SHA512" | xxd -r -p | base64 | tr -d '\n')"
-          EXPECTED_ATTESTATION_URL="https://registry.npmjs.org/-/npm/v1/attestations/$RELEASE_PACKAGE@$RELEASE_VERSION"
-          SPEC="$RELEASE_PACKAGE@$RELEASE_VERSION"
-          VIEW_JSON="$RUNNER_TEMP/npm-publication.json"
-          OBSERVED_INTEGRITY=none
-          OBSERVED_ATTESTATION_URL=none
-          for attempt in $(seq 1 12); do
-            if npm view "$SPEC" --registry=https://registry.npmjs.org/ --json > "$VIEW_JSON" 2>/dev/null; then
-              OBSERVED_INTEGRITY=$(jq -r '.dist.integrity // empty' "$VIEW_JSON")
-              OBSERVED_ATTESTATION_URL=$(jq -r '.dist.attestations.url // empty' "$VIEW_JSON")
-              if [ "$OBSERVED_INTEGRITY" = "$EXPECTED_INTEGRITY" ] && [ "$OBSERVED_ATTESTATION_URL" = "$EXPECTED_ATTESTATION_URL" ]; then
-                break
-              fi
-            fi
-            if [ "$attempt" -eq 12 ]; then
-              echo "::error::npm publication did not converge to the prepared bytes and canonical attestation URL"
-              exit 1
-            fi
-            sleep 5
-          done
-          test "$OBSERVED_INTEGRITY" = "$EXPECTED_INTEGRITY"
-          test "$OBSERVED_ATTESTATION_URL" = "$EXPECTED_ATTESTATION_URL"
-          ATTESTATION_FILE="$RUNNER_TEMP/npm-attestations.json"
-          curl --fail-with-body --silent --show-error --location \
-            --retry 5 --retry-delay 3 --retry-all-errors --max-time 30 \
-            --output "$ATTESTATION_FILE" "$EXPECTED_ATTESTATION_URL"
-          CONSUMER_DIR="$RUNNER_TEMP/npm-signature-consumer"
-          mkdir -p "$CONSUMER_DIR"
-          (
-            cd "$CONSUMER_DIR"
-            npm init -y >/dev/null
-            npm install "$SPEC" --ignore-scripts --registry=https://registry.npmjs.org/
-            npm audit signatures --registry=https://registry.npmjs.org/
-          )
-          ALLOW_PRIOR_INVOCATION=false
-          if [ "$PUBLISHED_NEW" = "false" ]; then
-            ALLOW_PRIOR_INVOCATION=true
-          fi
-          pnpm desktop-release:transaction verify-npm-provenance \
-            --metadata "$ATTESTATION_FILE" \
-            --name "$RELEASE_PACKAGE" \
-            --version "$RELEASE_VERSION" \
-            --integrity "$EXPECTED_INTEGRITY" \
-            --repository "https://github.com/$WORKFLOW_REPOSITORY" \
-            --workflow .github/workflows/release.yml \
-            --ref "$PUBLICATION_REF" \
-            --commit "$RELEASE_COMMIT" \
-            --invocation-id "https://github.com/$WORKFLOW_REPOSITORY/actions/runs/$PUBLICATION_RUN_ID/attempts/$PUBLICATION_RUN_ATTEMPT" \
-            --allow-prior-invocation "$ALLOW_PRIOR_INVOCATION" \
-            --release-tag "$RELEASE_TAG" \
-            --event-name "$PUBLICATION_EVENT_NAME" \
-            --repository-id "$WORKFLOW_REPOSITORY_ID" \
-            --repository-owner-id "$WORKFLOW_REPOSITORY_OWNER_ID"
-          echo "npm_integrity=$EXPECTED_INTEGRITY" >> "$GITHUB_OUTPUT"
-          echo "npm_attestation_url=$EXPECTED_ATTESTATION_URL" >> "$GITHUB_OUTPUT"
-
-  prepare-release-draft:
-    runs-on: ubuntu-latest
-    needs: [parse-tag, verify-npm-publication]
-    if: ${{ false }}
-    permissions:
-      contents: write
-    outputs:
-      draft_id: ${{ steps.release-draft.outputs.draft_id }}
-      draft_body_sha256: ${{ steps.release-draft.outputs.body_sha256 }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ needs.parse-tag.outputs.commit }}
-          persist-credentials: false
-      - name: Create or validate GitHub Release draft
-        id: release-draft
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DESKTOP_ENABLED: ${{ needs.parse-tag.outputs.desktop_enabled }}
-          RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
-          RELEASE_TAG: ${{ needs.parse-tag.outputs.ref }}
-          RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
-        run: |
-          set -euo pipefail
-          PACKAGE="$RELEASE_PACKAGE"
-          TAG="$RELEASE_TAG"
-          COMMIT="$RELEASE_COMMIT"
-          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' "packages/$PACKAGE/CHANGELOG.md" | tail -n +2)
-          BODY_SHA256=$(printf '%s' "$BODY" | shasum -a 256 | awk '{print $1}')
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            RELEASE_JSON=$(gh release view "$TAG" --json body,databaseId,isDraft,isPrerelease,tagName)
-            RELEASE_TAG=$(printf '%s' "$RELEASE_JSON" | jq -r '.tagName')
-            IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')
-            IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.isPrerelease')
-            EXISTING_BODY_SHA256=$(printf '%s' "$RELEASE_JSON" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
-            if [ "$RELEASE_TAG" != "$TAG" ]; then
-              echo "::error::Existing GitHub Release is bound to a different tag"
-              exit 1
-            fi
-            if [ "$IS_PRERELEASE" != "false" ]; then
-              echo "::error::Stable desktop updater assets cannot use a prerelease"
-              exit 1
-            fi
-            if [ "$PACKAGE" = "cycling-coach" ] && [ "$DESKTOP_ENABLED" = "true" ] && [ "$IS_DRAFT" != "true" ]; then
-              echo "::error::Desktop assets require an unpublished GitHub Release draft"
-              exit 1
-            fi
-            if [ "$PACKAGE" = "cycling-coach" ] && [ "$DESKTOP_ENABLED" = "true" ] && [ "$EXISTING_BODY_SHA256" != "$BODY_SHA256" ]; then
-              echo "::error::Existing desktop draft body differs from the bound pre-GA release notes"
-              exit 1
-            fi
-          else
-            gh release create "$TAG" --draft --latest=false --target "$COMMIT" --title "$TAG" --notes "$BODY"
-            RELEASE_JSON=$(gh release view "$TAG" --json databaseId,isDraft,isPrerelease,tagName)
-            echo "::notice::Created non-latest GitHub Release draft $TAG"
-          fi
-          DRAFT_ID=$(printf '%s' "$RELEASE_JSON" | jq -r '.databaseId')
-          if ! printf '%s' "$DRAFT_ID" | grep -Eq '^[1-9][0-9]*$'; then
-            echo "::error::GitHub Release draft id is invalid"
-            exit 1
-          fi
-          echo "draft_id=$DRAFT_ID" >> "$GITHUB_OUTPUT"
-          echo "body_sha256=$BODY_SHA256" >> "$GITHUB_OUTPUT"
+      - name: Verify both public packages and signed workflow provenance
+        run: node tools/npm-release.ts verify-public "$RUNNER_TEMP/npm-release"
 
   publish-package-only-release:
-    runs-on: ubuntu-latest
     needs: [parse-tag, verify-npm-publication]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ needs.parse-tag.outputs.ref }}
+      RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          ref: ${{ needs.parse-tag.outputs.commit }}
+          ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
-      - name: Publish non-latest package GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
-          RELEASE_TAG: ${{ needs.parse-tag.outputs.ref }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Publish verified package release notes
         run: |
           set -euo pipefail
-          PACKAGE="$RELEASE_PACKAGE"
-          TAG="$RELEASE_TAG"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" --latest=false
-            echo "::notice::Release $TAG already exists and remains non-latest."
+          git show "$RELEASE_COMMIT:packages/cycling-coach/CHANGELOG.md" > "$RUNNER_TEMP/package-changelog"
+          awk '/^## /{i++} i==1{print} i==2{exit}' "$RUNNER_TEMP/package-changelog" | tail -n +2 > "$RUNNER_TEMP/package-release-notes"
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" --latest=false
           else
-            BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' "packages/$PACKAGE/CHANGELOG.md" | tail -n +2)
-            gh release create "$TAG" --latest=false --title "$TAG" --notes "$BODY"
-            echo "::notice::Created GitHub Release $TAG"
+            gh release create "$RELEASE_TAG" --latest=false --target "$RELEASE_COMMIT" \
+              --title "$RELEASE_TAG" --notes-file "$RUNNER_TEMP/package-release-notes"
           fi

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -1,11 +1,5 @@
 name: Version PR
 
-# Opens or updates the changesets "Version Packages" PR whenever a push to
-# main contains unconsumed `.changeset/*.md` files. The Version PR is the
-# accumulator for pending releases — multiple changesets across multiple
-# pushes batch into one PR. Merging the Version PR doesn't ship anything;
-# release.yml ships it on tag push.
-
 on:
   push:
     branches: [main]
@@ -14,8 +8,6 @@ on:
 permissions:
   contents: read
 
-# Serialize so concurrent pushes to main don't race each other when both
-# trying to update changeset-release/main.
 concurrency:
   group: version-pr
   cancel-in-progress: false
@@ -27,7 +19,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write   # dispatch package or desktop release workflows after a Version-PR merge
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -43,36 +34,25 @@ jobs:
       - name: Open or update Version PR
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          # `version` consumes .changeset/*.md, bumps package.json, updates
-          # CHANGELOG.md, then bump-binaries-to-calver.ts overrides binary
-          # versions to today's UTC YYYY.M.D (and rewrites their CHANGELOG headers
-          # to match). All run inside pnpm's shell so `&&` chaining works.
           version: pnpm release-version
-          # No `publish:` field — publishing happens in release.yml on tag
-          # push, not here. This action only manages the Version PR; if no
-          # changesets exist, it's a no-op.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Dispatch changed package and desktop releases on Version-PR merge
-        # Closes the manual gap between "Version PR merged" and "release fires".
-        # When the operator merges the changesets-bot PR, package.json versions
-        # bump on main but no tag is created. This step tags and dispatches only
-        # public packages whose versions changed, then independently tags and
-        # dispatches the desktop app when its private SemVer changed.
-        #
-        # Why dispatch instead of relying on the `push: tags:` trigger in
-        # release.yml: GitHub blocks workflow runs from events triggered by
-        # GITHUB_TOKEN as an anti-recursion measure, EXCEPT for workflow_dispatch
-        # and repository_dispatch (documented exception). Tag pushes from this
-        # job use GITHUB_TOKEN, so the tag-push event is silently dropped by
-        # release.yml. workflow_dispatch is the supported escape hatch.
-        #
-        # Gated to push events (skip workflow_dispatch — that path is for
-        # operator-driven re-runs of the changesets step itself, not for
-        # tagging) and to commits whose message starts with "Version Packages",
-        # the changesets/action default PR title that the squash-merge inherits.
-        if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Version Packages')
+  package-coordinator:
+    if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Version Packages')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Tag changed npm packages and dispatch protected-main preparation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -91,23 +71,37 @@ jobs:
               echo "::notice::$NAME remains at $VERSION — skipping npm release"
               continue
             fi
+            test "$NAME" = cycling-coach
+            printf '%s' "$VERSION" | grep -Eq '^[1-9][0-9]{3}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])(-[1-9][0-9]*)?$'
             TAG="$NAME@$VERSION"
-            if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-              git fetch --force --no-tags origin "refs/tags/$TAG:refs/tags/$TAG"
-              TAG_COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
+            TAG_RESPONSE="$RUNNER_TEMP/npm-tag.json"
+            TAG_ERROR="$RUNNER_TEMP/npm-tag.error"
+            if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" > "$TAG_RESPONSE" 2> "$TAG_ERROR"; then
+              TAG_COMMIT=$(jq -er '.object.sha' "$TAG_RESPONSE")
+              TAG_TYPE=$(jq -er '.object.type' "$TAG_RESPONSE")
+              for depth in $(seq 1 10); do
+                test "$TAG_TYPE" = tag || break
+                gh api "repos/$GITHUB_REPOSITORY/git/tags/$TAG_COMMIT" > "$TAG_RESPONSE"
+                TAG_COMMIT=$(jq -er '.object.sha' "$TAG_RESPONSE")
+                TAG_TYPE=$(jq -er '.object.type' "$TAG_RESPONSE")
+              done
+              test "$TAG_TYPE" = commit
               if [ "$TAG_COMMIT" != "$RELEASE_COMMIT" ]; then
-                echo "::error::Existing tag $TAG resolves to $TAG_COMMIT, expected $RELEASE_COMMIT"
+                echo "::error::Existing tag resolves to a different source commit"
                 exit 1
               fi
-              echo "::notice::Existing tag $TAG resolves to the Version Packages commit"
-            else
+            elif grep -q 'HTTP 404' "$TAG_ERROR"; then
               gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
                 -f ref="refs/tags/$TAG" -f sha="$RELEASE_COMMIT" >/dev/null
-              echo "::notice::Created tag $TAG at $RELEASE_COMMIT"
+            else
+              echo "::error::Release tag lookup failed; refusing to create or dispatch"
+              exit 1
             fi
             DISPATCHED=false
             for attempt in $(seq 1 6); do
-              if gh workflow run release.yml --ref "$TAG" -f tag="$TAG"; then
+              if gh workflow run release.yml --ref main -f phase=prepare -f tag="$TAG" \
+                -f commit="$RELEASE_COMMIT" -f coordinator_run_id="$GITHUB_RUN_ID" \
+                -f coordinator_run_attempt="$GITHUB_RUN_ATTEMPT"; then
                 DISPATCHED=true
                 break
               fi
@@ -116,12 +110,33 @@ jobs:
               fi
             done
             if [ "$DISPATCHED" != "true" ]; then
-              echo "::error::Unable to dispatch release.yml on exact tag $TAG after bounded retries"
+              echo "::error::Unable to dispatch release.yml from main for $TAG after bounded retries"
               exit 1
             fi
-            echo "::notice::Dispatched release.yml on exact tag $TAG"
+            echo "::notice::Dispatched release.yml from main for $TAG"
           done
 
+  desktop-coordinator:
+    if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Version Packages')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+      - name: Dispatch desktop release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          RELEASE_COMMIT=$(git rev-parse HEAD)
+          PREVIOUS_COMMIT=$(git rev-parse HEAD^)
           DESKTOP_PACKAGE_JSON=apps/desktop/package.json
           DESKTOP_CHANGELOG=apps/desktop/CHANGELOG.md
           DESKTOP_VERSION=$(jq -er '.version' "$DESKTOP_PACKAGE_JSON")

--- a/tools/desktop-release-transaction.test.ts
+++ b/tools/desktop-release-transaction.test.ts
@@ -100,7 +100,7 @@ describe("advertised npm attestation claims", () => {
     workflow: ".github/workflows/release.yml",
     ref: `refs/tags/cycling-coach@${npmVersion}`,
     releaseTag: `cycling-coach@${npmVersion}`,
-    commit: "a".repeat(40),
+    workflowCommit: "a".repeat(40),
     invocationId: "https://github.com/yerzhansa/enduragent/actions/runs/456/attempts/1",
     eventName: "push",
     repositoryId: "1209631813",
@@ -130,7 +130,11 @@ describe("advertised npm attestation claims", () => {
     };
   }
 
-  function document(commit = expectation.commit) {
+  function document(
+    commit = expectation.workflowCommit,
+    ref = expectation.ref,
+    eventName = expectation.eventName,
+  ) {
     return {
       attestations: [
         attestation("https://slsa.dev/provenance/v1", {
@@ -138,21 +142,21 @@ describe("advertised npm attestation claims", () => {
             buildType: "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
             internalParameters: {
               github: {
-                event_name: expectation.eventName,
+                event_name: eventName,
                 repository_id: expectation.repositoryId,
                 repository_owner_id: expectation.repositoryOwnerId,
               },
             },
             externalParameters: {
               workflow: {
-                ref: expectation.ref,
+                ref,
                 repository: expectation.repository,
                 path: expectation.workflow,
               },
             },
             resolvedDependencies: [
               {
-                uri: `git+${expectation.repository}@${expectation.ref}`,
+                uri: `git+${expectation.repository}@${ref}`,
                 digest: { gitCommit: commit },
               },
             ],
@@ -173,6 +177,27 @@ describe("advertised npm attestation claims", () => {
 
   it("accepts statements bound to the exact tarball, workflow, ref, and commit", () => {
     expect(() => inspectNpmAttestationClaims(document(), expectation)).not.toThrow();
+  });
+
+  it("binds main dispatch provenance to the publisher workflow commit independently of source", () => {
+    const sourceCommit = expectation.workflowCommit;
+    const main = {
+      ...expectation,
+      ref: "refs/heads/main",
+      eventName: "workflow_dispatch",
+      workflowCommit: "b".repeat(40),
+    };
+    const metadata = document(main.workflowCommit, main.ref, main.eventName);
+    expect(() => inspectNpmAttestationClaims(metadata, main)).not.toThrow();
+    expect(() =>
+      inspectNpmAttestationClaims(metadata, { ...main, workflowCommit: sourceCommit }),
+    ).toThrow("workflow binding");
+    expect(() =>
+      inspectNpmAttestationClaims(metadata, {
+        ...main,
+        invocationId: "https://github.com/yerzhansa/enduragent/actions/runs/999/attempts/1",
+      }),
+    ).toThrow("workflow binding");
   });
 
   it("accepts workflow_dispatch provenance on the exact release tag ref", () => {

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -113,7 +113,7 @@ export interface NpmAttestationExpectation {
   readonly repository: string;
   readonly workflow: string;
   readonly ref: string;
-  readonly commit: string;
+  readonly workflowCommit: string;
   readonly invocationId: string;
   readonly allowPriorInvocation?: boolean;
   readonly releaseTag: string;
@@ -480,7 +480,7 @@ export function inspectNpmAttestationClaims(
   const matchingDependencies = dependencies.filter((dependency) => {
     if (!exactObject(dependency) || !exactObject(dependency.digest)) return false;
     return (
-      dependency.digest.gitCommit === expected.commit &&
+      dependency.digest.gitCommit === expected.workflowCommit &&
       dependency.uri === `git+${expected.repository}@${workflowRef}`
     );
   });
@@ -2418,7 +2418,7 @@ async function main(): Promise<void> {
         repository: argument("repository"),
         workflow: argument("workflow"),
         ref: argument("ref"),
-        commit: argument("commit"),
+        workflowCommit: argument("workflow-commit"),
         invocationId: argument("invocation-id"),
         allowPriorInvocation: argument("allow-prior-invocation") === "true",
         releaseTag: argument("release-tag"),

--- a/tools/npm-release-workflow.test.ts
+++ b/tools/npm-release-workflow.test.ts
@@ -1,0 +1,434 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { z } from "zod";
+
+const stepSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().optional(),
+  uses: z.string().optional(),
+  run: z.string().optional(),
+  if: z.string().optional(),
+  env: z.record(z.string(), z.string()).default({}),
+  with: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).default({}),
+});
+const jobSchema = z.object({
+  if: z.string().optional(),
+  needs: z.union([z.string(), z.array(z.string())]).default([]),
+  environment: z.string().optional(),
+  permissions: z.record(z.string(), z.string()).default({}),
+  env: z.record(z.string(), z.string()).default({}),
+  steps: z.array(stepSchema),
+});
+const workflowSchema = z.object({
+  on: z.record(z.string(), z.unknown()),
+  permissions: z.record(z.string(), z.string()),
+  jobs: z.record(z.string(), jobSchema),
+});
+type Workflow = z.infer<typeof workflowSchema>;
+type Job = z.infer<typeof jobSchema>;
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+
+function workflow(name: string): Workflow {
+  return workflowSchema.parse(
+    parse(readFileSync(join(repositoryRoot, ".github/workflows", name), "utf8")),
+  );
+}
+
+function job(source: Workflow, name: string): Job {
+  const result = source.jobs[name];
+  if (!result) throw new Error(`Missing workflow job ${name}`);
+  return result;
+}
+
+function script(source: Job): string {
+  return source.steps.flatMap((step) => step.run ?? []).join("\n");
+}
+
+function dependencies(source: Job): string[] {
+  return typeof source.needs === "string" ? [source.needs] : source.needs;
+}
+
+const release = workflow("release.yml");
+const coordinator = workflow("version-pr.yml");
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+});
+
+function runCoordinator(options: {
+  previousVersion?: string;
+  version?: string;
+  tagCommit?: string;
+  tagDepth?: number;
+  tagLookupFails?: boolean;
+  dispatchFails?: boolean;
+}) {
+  const directory = mkdtempSync(join(tmpdir(), "npm-coordinator-"));
+  directories.push(directory);
+  const bin = join(directory, "bin");
+  const log = join(directory, "calls.jsonl");
+  mkdirSync(bin);
+  writeFileSync(log, "");
+  symlinkSync(process.execPath, join(bin, "node"));
+  for (const [name, contents] of Object.entries({
+    git: `const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.CALL_LOG, JSON.stringify(["git", ...args]) + "\\n");
+if (args[0] === "rev-parse") {
+  if (!["HEAD", "HEAD^"].includes(args[1])) throw new Error("Unexpected git ref");
+  console.log(args[1] === "HEAD" ? process.env.SOURCE_COMMIT : "b".repeat(40));
+} else if (args[0] === "show") {
+  console.log(JSON.stringify({ version: process.env.PREVIOUS_VERSION }));
+} else {
+  throw new Error("Unexpected git invocation: " + args.join(" "));
+}`,
+    gh: `const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.CALL_LOG, JSON.stringify(["gh", ...args]) + "\\n");
+if (args[0] !== "workflow" && args[0] !== "api") throw new Error("Unexpected gh invocation");
+if (args[1]?.includes("/git/ref/tags/")) {
+  if (process.env.TAG_LOOKUP_FAILS === "true") {
+    console.error("HTTP 403");
+    process.exit(1);
+  }
+  if (!process.env.FIXTURE_TAG_COMMIT) {
+    console.error("HTTP 404");
+    process.exit(1);
+  }
+  const depth = Number(process.env.TAG_DEPTH);
+  console.log(JSON.stringify({object: depth > 0 ? {type: "tag", sha: "tag" + depth} : {type: "commit", sha: process.env.FIXTURE_TAG_COMMIT}}));
+} else if (args[1]?.includes("/git/tags/")) {
+  const depth = Number(args[1].split("/git/tags/tag")[1]) - 1;
+  console.log(JSON.stringify({object: depth > 0 ? {type: "tag", sha: "tag" + depth} : {type: "commit", sha: process.env.FIXTURE_TAG_COMMIT}}));
+}
+if (args[0] === "workflow" && process.env.DISPATCH_FAILS === "true") process.exit(1);`,
+    jq: `const fs = require("node:fs");
+const [flag, field, input] = process.argv.slice(2);
+if (flag !== "-er" || ![".version", ".object.sha", ".object.type"].includes(field)) throw new Error("Unexpected jq invocation");
+console.log(field.slice(1).split(".").reduce((value, key) => value[key], JSON.parse(fs.readFileSync(input || 0, "utf8"))));`,
+    sleep: `process.exit(0);`,
+  })) {
+    writeFileSync(join(bin, name), `#!${process.execPath}\n${contents}\n`, { mode: 0o755 });
+  }
+  for (const [name, contents] of Object.entries({
+    "cycling-coach": { name: "cycling-coach", version: options.version ?? "2026.9.5" },
+    "private-package": { name: "@enduragent/private-package", private: true, version: "0.0.0" },
+  })) {
+    const target = join(directory, "packages", name);
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "package.json"), JSON.stringify(contents));
+  }
+  const result = spawnSync("/bin/bash", ["-c", script(job(coordinator, "package-coordinator"))], {
+    cwd: directory,
+    encoding: "utf8",
+    timeout: 25_000,
+    env: {
+      PATH: [bin, dirname(process.execPath), "/usr/bin", "/bin"].join(delimiter),
+      HOME: directory,
+      CALL_LOG: log,
+      SOURCE_COMMIT: "a".repeat(40),
+      FIXTURE_TAG_COMMIT: options.tagCommit ?? "",
+      TAG_DEPTH: String(options.tagDepth ?? 0),
+      TAG_LOOKUP_FAILS: String(options.tagLookupFails ?? false),
+      PREVIOUS_VERSION: options.previousVersion ?? "2026.8.18",
+      DISPATCH_FAILS: String(options.dispatchFails ?? false),
+      GITHUB_REPOSITORY: "fixture/project",
+      GITHUB_RUN_ID: "1234",
+      GITHUB_RUN_ATTEMPT: "3",
+      RUNNER_TEMP: directory,
+    },
+  });
+  const calls = readFileSync(log, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => z.array(z.string()).parse(JSON.parse(line)));
+  return { result, calls };
+}
+
+describe("npm package coordinator dispatch", { timeout: 30_000 }, () => {
+  it("dispatches from main with the exact source and coordinator attempt identity", () => {
+    const { result, calls } = runCoordinator({});
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls.filter((call) => call[0] === "gh")).toEqual([
+      ["gh", "api", "repos/fixture/project/git/ref/tags/cycling-coach@2026.9.5"],
+      [
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        "repos/fixture/project/git/refs",
+        "-f",
+        "ref=refs/tags/cycling-coach@2026.9.5",
+        "-f",
+        `sha=${"a".repeat(40)}`,
+      ],
+      [
+        "gh",
+        "workflow",
+        "run",
+        "release.yml",
+        "--ref",
+        "main",
+        "-f",
+        "phase=prepare",
+        "-f",
+        "tag=cycling-coach@2026.9.5",
+        "-f",
+        `commit=${"a".repeat(40)}`,
+        "-f",
+        "coordinator_run_id=1234",
+        "-f",
+        "coordinator_run_attempt=3",
+      ],
+    ]);
+    expect(calls.some((call) => call.some((arg) => arg.includes("private-package")))).toBe(false);
+  });
+
+  it("reuses a tag only when it resolves to the exact source commit", () => {
+    const { result, calls } = runCoordinator({ tagCommit: "a".repeat(40) });
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls.some((call) => call.includes("POST"))).toBe(false);
+    expect(calls.filter((call) => call[0] === "gh" && call[1] === "workflow")).toHaveLength(1);
+    expect(calls).toContainEqual([
+      "gh",
+      "api",
+      "repos/fixture/project/git/ref/tags/cycling-coach@2026.9.5",
+    ]);
+  });
+
+  it("refuses a mismatching tag before dispatch or tag mutation", () => {
+    const { result, calls } = runCoordinator({ tagCommit: "c".repeat(40) });
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain("Existing tag resolves to a different source commit");
+    expect(calls.some((call) => call.includes("POST") || call[1] === "workflow")).toBe(false);
+  });
+
+  it("peels annotated tags before checking their source commit", () => {
+    const { result, calls } = runCoordinator({ tagCommit: "a".repeat(40), tagDepth: 2 });
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls).toContainEqual(["gh", "api", "repos/fixture/project/git/tags/tag2"]);
+    expect(calls).toContainEqual(["gh", "api", "repos/fixture/project/git/tags/tag1"]);
+    expect(calls.filter((call) => call[1] === "workflow")).toHaveLength(1);
+  });
+
+  it("refuses to dispatch an unresolved tag after ten indirections", () => {
+    const { result, calls } = runCoordinator({ tagCommit: "a".repeat(40), tagDepth: 11 });
+    expect(result.status).not.toBe(0);
+    expect(calls.filter((call) => call[2]?.includes("/git/tags/"))).toHaveLength(10);
+    expect(calls.some((call) => call.includes("POST") || call[1] === "workflow")).toBe(false);
+  });
+
+  it("refuses tag creation and dispatch on lookup errors other than absence", () => {
+    const { result, calls } = runCoordinator({ tagLookupFails: true });
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain("Release tag lookup failed");
+    expect(calls.some((call) => call.includes("POST") || call[1] === "workflow")).toBe(false);
+  });
+
+  it("skips an unchanged package version without remote tag lookups", () => {
+    const { result, calls } = runCoordinator({ previousVersion: "2026.9.5" });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("skipping npm release");
+    expect(calls.filter((call) => call[0] === "gh" || call[1] === "ls-remote")).toEqual([]);
+  });
+
+  it("rejects shell metacharacters in package metadata before external mutations", () => {
+    const { result, calls } = runCoordinator({ version: "2026.9.5; gh forbidden" });
+    expect(result.status).not.toBe(0);
+    expect(calls.filter((call) => call[0] === "gh")).toEqual([]);
+  });
+
+  it("reports dispatch failure after six attempts", () => {
+    const { result, calls } = runCoordinator({ dispatchFails: true });
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain("after bounded retries");
+    expect(calls.filter((call) => call[0] === "gh" && call[1] === "workflow")).toHaveLength(6);
+  });
+});
+
+describe("protected-main npm workflow boundaries", () => {
+  it("gates every job through a main-only explicit dispatch", () => {
+    expect(Object.keys(release.on)).toEqual(["workflow_dispatch"]);
+    expect(job(release, "parse-tag").if).toBe(
+      "github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'",
+    );
+    function reachesGate(name: string, seen = new Set<string>()): boolean {
+      if (name === "parse-tag") return true;
+      if (seen.has(name)) return false;
+      return dependencies(job(release, name)).some((dependency) =>
+        reachesGate(dependency, new Set([...seen, name])),
+      );
+    }
+    for (const name of Object.keys(release.jobs)) expect(reachesGate(name), name).toBe(true);
+  });
+
+  it("keeps dependency installation outside tag and stage coordinators", () => {
+    for (const name of ["package-coordinator", "desktop-coordinator"]) {
+      expect(script(job(coordinator, name))).not.toMatch(/(?:pnpm|npm)\s+(?:install|ci|exec)/);
+      expect(job(coordinator, name).steps.some((step) => step.uses?.startsWith("pnpm/"))).toBe(
+        false,
+      );
+    }
+    for (const name of [
+      "parse-tag",
+      "reserve",
+      "primary-intent",
+      "alias-intent",
+      "primary-stage",
+      "alias-stage",
+    ]) {
+      expect(script(job(release, name)), name).not.toMatch(
+        /(?:pnpm|npm)\s+(?:install|ci|exec|run)/,
+      );
+    }
+  });
+
+  it("runs release control from the workflow commit and builds only the validated source", () => {
+    for (const [name, source] of Object.entries(release.jobs)) {
+      const checkouts = source.steps.filter((step) => step.uses?.startsWith("actions/checkout@"));
+      for (const checkout of checkouts) {
+        const buildsPackage =
+          ["build", "test", "smoke"].includes(name) && checkout.with.path !== ".release-control";
+        expect(checkout.with.ref, name).toBe(
+          buildsPackage ? "${{ needs.parse-tag.outputs.commit }}" : "${{ github.sha }}",
+        );
+        if (buildsPackage) expect(source.permissions, name).toEqual({ contents: "read" });
+      }
+    }
+  });
+
+  it("grants publishing identity only to the two stage jobs", () => {
+    expect(release.permissions).toEqual({ contents: "read" });
+    expect(
+      Object.entries(release.jobs)
+        .filter(([, value]) => value.permissions["id-token"] === "write")
+        .map(([name]) => name)
+        .sort(),
+    ).toEqual(["alias-stage", "primary-stage"]);
+    for (const name of ["primary-stage", "alias-stage"]) {
+      expect(job(release, name).environment).toBe("npm-production");
+      expect(job(release, name).permissions).toEqual({
+        actions: "read",
+        contents: "read",
+        "id-token": "write",
+      });
+    }
+    for (const source of [release, coordinator]) {
+      for (const value of Object.values(source.jobs)) {
+        expect(JSON.stringify(value)).not.toMatch(/secrets\.(?:NPM_TOKEN|NODE_AUTH_TOKEN)/);
+        for (const step of value.steps.filter((entry) =>
+          entry.uses?.startsWith("actions/checkout@"),
+        )) {
+          expect(step.with["persist-credentials"]).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("pins the administrator-verified reservation policy in every reserve, intent, and stage job", () => {
+    for (const name of ["reserve", "primary-intent", "alias-intent", "primary-stage", "alias-stage"]) {
+      const source = job(release, name);
+      expect(source.env, name).toMatchObject({
+        RESERVATION_RULESET_ID: "${{ vars.RESERVATION_RULESET_ID }}",
+        RESERVATION_RULESET_UPDATED_AT: "${{ vars.RESERVATION_RULESET_UPDATED_AT }}",
+        GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+      });
+      expect(source.permissions.administration, name).toBeUndefined();
+    }
+  });
+
+  it("passes event input through environment values instead of interpolating shell programs", () => {
+    for (const source of [release, coordinator]) {
+      for (const [name, value] of Object.entries(source.jobs))
+        expect(script(value), name).not.toContain("${{");
+    }
+    expect(job(release, "parse-tag").env).toMatchObject({
+      RELEASE_TAG: "${{ inputs.tag }}",
+      RELEASE_COMMIT: "${{ inputs.commit }}",
+      COORDINATOR_RUN_ID: "${{ inputs.coordinator_run_id }}",
+      COORDINATOR_RUN_ATTEMPT: "${{ inputs.coordinator_run_attempt }}",
+    });
+  });
+
+  it("seals both archives and their source identity before an immutable upload and reservation", () => {
+    const smoke = job(release, "smoke");
+    const sealIndex = smoke.steps.findIndex((step) => step.run?.includes("npm-release.ts seal"));
+    const uploadIndex = smoke.steps.findIndex((step) => step.id === "npm-artifact");
+    expect(sealIndex).toBeGreaterThan(0);
+    expect(uploadIndex).toBeGreaterThan(sealIndex);
+    expect(smoke.steps[sealIndex]?.env).toMatchObject({
+      RELEASE_COMMIT: "${{ needs.parse-tag.outputs.commit }}",
+      COORDINATOR_RUN_ID: "${{ inputs.coordinator_run_id }}",
+      COORDINATOR_RUN_ATTEMPT: "${{ inputs.coordinator_run_attempt }}",
+    });
+    expect(smoke.steps[uploadIndex]?.with).toMatchObject({
+      name: "npm-release-${{ github.run_id }}-${{ github.run_attempt }}-${{ needs.parse-tag.outputs.package }}",
+      path: "${{ steps.pack.outputs.pack_dir }}/*.tgz\n${{ steps.pack.outputs.pack_dir }}/release-manifest.json\n",
+      "if-no-files-found": "error",
+    });
+    const packing = smoke.steps.find((step) => step.id === "pack")?.run;
+    expect(packing).toContain('pnpm check:published-package -- "$TARBALL"');
+    expect(packing).toContain('pnpm check:published-package -- "$PACK_DIR/$ALIAS_FILENAME"');
+    expect(packing).toContain('shasum -a 512 "$TARBALL"');
+    expect(packing).toContain('shasum -a 512 "$PACK_DIR/$ALIAS_FILENAME"');
+    expect(dependencies(job(release, "reserve"))).toContain("smoke");
+    expect(dependencies(job(release, "primary-intent"))).toContain("reserve");
+  });
+
+  it("restores exact archives before staging and retains outcomes even on failure", () => {
+    for (const name of ["primary-stage", "alias-stage"]) {
+      const source = job(release, name);
+      const intent = name === "primary-stage" ? "primary-intent" : "alias-intent";
+      expect(source.if).toBe(`needs.${intent}.outputs.stage == 'true'`);
+      expect(dependencies(source)).toContain(intent);
+      const restoreIndex = source.steps.findIndex((step) =>
+        step.run?.includes("npm-release.ts restore"),
+      );
+      const stageIndex = source.steps.findIndex((step) =>
+        step.run?.includes("npm-release.ts stage"),
+      );
+      const receipt = source.steps.find((step) =>
+        step.uses?.startsWith("actions/upload-artifact@"),
+      );
+      expect(restoreIndex, name).toBeGreaterThan(0);
+      expect(stageIndex, name).toBeGreaterThan(restoreIndex);
+      expect(receipt?.if).toBe("always()");
+      expect(receipt?.with["if-no-files-found"]).toBe("error");
+      expect(script(source).indexOf("sha512sum --check")).toBeLessThan(
+        script(source).indexOf("npm-release.ts stage"),
+      );
+      expect(script(source).match(/[a-f0-9]{128}/g)).toEqual(
+        script(job(release, "publisher-tools")).match(/[a-f0-9]{128}/g),
+      );
+      for (const step of source.steps.filter((entry) =>
+        entry.uses?.startsWith("actions/download-artifact@"),
+      )) {
+        expect(step.with["artifact-ids"]).toBeTruthy();
+        expect(step.with["digest-mismatch"]).toBe("error");
+      }
+    }
+    expect(dependencies(job(release, "alias-intent"))).toContain("primary-stage");
+    expect(job(release, "alias-intent").if).toContain(
+      "needs.primary-stage.result == 'success' || needs.primary-stage.result == 'skipped'",
+    );
+    expect(dependencies(job(release, "publish-package-only-release"))).toContain(
+      "verify-npm-publication",
+    );
+    expect(job(release, "verify-npm-publication").if).toBe("inputs.phase == 'finalize'");
+  });
+
+  it("preserves desktop dispatch from its validated release tag", () => {
+    const desktop = script(job(coordinator, "desktop-coordinator"));
+    expect(desktop).toContain('gh workflow run desktop-release.yml --ref "$DESKTOP_TAG"');
+    expect(desktop).toContain('if [ "$DESKTOP_TAG_COMMIT" != "$RELEASE_COMMIT" ]');
+    expect(desktop).toContain('-f commit="$RELEASE_COMMIT"');
+    expect(desktop).toContain('-f draft_id="$DRAFT_ID"');
+    expect(desktop).toContain('-f draft_body_sha256="$RELEASE_BODY_SHA256"');
+  });
+});

--- a/tools/npm-release.test.ts
+++ b/tools/npm-release.test.ts
@@ -366,6 +366,21 @@ describe("protected workflow and source identities", () => {
 });
 
 describe("policy and sealed artifact gates", () => {
+  it("accepts GitHub revision timestamps with offsets and fractional seconds", async () => {
+    const revision = "1998-08-06T14:37:10.649+05:00";
+    routes.set("rulesets/1", tagPolicy({ updated_at: revision }));
+    vi.stubEnv("RESERVATION_RULESET_UPDATED_AT", revision);
+    await expect(validatePolicies()).resolves.toBeUndefined();
+    await expect(verifyPolicy()).resolves.toEqual({
+      RESERVATION_RULESET_ID: "1",
+      RESERVATION_RULESET_UPDATED_AT: revision,
+    });
+    vi.stubEnv("RESERVATION_RULESET_UPDATED_AT", "1998-08-06T09:37:10.649Z");
+    await expect(validatePolicies()).rejects.toThrow("ruleset changed");
+    vi.stubEnv("RESERVATION_RULESET_UPDATED_AT", "1998-08-06T14:37:10.650+05:00");
+    await expect(validatePolicies()).rejects.toThrow("ruleset changed");
+  });
+
   it("accepts active main-only environments and immutable reservation tags", async () => {
     await expect(validatePolicies()).resolves.toBeUndefined();
   });

--- a/tools/npm-release.test.ts
+++ b/tools/npm-release.test.ts
@@ -1,0 +1,624 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  acceptedReceipt,
+  manifest,
+  promoteLatest,
+  restore,
+  runNpmRelease,
+  stageResponse,
+  validateArtifact,
+  validateInvocation,
+  validatePolicies,
+  validateRun,
+  validateSource,
+  verifyArchives,
+  verifyPolicy,
+} from "./npm-release.js";
+
+const repository = "yerzhansa/enduragent";
+const version = "1998.8.7";
+const tag = `cycling-coach@${version}`;
+const source = "a".repeat(40);
+const preparation = { runId: "456", attempt: "2", workflowCommit: "b".repeat(40) };
+const publisher = { runId: "789", attempt: "1", workflowCommit: "c".repeat(40) };
+const coordinator = { runId: "123", attempt: "1", workflowCommit: source };
+const reservationSha = "d".repeat(40);
+const stageId = "12345678-1234-1234-1234-123456789abc";
+const policyRevision = "1998-08-07T00:00:00Z";
+const tagPolicy = (extra: Record<string, unknown> = {}) => ({
+  id: 1,
+  updated_at: policyRevision,
+  target: "tag",
+  enforcement: "active",
+  bypass_actors: [],
+  rules: [{ type: "update" }, { type: "deletion" }],
+  conditions: {
+    ref_name: {
+      include: ["refs/tags/npm-stage/**", "refs/tags/npm-stage-attempt/**"],
+      exclude: [],
+    },
+  },
+  ...extra,
+});
+const json = (value: unknown) => `${JSON.stringify(value)}\n`;
+const sha = (value: string | Buffer, algorithm = "sha256") =>
+  createHash(algorithm).update(value).digest("hex");
+const routes = new Map<string, unknown>();
+const requests: { path: string; method: string; body?: unknown }[] = [];
+let directory: string;
+let release: ReturnType<typeof manifest>;
+let reservation: {
+  manifest: ReturnType<typeof manifest>;
+  artifactId: string;
+  artifactDigest: string;
+  sha: string;
+};
+
+function workflowRun(invocation: typeof preparation, workflow: string, event: string) {
+  return {
+    id: Number(invocation.runId),
+    run_attempt: Number(invocation.attempt),
+    head_sha: invocation.workflowCommit,
+    head_branch: "main",
+    path: `.github/workflows/${workflow}`,
+    event,
+    repository: { full_name: repository },
+    head_repository: { full_name: repository },
+  };
+}
+
+function installRun(invocation: typeof preparation, workflow: string, event: string, job: string) {
+  const path = `actions/runs/${invocation.runId}/attempts/${invocation.attempt}`;
+  routes.set(path, workflowRun(invocation, workflow, event));
+  routes.set(`${path}/jobs?per_page=100&page=1`, {
+    jobs: [{ name: job, status: "completed", conclusion: "success" }],
+  });
+}
+
+function installAttempt(name: "cycling-coach" | "enduragent" = "cycling-coach", owner = publisher) {
+  const attempt = { reservation: reservationSha, name, publisher: owner };
+  const attemptName = `npm-stage-attempt/${tag}/${name}`;
+  const id = (name === "cycling-coach" ? "e" : "f").repeat(40);
+  routes.set(`git/ref/tags/${attemptName}`, { object: { type: "tag", sha: id } });
+  routes.set(`git/tags/${id}`, {
+    tag: attemptName,
+    object: { type: "commit", sha: owner.workflowCommit },
+    message: json(attempt),
+  });
+  return attempt;
+}
+
+function zip(name: string, folder: string, files: string[]) {
+  const path = join(directory, name);
+  execFileSync("zip", ["-q", path, ...files], { cwd: folder });
+  return path;
+}
+
+function installReceipt(status = "accepted") {
+  const attempt = installAttempt();
+  const name = `npm-stage-receipt-${preparation.runId}-${preparation.attempt}-cycling-coach-${publisher.runId}-${publisher.attempt}`;
+  const folder = join(directory, "receipt");
+  mkdirSync(folder, { recursive: true });
+  writeFileSync(
+    join(folder, "receipt.json"),
+    json({
+      status,
+      reservation: reservationSha,
+      name: "cycling-coach",
+      publisher,
+      manifestSha256: sha(json(release)),
+      stageId,
+    }),
+  );
+  const path = zip(`receipt-${status}.zip`, folder, ["receipt.json"]);
+  routes.set(`actions/runs/${publisher.runId}/artifacts?name=${name}&per_page=100`, {
+    artifacts: [
+      {
+        id: 901,
+        name,
+        expired: false,
+        workflow_run: { id: Number(publisher.runId), head_sha: publisher.workflowCommit },
+        digest: `sha256:${sha(readFileSync(path))}`,
+      },
+    ],
+  });
+  vi.stubEnv("FAKE_RECEIPT_ZIP", path);
+  return attempt;
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "npm-release-contract-"));
+  routes.clear();
+  requests.length = 0;
+  const archives = (["cycling-coach", "enduragent"] as const).map((name) => {
+    const folder = join(directory, name);
+    mkdirSync(join(folder, "package"), { recursive: true });
+    writeFileSync(
+      join(folder, "package/package.json"),
+      json({
+        name,
+        version,
+        repository: {
+          type: "git",
+          url: `git+https://github.com/${repository}.git`,
+          directory: "packages/cycling-coach",
+        },
+      }),
+    );
+    const filename = `${name}-${version}.tgz`;
+    execFileSync("tar", ["-czf", join(directory, filename), "package/package.json"], {
+      cwd: folder,
+    });
+    const bytes = readFileSync(join(directory, filename));
+    return { name, filename, size: bytes.length, sha512: sha(bytes, "sha512") };
+  });
+  release = manifest({
+    schema: 1,
+    tag,
+    version,
+    sourceCommit: source,
+    coordinator,
+    preparation,
+    archives,
+  });
+  writeFileSync(join(directory, "release-manifest.json"), json(release));
+  const artifactZip = zip("prepared.zip", directory, [
+    "release-manifest.json",
+    ...archives.map((archive) => archive.filename),
+  ]);
+  reservation = {
+    manifest: release,
+    artifactId: "900",
+    artifactDigest: sha(readFileSync(artifactZip)),
+    sha: reservationSha,
+  };
+  routes.set(`git/ref/tags/npm-stage/${tag}`, { object: { type: "tag", sha: reservationSha } });
+  routes.set(`git/tags/${reservationSha}`, {
+    tag: `npm-stage/${tag}`,
+    object: { type: "commit", sha: source },
+    message: json(reservation),
+  });
+  routes.set(`git/ref/tags/${tag}`, { object: { type: "commit", sha: source } });
+  routes.set("branches/main", { protected: true, commit: { sha: publisher.workflowCommit } });
+  for (const ancestor of [source, preparation.workflowCommit])
+    routes.set(`compare/${ancestor}...${publisher.workflowCommit}`, {
+      status: "ahead",
+      base_commit: { sha: ancestor },
+      merge_base_commit: { sha: ancestor },
+    });
+  routes.set(`contents/packages/cycling-coach/package.json?ref=${source}`, {
+    type: "file",
+    encoding: "base64",
+    content: Buffer.from(json({ name: "cycling-coach", version })).toString("base64"),
+  });
+  installRun(coordinator, "version-pr.yml", "push", "package-coordinator");
+  installRun(preparation, "release.yml", "workflow_dispatch", "smoke");
+  installRun(publisher, "release.yml", "workflow_dispatch", "primary-intent");
+  routes.set("actions/artifacts/900", {
+    id: 900,
+    expired: false,
+    name: `npm-release-${preparation.runId}-${preparation.attempt}-cycling-coach`,
+    digest: `sha256:${reservation.artifactDigest}`,
+    workflow_run: { id: Number(preparation.runId), head_sha: preparation.workflowCommit },
+  });
+  for (const name of ["npm-production", "npm-stage"]) {
+    routes.set(`environments/${name}`, {
+      can_admins_bypass: false,
+      deployment_branch_policy: { protected_branches: false, custom_branch_policies: true },
+    });
+    routes.set(`environments/${name}/deployment-branch-policies`, {
+      branch_policies: [{ name: "main", type: "branch" }],
+    });
+  }
+  routes.set("rulesets/1", tagPolicy());
+  vi.stubEnv("RESERVATION_RULESET_ID", "1");
+  vi.stubEnv("RESERVATION_RULESET_UPDATED_AT", policyRevision);
+  vi.stubEnv("GH_TOKEN", "fixture-github-token");
+  vi.stubEnv("GITHUB_REPOSITORY", repository);
+  vi.stubEnv("GITHUB_REF", "refs/heads/main");
+  vi.stubEnv("GITHUB_EVENT_NAME", "workflow_dispatch");
+  vi.stubEnv("GITHUB_SHA", publisher.workflowCommit);
+  vi.stubEnv("GITHUB_RUN_ID", publisher.runId);
+  vi.stubEnv("GITHUB_RUN_ATTEMPT", publisher.attempt);
+  vi.stubEnv("GITHUB_OUTPUT", join(directory, "output"));
+  vi.stubEnv("RELEASE_TAG", tag);
+  vi.stubEnv("RELEASE_PACKAGE", "cycling-coach");
+  vi.stubEnv("RUNNER_TEMP", directory);
+  vi.stubEnv("FAKE_ARTIFACT_ZIP", artifactZip);
+  const binaries = join(directory, "bin");
+  mkdirSync(binaries);
+  writeFileSync(
+    join(binaries, "gh"),
+    `#!/usr/bin/env node\nconst {readFileSync} = require('node:fs');\nconst path = process.argv[3];\nif (!path?.endsWith('/900/zip') && !path?.endsWith('/901/zip')) throw new Error('Unexpected fake GitHub command');\nprocess.stdout.write(readFileSync(path.endsWith('/900/zip') ? process.env.FAKE_ARTIFACT_ZIP : process.env.FAKE_RECEIPT_ZIP));\n`,
+  );
+  chmodSync(join(binaries, "gh"), 0o755);
+  vi.stubEnv("PATH", `${binaries}:${process.env.PATH}`);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, options?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      expect(url.origin).toBe("https://api.github.com");
+      const path = `${url.pathname.replace(`/repos/${repository}/`, "")}${url.search}`;
+      const method = options?.method ?? "GET";
+      requests.push({
+        path,
+        method,
+        ...(typeof options?.body === "string" ? { body: JSON.parse(options.body) } : {}),
+      });
+      expect(new Headers(options?.headers).get("authorization")).toBe(
+        "Bearer fixture-github-token",
+      );
+      if (method !== "GET") throw new Error("Unexpected GitHub mutation in fixture");
+      return new Response(routes.has(path) ? json(routes.get(path)) : "{}", {
+        status: routes.has(path) ? 200 : 404,
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("protected workflow and source identities", () => {
+  it("checks distinct workflow and source commits through protected main without git credentials", async () => {
+    await expect(validateSource(release)).resolves.toBeUndefined();
+    expect(
+      requests.some((request) => request.path.includes(`compare/${preparation.workflowCommit}`)),
+    ).toBe(true);
+    expect(requests.some((request) => request.path.endsWith(`?ref=${source}`))).toBe(true);
+  });
+
+  it("rejects a coordinator for another source before accepting its manifest", () => {
+    expect(() => manifest({ ...release, sourceCommit: publisher.workflowCommit })).toThrow(
+      "Coordinator",
+    );
+  });
+
+  it.each(["head_sha", "head_branch", "path", "event", "id", "run_attempt"])(
+    "rejects mismatched run field %s",
+    (key) => {
+      expect(() =>
+        validateRun(
+          { ...workflowRun(publisher, "release.yml", "workflow_dispatch"), [key]: "wrong" },
+          publisher,
+          "release.yml",
+          "workflow_dispatch",
+        ),
+      ).toThrow("identity mismatch");
+    },
+  );
+
+  it.each([
+    [
+      "branches/main",
+      { protected: false, commit: { sha: publisher.workflowCommit } },
+      "protected main",
+    ],
+    [
+      `git/ref/tags/${tag}`,
+      { object: { type: "commit", sha: preparation.workflowCommit } },
+      "tag changed",
+    ],
+    [
+      `compare/${source}...${publisher.workflowCommit}`,
+      { status: "diverged", base_commit: { sha: source }, merge_base_commit: { sha: source } },
+      "ancestor",
+    ],
+  ])("rejects source boundary drift at %s", async (path, value, message) => {
+    routes.set(String(path), value);
+    await expect(validateSource(release)).rejects.toThrow(String(message));
+  });
+
+  it("peels annotated release tags", async () => {
+    routes.set(`git/ref/tags/${tag}`, { object: { type: "tag", sha: "f".repeat(40) } });
+    routes.set(`git/tags/${"f".repeat(40)}`, { object: { type: "commit", sha: source } });
+    await expect(validateSource(release)).resolves.toBeUndefined();
+  });
+
+  it("waits for the exact dispatching coordinator job to finish", async () => {
+    vi.useFakeTimers();
+    const path = "actions/runs/123/attempts/1/jobs?per_page=100&page=1";
+    routes.set(path, {
+      jobs: [{ name: "package-coordinator", status: "in_progress", conclusion: null }],
+    });
+    const pending = validateInvocation(
+      coordinator,
+      "version-pr.yml",
+      "push",
+      "package-coordinator",
+    );
+    await vi.advanceTimersByTimeAsync(1);
+    routes.set(path, {
+      jobs: [{ name: "package-coordinator", status: "completed", conclusion: "success" }],
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(pending).resolves.toBeUndefined();
+    expect(requests.filter((request) => request.path === path)).toHaveLength(2);
+  });
+
+  it("stops waiting after a bounded coordinator timeout", async () => {
+    vi.useFakeTimers();
+    routes.set("actions/runs/123/attempts/1/jobs?per_page=100&page=1", { jobs: [] });
+    const pending = expect(
+      validateInvocation(coordinator, "version-pr.yml", "push", "package-coordinator"),
+    ).rejects.toThrow("has not succeeded");
+    await vi.advanceTimersByTimeAsync(60_000);
+    await pending;
+    expect(requests.filter((request) => request.path.includes("/jobs?"))).toHaveLength(12);
+  });
+});
+
+describe("policy and sealed artifact gates", () => {
+  it("accepts active main-only environments and immutable reservation tags", async () => {
+    await expect(validatePolicies()).resolves.toBeUndefined();
+  });
+
+  it("rejects stored main patterns when custom restrictions are disabled", async () => {
+    routes.set("environments/npm-production", {
+      can_admins_bypass: false,
+      deployment_branch_policy: { protected_branches: true, custom_branch_policies: false },
+    });
+    await expect(validatePolicies()).rejects.toThrow("permit only main");
+  });
+
+  it("rejects tag protection with an administrator bypass", async () => {
+    routes.set("rulesets/1", tagPolicy({ bypass_actors: [{ actor_id: 1 }] }));
+    await expect(validatePolicies()).rejects.toThrow("without bypass");
+  });
+
+  it("accepts hidden bypass data only against the administrator-verified revision", async () => {
+    routes.set("rulesets/1", tagPolicy({ bypass_actors: undefined }));
+    await expect(validatePolicies()).resolves.toBeUndefined();
+    routes.set(
+      "rulesets/1",
+      tagPolicy({ bypass_actors: undefined, updated_at: "1998-08-07T00:00:01Z" }),
+    );
+    await expect(validatePolicies()).rejects.toThrow("ruleset changed");
+  });
+
+  it.each(["RESERVATION_RULESET_ID", "RESERVATION_RULESET_UPDATED_AT"])(
+    "requires setup pin %s",
+    async (name) => {
+      vi.stubEnv(name, "");
+      await expect(validatePolicies()).rejects.toThrow(`Missing ${name}`);
+    },
+  );
+
+  it("outputs policy setup evidence only when the administrator can see every bypass", async () => {
+    await expect(verifyPolicy()).resolves.toEqual({
+      RESERVATION_RULESET_ID: "1",
+      RESERVATION_RULESET_UPDATED_AT: policyRevision,
+    });
+    routes.set("rulesets/1", tagPolicy({ bypass_actors: undefined }));
+    await expect(verifyPolicy()).rejects.toThrow("visible empty ruleset bypass list");
+  });
+
+  it("rejects artifact replacement, expiration, and wrong attempt names", async () => {
+    for (const change of [
+      { expired: true },
+      { digest: `sha256:${"f".repeat(64)}` },
+      { name: "npm-release-456-3-cycling-coach" },
+    ]) {
+      routes.set("actions/artifacts/900", {
+        id: 900,
+        expired: false,
+        name: "npm-release-456-2-cycling-coach",
+        digest: `sha256:${reservation.artifactDigest}`,
+        workflow_run: { id: 456, head_sha: preparation.workflowCommit },
+        ...change,
+      });
+      await expect(validateArtifact(reservation)).rejects.toThrow("unavailable or mismatched");
+    }
+  });
+
+  it("restores actual sealed ZIP bytes and exports source identity", async () => {
+    const destination = join(directory, "restored");
+    await runNpmRelease("restore", destination);
+    expect(readFileSync(join(destination, release.archives[0].filename))).toEqual(
+      readFileSync(join(directory, release.archives[0].filename)),
+    );
+    const outputs = readFileSync(join(directory, "output"), "utf8");
+    expect(outputs).toContain(`commit=${source}\n`);
+    expect(outputs).toContain(`ref=${tag}\n`);
+    expect(outputs).toContain("preparation_run_attempt=2\n");
+  });
+
+  it("rejects modified archive bytes and symlinked archives", () => {
+    const path = join(directory, release.archives[0].filename);
+    writeFileSync(path, "modified");
+    expect(() => verifyArchives(release, directory)).toThrow("changed");
+    rmSync(path);
+    symlinkSync(join(directory, release.archives[1].filename), path);
+    expect(() => verifyArchives(release, directory)).toThrow("regular file");
+  });
+
+  it("rejects unexpected ZIP entries before extracting them", async () => {
+    writeFileSync(join(directory, "unexpected"), "extra");
+    const path = zip("extra.zip", directory, [
+      "release-manifest.json",
+      ...release.archives.map((archive) => archive.filename),
+      "unexpected",
+    ]);
+    reservation.artifactDigest = sha(readFileSync(path));
+    routes.set(`git/tags/${reservationSha}`, {
+      tag: `npm-stage/${tag}`,
+      object: { type: "commit", sha: source },
+      message: json(reservation),
+    });
+    routes.set("actions/artifacts/900", {
+      expired: false,
+      name: "npm-release-456-2-cycling-coach",
+      digest: `sha256:${reservation.artifactDigest}`,
+      workflow_run: { id: 456, head_sha: preparation.workflowCommit },
+    });
+    vi.stubEnv("FAKE_ARTIFACT_ZIP", path);
+    await expect(restore(tag, join(directory, "restore-extra"))).rejects.toThrow(
+      "Unexpected artifact entries",
+    );
+  });
+});
+
+describe("latest promotion", () => {
+  it("checks both package versions before changing either latest tag", () => {
+    const read = vi.fn((name: string) => (name === "cycling-coach" ? "1998.8.6" : "1998.8.8"));
+    const write = vi.fn();
+    expect(() => promoteLatest(version, read, write)).toThrow("newer npm latest");
+    expect(read.mock.calls).toEqual([["cycling-coach"], ["enduragent"]]);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("treats the project same-day -N release as newer than its base date", () => {
+    const latest: Record<string, string> = { "cycling-coach": version, enduragent: version };
+    const writes: string[] = [];
+    promoteLatest(
+      `${version}-1`,
+      (name) => latest[name],
+      (name, next) => {
+        writes.push(name);
+        latest[name] = next;
+      },
+    );
+    expect(writes).toEqual(["cycling-coach", "enduragent"]);
+    expect(() =>
+      promoteLatest(
+        version,
+        (name) => latest[name],
+        () => {
+          throw new Error("Must not write");
+        },
+      ),
+    ).toThrow("newer npm latest");
+  });
+
+  it("rechecks before each mutation and refuses a concurrent newer version", () => {
+    const latest: Record<string, string> = { "cycling-coach": "1998.8.6", enduragent: "1998.8.6" };
+    const writes: string[] = [];
+    expect(() =>
+      promoteLatest(
+        version,
+        (name) => latest[name],
+        (name, next) => {
+          writes.push(name);
+          latest[name] = next;
+          latest.enduragent = "1998.8.8";
+        },
+      ),
+    ).toThrow("newer npm latest");
+    expect(writes).toEqual(["cycling-coach"]);
+    expect(latest.enduragent).toBe("1998.8.8");
+  });
+
+  it("requires reconciliation when a mutation has an uncertain result", () => {
+    const write = vi.fn(() => {
+      throw new Error("Response lost");
+    });
+    expect(() => promoteLatest(version, () => "1998.8.6", write)).toThrow(
+      "promotion is incomplete",
+    );
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves already promoted versions unchanged", () => {
+    const write = vi.fn();
+    promoteLatest(version, () => version, write);
+    expect(write).not.toHaveBeenCalled();
+  });
+});
+
+describe("staged publication and retry evidence", () => {
+  function response() {
+    const archive = release.archives[0];
+    return {
+      "cycling-coach": {
+        name: archive.name,
+        version,
+        size: archive.size,
+        integrity: `sha512-${Buffer.from(archive.sha512, "hex").toString("base64")}`,
+        stageId,
+      },
+    };
+  }
+
+  it("parses the package-keyed JSON emitted by npm 11.19.1", () => {
+    expect(stageResponse(response(), release.archives[0], version)).toBe(stageId);
+    expect(() => stageResponse(response()["cycling-coach"], release.archives[0], version)).toThrow(
+      "exactly the expected package",
+    );
+    expect(() => stageResponse({ ...response(), error: {} }, release.archives[0], version)).toThrow(
+      "exactly the expected package",
+    );
+    expect(() =>
+      stageResponse(
+        { "cycling-coach": { ...response()["cycling-coach"], size: 1 } },
+        release.archives[0],
+        version,
+      ),
+    ).toThrow("archive mismatch");
+  });
+
+  it("restores a verified accepted receipt and refuses to restage", async () => {
+    installReceipt();
+    await runNpmRelease("begin", join(directory, "resume"));
+    expect(readFileSync(join(directory, "output"), "utf8")).toContain("stage=false\n");
+    expect(requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  it.each(["missing", "unknown"])("does not restage an existing %s outcome", async (status) => {
+    if (status === "missing") installAttempt();
+    else installReceipt(status);
+    await expect(runNpmRelease("begin", join(directory, `resume-${status}`))).rejects.toThrow(
+      status === "missing" ? "Missing stage receipt" : "Unknown or mismatched stage outcome",
+    );
+    expect(requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  it("does not trust a receipt from a different publisher commit", async () => {
+    const attempt = installReceipt();
+    await expect(
+      acceptedReceipt(reservation, {
+        ...attempt,
+        publisher: { ...publisher, workflowCommit: source },
+      }),
+    ).rejects.toThrow("identity mismatch");
+  });
+
+  it.each(["accepted", "interrupted"])(
+    "records %s publication without a second request",
+    async (result) => {
+      installAttempt();
+      const script = join(directory, "publisher.mjs");
+      const calls = join(directory, "publisher-calls");
+      writeFileSync(
+        script,
+        `import {appendFileSync} from 'node:fs';\nappendFileSync(${JSON.stringify(calls)}, 'called\\n');\n${result === "accepted" ? `process.stdout.write(${JSON.stringify(json(response()))});` : "process.exitCode = 1;"}\n`,
+      );
+      vi.stubEnv("PUBLISHER_NODE", process.execPath);
+      vi.stubEnv("PUBLISHER_NPM", script);
+      vi.stubEnv("RECEIPT_PATH", join(directory, "stage-receipt.json"));
+      if (result === "accepted") await runNpmRelease("stage", directory);
+      else await expect(runNpmRelease("stage", directory)).rejects.toThrow();
+      expect(JSON.parse(readFileSync(join(directory, "stage-receipt.json"), "utf8")).status).toBe(
+        result === "accepted" ? "accepted" : "unknown",
+      );
+      await expect(runNpmRelease("stage", directory)).rejects.toThrow("EEXIST");
+      expect(readFileSync(calls, "utf8")).toBe("called\n");
+    },
+  );
+});

--- a/tools/npm-release.ts
+++ b/tools/npm-release.ts
@@ -232,7 +232,10 @@ async function reservationPolicy() {
   return {
     id,
     ruleset,
-    updatedAt: text(ruleset.updated_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/u),
+    updatedAt: text(
+      ruleset.updated_at,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/u,
+    ),
   };
 }
 

--- a/tools/npm-release.ts
+++ b/tools/npm-release.ts
@@ -1,0 +1,866 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  appendFileSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repository = "yerzhansa/enduragent";
+const packages = ["cycling-coach", "enduragent"] as const;
+type PackageName = (typeof packages)[number];
+type Invocation = { runId: string; attempt: string; workflowCommit: string };
+type Archive = { name: PackageName; filename: string; size: number; sha512: string };
+type Manifest = {
+  schema: 1;
+  tag: string;
+  version: string;
+  sourceCommit: string;
+  coordinator: Invocation;
+  preparation: Invocation;
+  archives: Archive[];
+};
+type Reservation = { manifest: Manifest; artifactId: string; artifactDigest: string };
+type Attempt = { reservation: string; name: PackageName; publisher: Invocation };
+
+function record(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Expected an object");
+  return Object.fromEntries(Object.entries(value));
+}
+
+function text(value: unknown, pattern: RegExp): string {
+  if (typeof value !== "string" || !pattern.test(value))
+    throw new Error("Invalid release identity");
+  return value;
+}
+
+const identifier = (value: unknown) => text(String(value), /^[1-9]\d*$/u);
+const commit = (value: unknown) => text(value, /^[0-9a-f]{40}$/u);
+const digest = (value: unknown) => text(value, /^[0-9a-f]{64}$/u);
+const hash = (value: string | Buffer, algorithm = "sha256") =>
+  createHash(algorithm).update(value).digest("hex");
+const json = (value: unknown) => `${JSON.stringify(value)}\n`;
+const parse = (value: string): unknown => JSON.parse(value);
+const environment = (name: string) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+};
+const output = (name: string, value: string) => {
+  if (/[\r\n]/u.test(value)) throw new Error("Invalid workflow output");
+  appendFileSync(environment("GITHUB_OUTPUT"), `${name}=${value}\n`);
+};
+const run = (command: string, args: string[]) =>
+  execFileSync(command, args, { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }).trim();
+
+export function invocation(value: unknown): Invocation {
+  const item = record(value);
+  return {
+    runId: identifier(item.runId),
+    attempt: identifier(item.attempt),
+    workflowCommit: commit(item.workflowCommit),
+  };
+}
+
+export function manifest(value: unknown): Manifest {
+  const item = record(value);
+  if (item.schema !== 1) throw new Error("Unsupported release manifest");
+  const version = text(
+    item.version,
+    /^[1-9]\d{3}\.([1-9]|1[0-2])\.([1-9]|[12]\d|3[01])(?:-[1-9]\d*)?$/u,
+  );
+  if (item.tag !== `cycling-coach@${version}`) throw new Error("Release tag mismatch");
+  if (!Array.isArray(item.archives) || item.archives.length !== 2)
+    throw new Error("Both release archives are required");
+  const rawArchives = item.archives;
+  const archives = packages.map((name) => {
+    const matches = rawArchives.filter((raw: unknown) => record(raw).name === name);
+    if (matches.length !== 1) throw new Error("Duplicate or missing package");
+    const archive = record(matches[0]);
+    if (
+      archive.filename !== `${name}-${version}.tgz` ||
+      typeof archive.size !== "number" ||
+      !Number.isSafeInteger(archive.size) ||
+      archive.size <= 0
+    )
+      throw new Error("Invalid archive identity");
+    return {
+      name,
+      filename: archive.filename,
+      size: archive.size,
+      sha512: text(archive.sha512, /^[0-9a-f]{128}$/u),
+    };
+  });
+  const sourceCommit = commit(item.sourceCommit);
+  const coordinator = invocation(item.coordinator);
+  if (coordinator.workflowCommit !== sourceCommit)
+    throw new Error("Coordinator does not bind the source commit");
+  return {
+    schema: 1,
+    tag: item.tag,
+    version,
+    sourceCommit,
+    coordinator,
+    preparation: invocation(item.preparation),
+    archives,
+  };
+}
+
+function current(): Invocation {
+  if (
+    environment("GITHUB_REPOSITORY") !== repository ||
+    environment("GITHUB_REF") !== "refs/heads/main" ||
+    environment("GITHUB_EVENT_NAME") !== "workflow_dispatch"
+  )
+    throw new Error("Release execution requires protected main dispatch");
+  return invocation({
+    runId: environment("GITHUB_RUN_ID"),
+    attempt: environment("GITHUB_RUN_ATTEMPT"),
+    workflowCommit: environment("GITHUB_SHA"),
+  });
+}
+
+async function github(path: string, body?: unknown, method = body === undefined ? "GET" : "POST") {
+  const response = await fetch(`https://api.github.com/repos/${repository}/${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${environment("GH_TOKEN")}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (response.status === 404 && method === "GET") return null;
+  if (!response.ok) throw new Error(`GitHub request failed with ${response.status}`);
+  return response.json() as Promise<unknown>;
+}
+
+export function validateRun(value: unknown, expected: Invocation, workflow: string, event: string) {
+  const item = record(value);
+  if (
+    String(item.id) !== expected.runId ||
+    String(item.run_attempt) !== expected.attempt ||
+    item.head_sha !== expected.workflowCommit ||
+    item.head_branch !== "main" ||
+    item.path !== `.github/workflows/${workflow}` ||
+    item.event !== event ||
+    record(item.repository).full_name !== repository ||
+    record(item.head_repository).full_name !== repository
+  )
+    throw new Error("Workflow run identity mismatch");
+}
+
+export async function validateInvocation(
+  expected: Invocation,
+  workflow: string,
+  event: string,
+  job?: string,
+) {
+  const path = `actions/runs/${expected.runId}/attempts/${expected.attempt}`;
+  validateRun(await github(path), expected, workflow, event);
+  if (!job) return;
+  const polls = job === "package-coordinator" ? 12 : 1;
+  for (let poll = 0; poll < polls; poll += 1) {
+    const matches: Record<string, unknown>[] = [];
+    for (let page = 1; ; page += 1) {
+      const response = record(await github(`${path}/jobs?per_page=100&page=${page}`));
+      if (!Array.isArray(response.jobs)) throw new Error("Missing workflow jobs");
+      matches.push(...response.jobs.map(record).filter((entry) => entry.name === job));
+      if (response.jobs.length < 100) break;
+    }
+    if (
+      matches.length === 1 &&
+      matches[0]?.status === "completed" &&
+      matches[0].conclusion === "success"
+    )
+      return;
+    if (
+      matches.length > 1 ||
+      matches.some((entry) => entry.status === "completed") ||
+      poll === polls - 1
+    )
+      throw new Error(`Required job ${job} has not succeeded`);
+    await new Promise<void>((done) => setTimeout(done, 5_000));
+  }
+}
+
+async function validateEnvironments() {
+  for (const name of ["npm-production", "npm-stage"]) {
+    const environment = record(await github(`environments/${name}`));
+    const policies = record(await github(`environments/${name}/deployment-branch-policies`));
+    const mode = record(environment.deployment_branch_policy);
+    if (
+      environment.can_admins_bypass !== false ||
+      mode.custom_branch_policies !== true ||
+      mode.protected_branches !== false ||
+      !Array.isArray(policies.branch_policies) ||
+      policies.branch_policies.length !== 1 ||
+      record(policies.branch_policies[0]).name !== "main" ||
+      record(policies.branch_policies[0]).type !== "branch"
+    )
+      throw new Error(`Environment ${name} must permit only main and prevent administrator bypass`);
+  }
+}
+
+async function reservationPolicy() {
+  const id = identifier(environment("RESERVATION_RULESET_ID"));
+  const ruleset = record(await github(`rulesets/${id}`));
+  const refs = record(record(ruleset.conditions).ref_name);
+  if (
+    identifier(ruleset.id) !== id ||
+    ruleset.target !== "tag" ||
+    ruleset.enforcement !== "active" ||
+    !Array.isArray(refs.include) ||
+    !refs.include.includes("refs/tags/npm-stage/**") ||
+    !refs.include.includes("refs/tags/npm-stage-attempt/**") ||
+    !Array.isArray(refs.exclude) ||
+    refs.exclude.length !== 0 ||
+    !Array.isArray(ruleset.rules)
+  )
+    throw new Error("Reservation ruleset must protect both namespaces without exclusions");
+  const types = ruleset.rules.map((entry) => record(entry).type);
+  if (!types.includes("update") || !types.includes("deletion"))
+    throw new Error("Reservation ruleset must prevent updates and deletion");
+  return {
+    id,
+    ruleset,
+    updatedAt: text(ruleset.updated_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/u),
+  };
+}
+
+export async function verifyPolicy() {
+  await validateEnvironments();
+  const policy = await reservationPolicy();
+  if (!Array.isArray(policy.ruleset.bypass_actors) || policy.ruleset.bypass_actors.length !== 0)
+    throw new Error("Administrator verification requires a visible empty ruleset bypass list");
+  return { RESERVATION_RULESET_ID: policy.id, RESERVATION_RULESET_UPDATED_AT: policy.updatedAt };
+}
+
+export async function validatePolicies() {
+  const pinnedRevision = environment("RESERVATION_RULESET_UPDATED_AT");
+  await validateEnvironments();
+  const policy = await reservationPolicy();
+  if (policy.updatedAt !== pinnedRevision)
+    throw new Error("Reservation ruleset changed; administrator verification is required");
+  if (
+    Object.hasOwn(policy.ruleset, "bypass_actors") &&
+    (!Array.isArray(policy.ruleset.bypass_actors) || policy.ruleset.bypass_actors.length !== 0)
+  )
+    throw new Error("Reservation ruleset must remain without bypass");
+}
+
+export async function validateSource(value: Manifest) {
+  await validateInvocation(value.coordinator, "version-pr.yml", "push", "package-coordinator");
+  if (value.coordinator.workflowCommit !== value.sourceCommit)
+    throw new Error("Coordinator does not bind the source commit");
+  const main = record(await github("branches/main"));
+  if (main.protected !== true) throw new Error("Release source requires protected main");
+  const mainCommit = commit(record(main.commit).sha);
+  const reference = record(await github(`git/ref/tags/${value.tag}`));
+  let target = record(reference.object);
+  for (let depth = 0; target.type === "tag" && depth < 8; depth += 1)
+    target = record(record(await github(`git/tags/${commit(target.sha)}`)).object);
+  if (target.type !== "commit" || target.sha !== value.sourceCommit)
+    throw new Error("Release tag changed");
+  for (const ancestor of new Set([value.sourceCommit, value.preparation.workflowCommit])) {
+    const comparison = record(await github(`compare/${ancestor}...${mainCommit}`));
+    if (
+      (comparison.status !== "ahead" && comparison.status !== "identical") ||
+      record(comparison.base_commit).sha !== ancestor ||
+      record(comparison.merge_base_commit).sha !== ancestor
+    )
+      throw new Error("Release commit is not an ancestor of protected main");
+  }
+  const contents = record(
+    await github(`contents/packages/cycling-coach/package.json?ref=${value.sourceCommit}`),
+  );
+  if (
+    contents.type !== "file" ||
+    contents.encoding !== "base64" ||
+    typeof contents.content !== "string"
+  )
+    throw new Error("Source package manifest is unavailable");
+  const source = record(parse(Buffer.from(contents.content, "base64").toString("utf8")));
+  if (
+    source.name !== "cycling-coach" ||
+    source.version !== value.version ||
+    source.private === true
+  )
+    throw new Error("Source package identity mismatch");
+}
+
+export function verifyArchives(value: Manifest, directory: string) {
+  for (const archive of value.archives) {
+    const path = join(directory, archive.filename);
+    if (!lstatSync(path).isFile()) throw new Error("Sealed archive must be a regular file");
+    const bytes = readFileSync(path);
+    if (bytes.length !== archive.size || hash(bytes, "sha512") !== archive.sha512)
+      throw new Error("Sealed archive changed");
+    const packed = record(parse(run("tar", ["-xOf", path, "package/package.json"])));
+    const source = record(packed.repository);
+    if (
+      packed.name !== archive.name ||
+      packed.version !== value.version ||
+      packed.publishConfig != null ||
+      source.type !== "git" ||
+      source.url !== `git+https://github.com/${repository}.git` ||
+      source.directory !== "packages/cycling-coach"
+    )
+      throw new Error("Packed package identity mismatch");
+  }
+}
+
+async function readTag(name: string) {
+  const ref = await github(`git/ref/tags/${name}`);
+  if (ref === null) return null;
+  const object = record(record(ref).object);
+  if (object.type !== "tag") throw new Error("Reservation must be an annotated tag");
+  const tag = record(await github(`git/tags/${commit(object.sha)}`));
+  if (tag.tag !== name || typeof tag.message !== "string")
+    throw new Error("Invalid reservation tag");
+  return { sha: commit(object.sha), object: record(tag.object), value: parse(tag.message) };
+}
+
+async function createTag(name: string, source: string, value: unknown) {
+  const tag = record(
+    await github("git/tags", { tag: name, message: json(value), object: source, type: "commit" }),
+  );
+  await github("git/refs", { ref: `refs/tags/${name}`, sha: commit(tag.sha) });
+  return commit(tag.sha);
+}
+
+function reservation(value: unknown): Reservation {
+  const item = record(value);
+  return {
+    manifest: manifest(item.manifest),
+    artifactId: identifier(item.artifactId),
+    artifactDigest: digest(item.artifactDigest),
+  };
+}
+
+export async function validateArtifact(value: Reservation) {
+  const artifact = record(await github(`actions/artifacts/${value.artifactId}`));
+  if (
+    artifact.expired !== false ||
+    artifact.name !==
+      `npm-release-${value.manifest.preparation.runId}-${value.manifest.preparation.attempt}-cycling-coach` ||
+    artifact.digest !== `sha256:${value.artifactDigest}` ||
+    String(record(artifact.workflow_run).id) !== value.manifest.preparation.runId ||
+    record(artifact.workflow_run).head_sha !== value.manifest.preparation.workflowCommit
+  )
+    throw new Error("Prepared artifact unavailable or mismatched; operator disposition required");
+}
+
+export async function restore(tag: string, directory: string) {
+  text(tag, /^cycling-coach@[1-9]\d{3}\.\d{1,2}\.\d{1,2}(?:-[1-9]\d*)?$/u);
+  const stored = await readTag(`npm-stage/${tag}`);
+  if (!stored) throw new Error("No prepared reservation exists");
+  const value = reservation(stored.value);
+  if (
+    value.manifest.tag !== tag ||
+    stored.object.type !== "commit" ||
+    stored.object.sha !== value.manifest.sourceCommit
+  )
+    throw new Error("Reservation source mismatch");
+  await validateSource(value.manifest);
+  await validateInvocation(value.manifest.preparation, "release.yml", "workflow_dispatch", "smoke");
+  await validateArtifact(value);
+  mkdirSync(directory, { recursive: true });
+  const archive = join(directory, "artifact.zip");
+  writeFileSync(
+    archive,
+    execFileSync("gh", ["api", `repos/${repository}/actions/artifacts/${value.artifactId}/zip`], {
+      maxBuffer: 64 * 1024 * 1024,
+    }),
+  );
+  if (hash(readFileSync(archive)) !== value.artifactDigest)
+    throw new Error("Artifact ZIP digest mismatch");
+  const expected = [
+    "release-manifest.json",
+    ...value.manifest.archives.map((entry) => entry.filename),
+  ].sort();
+  const observed = run("unzip", ["-Z1", archive]).split("\n").sort();
+  if (json(expected) !== json(observed)) throw new Error("Unexpected artifact entries");
+  run("unzip", ["-o", archive, "-d", directory]);
+  if (
+    json(manifest(parse(readFileSync(join(directory, "release-manifest.json"), "utf8")))) !==
+    json(value.manifest)
+  )
+    throw new Error("Reservation does not match prepared manifest");
+  verifyArchives(value.manifest, directory);
+  return { ...value, sha: stored.sha };
+}
+
+function packageName(value: unknown): PackageName {
+  if (value !== "cycling-coach" && value !== "enduragent")
+    throw new Error("Unsupported npm package");
+  return value;
+}
+
+async function readAttempt(value: Reservation & { sha: string }, name: PackageName) {
+  const stored = await readTag(`npm-stage-attempt/${value.manifest.tag}/${name}`);
+  if (!stored) return null;
+  const raw = record(stored.value);
+  const attempt: Attempt = {
+    reservation: commit(raw.reservation),
+    name: packageName(raw.name),
+    publisher: invocation(raw.publisher),
+  };
+  if (
+    attempt.reservation !== value.sha ||
+    attempt.name !== name ||
+    stored.object.type !== "commit" ||
+    stored.object.sha !== attempt.publisher.workflowCommit
+  )
+    throw new Error("Publisher attempt mismatch");
+  await validateInvocation(attempt.publisher, "release.yml", "workflow_dispatch");
+  return attempt;
+}
+
+function receiptName(value: Manifest, attempt: Attempt) {
+  return `npm-stage-receipt-${value.preparation.runId}-${value.preparation.attempt}-${attempt.name}-${attempt.publisher.runId}-${attempt.publisher.attempt}`;
+}
+
+export async function acceptedReceipt(value: Reservation & { sha: string }, attempt: Attempt) {
+  const name = receiptName(value.manifest, attempt);
+  const response = record(
+    (await github(`actions/runs/${attempt.publisher.runId}/artifacts?name=${name}&per_page=100`)) ??
+      {},
+  );
+  if (!Array.isArray(response.artifacts) || response.artifacts.length !== 1)
+    throw new Error("Missing stage receipt; reconcile with npm using maintainer authentication");
+  const artifact = record(response.artifacts[0]);
+  if (
+    artifact.name !== name ||
+    artifact.expired !== false ||
+    String(record(artifact.workflow_run).id) !== attempt.publisher.runId ||
+    record(artifact.workflow_run).head_sha !== attempt.publisher.workflowCommit
+  )
+    throw new Error("Stage receipt artifact identity mismatch");
+  const bytes = execFileSync(
+    "gh",
+    ["api", `repos/${repository}/actions/artifacts/${identifier(artifact.id)}/zip`],
+    {
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  if (artifact.digest !== `sha256:${hash(bytes)}`)
+    throw new Error("Stage receipt artifact changed");
+  const path = join(environment("RUNNER_TEMP"), `${name}.zip`);
+  writeFileSync(path, bytes);
+  if (run("unzip", ["-Z1", path]) !== "receipt.json")
+    throw new Error("Unexpected stage receipt content");
+  const receipt = record(parse(run("unzip", ["-p", path, "receipt.json"])));
+  if (
+    receipt.status !== "accepted" ||
+    receipt.reservation !== value.sha ||
+    receipt.name !== attempt.name ||
+    json(invocation(receipt.publisher)) !== json(attempt.publisher) ||
+    receipt.manifestSha256 !== hash(json(value.manifest))
+  )
+    throw new Error("Unknown or mismatched stage outcome; do not restage automatically");
+  return text(receipt.stageId, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu);
+}
+
+async function verifyPublic(
+  value: Reservation & { sha: string },
+  directory: string,
+  names: readonly PackageName[] = packages,
+) {
+  for (const archive of value.manifest.archives.filter((item) => names.includes(item.name))) {
+    const attempt = await readAttempt(value, archive.name);
+    if (!attempt) throw new Error("No publisher attempt exists for the package");
+    const spec = `${archive.name}@${value.manifest.version}`;
+    const metadata = record(
+      parse(run("npm", ["view", spec, "--json", "--registry=https://registry.npmjs.org/"])),
+    );
+    const dist = record(metadata.dist);
+    const integrity = `sha512-${Buffer.from(archive.sha512, "hex").toString("base64")}`;
+    const tarballUrl = `https://registry.npmjs.org/${archive.name}/-/${archive.filename}`;
+    const attestationUrl = `https://registry.npmjs.org/-/npm/v1/attestations/${spec}`;
+    if (
+      metadata.name !== archive.name ||
+      metadata.version !== value.manifest.version ||
+      dist.integrity !== integrity ||
+      dist.tarball !== tarballUrl ||
+      record(dist.attestations).url !== attestationUrl
+    )
+      throw new Error("Public npm metadata mismatch");
+    const response = await fetch(tarballUrl, {
+      redirect: "error",
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) throw new Error("Public npm archive is unavailable");
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.length !== archive.size || hash(bytes, "sha512") !== archive.sha512)
+      throw new Error("Public npm archive does not match the approved release");
+    const attestationResponse = await fetch(attestationUrl, {
+      redirect: "error",
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!attestationResponse.ok) throw new Error("Public npm provenance is unavailable");
+    const attestationPath = join(directory, `${archive.name}-attestations.json`);
+    writeFileSync(attestationPath, await attestationResponse.text());
+    run("pnpm", [
+      "desktop-release:transaction",
+      "verify-npm-provenance",
+      "--metadata",
+      attestationPath,
+      "--name",
+      archive.name,
+      "--version",
+      value.manifest.version,
+      "--integrity",
+      integrity,
+      "--repository",
+      `https://github.com/${repository}`,
+      "--workflow",
+      ".github/workflows/release.yml",
+      "--ref",
+      "refs/heads/main",
+      "--workflow-commit",
+      attempt.publisher.workflowCommit,
+      "--invocation-id",
+      `https://github.com/${repository}/actions/runs/${attempt.publisher.runId}/attempts/${attempt.publisher.attempt}`,
+      "--allow-prior-invocation",
+      "false",
+      "--release-tag",
+      value.manifest.tag,
+      "--event-name",
+      "workflow_dispatch",
+      "--repository-id",
+      environment("REPOSITORY_ID"),
+      "--repository-owner-id",
+      environment("REPOSITORY_OWNER_ID"),
+    ]);
+  }
+}
+
+export function stageResponse(value: unknown, archive: Archive, version: string): string {
+  const document = record(value);
+  if (Object.keys(document).length !== 1 || !Object.hasOwn(document, archive.name))
+    throw new Error("npm stage response must contain exactly the expected package");
+  const result = record(document[archive.name]);
+  if (
+    result.name !== archive.name ||
+    result.version !== version ||
+    result.size !== archive.size ||
+    result.integrity !== `sha512-${Buffer.from(archive.sha512, "hex").toString("base64")}`
+  )
+    throw new Error("npm stage response archive mismatch");
+  return text(result.stageId, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu);
+}
+
+function assertLatestIsNotNewer(latest: string, version: string) {
+  const order = (value: string) => {
+    text(value, /^[1-9]\d{3}\.([1-9]|1[0-2])\.([1-9]|[12]\d|3[01])(?:-[1-9]\d*)?$/u);
+    const [year, month, day, sequence = 0] = value.split(/[.-]/u).map(Number);
+    return [year, month, day, sequence];
+  };
+  const observed = order(latest);
+  const proposed = order(version);
+  for (let index = 0; index < proposed.length; index += 1) {
+    if (observed[index] > proposed[index])
+      throw new Error("Refusing to replace a newer npm latest version");
+    if (observed[index] < proposed[index]) return;
+  }
+}
+
+export function promoteLatest(
+  version: string,
+  readLatest: (name: PackageName) => string,
+  writeLatest: (name: PackageName, version: string) => void,
+) {
+  const observed = packages.map((name) => ({ name, version: readLatest(name) }));
+  for (const entry of observed) assertLatestIsNotNewer(entry.version, version);
+  for (const name of packages) {
+    const latest = readLatest(name);
+    assertLatestIsNotNewer(latest, version);
+    if (latest === version) continue;
+    try {
+      writeLatest(name, version);
+      if (readLatest(name) !== version) throw new Error("Latest did not converge");
+    } catch (cause) {
+      throw new Error("Latest promotion is incomplete; reconcile both packages before retrying", {
+        cause,
+      });
+    }
+  }
+}
+
+export async function runNpmRelease(command: string, directory: string) {
+  const operatorCommand =
+    command === "reconcile" || command === "promote-latest" || command === "verify-policy";
+  const caller = operatorCommand ? null : current();
+  if (command === "verify-policy") {
+    process.stdout.write(json(await verifyPolicy()));
+    return;
+  }
+  if (command === "validate-input") {
+    if (!caller) throw new Error("Missing workflow identity");
+    const version = environment("RELEASE_TAG").replace(/^cycling-coach@/u, "");
+    const value = manifest({
+      schema: 1,
+      tag: environment("RELEASE_TAG"),
+      version,
+      sourceCommit: environment("RELEASE_COMMIT"),
+      preparation: caller,
+      coordinator: {
+        runId: environment("COORDINATOR_RUN_ID"),
+        attempt: environment("COORDINATOR_RUN_ATTEMPT"),
+        workflowCommit: environment("RELEASE_COMMIT"),
+      },
+      archives: packages.map((name) => ({
+        name,
+        filename: `${name}-${version}.tgz`,
+        size: 1,
+        sha512: "0".repeat(128),
+      })),
+    });
+    await validateSource(value);
+    output("package", "cycling-coach");
+    output("version", value.version);
+    output("ref", value.tag);
+    output("commit", value.sourceCommit);
+    return;
+  }
+  if (command === "seal") {
+    const version = environment("RELEASE_VERSION");
+    const value = manifest({
+      schema: 1,
+      tag: `cycling-coach@${version}`,
+      version,
+      sourceCommit: environment("RELEASE_COMMIT"),
+      coordinator: {
+        runId: environment("COORDINATOR_RUN_ID"),
+        attempt: environment("COORDINATOR_RUN_ATTEMPT"),
+        workflowCommit: environment("RELEASE_COMMIT"),
+      },
+      preparation: caller,
+      archives: packages.map((name) => {
+        const filename = `${name}-${version}.tgz`;
+        const path = join(directory, filename);
+        return {
+          name,
+          filename,
+          size: statSync(path).size,
+          sha512: hash(readFileSync(path), "sha512"),
+        };
+      }),
+    });
+    verifyArchives(value, directory);
+    writeFileSync(join(directory, "release-manifest.json"), json(value));
+    return;
+  }
+  if (command === "reserve") {
+    await validatePolicies();
+    const value = manifest(parse(readFileSync(join(directory, "release-manifest.json"), "utf8")));
+    if (json(value.preparation) !== json(caller))
+      throw new Error("Preparation invocation mismatch");
+    await validateSource(value);
+    await validateInvocation(value.preparation, "release.yml", "workflow_dispatch", "smoke");
+    const name = `npm-stage/${value.tag}`;
+    if (await readTag(name))
+      throw new Error("A reservation already exists; use resume without rebuilding");
+    const reserved = {
+      manifest: value,
+      artifactId: identifier(environment("ARTIFACT_ID")),
+      artifactDigest: digest(environment("ARTIFACT_DIGEST")),
+    };
+    await validateArtifact(reserved);
+    await createTag(name, value.sourceCommit, reserved);
+    return;
+  }
+  if (command === "stage") {
+    await validatePolicies();
+    if (!caller) throw new Error("Missing publisher identity");
+    const name = packageName(environment("RELEASE_PACKAGE"));
+    const stored = await readTag(`npm-stage/${environment("RELEASE_TAG")}`);
+    if (!stored) throw new Error("Missing reservation");
+    const value = { ...reservation(stored.value), sha: stored.sha };
+    if (
+      stored.object.type !== "commit" ||
+      stored.object.sha !== value.manifest.sourceCommit ||
+      value.manifest.tag !== environment("RELEASE_TAG")
+    )
+      throw new Error("Reservation source mismatch");
+    await validateSource(value.manifest);
+    const attempt = await readAttempt(value, name);
+    if (!attempt || json(attempt.publisher) !== json(caller))
+      throw new Error("Stage attempt is not owned by this invocation");
+    await validateInvocation(
+      caller,
+      "release.yml",
+      "workflow_dispatch",
+      name === "cycling-coach" ? "primary-intent" : "alias-intent",
+    );
+    if (
+      json(manifest(parse(readFileSync(join(directory, "release-manifest.json"), "utf8")))) !==
+      json(value.manifest)
+    )
+      throw new Error("Publisher manifest mismatch");
+    verifyArchives(value.manifest, directory);
+    const archive = value.manifest.archives.find((entry) => entry.name === name);
+    if (!archive) throw new Error("Missing archive");
+    const receipt = {
+      status: "unknown",
+      reservation: value.sha,
+      name,
+      publisher: caller,
+      manifestSha256: hash(json(value.manifest)),
+    };
+    const receiptPath = environment("RECEIPT_PATH");
+    writeFileSync(receiptPath, json(receipt), { flag: "wx" });
+    const response = run(environment("PUBLISHER_NODE"), [
+      environment("PUBLISHER_NPM"),
+      "stage",
+      "publish",
+      join(directory, archive.filename),
+      "--access",
+      "public",
+      "--ignore-scripts",
+      "--json",
+      "--provenance",
+      "--tag",
+      `candidate-${value.manifest.preparation.runId}-${value.manifest.preparation.attempt}`,
+      "--fetch-retries=0",
+      "--fetch-timeout=30000",
+      "--registry=https://registry.npmjs.org/",
+    ]);
+    const stageId = stageResponse(parse(response), archive, value.manifest.version);
+    writeFileSync(receiptPath, json({ ...receipt, status: "accepted", stageId }));
+    output("stage_id", stageId);
+    return;
+  }
+  const value = await restore(environment("RELEASE_TAG"), directory);
+  if (command === "restore") {
+    output("package", "cycling-coach");
+    output("version", value.manifest.version);
+    output("ref", value.manifest.tag);
+    output("commit", value.manifest.sourceCommit);
+    output("artifact_id", value.artifactId);
+    output("artifact_digest", value.artifactDigest);
+    output("preparation_run_id", value.manifest.preparation.runId);
+    output("preparation_run_attempt", value.manifest.preparation.attempt);
+    return;
+  }
+  if (command === "begin") {
+    await validatePolicies();
+    if (!caller) throw new Error("Missing publisher identity");
+    const name = packageName(environment("RELEASE_PACKAGE"));
+    if (name === "enduragent") {
+      const primary = await readAttempt(value, "cycling-coach");
+      if (!primary) throw new Error("Primary package has not been staged");
+      await acceptedReceipt(value, primary);
+    }
+    const existing = await readAttempt(value, name);
+    if (existing) {
+      output("stage_id", await acceptedReceipt(value, existing));
+      output("stage", "false");
+      return;
+    }
+    const attempt = { reservation: value.sha, name, publisher: caller };
+    await createTag(
+      `npm-stage-attempt/${value.manifest.tag}/${name}`,
+      caller.workflowCommit,
+      attempt,
+    );
+    output("stage", "true");
+    output("artifact_id", value.artifactId);
+    output("preparation_run_id", value.manifest.preparation.runId);
+    output("receipt_name", receiptName(value.manifest, attempt));
+    return;
+  }
+  if (command === "reconcile") {
+    const verified: { name: PackageName; stageId: string }[] = [];
+    for (const archive of value.manifest.archives) {
+      const attempt = await readAttempt(value, archive.name);
+      if (!attempt) continue;
+      const list: unknown = parse(
+        run("npm", [
+          "stage",
+          "list",
+          archive.name,
+          "--json",
+          "--registry=https://registry.npmjs.org/",
+        ]),
+      );
+      if (!Array.isArray(list)) throw new Error("Invalid staged package list");
+      const candidates = list
+        .map(record)
+        .filter(
+          (item) =>
+            item.packageName === archive.name &&
+            item.version === value.manifest.version &&
+            item.tag ===
+              `candidate-${value.manifest.preparation.runId}-${value.manifest.preparation.attempt}`,
+        );
+      if (candidates.length !== 1)
+        throw new Error("Stage result remains ambiguous; do not restage");
+      const stageId = text(
+        candidates[0]?.id,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu,
+      );
+      execFileSync(
+        "npm",
+        ["stage", "download", stageId, "--registry=https://registry.npmjs.org/"],
+        { cwd: directory },
+      );
+      const bytes = readFileSync(
+        join(directory, `${archive.name}-${value.manifest.version}-${stageId}.tgz`),
+      );
+      if (bytes.length !== archive.size || hash(bytes, "sha512") !== archive.sha512)
+        throw new Error("Staged package archive mismatch");
+      verified.push({ name: archive.name, stageId });
+    }
+    if (verified.length === 0) throw new Error("No attempted packages to reconcile");
+    process.stdout.write(
+      json({ status: "attempted-staged-archives-verified", packages: verified }),
+    );
+    return;
+  }
+  if (command === "verify-primary-public") {
+    await verifyPublic(value, directory, ["cycling-coach"]);
+    return;
+  }
+  if (command === "verify-public" || command === "promote-latest") {
+    await verifyPublic(value, directory);
+    const readLatest = (name: PackageName) =>
+      run("npm", ["view", `${name}@latest`, "version", "--registry=https://registry.npmjs.org/"]);
+    if (command === "verify-public") {
+      if (packages.some((name) => readLatest(name) !== value.manifest.version))
+        throw new Error("Both public archives verified; operator must promote latest");
+    } else {
+      promoteLatest(value.manifest.version, readLatest, (name, version) => {
+        execFileSync(
+          "npm",
+          [
+            "dist-tag",
+            "add",
+            `${name}@${version}`,
+            "latest",
+            "--registry=https://registry.npmjs.org/",
+          ],
+          { stdio: "inherit" },
+        );
+      });
+    }
+    return;
+  }
+  throw new Error("Unsupported release operation");
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runNpmRelease(process.argv[2] ?? "", resolve(process.argv[3] ?? ".")).catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : "Release failed"}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Package tags could select the workflow code that received npm publishing authority. This change dispatches release control code from protected `main`, validates the exact Changesets source commit and coordinator attempt, and stages the two tested package archives for human npm approval.

Preparation retains a manifest binding the source and workflow identities to archive hashes. Immutable reservation and attempt tags prevent blind retries: accepted receipts resume without another stage request, while missing or uncertain receipts stop for maintainer reconciliation. Publishing jobs use a hash-pinned npm executable with no dependency installation or repository-write token. Finalization verifies both public archives and signed workflow provenance before creating release notes. The operator promotion helper prevents an observed newer `latest` version from being replaced.

The package coordinator now runs separately from Changesets dependency installation. Existing desktop release dispatch behavior is preserved. The shared provenance verifier names the publishing workflow commit explicitly, since it can differ from the package source commit.

Validation:
- Full workspace build passed.
- 72 helper and provenance tests passed; focused strict TypeScript checking passed.
- Nine synthetic coordinator scenarios, nine workflow-boundary checks, and four existing desktop workflow guards passed.
- Both real built package archives passed package-content validation and manifest sealing, using synthetic local invocation IDs without publication.
- Fixture privacy passed across 3,253 source files and 21 golden fixtures.
- Required isolated Codex autoreview and TruffleHog completed without actionable findings at the default P0 threshold.
- Hosted CI passed on commit `9875437f`: full repository checks, Linux workspace tests, security checks, and package install/smoke verification. Native desktop and UI jobs were correctly excluded by scope detection.

Live setup returned a ruleset revision timestamp with a numeric timezone offset. Correction `df3ca39c` accepts that format while preserving exact string revision matching; equivalent UTC representations and changed fractional seconds remain rejected. All 73 helper/provenance tests, focused strict TypeScript, lint, and the final isolated review passed. Fresh CI passed on this corrected head: https://github.com/yerzhansa/enduragent/actions/runs/33959363197.

Merge and cutover hold: this changes release workflows and requires operator approval. Configure both protected environments for main-only deployment with administrator bypass disabled, and configure a no-bypass immutable reservation-tag ruleset. Administrator-authenticated `verify-policy` output supplies the exact ruleset ID/revision to both environments; normal workflow tokens cannot inspect hidden bypass actors, and policy revision drift blocks staging. Configure both npm trusted publishers for staged publication only and retain human 2FA approval. The immutable staging-evidence ruleset has been created. Environment and npm cutover remain unapplied; no package has been staged or published.

Recovery limits: retained artifacts expire, uncertain requests need maintainer disposition, and the two npm `latest` updates are not atomic. Tag writers can still deny service by occupying a reservation name; they cannot bypass the independent source, artifact, and invocation validation.
