### PR TITLE
fix(release): resolve publisher paths in step context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,8 +338,6 @@ jobs:
       REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
       RELEASE_PACKAGE: cycling-coach
       PUBLISHER_NODE: node
-      PUBLISHER_NPM: ${{ runner.temp }}/publisher/package/bin/npm-cli.js
-      RECEIPT_PATH: ${{ runner.temp }}/receipt/receipt.json
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -365,6 +363,9 @@ jobs:
       - name: Restore the exact prepared archives
         run: node tools/npm-release.ts restore "$RUNNER_TEMP/npm-release"
       - name: Stage exact archive for human approval
+        env:
+          PUBLISHER_NPM: ${{ runner.temp }}/publisher/package/bin/npm-cli.js
+          RECEIPT_PATH: ${{ runner.temp }}/receipt/receipt.json
         run: node tools/npm-release.ts stage "$RUNNER_TEMP/npm-release"
       - name: Retain accepted or uncertain stage outcome
         if: always()
@@ -425,8 +426,6 @@ jobs:
       REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
       RELEASE_PACKAGE: enduragent
       PUBLISHER_NODE: node
-      PUBLISHER_NPM: ${{ runner.temp }}/publisher/package/bin/npm-cli.js
-      RECEIPT_PATH: ${{ runner.temp }}/receipt/receipt.json
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -452,6 +451,9 @@ jobs:
       - name: Restore the exact prepared archives
         run: node tools/npm-release.ts restore "$RUNNER_TEMP/npm-release"
       - name: Stage exact archive for human approval
+        env:
+          PUBLISHER_NPM: ${{ runner.temp }}/publisher/package/bin/npm-cli.js
+          RECEIPT_PATH: ${{ runner.temp }}/receipt/receipt.json
         run: node tools/npm-release.ts stage "$RUNNER_TEMP/npm-release"
       - name: Retain accepted or uncertain stage outcome
         if: always()

--- a/tools/npm-release-workflow.test.ts
+++ b/tools/npm-release-workflow.test.ts
@@ -253,6 +253,27 @@ describe("npm package coordinator dispatch", { timeout: 30_000 }, () => {
 });
 
 describe("protected-main npm workflow boundaries", () => {
+  it("resolves runner paths only in the publishing step environment", () => {
+    for (const source of [release, coordinator]) {
+      for (const [name, value] of Object.entries(source.jobs)) {
+        for (const expression of Object.values(value.env)) {
+          expect(expression, name).not.toMatch(/\brunner\s*(?:\.|\[)/);
+        }
+      }
+    }
+    for (const name of ["primary-stage", "alias-stage"]) {
+      const source = job(release, name);
+      const stage = source.steps.find((step) => step.run?.includes("npm-release.ts stage"));
+      const receipt = source.steps.find((step) =>
+        step.uses?.startsWith("actions/upload-artifact@"),
+      );
+      expect(stage?.env, name).toMatchObject({
+        PUBLISHER_NPM: "${{ runner.temp }}/publisher/package/bin/npm-cli.js",
+        RECEIPT_PATH: receipt?.with.path,
+      });
+    }
+  });
+
   it("gates every job through a main-only explicit dispatch", () => {
     expect(Object.keys(release.on)).toEqual(["workflow_dispatch"]);
     expect(job(release, "parse-tag").if).toBe(
@@ -332,7 +353,13 @@ describe("protected-main npm workflow boundaries", () => {
   });
 
   it("pins the administrator-verified reservation policy in every reserve, intent, and stage job", () => {
-    for (const name of ["reserve", "primary-intent", "alias-intent", "primary-stage", "alias-stage"]) {
+    for (const name of [
+      "reserve",
+      "primary-intent",
+      "alias-intent",
+      "primary-stage",
+      "alias-stage",
+    ]) {
       const source = job(release, name);
       expect(source.env, name).toMatchObject({
         RESERVATION_RULESET_ID: "${{ vars.RESERVATION_RULESET_ID }}",


### PR DESCRIPTION
GitHub rejected the npm release workflow after #895 because `runner.temp` is unavailable in job-level environment expressions. Move the npm executable and receipt paths into the publishing step for both packages, where the runner context is available. The receipt uploader still reads the same file, and exact policy revision matching and publication permissions are unchanged.

Add a regression check that fails on the merged workflow, rejects runner references in release/coordinator job environments, and verifies each publishing step receives the npm executable and matching receipt path.

Validation: 92 release workflow/helper/provenance tests passed, along with strict TypeScript, formatting, and lint. Actionlint reproduced all four context errors before the fix and validates the corrected release/coordinator workflows. Its obsolete diagnostic for the existing `queue: max` setting is narrowly excluded; [GitHub documents that setting](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency). Required isolated Codex autoreview and TruffleHog passed with no actionable findings at the default P0 threshold. No package was staged or published.

GitHub accepted the corrected workflow in [validation run 33961506027](https://github.com/yerzhansa/enduragent/actions/runs/33961506027) at `e08b78a33394d0ad3232c170e6261aa47c8bb458`. Dispatching from the PR branch kept the main-only gate false: all 12 jobs skipped, with no package preparation or publication.

[CI run 33961461147](https://github.com/yerzhansa/enduragent/actions/runs/33961461147) passed on the same head, including full repository checks, Linux workspace tests, security checks, and package smoke verification.

This PR changes release tooling and requires operator merge. Remaining environment/npm configuration is separate from this source correction.
