### PR TITLE
feat(coach): build and store a Plan Draft from Plan creation answers

### DIFF
--- a/.changeset/build-plan-draft-in-chat.md
+++ b/.changeset/build-plan-draft-in-chat.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/coach": patch
+"@enduragent/coach-client": patch
+"@enduragent/kernel": patch
+"@enduragent/sport-cycling": patch
+---
+
+User-facing: Plan creation in Chat can now build a Draft from your answers, with every week and Workout laid out under your confirmed limits.

--- a/.changeset/build-plan-draft-in-chat.md
+++ b/.changeset/build-plan-draft-in-chat.md
@@ -1,4 +1,5 @@
 ---
+"@enduragent/desktop": patch
 "@enduragent/coach-contract": patch
 "@enduragent/coach": patch
 "@enduragent/coach-client": patch
@@ -6,4 +7,4 @@
 "@enduragent/sport-cycling": patch
 ---
 
-User-facing: Plan creation in Chat can now build a Draft from your answers, with every week and Workout laid out under your confirmed limits.
+User-facing: Plan creation in Chat can now build a Draft from your answers, with every week and Workout laid out under your confirmed limits. The Draft keeps the answers it was built from when you edit them.

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -232,6 +232,8 @@ describe("chat view adapter", () => {
     const published: ChatSurfaceState[] = [];
     const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
     const model = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress" as const,
@@ -363,6 +365,8 @@ describe("chat view adapter", () => {
     const published: ChatSurfaceState[] = [];
     const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
     const model: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -455,6 +459,8 @@ describe("chat view adapter", () => {
     });
 
     const nextModel: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000001",
       version: 1,
       status: "in-progress",
@@ -508,6 +514,8 @@ describe("chat view adapter", () => {
       controls({
         planCreation: {
           value: {
+            draft: null,
+            draftStale: false,
             creationId: "01J00000000000000000000000",
             version: 1,
             status: "in-progress",

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -1780,6 +1780,8 @@ describe("chat controller", () => {
 
   it("gates coaching work only while a Plan Creation Card is visible", async () => {
     const planCreation: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",
@@ -1849,6 +1851,8 @@ describe("chat controller", () => {
 
   it("guards an in-flight discard, sends the displayed revision, and clears the Card", async () => {
     const completeCard: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -1921,6 +1925,8 @@ describe("chat controller", () => {
 
   it("retries a failed discard with the identical command and no premature consequence", async () => {
     const card: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -1964,6 +1970,8 @@ describe("chat controller", () => {
 
   it("cancels discard with focus restoration and keeps Chat gated only while open", async () => {
     const completeCard: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -1992,6 +2000,8 @@ describe("chat controller", () => {
 
   it("installs the returned Card and publishes an inline notice after discard rejection", async () => {
     const card: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -2046,6 +2056,8 @@ describe("chat controller", () => {
 
   it("returns focus to Start when refresh removes a Card behind its discard dialog", async () => {
     const card: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -2081,6 +2093,8 @@ describe("chat controller", () => {
       removeItem: (key: string) => stored.delete(key),
     });
     const planCreation: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 4,
       status: "in-progress",
@@ -2157,6 +2171,8 @@ describe("chat controller", () => {
       items: [restoredMessage],
     };
     const planCreation: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",
@@ -2228,6 +2244,8 @@ describe("chat controller", () => {
 
   it("retries Card commands with stable ids, installs monotonically, and unblocks Chat", async () => {
     const goalCard: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",
@@ -2285,6 +2303,8 @@ describe("chat controller", () => {
 
   it("submits an edited answer at the current version and closes the editor", async () => {
     const ready: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 10,
       status: "in-progress",
@@ -2326,6 +2346,8 @@ describe("chat controller", () => {
 
   it("preserves Edit and focus state when an identical Plan Creation model is restored", async () => {
     const ready: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 10,
       status: "in-progress",
@@ -2353,6 +2375,8 @@ describe("chat controller", () => {
 
   it("keeps a rejected Edit open with its error and current answer", async () => {
     const ready: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 10,
       status: "in-progress",
@@ -2389,6 +2413,8 @@ describe("chat controller", () => {
 
   it("clears and replaces server-authoritative Plan Creation cards", async () => {
     const first: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 4,
       status: "in-progress",
@@ -2397,6 +2423,8 @@ describe("chat controller", () => {
       openQuestion: goalQuestion("First goal?"),
     };
     const replacement: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000001",
       version: 1,
       status: "in-progress",
@@ -2430,6 +2458,8 @@ describe("chat controller", () => {
 
   it("keeps interrupted recovery inert while a Plan Creation question is open", async () => {
     const planCreation: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -350,6 +350,8 @@ function planCreationModel(
   patch: PlanCreationModelPatch = {},
 ): PlanCreationCardModel {
   return {
+    draft: null,
+    draftStale: false,
     creationId: "01J00000000000000000000000",
     version: patch.version ?? 1,
     status: "in-progress",

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -569,6 +569,11 @@ export async function launchDesktopFixture(input: {
         ReturnType<PlanCreationOperations["plan_creation.answer"]>
       >;
     },
+    async "plan_creation.preview"(request) {
+      return finalFrame(await invoke("plan_creation.preview", request)) as Awaited<
+        ReturnType<PlanCreationOperations["plan_creation.preview"]>
+      >;
+    },
     async "plan_creation.discard"(request) {
       return finalFrame(await invoke("plan_creation.discard", request)) as Awaited<
         ReturnType<PlanCreationOperations["plan_creation.discard"]>

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -185,6 +185,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   listPlanningRequests: 30_000,
   "plan_creation.start": 30_000,
   "plan_creation.answer": 30_000,
+  "plan_creation.preview": 30_000,
   "plan_creation.discard": 30_000,
 };
 

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -233,6 +233,15 @@ const rpcDeadlineCases = [
     30_000,
   ],
   [
+    "plan_creation.preview",
+    {
+      commandId: "plan-preview",
+      creationId: "00000000000000000000000000",
+      expectedVersion: 1,
+    },
+    30_000,
+  ],
+  [
     "plan_creation.discard",
     {
       commandId: "plan-discard",
@@ -1197,6 +1206,11 @@ describe("RPC receive and observers", () => {
         "plan_creation.answer": {
           status: "rejected",
           reason: "no-unfinished-creation",
+          planCreation: null,
+        },
+        "plan_creation.preview": {
+          status: "rejected",
+          reason: "not-ready",
           planCreation: null,
         },
         "plan_creation.discard": { status: "discarded" },

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -489,6 +489,7 @@ const PlanCreationDraftWorkoutSchema = z
 export const PlanCreationDraftSchema = z
   .object({
     kind: z.literal("draft"),
+    answeredSummaries: z.array(PlanCreationAnswerSummarySchema).max(16),
     goal: z.discriminatedUnion("kind", [
       z
         .object({

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -473,17 +473,91 @@ export const PlanCreationAnswerSummarySchema = z
   });
 export type PlanCreationAnswerSummary = z.infer<typeof PlanCreationAnswerSummarySchema>;
 
+const PlanCreationDraftWorkoutSchema = z
+  .object({
+    id: z.string().min(1).max(128),
+    name: z.string().min(1).max(512),
+    kind: z.enum(["hard", "endurance", "long", "easy", "event"]),
+    date: PlanCreationCivilDateSchema.nullable(),
+    minutes: z.number().positive().max(1440),
+    pinned: z.boolean(),
+    guidance: z.string().min(1).max(512),
+    power: z.null(),
+  })
+  .strict();
+
+export const PlanCreationDraftSchema = z
+  .object({
+    kind: z.literal("draft"),
+    goal: z.discriminatedUnion("kind", [
+      z
+        .object({
+          kind: z.literal("fitness"),
+          outcome: z.string().min(1).max(2_000).optional(),
+          weeks: PlanCreationPlanLengthWeeksSchema,
+        })
+        .strict(),
+      z
+        .object({
+          kind: z.literal("event"),
+          name: z.string().min(1).max(512),
+          date: PlanCreationCivilDateSchema,
+        })
+        .strict(),
+    ]),
+    mode: z.enum(["fixed", "flexible"]),
+    start: PlanCreationCivilDateSchema,
+    end: PlanCreationCivilDateSchema,
+    spanKind: z.enum(["Short block", "Event preparation", "Base Plan", "Fitness Plan"]),
+    computedWeeks: z.number().int().positive(),
+    weeks: z
+      .array(
+        z
+          .object({
+            number: z.number().int().min(1).max(24),
+            start: PlanCreationCivilDateSchema,
+            end: PlanCreationCivilDateSchema,
+            workouts: z.array(PlanCreationDraftWorkoutSchema).max(6),
+            notes: z.array(z.string().min(1).max(2_000)).max(32),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(24),
+    notes: z.array(z.string().min(1).max(2_000)).max(1_000),
+    guidance: z.string().min(1).max(512),
+    ftp: z.null(),
+    builderId: z.string().min(1).max(128),
+    builderVersion: z.string().min(1).max(128),
+    inputFingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+    outputFingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+  })
+  .strict();
+export type PlanCreationDraft = z.infer<typeof PlanCreationDraftSchema>;
+
 export const PlanCreationCardModelSchema = z
   .object({
     creationId: PlanCreationUlidSchema,
     version: z.number().int().positive(),
-    status: z.literal("in-progress"),
+    status: z.enum(["in-progress", "review"]),
+    draft: PlanCreationDraftSchema.nullable(),
+    draftStale: z.boolean(),
     readiness: z.enum(["incomplete", "ready"]),
     answeredSummaries: z.array(PlanCreationAnswerSummarySchema).max(16),
     openQuestion: PlanCreationOpenQuestionSchema.nullable(),
   })
   .strict()
   .superRefine((card, context) => {
+    if ((card.status === "review") !== (card.draft !== null)) {
+      context.addIssue({ code: "custom", path: ["draft"], message: "review requires a Draft" });
+    }
+    if (card.draft === null && card.draftStale) {
+      context.addIssue({
+        code: "custom",
+        path: ["draftStale"],
+        message: "missing Draft cannot be stale",
+      });
+    }
     if ((card.readiness === "ready") !== (card.openQuestion === null)) {
       context.addIssue({
         code: "custom",
@@ -560,7 +634,46 @@ export const PlanCreationDiscardRpcResultSchema = z.discriminatedUnion("status",
 ]);
 export type PlanCreationDiscardRpcResult = z.infer<typeof PlanCreationDiscardRpcResultSchema>;
 
+export const PlanCreationPreviewRpcParamsSchema = z
+  .object({
+    commandId: PlanCreationCommandIdSchema,
+    creationId: PlanCreationUlidSchema,
+    expectedVersion: z.number().int().positive(),
+  })
+  .strict();
+export type PlanCreationPreviewRpcParams = z.infer<typeof PlanCreationPreviewRpcParamsSchema>;
+
+export const PlanCreationPreviewRpcResultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("previewed"), planCreation: PlanCreationCardModelSchema }).strict(),
+  z.discriminatedUnion("reason", [
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum([
+          "stale-version",
+          "command-conflict",
+          "no-unfinished-creation",
+          "not-ready",
+        ]),
+        planCreation: PlanCreationCardModelSchema.nullable(),
+      })
+      .strict(),
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.literal("no-workouts"),
+        explanation: z.string().min(1).max(2_000),
+        planCreation: PlanCreationCardModelSchema.nullable(),
+      })
+      .strict(),
+  ]),
+]);
+export type PlanCreationPreviewRpcResult = z.infer<typeof PlanCreationPreviewRpcResultSchema>;
+
 export interface PlanCreationOperations {
+  "plan_creation.preview"(
+    request: PlanCreationPreviewRpcParams,
+  ): Promise<PlanCreationPreviewRpcResult>;
   "plan_creation.start"(request: PlanCreationStartRpcParams): Promise<PlanCreationStartRpcResult>;
   "plan_creation.answer"(
     request: PlanCreationAnswerRpcParams,

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -142,6 +142,8 @@ import {
 import {
   PlanCreationAnswerRpcParamsSchema,
   PlanCreationAnswerRpcResultSchema,
+  PlanCreationPreviewRpcParamsSchema,
+  PlanCreationPreviewRpcResultSchema,
   PlanCreationDiscardRpcParamsSchema,
   PlanCreationDiscardRpcResultSchema,
   PlanCreationStartRpcParamsSchema,
@@ -310,6 +312,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "listPlanningRequests",
   "plan_creation.start",
   "plan_creation.answer",
+  "plan_creation.preview",
   "plan_creation.discard",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
@@ -1901,6 +1904,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
     .object({
       jsonrpc: z.literal("2.0"),
       id: JsonRpcIdSchema,
+      method: z.literal("plan_creation.preview"),
+      params: PlanCreationPreviewRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
       method: z.literal("plan_creation.discard"),
       params: PlanCreationDiscardRpcParamsSchema,
     })
@@ -2435,6 +2446,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "plan_creation.answer",
     requestSchema: PlanCreationAnswerRpcParamsSchema,
     responseSchema: PlanCreationAnswerRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  "plan_creation.preview": {
+    wireName: "plan_creation.preview",
+    requestSchema: PlanCreationPreviewRpcParamsSchema,
+    responseSchema: PlanCreationPreviewRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   "plan_creation.discard": {

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -731,6 +731,16 @@ describe("Plan Creation contract", () => {
 
 const draft = {
   kind: "draft",
+  answeredSummaries: [
+    {
+      answerKey: "goal",
+      title: "Goal",
+      detail: "Build fitness",
+      source: { kind: "athlete" },
+      question: goalQuestion,
+      answer: { kind: "goal", goal: { kind: "fitness" } },
+    },
+  ],
   goal: { kind: "fitness", weeks: 4 },
   mode: "flexible",
   start: "1998-09-02",
@@ -780,6 +790,34 @@ describe("Plan Creation Draft contract", () => {
     expect(PlanCreationCardModelSchema.parse({ ...review, draftStale: true }).draftStale).toBe(
       true,
     );
+  });
+
+  it("requires valid answer summaries and limits them to sixteen", () => {
+    expect(PlanCreationDraftSchema.parse(draft).answeredSummaries).toEqual(draft.answeredSummaries);
+    expect(
+      PlanCreationDraftSchema.safeParse({ ...draft, answeredSummaries: undefined }).success,
+    ).toBe(false);
+    expect(PlanCreationDraftSchema.safeParse({ ...draft, answeredSummaries: [] }).success).toBe(
+      true,
+    );
+    expect(
+      PlanCreationDraftSchema.safeParse({
+        ...draft,
+        answeredSummaries: Array(16).fill(draft.answeredSummaries[0]),
+      }).success,
+    ).toBe(true);
+    expect(
+      PlanCreationDraftSchema.safeParse({
+        ...draft,
+        answeredSummaries: Array(17).fill(draft.answeredSummaries[0]),
+      }).success,
+    ).toBe(false);
+    expect(
+      PlanCreationDraftSchema.safeParse({
+        ...draft,
+        answeredSummaries: [{ ...draft.answeredSummaries[0], answerKey: "baseline" }],
+      }).success,
+    ).toBe(false);
   });
 
   it("requires a stored Draft for review and valid fingerprints and dates", () => {

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -12,6 +12,10 @@ import {
   PlanCreationDiscardRpcParamsSchema,
   PlanCreationDiscardRpcResultSchema,
   PlanCreationOpenQuestionSchema,
+  PlanCreationDraftSchema,
+  PlanCreationPreviewRpcParamsSchema,
+  PlanCreationPreviewRpcResultSchema,
+  ListPlanningRequestsRpcResultSchema,
   PlanCreationStartRpcParamsSchema,
   PlanCreationStartRpcResultSchema,
   NoRpcEventSchema,
@@ -48,6 +52,8 @@ const card = {
   creationId,
   version: 1,
   status: "in-progress" as const,
+  draft: null,
+  draftStale: false,
   readiness: "incomplete" as const,
   answeredSummaries: [],
   openQuestion: goalQuestion,
@@ -633,7 +639,7 @@ describe("Plan Creation contract", () => {
     ).toThrow();
   });
 
-  it("accepts every terminal result and only the three registered operations", () => {
+  it("accepts every terminal result and only the four registered operations", () => {
     expect(
       PlanCreationStartRpcResultSchema.parse({
         status: "started",
@@ -680,6 +686,7 @@ describe("Plan Creation contract", () => {
     expect(COACH_RPC_METHOD_NAMES.filter((name) => name.startsWith("plan_creation."))).toEqual([
       "plan_creation.start",
       "plan_creation.answer",
+      "plan_creation.preview",
       "plan_creation.discard",
     ]);
   });
@@ -690,6 +697,10 @@ describe("Plan Creation contract", () => {
       {
         method: "plan_creation.answer",
         params: { commandId: "answer", creationId, expectedVersion: 1, answer: answers[2] },
+      },
+      {
+        method: "plan_creation.preview",
+        params: { commandId: "preview", creationId, expectedVersion: 1 },
       },
       {
         method: "plan_creation.discard",
@@ -704,6 +715,7 @@ describe("Plan Creation contract", () => {
     for (const method of [
       "plan_creation.start",
       "plan_creation.answer",
+      "plan_creation.preview",
       "plan_creation.discard",
     ] as const) {
       expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse({}).success).toBe(false);
@@ -714,5 +726,107 @@ describe("Plan Creation contract", () => {
       responseSchema: PlanCreationDiscardRpcResultSchema,
       eventSchema: NoRpcEventSchema,
     });
+  });
+});
+
+const draft = {
+  kind: "draft",
+  goal: { kind: "fitness", weeks: 4 },
+  mode: "flexible",
+  start: "1998-09-02",
+  end: "1998-09-29",
+  spanKind: "Fitness Plan",
+  computedWeeks: 4,
+  weeks: [
+    {
+      number: 1,
+      start: "1998-09-02",
+      end: "1998-09-08",
+      notes: [],
+      workouts: [
+        {
+          id: "w1-template-1",
+          name: "Controlled effort",
+          kind: "hard",
+          date: null,
+          minutes: 45,
+          pinned: false,
+          power: null,
+          guidance: "Use comfortable perceived effort or your known heart-rate guidance",
+        },
+      ],
+    },
+  ],
+  notes: [],
+  guidance: "Use comfortable perceived effort or your known heart-rate guidance",
+  ftp: null,
+  builderId: "cycling-creation-draft",
+  builderVersion: "1",
+  inputFingerprint: "a".repeat(64),
+  outputFingerprint: "b".repeat(64),
+};
+
+describe("Plan Creation Draft contract", () => {
+  it("round-trips a review Draft through preview and planning request hydration", () => {
+    const review = { ...card, status: "review", readiness: "ready", openQuestion: null, draft };
+    const result = { status: "previewed", planCreation: review };
+    expect(PlanCreationPreviewRpcResultSchema.parse(JSON.parse(JSON.stringify(result)))).toEqual(
+      result,
+    );
+    expect(
+      ListPlanningRequestsRpcResultSchema.parse({ deliveries: [], planCreation: review })
+        .planCreation,
+    ).toEqual(review);
+    expect(PlanCreationCardModelSchema.parse({ ...review, draftStale: true }).draftStale).toBe(
+      true,
+    );
+  });
+
+  it("requires a stored Draft for review and valid fingerprints and dates", () => {
+    expect(PlanCreationCardModelSchema.safeParse({ ...card, status: "review" }).success).toBe(
+      false,
+    );
+    expect(PlanCreationCardModelSchema.safeParse({ ...card, draftStale: true }).success).toBe(
+      false,
+    );
+    expect(
+      PlanCreationDraftSchema.safeParse({ ...draft, inputFingerprint: "not-a-hash" }).success,
+    ).toBe(false);
+    expect(PlanCreationDraftSchema.safeParse({ ...draft, start: "1998-02-30" }).success).toBe(
+      false,
+    );
+    expect(PlanCreationDraftSchema.safeParse({ ...draft, ftp: 250 }).success).toBe(false);
+  });
+
+  it("rejects forged preview fields and preserves every rejection reason", () => {
+    const request = { commandId: "preview", creationId, expectedVersion: 1 };
+    expect(PlanCreationPreviewRpcParamsSchema.parse(request)).toEqual(request);
+    for (const extra of [{ draft }, { readiness: "ready" }, { expectedVersion: 0 }])
+      expect(PlanCreationPreviewRpcParamsSchema.safeParse({ ...request, ...extra }).success).toBe(
+        false,
+      );
+    for (const reason of [
+      "not-ready",
+      "stale-version",
+      "command-conflict",
+      "no-unfinished-creation",
+    ])
+      expect(
+        PlanCreationPreviewRpcResultSchema.parse({
+          status: "rejected",
+          reason,
+          planCreation: null,
+        }),
+      ).toEqual({ status: "rejected", reason, planCreation: null });
+    const noWorkouts = {
+      status: "rejected",
+      reason: "no-workouts",
+      planCreation: null,
+      explanation: "No Workouts fit under the confirmed limits.",
+    };
+    expect(PlanCreationPreviewRpcResultSchema.parse(noWorkouts)).toEqual(noWorkouts);
+    expect(
+      PlanCreationPreviewRpcResultSchema.safeParse({ ...noWorkouts, explanation: "" }).success,
+    ).toBe(false);
   });
 });

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1458,6 +1458,11 @@ describe("coach request and event projection", () => {
         reason: "no-unfinished-creation",
         planCreation: null,
       }),
+      "plan_creation.preview": async () => ({
+        status: "rejected",
+        reason: "no-unfinished-creation",
+        planCreation: null,
+      }),
       "plan_creation.discard": async () => ({ status: "discarded" }),
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -2250,6 +2250,7 @@ export async function createLocalCoachComposition(
       ...planningRequestOperations,
       "plan_creation.start": planCreationOperations["plan_creation.start"],
       "plan_creation.answer": planCreationOperations["plan_creation.answer"],
+      "plan_creation.preview": planCreationOperations["plan_creation.preview"],
       "plan_creation.discard": planCreationOperations["plan_creation.discard"],
       ...planningOperations,
     } satisfies CoachOperations &

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -549,6 +549,7 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "listPlanningRequests",
   "plan_creation.start",
   "plan_creation.answer",
+  "plan_creation.preview",
   "plan_creation.discard",
 ]);
 
@@ -1840,6 +1841,17 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
             try {
               result = await input.operations["plan_creation.answer"](
                 COACH_RPC_METHOD_REGISTRY["plan_creation.answer"].requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "plan_creation.preview":
+            try {
+              result = await input.operations["plan_creation.preview"](
+                COACH_RPC_METHOD_REGISTRY["plan_creation.preview"].requestSchema.parse(
                   generic.data.params,
                 ),
               );

--- a/packages/coach/src/plan-creation-answers.ts
+++ b/packages/coach/src/plan-creation-answers.ts
@@ -2,12 +2,14 @@ import {
   PLAN_CREATION_ANSWER_KEYS,
   PlanCreationAnswerInputSchema,
   PlanCreationCardModelSchema,
+  PlanCreationDraftSchema,
   type PlanCreationAnswerInput,
   type PlanCreationAnswerSummary,
   type PlanCreationCardModel,
   type PlanCreationGoal,
   type PlanCreationOpenQuestion,
 } from "@enduragent/coach-contract";
+import type { CreationDraftInput } from "@enduragent/sport-cycling";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import {
   PlanCreationStoreError,
@@ -620,7 +622,7 @@ export function projectPlanCreationCard(
     today: new Date().toISOString().slice(0, 10),
   },
 ): PlanCreationCardModel {
-  if (snapshot.status !== "in-progress") return corrupt();
+  if (snapshot.status !== "in-progress" && snapshot.status !== "review") return corrupt();
   const flow = resolvePlanCreationAnswerFlow(snapshot);
   const answeredSummaries = flow.order.flatMap((key) => {
     const stored = flow.valid.get(key);
@@ -632,7 +634,13 @@ export function projectPlanCreationCard(
   return PlanCreationCardModelSchema.parse({
     creationId: snapshot.id,
     version: snapshot.version,
-    status: "in-progress",
+    status: snapshot.status,
+    draft:
+      snapshot.currentDraft === null
+        ? null
+        : PlanCreationDraftSchema.parse(JSON.parse(snapshot.currentDraft.outputSnapshotJson)),
+    draftStale:
+      snapshot.currentDraft !== null && snapshot.currentDraft.inputVersion + 1 !== snapshot.version,
     readiness: question === null ? "ready" : "incomplete",
     answeredSummaries,
     openQuestion: question,
@@ -673,4 +681,53 @@ export function validPlanCreationAnswer(
       : answer.restriction.endDate >= today;
   }
   return true;
+}
+
+export function resolvePlanCreationDraftAnswers(
+  snapshot: PlanCreationSnapshot,
+): CreationDraftInput["answers"] | null {
+  const flow = resolvePlanCreationAnswerFlow(snapshot);
+  if (flow.next !== null) return null;
+  const goalAnswer = flow.valid.get("goal")?.answer;
+  const length = flow.valid.get("plan-length")?.answer;
+  const availability = flow.valid.get("availability")?.answer;
+  const startTiming = flow.valid.get("start-timing")?.answer;
+  const commitments = flow.valid.get("commitments")?.answer;
+  const baseline = flow.valid.get("baseline")?.answer;
+  const success = flow.valid.get("success")?.answer;
+  const restriction = flow.valid.get("restriction")?.answer;
+  if (
+    goalAnswer?.kind !== "goal" ||
+    availability?.kind !== "availability" ||
+    startTiming?.kind !== "start-timing" ||
+    commitments?.kind !== "commitments" ||
+    baseline?.kind !== "baseline" ||
+    success?.kind !== "success" ||
+    restriction?.kind !== "restriction"
+  )
+    return corrupt();
+  const goal = goalAnswer.goal;
+  const normalizedGoal = (): CreationDraftInput["answers"]["goal"] => {
+    if (goal.kind === "fitness") {
+      if (length?.kind !== "plan-length") return corrupt();
+      return { ...goal, weeks: length.weeks };
+    }
+    if (goal.kind === "event-manual") return { kind: "event", name: goal.name, date: goal.date };
+    const candidate = snapshot.seed?.eventCandidates.find(
+      (value) => value.candidateId === goal.candidateId,
+    );
+    return candidate === undefined
+      ? corrupt()
+      : { kind: "event", name: candidate.name, date: candidate.date };
+  };
+  const { kind: _kind, ...schedule } = availability;
+  return {
+    goal: normalizedGoal(),
+    availability: schedule,
+    startTiming: startTiming.timing,
+    commitments: commitments.commitments,
+    baseline: baseline.baseline,
+    success: success.success,
+    restriction: restriction.restriction,
+  };
 }

--- a/packages/coach/src/plan-creation-answers.ts
+++ b/packages/coach/src/plan-creation-answers.ts
@@ -616,6 +616,19 @@ function questionForKey(
   }
 }
 
+export function projectPlanCreationAnswerSummaries(
+  snapshot: PlanCreationSnapshot,
+  flow: PlanCreationAnswerFlow,
+  context: PlanCreationProjectionContext,
+): PlanCreationAnswerSummary[] {
+  return flow.order.flatMap((key) => {
+    const stored = flow.valid.get(key);
+    return stored === undefined
+      ? []
+      : [answerSummary(snapshot, stored, questionForKey(snapshot, flow, context, key))];
+  });
+}
+
 export function projectPlanCreationCard(
   snapshot: PlanCreationSnapshot,
   context: PlanCreationProjectionContext = {
@@ -624,12 +637,6 @@ export function projectPlanCreationCard(
 ): PlanCreationCardModel {
   if (snapshot.status !== "in-progress" && snapshot.status !== "review") return corrupt();
   const flow = resolvePlanCreationAnswerFlow(snapshot);
-  const answeredSummaries = flow.order.flatMap((key) => {
-    const stored = flow.valid.get(key);
-    return stored === undefined
-      ? []
-      : [answerSummary(snapshot, stored, questionForKey(snapshot, flow, context, key))];
-  });
   const question = flow.next === null ? null : questionForKey(snapshot, flow, context, flow.next);
   return PlanCreationCardModelSchema.parse({
     creationId: snapshot.id,
@@ -642,7 +649,7 @@ export function projectPlanCreationCard(
     draftStale:
       snapshot.currentDraft !== null && snapshot.currentDraft.inputVersion + 1 !== snapshot.version,
     readiness: question === null ? "ready" : "incomplete",
-    answeredSummaries,
+    answeredSummaries: projectPlanCreationAnswerSummaries(snapshot, flow, context),
     openQuestion: question,
   });
 }

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -1,13 +1,18 @@
+import { z } from "zod";
 import {
   PlanCreationAnswerRpcParamsSchema,
   PlanCreationAnswerRpcResultSchema,
   PlanCreationDiscardRpcParamsSchema,
   PlanCreationDiscardRpcResultSchema,
+  PlanCreationDraftSchema,
+  PlanCreationPreviewRpcParamsSchema,
+  PlanCreationPreviewRpcResultSchema,
   PlanCreationStartRpcParamsSchema,
   PlanCreationStartRpcResultSchema,
   type PlanCreationCardModel,
   type PlanCreationOperations,
 } from "@enduragent/coach-contract";
+import { buildCreationDraft } from "@enduragent/sport-cycling";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import {
   PlanCreationStoreError,
@@ -19,6 +24,7 @@ import {
   encodePlanCreationAnswer,
   projectPlanCreationCard,
   resolvePlanCreationAnswerFlow,
+  resolvePlanCreationDraftAnswers,
   validPlanCreationAnswer,
   type PlanCreationAnswerKey,
   type PlanCreationBaselineEvidence,
@@ -51,6 +57,8 @@ async function requestDigest(crypto: Crypto, request: unknown): Promise<string> 
   );
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
+
+const PreviewInputDateSchema = z.object({ today: z.iso.date() });
 
 const defaultBaselineEvidence: BaselineEvidenceSource = { read: async () => undefined };
 
@@ -207,6 +215,91 @@ export function createPlanCreationOperations(input: {
           ["stale-version", "command-conflict", "missing-creation"].includes(error.code)
         ) {
           return PlanCreationAnswerRpcResultSchema.parse({
+            status: "rejected",
+            reason: error.code === "missing-creation" ? "no-unfinished-creation" : error.code,
+            planCreation: await readCard(),
+          });
+        }
+        throw error;
+      }
+    },
+    async "plan_creation.preview"(request) {
+      const parsed = PlanCreationPreviewRpcParamsSchema.parse(request);
+      const command = await stamp(parsed.commandId, await requestDigest(input.crypto, parsed));
+      try {
+        const replayed = await input.repository.replayDraft(command);
+        if (replayed !== undefined) {
+          if (replayed.currentDraft === null) throw new PlanCreationStoreError("corrupt-record");
+          const context = PreviewInputDateSchema.parse(
+            JSON.parse(replayed.currentDraft.inputSnapshotJson),
+          );
+          return PlanCreationPreviewRpcResultSchema.parse({
+            status: "previewed",
+            planCreation: projectPlanCreationCard(replayed, context),
+          });
+        }
+        const snapshot = await input.repository.readUnfinished();
+        if (snapshot === undefined || snapshot.id !== parsed.creationId) {
+          return PlanCreationPreviewRpcResultSchema.parse({
+            status: "rejected",
+            reason: "no-unfinished-creation",
+            planCreation:
+              snapshot === undefined ? null : projectPlanCreationCard(snapshot, { today: today() }),
+          });
+        }
+        if (snapshot.version !== parsed.expectedVersion) {
+          return PlanCreationPreviewRpcResultSchema.parse({
+            status: "rejected",
+            reason: "stale-version",
+            planCreation: projectPlanCreationCard(snapshot, { today: today() }),
+          });
+        }
+        const answers = resolvePlanCreationDraftAnswers(snapshot);
+        if (answers === null) {
+          return PlanCreationPreviewRpcResultSchema.parse({
+            status: "rejected",
+            reason: "not-ready",
+            planCreation: projectPlanCreationCard(snapshot, { today: today() }),
+          });
+        }
+        const buildInput = { answers, today: today(), ftp: null } as const;
+        const built = buildCreationDraft(buildInput);
+        if (built.kind === "no-workouts") {
+          return PlanCreationPreviewRpcResultSchema.parse({
+            status: "rejected",
+            reason: "no-workouts",
+            explanation: built.explanation,
+            planCreation: projectPlanCreationCard(snapshot, { today: buildInput.today }),
+          });
+        }
+        const draft = PlanCreationDraftSchema.parse(built);
+        const result = await input.repository.recordDraft({
+          command,
+          creationId: parsed.creationId,
+          expectedVersion: parsed.expectedVersion,
+          draftId: input.identity.newUlid(),
+          inputSnapshotJson: canonicalJson(buildInput),
+          inputFingerprint: draft.inputFingerprint,
+          outputSnapshotJson: canonicalJson(draft),
+          builderId: draft.builderId,
+          builderVersion: draft.builderVersion,
+          activationFingerprint: draft.outputFingerprint,
+        });
+        return PlanCreationPreviewRpcResultSchema.parse({
+          status: "previewed",
+          planCreation: projectPlanCreationCard(result.snapshot, { today: buildInput.today }),
+        });
+      } catch (error) {
+        if (
+          error instanceof PlanCreationStoreError &&
+          [
+            "stale-version",
+            "command-conflict",
+            "missing-creation",
+            "no-unfinished-creation",
+          ].includes(error.code)
+        ) {
+          return PlanCreationPreviewRpcResultSchema.parse({
             status: "rejected",
             reason: error.code === "missing-creation" ? "no-unfinished-creation" : error.code,
             planCreation: await readCard(),

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -23,6 +23,7 @@ import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import {
   encodePlanCreationAnswer,
   projectPlanCreationCard,
+  projectPlanCreationAnswerSummaries,
   resolvePlanCreationAnswerFlow,
   resolvePlanCreationDraftAnswers,
   validPlanCreationAnswer,
@@ -272,7 +273,20 @@ export function createPlanCreationOperations(input: {
             planCreation: projectPlanCreationCard(snapshot, { today: buildInput.today }),
           });
         }
-        const draft = PlanCreationDraftSchema.parse(built);
+        const { inputFingerprint, outputFingerprint: _builderOutputFingerprint, ...output } = built;
+        const draftOutput = {
+          ...output,
+          answeredSummaries: projectPlanCreationAnswerSummaries(
+            snapshot,
+            resolvePlanCreationAnswerFlow(snapshot),
+            { today: buildInput.today },
+          ),
+        };
+        const draft = PlanCreationDraftSchema.parse({
+          ...draftOutput,
+          inputFingerprint,
+          outputFingerprint: await requestDigest(input.crypto, draftOutput),
+        });
         const result = await input.repository.recordDraft({
           command,
           creationId: parsed.creationId,

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -2308,10 +2308,25 @@ describe("local coach composition", () => {
             source: { kind: "athlete" },
           });
         }
+        const previewed = await lifecycle.operations["plan_creation.preview"]({
+          commandId: "creation-preview",
+          creationId: card.creationId,
+          expectedVersion: card.version,
+        });
+        if (previewed.status !== "previewed") throw new TypeError("Plan Draft did not build.");
+        card = previewed.planCreation;
+        expect(card).toMatchObject({
+          status: "review",
+          readiness: "ready",
+          version: answers.length + 2,
+          draftStale: false,
+        });
+        expect(card.draft).not.toBeNull();
+        expect(await store.all("SELECT * FROM plan_creation_draft_revision")).toHaveLength(1);
         const commands = await store.all(
           "SELECT * FROM planning_command ORDER BY command_name,command_id",
         );
-        expect(commands).toHaveLength(answers.length + 1);
+        expect(commands).toHaveLength(answers.length + 2);
         for (const command of commands) expect(command.status).toBe("succeeded");
         for (const [index] of answers.entries()) {
           const command = commands.find((row) => row.command_id === `creation-answer-${index}`);

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2222,6 +2222,8 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       creationId,
       version: 1,
       status: "in-progress",
+      draft: null,
+      draftStale: false,
       readiness: "incomplete",
       answeredSummaries: [],
       openQuestion: {
@@ -2253,6 +2255,8 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       creationId,
       version: 2,
       status: "in-progress",
+      draft: null,
+      draftStale: false,
       readiness: "incomplete",
       answeredSummaries: [
         {
@@ -2328,6 +2332,9 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       status: "answered",
       planCreation: answeredCard,
     }));
+    const previewPlanCreation = vi.fn<PlanCreationOperations["plan_creation.preview"]>(
+      async () => ({ status: "rejected", reason: "not-ready", planCreation: answeredCard }),
+    );
     const discardPlanCreation = vi.fn<PlanCreationOperations["plan_creation.discard"]>(
       async () => ({ status: "discarded" }),
     );
@@ -2337,6 +2344,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         ...operations,
         "plan_creation.start": startPlanCreation,
         "plan_creation.answer": answerPlanCreation,
+        "plan_creation.preview": previewPlanCreation,
         "plan_creation.discard": discardPlanCreation,
       },
       token,
@@ -2356,6 +2364,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       expectedVersion: 1,
       answer: { kind: "goal" as const, goal: { kind: "fitness" as const, outcome: "Build power" } },
     };
+    const previewParams = { commandId: "preview-1", creationId, expectedVersion: 2 };
     const discardParams = { commandId: "discard-1", creationId, expectedVersion: 2 };
     for (const { result, ...request } of [
       {
@@ -2369,6 +2378,12 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         method: "plan_creation.answer",
         params: answerParams,
         result: { status: "answered", planCreation: answeredCard },
+      },
+      {
+        id: "preview",
+        method: "plan_creation.preview",
+        params: previewParams,
+        result: { status: "rejected", reason: "not-ready", planCreation: answeredCard },
       },
       {
         id: "discard",
@@ -2386,6 +2401,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     }
     expect(startPlanCreation).toHaveBeenCalledWith(startParams);
     expect(answerPlanCreation).toHaveBeenCalledWith(answerParams);
+    expect(previewPlanCreation).toHaveBeenCalledWith(previewParams);
     expect(discardPlanCreation).toHaveBeenCalledWith(discardParams);
 
     for (const request of [
@@ -2398,6 +2414,11 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         id: "invalid-answer",
         method: "plan_creation.answer",
         params: { ...answerParams, extra: true },
+      },
+      {
+        id: "invalid-preview",
+        method: "plan_creation.preview",
+        params: { ...previewParams, extra: true },
       },
       {
         id: "invalid-discard",
@@ -2413,6 +2434,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     }
     expect(startPlanCreation).toHaveBeenCalledOnce();
     expect(answerPlanCreation).toHaveBeenCalledOnce();
+    expect(previewPlanCreation).toHaveBeenCalledOnce();
     expect(discardPlanCreation).toHaveBeenCalledOnce();
     await renderer.close();
   });

--- a/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
+++ b/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
@@ -10,6 +10,11 @@ export const planCreationOperationStubs = {
     reason: "no-unfinished-creation",
     planCreation: null,
   }),
+  "plan_creation.preview": async () => ({
+    status: "rejected",
+    reason: "no-unfinished-creation",
+    planCreation: null,
+  }),
   "plan_creation.discard": async () => ({
     status: "rejected",
     reason: "no-unfinished-creation",

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@enduragent/kernel/archive";
 import { describe, expect, it, vi, onTestFinished } from "vitest";
 import {
   PlanCreationCardModelSchema,
@@ -911,7 +913,23 @@ describe("Plan Creation preview", () => {
         draft: { mode: "flexible", weeks: expect.any(Array), ftp: null },
       },
     });
+    if (first.status !== "previewed" || first.planCreation.draft === null)
+      throw new Error("Expected Draft");
+    const draft = first.planCreation.draft;
+    expect(draft.answeredSummaries).toEqual(card.answeredSummaries);
+    expect(draft.answeredSummaries).toEqual(first.planCreation.answeredSummaries);
+    const { inputFingerprint, outputFingerprint, ...output } = draft;
+    expect(outputFingerprint).toBe(
+      createHash("sha256").update(canonicalJson(output)).digest("hex"),
+    );
     const snapshot = await test.repository.readUnfinished();
+    expect(snapshot?.currentDraft?.outputSnapshotJson).toBe(canonicalJson(draft));
+    expect(snapshot?.currentDraft?.activationFingerprint).toBe(outputFingerprint);
+    expect(inputFingerprint).toBe(
+      createHash("sha256")
+        .update(snapshot?.currentDraft?.inputSnapshotJson ?? "")
+        .digest("hex"),
+    );
     expect(snapshot?.currentDraft?.inputFingerprint).toMatch(/^[0-9a-f]{64}$/u);
     const before = await test.store.all("SELECT * FROM plan_creation_draft_revision");
     const edited = await answered(
@@ -923,6 +941,18 @@ describe("Plan Creation preview", () => {
       }),
     );
     expect(edited).toMatchObject({ status: "review", draftStale: true });
+    expect(
+      edited.answeredSummaries.find((summary) => summary.answerKey === "plan-length")?.answer,
+    ).toEqual({ kind: "plan-length", weeks: 8 });
+    expect(
+      edited.draft?.answeredSummaries.find((summary) => summary.answerKey === "plan-length")
+        ?.answer,
+    ).toEqual({ kind: "plan-length", weeks: 4 });
+    expect(edited.draft).toEqual(draft);
+    test.advanceDay();
+    const reloaded = await test.host.readCard();
+    expect(reloaded?.draft).toEqual(draft);
+    expect(reloaded?.draftStale).toBe(true);
     expect(await test.host["plan_creation.preview"](request)).toEqual(first);
     expect(await test.store.all("SELECT * FROM plan_creation_draft_revision")).toEqual(before);
     await expect(

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, onTestFinished } from "vitest";
 import {
   PlanCreationCardModelSchema,
   type PlanCreationAnswerInput,
@@ -6,6 +6,7 @@ import {
   type PlanCreationCardModel,
 } from "@enduragent/coach-contract";
 import {
+  createPlanCreationRepository,
   PlanCreationStoreError,
   type PlanCreationAnswerRecord,
   type PlanCreationRepository,
@@ -17,6 +18,9 @@ import {
   projectPlanCreationCard,
   type BaselineEvidenceSource,
 } from "../src/plan-creation-operations.js";
+import { runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import { readPlanCreationAnswers } from "../src/plan-creation-answers.js";
 
 const id = (value: string) => `${"0".repeat(26 - value.length)}${value}`;
@@ -91,6 +95,7 @@ const stored = (
 const snapshot = (answers: readonly PlanCreationAnswerRecord[] = []): PlanCreationSnapshot => ({
   id: id("1"),
   status: "in-progress",
+  currentDraft: null,
   version: answers.length + 1,
   seed: { schemaVersion: 1, eventCandidates: [eventCandidate] },
   createdAtMs: 883_612_800_000,
@@ -148,6 +153,10 @@ function harness(
     return { outcome: "recorded", snapshot: current };
   });
   const repository: PlanCreationRepository = {
+    replayDraft: async () => undefined,
+    recordDraft: async () => {
+      throw new Error("unused");
+    },
     readUnfinished: async () => current,
     start: async () => ({ outcome: "resumed", snapshot: current }),
     recordAnswer,
@@ -258,10 +267,7 @@ describe("Plan Creation operations", () => {
     ];
     const cases: readonly [PlanCreationAnswerInput, string][] = [
       [noRestriction, "No training restrictions"],
-      [
-        { kind: "restriction", restriction: { kind: "no-training" } },
-        "No training",
-      ],
+      [{ kind: "restriction", restriction: { kind: "no-training" } }, "No training"],
       [
         {
           kind: "restriction",
@@ -269,10 +275,7 @@ describe("Plan Creation operations", () => {
         },
         "No training until 1998-09-14",
       ],
-      [
-        { kind: "restriction", restriction: { kind: "no-hard-training" } },
-        "No hard training",
-      ],
+      [{ kind: "restriction", restriction: { kind: "no-hard-training" } }, "No hard training"],
       [
         {
           kind: "restriction",
@@ -651,6 +654,10 @@ describe("Plan Creation operations", () => {
     let sequence = 8;
     const host = createPlanCreationOperations({
       repository: {
+        replayDraft: async () => undefined,
+        recordDraft: async () => {
+          throw new Error("unused");
+        },
         readUnfinished: async () => current,
         start,
         recordAnswer: async () => {
@@ -742,6 +749,10 @@ describe("Plan Creation operations", () => {
     });
     const host = createPlanCreationOperations({
       repository: {
+        replayDraft: async () => undefined,
+        recordDraft: async () => {
+          throw new Error("unused");
+        },
         readUnfinished,
         start: async () => {
           throw new Error("unused");
@@ -818,5 +829,195 @@ describe("Plan Creation operations", () => {
 
     discardError = new Error("unexpected");
     await expect(host["plan_creation.discard"](request)).rejects.toThrow("unexpected");
+  });
+});
+
+async function previewHarness() {
+  let currentToday = today;
+  const store = openSqliteStorage(":memory:");
+  onTestFinished(() => store.close());
+  await runMigrations(store, MIGRATIONS);
+  const repository = createPlanCreationRepository(store);
+  let sequence = 100;
+  const host = createPlanCreationOperations({
+    repository,
+    identity: {
+      deviceId: async () => "preview-test-device",
+      newUlid: () => id(`${++sequence}`),
+      hlcStamp: () => ({ physicalMs: 883_612_800_000, counter: 0 }),
+    },
+    crypto: globalThis.crypto,
+    eventCandidates: { read: async () => [candidateSource] },
+    today: () => currentToday,
+  });
+  const started = await host["plan_creation.start"]({ commandId: "start" });
+  if (started.status !== "started") throw new Error("Expected creation");
+  let card = started.planCreation;
+  const answer = async (value: PlanCreationAnswerInput) => {
+    card = await answered(
+      host["plan_creation.answer"]({
+        commandId: `answer-${++sequence}`,
+        creationId: card.creationId,
+        expectedVersion: card.version,
+        answer: value,
+      }),
+    );
+    return card;
+  };
+  const ready = async () => {
+    for (const value of [
+      fitnessGoal,
+      { kind: "plan-length", weeks: 4 } as const,
+      flexibleMode,
+      flexibleAvailability,
+      startTiming,
+      noCommitments,
+      regularBaseline,
+      fitnessSuccess,
+      noRestriction,
+    ])
+      await answer(value);
+    return card;
+  };
+  return {
+    store,
+    repository,
+    host,
+    ready,
+    answer,
+    card: () => card,
+    advanceDay: () => {
+      currentToday = "1998-09-03";
+    },
+  };
+}
+
+describe("Plan Creation preview", () => {
+  it("stores a complete Draft, replays its result, and rebuilds stale review answers", async () => {
+    const test = await previewHarness();
+    const card = await test.ready();
+    const request = {
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    };
+    const first = await test.host["plan_creation.preview"](request);
+    expect(first).toMatchObject({
+      status: "previewed",
+      planCreation: {
+        status: "review",
+        version: card.version + 1,
+        draftStale: false,
+        draft: { mode: "flexible", weeks: expect.any(Array), ftp: null },
+      },
+    });
+    const snapshot = await test.repository.readUnfinished();
+    expect(snapshot?.currentDraft?.inputFingerprint).toMatch(/^[0-9a-f]{64}$/u);
+    const before = await test.store.all("SELECT * FROM plan_creation_draft_revision");
+    const edited = await answered(
+      test.host["plan_creation.answer"]({
+        commandId: "edit",
+        creationId: card.creationId,
+        expectedVersion: card.version + 1,
+        answer: { kind: "plan-length", weeks: 8 },
+      }),
+    );
+    expect(edited).toMatchObject({ status: "review", draftStale: true });
+    expect(await test.host["plan_creation.preview"](request)).toEqual(first);
+    expect(await test.store.all("SELECT * FROM plan_creation_draft_revision")).toEqual(before);
+    await expect(
+      test.host["plan_creation.preview"]({ ...request, expectedVersion: edited.version }),
+    ).resolves.toMatchObject({ status: "rejected", reason: "command-conflict" });
+    const rebuilt = await test.host["plan_creation.preview"]({
+      ...request,
+      commandId: "rebuild",
+      expectedVersion: edited.version,
+    });
+    expect(rebuilt).toMatchObject({ status: "previewed", planCreation: { draftStale: false } });
+    const stored = await test.repository.readUnfinished();
+    expect(stored?.currentDraft).toMatchObject({ revisionNumber: 2, parentRevisionNumber: 1 });
+    expect(await test.host.readCard()).toEqual(
+      rebuilt.status === "previewed" ? rebuilt.planCreation : null,
+    );
+    expect(await test.store.all("SELECT * FROM plan")).toEqual([]);
+    expect(await test.store.all("SELECT * FROM plan_conversation")).toEqual([]);
+  });
+
+  it("rejects incomplete, stale, and missing creations without storing a revision", async () => {
+    const test = await previewHarness();
+    const card = test.card();
+    const request = {
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    };
+    await expect(test.host["plan_creation.preview"](request)).resolves.toMatchObject({
+      reason: "not-ready",
+    });
+    await expect(
+      test.host["plan_creation.preview"]({ ...request, expectedVersion: 10 }),
+    ).resolves.toMatchObject({ reason: "stale-version" });
+    await expect(
+      test.host["plan_creation.preview"]({ ...request, creationId: id("999") }),
+    ).resolves.toMatchObject({ reason: "no-unfinished-creation" });
+    await test.host["plan_creation.discard"]({ ...request, commandId: "discard" });
+    await expect(test.host["plan_creation.preview"](request)).resolves.toMatchObject({
+      reason: "no-unfinished-creation",
+      planCreation: null,
+    });
+    expect(await test.store.all("SELECT * FROM plan_creation_draft_revision")).toEqual([]);
+  });
+
+  it("preserves the prior complete Draft when no Workouts fit", async () => {
+    const test = await previewHarness();
+    const card = await test.ready();
+    const request = {
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    };
+    await test.host["plan_creation.preview"](request);
+    const before = await test.store.all("SELECT * FROM plan_creation_draft_revision");
+    const edited = await answered(
+      test.host["plan_creation.answer"]({
+        commandId: "restrict",
+        creationId: card.creationId,
+        expectedVersion: card.version + 1,
+        answer: { kind: "restriction", restriction: { kind: "no-training" } },
+      }),
+    );
+    await expect(
+      test.host["plan_creation.preview"]({
+        ...request,
+        commandId: "empty",
+        expectedVersion: edited.version,
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      reason: "no-workouts",
+      explanation: expect.stringContaining("No Workouts"),
+      planCreation: { draftStale: true },
+    });
+    expect(await test.store.all("SELECT * FROM plan_creation_draft_revision")).toEqual(before);
+    expect((await test.repository.readUnfinished())?.version).toBe(edited.version);
+  });
+
+  it("replays a successful preview after discard without reviving the creation", async () => {
+    const test = await previewHarness();
+    const card = await test.ready();
+    const request = {
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    };
+    const first = await test.host["plan_creation.preview"](request);
+    await test.host["plan_creation.discard"]({
+      ...request,
+      commandId: "discard",
+      expectedVersion: card.version + 1,
+    });
+    test.advanceDay();
+    await expect(test.host["plan_creation.preview"](request)).resolves.toEqual(first);
+    await expect(test.host.readCard()).resolves.toBeNull();
   });
 });

--- a/packages/coach/tests/planning-request-delivery.test.ts
+++ b/packages/coach/tests/planning-request-delivery.test.ts
@@ -277,6 +277,8 @@ describe("Planning request delivery", () => {
       creationId: "01J60HFQ7T0000000000000001",
       version: 1,
       status: "in-progress" as const,
+      draft: null,
+      draftStale: false,
       readiness: "incomplete" as const,
       answeredSummaries: [],
       openQuestion: {

--- a/packages/kernel-node/tests/plan-creation-repository.test.ts
+++ b/packages/kernel-node/tests/plan-creation-repository.test.ts
@@ -66,6 +66,151 @@ describe("Plan Creation repository", () => {
       expectedVersion,
     });
 
+  const draftInput = (expectedVersion = 1, commandId = "preview", draftId = id("8")) => ({
+    command: stamp(commandId, "d", 883_612_800_003),
+    creationId,
+    expectedVersion,
+    draftId,
+    inputSnapshotJson: JSON.stringify({ answers: [], today: "1998-01-01", ftp: null }),
+    inputFingerprint: "e".repeat(64),
+    outputSnapshotJson: JSON.stringify({ weeks: [{ workouts: [{ name: "Endurance ride" }] }] }),
+    builderId: "cycling",
+    builderVersion: "1",
+    activationFingerprint: "f".repeat(64),
+  });
+
+  it("stores immutable revisions and keeps the earlier draft after an answer edit", async () => {
+    await start();
+    const first = await repository.recordDraft(draftInput());
+    expect(first).toMatchObject({
+      outcome: "recorded",
+      snapshot: {
+        status: "review",
+        version: 2,
+        currentDraft: { revisionNumber: 1, parentRevisionNumber: null, inputVersion: 1 },
+      },
+    });
+    const before = await store.all("SELECT * FROM plan_creation_draft_revision");
+    const edited = await answer(2);
+    expect(edited.snapshot).toMatchObject({
+      status: "review",
+      version: 3,
+      currentDraft: first.snapshot.currentDraft,
+    });
+    expect(await store.all("SELECT * FROM plan_creation_draft_revision")).toEqual(before);
+    const second = await repository.recordDraft(draftInput(3, "rebuild", id("9")));
+    expect(second.snapshot).toMatchObject({
+      status: "review",
+      version: 4,
+      currentDraft: { revisionNumber: 2, parentRevisionNumber: 1, inputVersion: 3 },
+    });
+    expect(
+      (await store.all("SELECT * FROM plan_creation_draft_revision ORDER BY revision_number"))[0],
+    ).toEqual(before[0]);
+    await expect(
+      store.run("UPDATE plan_creation_draft_revision SET builder_version='2'"),
+    ).rejects.toThrow();
+    await expect(store.run("DELETE FROM plan_creation_draft_revision")).rejects.toThrow();
+    expect(await store.all("SELECT * FROM plan")).toEqual([]);
+    await expect(createPlanCreationRepository(store).readUnfinished()).resolves.toEqual(
+      second.snapshot,
+    );
+  });
+
+  it("replays the recorded preview after answers, rebuild, discard, and a new creation", async () => {
+    await start();
+    const input = draftInput();
+    const original = await repository.recordDraft(input);
+    await answer(2);
+    await repository.recordDraft(draftInput(3, "rebuild", id("9")));
+    await expect(repository.recordDraft(input)).resolves.toEqual({
+      outcome: "replayed",
+      snapshot: original.snapshot,
+    });
+    await discard(4);
+    await expect(repository.replayDraft(input.command)).resolves.toEqual(original.snapshot);
+    await repository.start({ command: stamp("next-start", "a"), creationId: secondId, seed });
+    await expect(repository.recordDraft(input)).resolves.toEqual({
+      outcome: "replayed",
+      snapshot: original.snapshot,
+    });
+    await expect(repository.readUnfinished()).resolves.toMatchObject({ id: secondId, version: 1 });
+    expect(await store.all("SELECT * FROM plan_creation_draft_revision")).toHaveLength(2);
+    await expect(
+      repository.recordDraft({ ...input, command: stamp("preview", "a") }),
+    ).rejects.toMatchObject({ code: "command-conflict" });
+    await expect(repository.replayDraft(stamp("preview", "a"))).rejects.toMatchObject({
+      code: "command-conflict",
+    });
+  });
+
+  it("rejects missing and stale previews without writing a revision or command", async () => {
+    await expect(repository.recordDraft(draftInput())).rejects.toMatchObject({
+      code: "no-unfinished-creation",
+    });
+    await start();
+    await expect(
+      repository.recordDraft({ ...draftInput(), creationId: secondId }),
+    ).rejects.toMatchObject({ code: "no-unfinished-creation" });
+    await answer();
+    await expect(repository.recordDraft(draftInput())).rejects.toMatchObject({
+      code: "stale-version",
+    });
+    await discard(2);
+    await expect(repository.recordDraft(draftInput(2))).rejects.toMatchObject({
+      code: "no-unfinished-creation",
+    });
+    expect(await store.all("SELECT * FROM plan_creation_draft_revision")).toEqual([]);
+    expect(
+      await store.all("SELECT * FROM planning_command WHERE command_name='plan_creation.preview'"),
+    ).toEqual([]);
+  });
+
+  it("serializes competing preview and answer commands against one expected version", async () => {
+    await start();
+    const results = await Promise.allSettled([repository.recordDraft(draftInput()), answer()]);
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(results.find(({ status }) => status === "rejected")).toMatchObject({
+      reason: { code: "stale-version" },
+    });
+    const snapshot = await repository.readUnfinished();
+    expect(snapshot?.version).toBe(2);
+    const revisionRows = await store.all("SELECT * FROM plan_creation_draft_revision");
+    expect(revisionRows.length + (snapshot?.answers.length ?? 0)).toBe(1);
+  });
+
+  it("serializes a preview racing discard without attaching a draft to a terminal creation", async () => {
+    await start();
+    const results = await Promise.allSettled([discard(), repository.recordDraft(draftInput())]);
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(results.find(({ status }) => status === "rejected")).toMatchObject({
+      reason: { code: "no-unfinished-creation" },
+    });
+    await expect(repository.readUnfinished()).resolves.toBeUndefined();
+    expect(await store.all("SELECT * FROM plan_creation_draft_revision")).toEqual([]);
+  });
+
+  it("rolls back the draft and review pointer when the command ledger fails", async () => {
+    await start();
+    const before = await dumpStore(store);
+    const failingRepository = createPlanCreationRepository({
+      exec: (sql) => store.exec(sql),
+      run(sql, params) {
+        if (sql.includes("INSERT INTO planning_command"))
+          throw new Error("Synthetic draft ledger failure");
+        return store.run(sql, params);
+      },
+      get: (sql, params) => store.get(sql, params),
+      all: (sql, params) => store.all(sql, params),
+      close: () => store.close(),
+      transaction: (operation) => store.transaction(operation),
+    });
+    await expect(failingRepository.recordDraft(draftInput())).rejects.toThrow(
+      "Synthetic draft ledger failure",
+    );
+    expect(await dumpStore(store)).toBe(before);
+  });
+
   it("creates once and resumes without replacing the seed", async () => {
     await expect(start()).resolves.toMatchObject({ outcome: "created", snapshot: { version: 1 } });
     const otherSeed = {
@@ -437,10 +582,13 @@ describe("Plan Creation repository", () => {
     };
     const answers = [goalAnswer, lengthAnswer, editedGoalAnswer];
     for (const input of answers) await repository.recordAnswer(input);
+    const draft = draftInput(4);
+    await repository.recordDraft(draft);
     const sourceSnapshot = await repository.readUnfinished();
     expect(sourceSnapshot).toMatchObject({
       id: creationId,
-      version: 4,
+      version: 5,
+      currentDraft: { revisionNumber: 1, inputVersion: 4 },
       answers: [
         { id: id("3"), answerKey: "goal", sequence: 1, creationVersion: 2 },
         { id: id("4"), answerKey: "plan-length", sequence: 2, creationVersion: 3 },
@@ -478,12 +626,17 @@ describe("Plan Creation repository", () => {
       for (const query of [
         "SELECT * FROM plan_creation ORDER BY id",
         "SELECT * FROM plan_creation_answer ORDER BY creation_id,sequence,id",
+        "SELECT * FROM plan_creation_draft_revision ORDER BY creation_id,revision_number,id",
         "SELECT * FROM planning_command ORDER BY command_name,command_id",
       ]) {
         expect(await destination.all(query)).toEqual(await store.all(query));
       }
       const restoredRepository = createPlanCreationRepository(destination);
       await expect(restoredRepository.readUnfinished()).resolves.toEqual(sourceSnapshot);
+      await expect(restoredRepository.recordDraft(draft)).resolves.toEqual({
+        outcome: "replayed",
+        snapshot: sourceSnapshot,
+      });
       for (const input of answers) {
         await expect(restoredRepository.recordAnswer(input)).resolves.toEqual({
           outcome: "replayed",

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -40,24 +40,46 @@ export const PlanCreationSeedV1Schema = z
   .readonly();
 export type PlanCreationSeedV1 = z.infer<typeof PlanCreationSeedV1Schema>;
 
-export interface PlanCreationAnswerRecord {
-  readonly id: string;
-  readonly sequence: number;
-  readonly creationVersion: number;
-  readonly answerKey: string;
-  readonly valueJson: string;
-  readonly confirmedAtMs: number;
-}
+const PlanCreationAnswerRecordSchema = z
+  .object({
+    id: z.string(),
+    sequence: z.number().int().positive(),
+    creationVersion: z.number().int().positive(),
+    answerKey: z.string(),
+    valueJson: z.string(),
+    confirmedAtMs: z.number().int().nonnegative(),
+  })
+  .readonly();
+export type PlanCreationAnswerRecord = z.infer<typeof PlanCreationAnswerRecordSchema>;
 
-export interface PlanCreationSnapshot {
-  readonly id: string;
-  readonly status: "in-progress" | "review" | "activated" | "discarded";
-  readonly version: number;
-  readonly seed: PlanCreationSeedV1 | null;
-  readonly createdAtMs: number;
-  readonly updatedAtMs: number;
-  readonly answers: readonly PlanCreationAnswerRecord[];
-}
+const PlanCreationDraftRevisionSchema = z
+  .object({
+    revisionNumber: z.number().int().positive(),
+    parentRevisionNumber: z.number().int().positive().nullable(),
+    inputVersion: z.number().int().positive(),
+    inputSnapshotJson: z.string(),
+    inputFingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+    outputSnapshotJson: z.string(),
+    builderId: z.string().min(1),
+    builderVersion: z.string().min(1),
+    activationFingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+  })
+  .readonly();
+export type PlanCreationDraftRevision = z.infer<typeof PlanCreationDraftRevisionSchema>;
+
+const PlanCreationSnapshotSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(["in-progress", "review", "activated", "discarded"]),
+    version: z.number().int().positive(),
+    seed: PlanCreationSeedV1Schema.nullable(),
+    createdAtMs: z.number().int().nonnegative(),
+    updatedAtMs: z.number().int().nonnegative(),
+    answers: z.array(PlanCreationAnswerRecordSchema).readonly(),
+    currentDraft: PlanCreationDraftRevisionSchema.nullable(),
+  })
+  .readonly();
+export type PlanCreationSnapshot = z.infer<typeof PlanCreationSnapshotSchema>;
 
 export interface PlanCreationCommandStamp {
   readonly commandId: string;
@@ -83,6 +105,19 @@ export interface RecordPlanCreationAnswerInput {
   readonly valueJson: string;
 }
 
+export interface RecordPlanCreationDraftInput {
+  readonly command: PlanCreationCommandStamp;
+  readonly creationId: string;
+  readonly expectedVersion: number;
+  readonly draftId: string;
+  readonly inputSnapshotJson: string;
+  readonly inputFingerprint: string;
+  readonly outputSnapshotJson: string;
+  readonly builderId: string;
+  readonly builderVersion: string;
+  readonly activationFingerprint: string;
+}
+
 export interface DiscardPlanCreationInput {
   readonly command: PlanCreationCommandStamp;
   readonly creationId: string;
@@ -96,6 +131,11 @@ export interface PlanCreationRepository {
     snapshot: PlanCreationSnapshot;
   }>;
   recordAnswer(input: RecordPlanCreationAnswerInput): Promise<{
+    outcome: "recorded" | "replayed";
+    snapshot: PlanCreationSnapshot;
+  }>;
+  replayDraft(command: PlanCreationCommandStamp): Promise<PlanCreationSnapshot | undefined>;
+  recordDraft(input: RecordPlanCreationDraftInput): Promise<{
     outcome: "recorded" | "replayed";
     snapshot: PlanCreationSnapshot;
   }>;
@@ -145,11 +185,36 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
       "SELECT * FROM plan_creation_answer WHERE creation_id=? ORDER BY sequence,id",
       [id],
     );
+    const revisionNumber = row.current_draft_revision_number;
+    let currentDraft: PlanCreationDraftRevision | null = null;
+    if (revisionNumber !== null) {
+      const draft = await store.get(
+        "SELECT * FROM plan_creation_draft_revision WHERE creation_id=? AND revision_number=?",
+        [id, integer(row, "current_draft_revision_number")],
+      );
+      if (draft === undefined) return fail();
+      const parsed = PlanCreationDraftRevisionSchema.safeParse({
+        revisionNumber: draft.revision_number,
+        parentRevisionNumber: draft.parent_revision_number,
+        inputVersion: draft.input_version,
+        inputSnapshotJson: draft.input_snapshot_json,
+        inputFingerprint: draft.input_fingerprint,
+        outputSnapshotJson: draft.output_snapshot_json,
+        builderId: draft.builder_id,
+        builderVersion: draft.builder_version,
+        activationFingerprint: draft.activation_fingerprint,
+      });
+      if (!parsed.success) return fail();
+      currentDraft = parsed.data;
+      json(currentDraft.inputSnapshotJson);
+      json(currentDraft.outputSnapshotJson);
+    }
     return {
       id,
       status: status === "review" ? "review" : "in-progress",
       version: integer(row, "version"),
       seed,
+      currentDraft,
       createdAtMs: integer(row, "created_at_ms"),
       updatedAtMs: integer(row, "updated_at_ms"),
       answers: answers.map((answer) => {
@@ -172,25 +237,39 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
     return snapshot;
   };
   const hasReplay = async (
-    name: "plan_creation.start" | "plan_creation.answer" | "plan_creation.discard",
+    name:
+      | "plan_creation.start"
+      | "plan_creation.answer"
+      | "plan_creation.discard"
+      | "plan_creation.preview",
     command: PlanCreationCommandStamp,
   ) => {
     const row = await store.get(
-      "SELECT request_digest,status FROM planning_command WHERE command_name=? AND command_id=?",
+      "SELECT request_digest,status,result_json FROM planning_command WHERE command_name=? AND command_id=?",
       [name, command.commandId],
     );
     if (row === undefined) return undefined;
     if (text(row, "request_digest") !== command.requestDigest)
       throw new PlanCreationStoreError("command-conflict");
     if (text(row, "status") !== "succeeded") fail();
-    return true;
+    return row;
   };
   const replay = async (
     name: "plan_creation.start" | "plan_creation.answer",
     command: PlanCreationCommandStamp,
   ) => ((await hasReplay(name, command)) ? requireUnfinished() : undefined);
+  const replayDraft = async (command: PlanCreationCommandStamp) => {
+    const row = await hasReplay("plan_creation.preview", command);
+    if (row === undefined) return undefined;
+    const parsed = PlanCreationSnapshotSchema.safeParse(json(text(row, "result_json")));
+    return parsed.success ? parsed.data : fail();
+  };
   const recordCommand = (
-    name: "plan_creation.start" | "plan_creation.answer" | "plan_creation.discard",
+    name:
+      | "plan_creation.start"
+      | "plan_creation.answer"
+      | "plan_creation.discard"
+      | "plan_creation.preview",
     command: PlanCreationCommandStamp,
     creationId: string,
     result: unknown,
@@ -215,6 +294,7 @@ version,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
     );
   return {
     readUnfinished,
+    replayDraft,
     async start({ command, creationId, seed }) {
       return store.transaction(async () => {
         const prior = await replay("plan_creation.start", command);
@@ -274,7 +354,7 @@ device_id,hlc_physical_ms,hlc_counter
         );
         await store.run(
           `UPDATE plan_creation SET version=?,updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=?
-WHERE id=? AND status='in-progress' AND version=?`,
+WHERE id=? AND status IN ('in-progress','review') AND version=?`,
           [
             version,
             command.nowMs,
@@ -293,6 +373,67 @@ WHERE id=? AND status='in-progress' AND version=?`,
           answerId,
           version,
         });
+        return { outcome: "recorded", snapshot };
+      });
+    },
+    async recordDraft(input) {
+      const { command, creationId, expectedVersion } = input;
+      return store.transaction(async () => {
+        const prior = await replayDraft(command);
+        if (prior) return { outcome: "replayed", snapshot: prior };
+        const current = await readUnfinished();
+        if (current === undefined || current.id !== creationId)
+          throw new PlanCreationStoreError("no-unfinished-creation");
+        if (current.version !== expectedVersion) throw new PlanCreationStoreError("stale-version");
+        const parentRevisionNumber = current.currentDraft?.revisionNumber ?? null;
+        const revisionNumber = (parentRevisionNumber ?? 0) + 1;
+        await store.run(
+          `INSERT INTO plan_creation_draft_revision (
+id,creation_id,revision_number,parent_revision_number,input_version,input_snapshot_json,
+input_fingerprint,builder_id,builder_version,output_snapshot_json,activation_fingerprint,
+created_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            input.draftId,
+            creationId,
+            revisionNumber,
+            parentRevisionNumber,
+            expectedVersion,
+            input.inputSnapshotJson,
+            input.inputFingerprint,
+            input.builderId,
+            input.builderVersion,
+            input.outputSnapshotJson,
+            input.activationFingerprint,
+            command.nowMs,
+            command.deviceId,
+            command.hlcPhysicalMs,
+            command.hlcCounter,
+          ],
+        );
+        await store.run(
+          `UPDATE plan_creation SET status='review',current_draft_revision_number=?,version=version+1,
+updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=?
+WHERE id=? AND status IN ('in-progress','review') AND version=?`,
+          [
+            revisionNumber,
+            command.nowMs,
+            command.deviceId,
+            command.hlcPhysicalMs,
+            command.hlcCounter,
+            creationId,
+            expectedVersion,
+          ],
+        );
+        const snapshot = await requireUnfinished();
+        if (
+          snapshot.id !== creationId ||
+          snapshot.version !== expectedVersion + 1 ||
+          snapshot.currentDraft?.revisionNumber !== revisionNumber ||
+          snapshot.status !== "review"
+        )
+          throw new PlanCreationStoreError("stale-version");
+        await recordCommand("plan_creation.preview", command, creationId, snapshot);
         return { outcome: "recorded", snapshot };
       });
     },

--- a/packages/sport-cycling/src/creation-draft-builder.ts
+++ b/packages/sport-cycling/src/creation-draft-builder.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import {
+  addCivilDays,
+  dateKeyFromText,
+  inclusiveCivilDays,
+  weekdayForDateKey,
+} from "@enduragent/kernel/planning";
+
+export interface CreationDraftInput {
+  answers: {
+    goal:
+      | { kind: "fitness"; outcome?: string; weeks: 4 | 8 | 12 | 16 }
+      | { kind: "event"; name: string; date: string };
+    availability:
+      | {
+          mode: "fixed";
+          weeklyHoursLimit: number;
+          longestWorkoutHours: number;
+          usableWeekdays: readonly number[];
+        }
+      | { mode: "flexible"; weeklyHoursLimit: number; longestWorkoutHours: number };
+    startTiming: { kind: "as-soon-as-possible" } | { kind: "earliest"; date: string };
+    restriction:
+      | { kind: "none" }
+      | { kind: "no-training" | "no-hard-training"; endDate?: string }
+      | { kind: "max-duration"; hours: number; endDate?: string };
+    commitments: { kind: "none" } | { kind: "authored"; text: string };
+    baseline: "regular" | "occasional" | "starting-again";
+    success:
+      | { kind: "fitness-choice"; choice: "train-consistently" | "climb-stronger" | "ride-farther" }
+      | { kind: "event-finish"; choice: "finish-comfortably" | "finish-fast" | "race-for-result" }
+      | { kind: "authored"; text: string };
+  };
+  today: string;
+  ftp: null;
+}
+
+interface DraftWorkout {
+  id: string;
+  name: string;
+  kind: "hard" | "endurance" | "long" | "easy" | "event";
+  date: string | null;
+  minutes: number;
+  pinned: boolean;
+  guidance: string;
+  power: null;
+}
+
+interface DraftWeek {
+  number: number;
+  start: string;
+  end: string;
+  workouts: DraftWorkout[];
+  notes: string[];
+}
+
+export interface CreationDraft {
+  kind: "draft";
+  goal: CreationDraftInput["answers"]["goal"];
+  mode: "fixed" | "flexible";
+  start: string;
+  end: string;
+  spanKind: "Short block" | "Event preparation" | "Base Plan" | "Fitness Plan";
+  computedWeeks: number;
+  weeks: DraftWeek[];
+  notes: string[];
+  guidance: string;
+  ftp: null;
+  builderId: string;
+  builderVersion: string;
+  inputFingerprint: string;
+  outputFingerprint: string;
+}
+
+export type CreationDraftResult = CreationDraft | { kind: "no-workouts"; explanation: string };
+
+const guidance = "Use comfortable perceived effort or your known heart-rate guidance";
+const templates: Pick<DraftWorkout, "name" | "kind" | "minutes">[] = [
+  { name: "Controlled effort", kind: "hard", minutes: 45 },
+  { name: "Endurance ride", kind: "endurance", minutes: 60 },
+  { name: "Long ride", kind: "long", minutes: 100 },
+  { name: "Optional easy ride", kind: "easy", minutes: 30 },
+  { name: "Additional endurance ride", kind: "endurance", minutes: 45 },
+];
+
+function civilText(key: number): string {
+  const digits = String(key).padStart(8, "0");
+  return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+}
+
+function rulesFor(answers: CreationDraftInput["answers"], key: number) {
+  const restriction = answers.restriction;
+  const active =
+    restriction.kind !== "none" && (!restriction.endDate || civilText(key) <= restriction.endDate);
+  return {
+    unavailable: active && restriction.kind === "no-training",
+    noHard: active && restriction.kind === "no-hard-training",
+    minutes: Math.floor(
+      Math.min(
+        answers.availability.longestWorkoutHours,
+        active && restriction.kind === "max-duration" ? restriction.hours : Infinity,
+      ) * 60,
+    ),
+  };
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+export function buildCreationDraft(input: CreationDraftInput): CreationDraftResult {
+  const { answers } = input;
+  const { availability, goal } = answers;
+  const earliest =
+    answers.startTiming.kind === "earliest" && answers.startTiming.date > input.today
+      ? answers.startTiming.date
+      : input.today;
+  const earliestKey = dateKeyFromText(earliest);
+  let startKey: number | undefined;
+  for (let offset = 0; offset < 370; offset++) {
+    const date = addCivilDays(earliestKey, offset);
+    if (
+      (availability.mode === "flexible" ||
+        availability.usableWeekdays.includes(weekdayForDateKey(date) || 7)) &&
+      !rulesFor(answers, date).unavailable
+    ) {
+      startKey = date;
+      break;
+    }
+  }
+  if (startKey === undefined)
+    return {
+      kind: "no-workouts",
+      explanation:
+        "No Workouts fit anywhere in this Plan under your confirmed limits. Edit those limits to continue.",
+    };
+  if (goal.kind === "event" && dateKeyFromText(goal.date) < startKey)
+    return { kind: "no-workouts", explanation: "Choose an event date on or after the Plan start." };
+  const computedWeeks =
+    goal.kind === "fitness"
+      ? goal.weeks
+      : Math.ceil(inclusiveCivilDays(startKey, dateKeyFromText(goal.date)) / 7);
+  const weekCount = goal.kind === "event" && computedWeeks > 24 ? 12 : computedWeeks;
+  const spanKind =
+    goal.kind === "fitness"
+      ? "Fitness Plan"
+      : computedWeeks <= 4
+        ? "Short block"
+        : computedWeeks > 24
+          ? "Base Plan"
+          : "Event preparation";
+  const count =
+    availability.mode === "fixed" || availability.weeklyHoursLimit <= 6
+      ? 3
+      : availability.weeklyHoursLimit <= 8
+        ? 4
+        : 5;
+  const weeks: DraftWeek[] = [];
+  for (let number = 1; number <= weekCount; number++) {
+    const key = addCivilDays(startKey, (number - 1) * 7);
+    const week: DraftWeek = {
+      number,
+      start: civilText(key),
+      end: civilText(addCivilDays(key, 6)),
+      workouts: [],
+      notes: [],
+    };
+    let remaining = Math.floor(availability.weeklyHoursLimit * 60);
+    const dates = Array.from({ length: 7 }, (_, index) => addCivilDays(key, index));
+    const possible = dates.filter((date) => !rulesFor(answers, date).unavailable);
+    if (goal.kind === "event" && goal.date >= week.start && goal.date <= week.end) {
+      const rule = rulesFor(answers, dateKeyFromText(goal.date));
+      const minutes = Math.min(60, rule.minutes, remaining);
+      if (rule.unavailable || minutes <= 0)
+        week.notes.push(`${goal.name} has no training assigned under your confirmed limits.`);
+      else {
+        week.workouts.push({
+          id: `w${number}-main-goal`,
+          name: goal.name,
+          kind: "event",
+          date: goal.date,
+          minutes,
+          pinned: true,
+          power: null,
+          guidance: "Follow the confirmed event limit",
+        });
+        remaining -= minutes;
+        if (minutes < 60)
+          week.notes.push(`${goal.name} limited to ${minutes} minutes by your confirmed limits.`);
+      }
+    }
+    for (const [index, template] of templates.slice(0, count).entries()) {
+      const assigned =
+        availability.mode === "fixed"
+          ? possible.find(
+              (date) =>
+                availability.usableWeekdays.includes(weekdayForDateKey(date) || 7) &&
+                !week.workouts.some((workout) => workout.date === civilText(date)),
+            )
+          : undefined;
+      const rule =
+        assigned === undefined
+          ? {
+              minutes: Math.min(...possible.map((date) => rulesFor(answers, date).minutes)),
+              noHard: possible.some((date) => rulesFor(answers, date).noHard),
+            }
+          : rulesFor(answers, assigned);
+      const minutes = Math.min(template.minutes, rule.minutes, remaining);
+      if (
+        (availability.mode === "fixed" && assigned === undefined) ||
+        possible.length === 0 ||
+        minutes <= 0
+      ) {
+        week.notes.push(`${template.name} removed because no compatible time remains.`);
+        continue;
+      }
+      const replaceHard = template.kind === "hard" && rule.noHard;
+      const name = replaceHard ? "Easy ride" : template.name;
+      if (minutes < template.minutes)
+        week.notes.push(`${name} limited to ${minutes} minutes by your confirmed limits.`);
+      if (replaceHard)
+        week.notes.push(
+          "Hard training replaced with an easy ride under the confirmed restriction.",
+        );
+      week.workouts.push({
+        id: `w${number}-template-${index + 1}`,
+        name,
+        kind: replaceHard ? "easy" : template.kind,
+        date: assigned === undefined ? null : civilText(assigned),
+        minutes,
+        pinned: false,
+        power: null,
+        guidance,
+      });
+      remaining -= minutes;
+    }
+    if (week.workouts.length === 0)
+      week.notes.push("Confirmed limits leave no Workouts in this week.");
+    weeks.push(week);
+  }
+  if (weeks.every((week) => week.workouts.length === 0))
+    return {
+      kind: "no-workouts",
+      explanation:
+        "No Workouts fit anywhere in this Plan under your confirmed limits. Edit those limits to continue.",
+    };
+  const notes = [...new Set(weeks.flatMap((week) => week.notes))];
+  if (answers.commitments.kind === "authored")
+    notes.push(
+      "Your written commitments are recorded for review and have not been applied to Workouts.",
+    );
+  const draft: Omit<CreationDraft, "inputFingerprint" | "outputFingerprint"> = {
+    kind: "draft",
+    goal: structuredClone(goal),
+    mode: availability.mode,
+    start: civilText(startKey),
+    end: civilText(addCivilDays(startKey, weekCount * 7 - 1)),
+    spanKind,
+    computedWeeks,
+    weeks,
+    notes,
+    guidance,
+    ftp: null,
+    builderId: "cycling-creation-draft",
+    builderVersion: "1",
+  };
+  return { ...draft, inputFingerprint: digest(input), outputFingerprint: digest(draft) };
+}

--- a/packages/sport-cycling/src/index.ts
+++ b/packages/sport-cycling/src/index.ts
@@ -59,3 +59,6 @@ export {
   projectDfaSummary,
   projectPowerCurveDelta,
 } from "./reference/index.js";
+
+export { buildCreationDraft } from "./creation-draft-builder.js";
+export type { CreationDraftInput, CreationDraft, CreationDraftResult } from "./creation-draft-builder.js";

--- a/packages/sport-cycling/tests/creation-draft-builder.test.ts
+++ b/packages/sport-cycling/tests/creation-draft-builder.test.ts
@@ -1,0 +1,273 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import {
+  addCivilDays,
+  dateKeyFromText,
+  inclusiveCivilDays,
+  weekdayForDateKey,
+} from "@enduragent/kernel/planning";
+import { describe, expect, it } from "vitest";
+import { buildCreationDraft, type CreationDraftInput } from "../src/creation-draft-builder.js";
+
+function input(): CreationDraftInput {
+  return {
+    today: "1998-08-24",
+    ftp: null,
+    answers: {
+      goal: { kind: "fitness", weeks: 4 },
+      availability: { mode: "flexible", weeklyHoursLimit: 6, longestWorkoutHours: 2 },
+      startTiming: { kind: "as-soon-as-possible" },
+      restriction: { kind: "none" },
+      commitments: { kind: "none" },
+      baseline: "regular",
+      success: { kind: "fitness-choice", choice: "train-consistently" },
+    },
+  };
+}
+
+function build(value: CreationDraftInput) {
+  const result = buildCreationDraft(value);
+  if (result.kind !== "draft") throw new Error(result.explanation);
+  return result;
+}
+
+function eventDate(weeks: number) {
+  const digits = String(addCivilDays(dateKeyFromText("1998-08-24"), weeks * 7 - 1));
+  return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+}
+
+describe("creation draft builder", () => {
+  it.each([1, 4, 5, 24, 25])(
+    "builds the %i-week Event boundary and retains the Goal date",
+    (weeks) => {
+      const value = input();
+      value.answers.goal = { kind: "event", name: "Autumn ride", date: eventDate(weeks) };
+      const draft = build(value);
+      expect(draft.computedWeeks).toBe(weeks);
+      expect(draft.weeks).toHaveLength(weeks > 24 ? 12 : weeks);
+      expect(draft.spanKind).toBe(
+        weeks <= 4 ? "Short block" : weeks > 24 ? "Base Plan" : "Event preparation",
+      );
+      expect(draft.goal).toEqual(value.answers.goal);
+      expect(
+        draft.weeks.flatMap((week) => week.workouts).filter((workout) => workout.pinned),
+      ).toEqual(
+        weeks > 24 ? [] : [expect.objectContaining({ kind: "event", date: eventDate(weeks) })],
+      );
+    },
+  );
+
+  it.each([4, 8, 12, 16] as const)("builds %i seven-day Fitness weeks", (weeks) => {
+    const value = input();
+    value.answers.goal = { kind: "fitness", weeks };
+    const draft = build(value);
+    expect(draft.spanKind).toBe("Fitness Plan");
+    expect(draft.weeks).toHaveLength(weeks);
+    for (const week of draft.weeks)
+      expect(inclusiveCivilDays(dateKeyFromText(week.start), dateKeyFromText(week.end))).toBe(7);
+  });
+
+  it.each([
+    [6, 3],
+    [6.01, 4],
+    [8, 4],
+    [8.01, 5],
+  ])("uses %i hours for an ordered pool of %i", (hours, count) => {
+    const value = input();
+    value.answers.availability.weeklyHoursLimit = hours;
+    const draft = build(value);
+    expect(draft.weeks[0]?.workouts.map((workout) => workout.name)).toEqual(
+      [
+        "Controlled effort",
+        "Endurance ride",
+        "Long ride",
+        "Optional easy ride",
+        "Additional endurance ride",
+      ].slice(0, count),
+    );
+    expect(
+      draft.weeks.every(
+        (week) =>
+          week.workouts.length === count && week.workouts.every((workout) => workout.date === null),
+      ),
+    ).toBe(true);
+  });
+
+  it("selects today when allowed and the earliest later usable date otherwise", () => {
+    const value = input();
+    expect(build(value).start).toBe(value.today);
+    value.answers.availability = {
+      mode: "fixed",
+      weeklyHoursLimit: 10,
+      longestWorkoutHours: 2,
+      usableWeekdays: [2, 4, 7],
+    };
+    const draft = build(value);
+    expect(draft.start).toBe("1998-08-25");
+    expect(draft.weeks.every((week) => week.workouts.length === 3)).toBe(true);
+    for (const workout of draft.weeks.flatMap((week) => week.workouts)) {
+      expect(workout.date).not.toBeNull();
+      expect([2, 4, 7]).toContain(weekdayForDateKey(dateKeyFromText(workout.date ?? "")) || 7);
+    }
+    value.answers.startTiming = { kind: "earliest", date: "1998-09-01" };
+    expect(build(value).start).toBe("1998-09-01");
+    value.answers.startTiming = { kind: "earliest", date: "1998-08-01" };
+    expect(build(value).start).toBe("1998-08-25");
+  });
+
+  it("caps each Workout and weekly totals and explains dropped Workouts", () => {
+    const value = input();
+    value.answers.availability.weeklyHoursLimit = 1;
+    value.answers.availability.longestWorkoutHours = 0.5;
+    const draft = build(value);
+    expect(draft.weeks[0]?.workouts.map((workout) => workout.minutes)).toEqual([30, 30]);
+    expect(draft.notes).toContain("Long ride removed because no compatible time remains.");
+    value.answers.availability = {
+      mode: "fixed",
+      usableWeekdays: [1],
+      weeklyHoursLimit: 6,
+      longestWorkoutHours: 2,
+    };
+    expect(build(value).weeks.every((week) => week.workouts.length === 1)).toBe(true);
+  });
+
+  it("applies no-hard and duration restrictions through their inclusive end date", () => {
+    const value = input();
+    value.answers.restriction = { kind: "no-hard-training", endDate: "1998-08-30" };
+    const draft = build(value);
+    expect(draft.weeks[0]?.workouts[0]).toMatchObject({ name: "Easy ride", kind: "easy" });
+    expect(draft.weeks[1]?.workouts[0]).toMatchObject({ name: "Controlled effort", kind: "hard" });
+    value.answers.restriction = { kind: "max-duration", hours: 0.25, endDate: "1998-08-30" };
+    expect(build(value).weeks[0]?.workouts.map((workout) => workout.minutes)).toEqual([15, 15, 15]);
+    expect(build(value).weeks[1]?.workouts.map((workout) => workout.minutes)).toEqual([
+      45, 60, 100,
+    ]);
+  });
+
+  it("starts after no-training ends on the first usable date in each mode", () => {
+    const value = input();
+    value.answers.restriction = { kind: "no-training", endDate: "1998-08-26" };
+    expect(build(value).start).toBe("1998-08-27");
+    value.answers.availability = {
+      mode: "fixed",
+      weeklyHoursLimit: 6,
+      longestWorkoutHours: 2,
+      usableWeekdays: [1, 3, 5],
+    };
+    const draft = build(value);
+    expect(draft.start).toBe("1998-08-28");
+    expect(draft.weeks[0]?.workouts.map((workout) => workout.date)).toEqual([
+      "1998-08-28",
+      "1998-08-31",
+      "1998-09-02",
+    ]);
+    value.answers.startTiming = { kind: "earliest", date: "1998-08-25" };
+    expect(build(value).start).toBe("1998-08-28");
+    value.answers.startTiming = { kind: "earliest", date: "1998-08-31" };
+    expect(build(value).start).toBe("1998-08-31");
+  });
+
+  it("searches exactly 370 dates from the earliest start", () => {
+    const value = input();
+    value.answers.startTiming = { kind: "earliest", date: "1998-08-31" };
+    value.answers.restriction = { kind: "no-training", endDate: "1999-09-03" };
+    expect(build(value).start).toBe("1999-09-04");
+    value.answers.restriction.endDate = "1999-09-04";
+    expect(buildCreationDraft(value)).toEqual({
+      kind: "no-workouts",
+      explanation:
+        "No Workouts fit anywhere in this Plan under your confirmed limits. Edit those limits to continue.",
+    });
+    value.answers.restriction = { kind: "none" };
+    value.answers.availability = {
+      mode: "fixed",
+      weeklyHoursLimit: 6,
+      longestWorkoutHours: 2,
+      usableWeekdays: [],
+    };
+    expect(buildCreationDraft(value).kind).toBe("no-workouts");
+  });
+
+  it.each(["fixed", "flexible"] as const)(
+    "retains empty %s weeks until the duration restriction ends mid-Plan",
+    (mode) => {
+      const value = input();
+      value.answers.availability =
+        mode === "fixed"
+          ? { mode, weeklyHoursLimit: 6, longestWorkoutHours: 2, usableWeekdays: [1, 3, 5] }
+          : { mode, weeklyHoursLimit: 6, longestWorkoutHours: 2 };
+      value.answers.restriction = { kind: "max-duration", hours: 0, endDate: "1998-09-06" };
+      const draft = build(value);
+      expect(draft.start).toBe(value.today);
+      expect(draft.weeks.map((week) => week.workouts.length)).toEqual([0, 0, 3, 3]);
+      for (const week of draft.weeks.slice(0, 2))
+        expect(week.notes).toContain("Confirmed limits leave no Workouts in this week.");
+    },
+  );
+
+  it("rejects an entirely empty Plan without constructing a Draft", () => {
+    const value = input();
+    value.answers.restriction = { kind: "no-training" };
+    expect(buildCreationDraft(value)).toEqual({
+      kind: "no-workouts",
+      explanation:
+        "No Workouts fit anywhere in this Plan under your confirmed limits. Edit those limits to continue.",
+    });
+    value.answers.restriction = { kind: "none" };
+    value.answers.goal = { kind: "event", name: "Autumn ride", date: "1998-08-23" };
+    expect(buildCreationDraft(value)).toEqual({
+      kind: "no-workouts",
+      explanation: "Choose an event date on or after the Plan start.",
+    });
+  });
+
+  it.each(["fixed", "flexible"] as const)(
+    "pins the Event before %s templates even on an unusable weekday",
+    (mode) => {
+      const value = input();
+      value.answers.goal = { kind: "event", name: "Autumn ride", date: "1998-08-25" };
+      value.answers.availability =
+        mode === "fixed"
+          ? { mode, weeklyHoursLimit: 1.5, longestWorkoutHours: 2, usableWeekdays: [1] }
+          : { mode, weeklyHoursLimit: 1.5, longestWorkoutHours: 2 };
+      const draft = build(value);
+      expect(draft.weeks[0]?.workouts).toMatchObject([
+        { date: "1998-08-25", kind: "event", minutes: 60, pinned: true },
+        { minutes: 30 },
+      ]);
+    },
+  );
+
+  it("uses civil weeks across leap day and rejects sub-minute capacity", () => {
+    const value = input();
+    value.today = "2000-02-28";
+    expect(build(value).weeks[0]).toMatchObject({ start: "2000-02-28", end: "2000-03-05" });
+    value.answers.availability.weeklyHoursLimit = 0.01;
+    value.answers.availability.longestWorkoutHours = 0.01;
+    expect(buildCreationDraft(value).kind).toBe("no-workouts");
+  });
+
+  it("is deterministic, keeps input unchanged, hashes canonical snapshots and invents no power", () => {
+    const value = input();
+    value.answers.commitments = { kind: "authored", text: "Social ride on Sunday" };
+    const original = structuredClone(value);
+    const first = build(value);
+    const second = build(value);
+    expect(first).toEqual(second);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    expect(value).toEqual(original);
+    const { inputFingerprint, outputFingerprint, ...snapshot } = first;
+    expect(inputFingerprint).toBe(createHash("sha256").update(canonicalJson(value)).digest("hex"));
+    expect(outputFingerprint).toBe(
+      createHash("sha256").update(canonicalJson(snapshot)).digest("hex"),
+    );
+    expect(first.notes).toContain(
+      "Your written commitments are recorded for review and have not been applied to Workouts.",
+    );
+    for (const workout of first.weeks.flatMap((week) => week.workouts))
+      expect(workout).toMatchObject({
+        power: null,
+        guidance: "Use comfortable perceived effort or your known heart-rate guidance",
+      });
+  });
+});


### PR DESCRIPTION
## Summary

Plan creation in Chat can now build a Draft. `plan_creation.preview` turns the recorded, valid answers into a deterministic Draft built by sport-owned code (`packages/sport-cycling/src/creation-draft-builder.ts`), stores it as an immutable `plan_creation_draft_revision`, moves the creation to `review`, and marks the Draft stale when a later answer changes the inputs. The card model gains `status: 'in-progress' | 'review'`, `draft`, and `draftStale`; the renderer surface lands in the next child PR.

Builder rules follow the approved prototype: span 1–4 weeks Short block, 5–24 Event preparation, over 24 a 12-week Base Plan, Fitness 4/8/12/16; start date is the first date from today that is not unavailable under the restriction and, in Fixed mode, falls on a usable weekday; seven civil dates per week; Fixed placement or a Flexible ordered pool of 3/4/5 Workouts by weekly hours; weekly, longest and max-duration caps; hard Workouts become `Easy ride` under a no-hard restriction; unplaceable Workouts are dropped with a note; a Draft with zero Workouts is rejected and any previous Draft is kept. FTP is always null in this PR; authored commitments are recorded but not applied.

## Verification

- Astra high verifier, two rounds. Round 1 found start-date selection ignoring an active no-training restriction; round 2 fixed it to match the prototype and the verifier reports no remaining defects (its one residual flag is the authorized fixture updates under `apps/*/tests`).
- `pnpm check:types` clean; `vitest run` workspace: 2815 passed, 1 skipped; `oxlint` clean; fixture privacy check clean.

| Limit | Value |
|---|---|
| Pool size by weekly hours | ≤6 → 3, ≤8 → 4, else 5 |
| Span collapse | >24 weeks → 12-week Base Plan |
| Start-date scan | 370 days |
| Fitness lengths | 4, 8, 12, 16 weeks |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
