### PR TITLE
feat(desktop): review the Plan Draft in Main Chat

### DIFF
--- a/.changeset/hungry-meteors-call.md
+++ b/.changeset/hungry-meteors-call.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Review every week and Workout in your Draft in Chat before activation. You can edit your answers and rebuild while keeping the earlier Draft available for comparison.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -359,6 +359,7 @@ export function bootRenderer(): Disposer {
     clearPlanningRequestFocus: () => chatController.clearPlanningRequestFocus(),
     startPlanCreation: () => void chatController.startPlanCreation(),
     answerPlanCreation: (answer) => void chatController.answerPlanCreation(answer),
+    buildPlanCreationDraft: () => void chatController.buildPlanCreationDraft(),
     pausePlanCreation: () => chatController.pausePlanCreation(),
     continuePlanCreation: () => chatController.continuePlanCreation(),
     editPlanCreation: (answerKey) => chatController.editPlanCreation(answerKey),

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -231,6 +231,7 @@ export interface ChatController {
   clearPlanningRequestFocus(): void;
   startPlanCreation(): Promise<void>;
   answerPlanCreation(answer: PlanCreationAnswerInput): Promise<void>;
+  buildPlanCreationDraft(): Promise<void>;
   pausePlanCreation(): void;
   continuePlanCreation(): void;
   editPlanCreation(answerKey: PlanCreationAnswerSummary["answerKey"]): void;
@@ -2026,6 +2027,50 @@ export function createChatController(input: {
         else planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
       } catch {
         planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
+      } finally {
+        planCreationBusy = false;
+        render();
+      }
+    },
+    async buildPlanCreationDraft() {
+      if (
+        disposed ||
+        planCreationBusy ||
+        planCreationDiscardConfirmationOpen ||
+        planCreation === null ||
+        planCreation.readiness !== "ready" ||
+        planCreationEditingKey !== null
+      )
+        return;
+      const creationId = planCreation.creationId;
+      const expectedVersion = planCreation.version;
+      const key = JSON.stringify({ operation: "preview", creationId, expectedVersion });
+      planCreationBusy = true;
+      planCreationError = null;
+      planCreationNotice = null;
+      render();
+      try {
+        const result = await (
+          await input.clients.getClient()
+        ).call("plan_creation.preview", {
+          commandId: planCommandId(key),
+          creationId,
+          expectedVersion,
+        });
+        pendingPlanCreationCommand = null;
+        installPlanCreation(result.planCreation);
+        if (result.status === "rejected") {
+          planCreationNotice =
+            result.reason === "no-workouts"
+              ? "No Workouts fit anywhere in this Plan under your confirmed limits. Edit those limits to continue."
+              : result.reason === "not-ready"
+                ? "Answer the remaining question before building."
+                : result.reason === "stale-version"
+                  ? "The answers changed. Start a fresh build."
+                  : "Build failed. Your answers and last complete Draft are preserved.";
+        }
+      } catch {
+        planCreationNotice = "Build failed. Your answers and last complete Draft are preserved.";
       } finally {
         planCreationBusy = false;
         render();

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -121,6 +121,7 @@ export interface ChatActions {
   clearPlanningRequestFocus(): void;
   startPlanCreation(): void;
   answerPlanCreation(answer: PlanCreationAnswerInput): void;
+  buildPlanCreationDraft(): void;
   pausePlanCreation(): void;
   continuePlanCreation(): void;
   editPlanCreation(answerKey: PlanCreationAnswerSummary["answerKey"]): void;

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -1,5 +1,5 @@
 import type { PlanCreationCardModel } from "@enduragent/coach-contract";
-import { useCallback, useEffect, useRef, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Button } from "../../components/ui/button";
 import {
   Dialog,
@@ -12,6 +12,8 @@ import {
 } from "../../components/ui/dialog";
 import { useEnduragentStore } from "../../state/store";
 import { PlanCreationQuestionCard } from "./PlanCreationQuestionCard";
+import { Card, CardContent } from "../../components/ui/card";
+import { PlanCreationDraftCards } from "./PlanCreationDraftCards";
 import { PlanCreationSummary } from "./PlanCreationSummary";
 
 export function PlanCreationDiscardDialog(): ReactElement {
@@ -145,8 +147,50 @@ export function PlanCreationDock(props: {
 export function PlanCreationConversation(props: {
   readonly model: PlanCreationCardModel | null;
 }): ReactElement | null {
+  const [editVersion, setEditVersion] = useState<number | null>(null);
+  const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
+  const actions = useEnduragentStore((state) => state.chatActions);
   if (props.model === null) return null;
-  return <PlanCreationSummary model={props.model} />;
+  const model = props.model;
+  if (model.draft === null) return <PlanCreationSummary model={model} />;
+  if (editVersion === model.version)
+    return (
+      <section className="grid min-w-0 gap-inset" aria-label="Edit Plan answers">
+        <Card size="sm">
+          <CardContent className="grid gap-inset">
+            <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+              Plan creation
+            </p>
+            <h3 className="m-0 text-base leading-6 font-semibold">Edit answers</h3>
+            <p className="m-0 text-sm text-ink-2">A changed answer makes the Draft stale.</p>
+            <div>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  actions?.cancelPlanCreationEdit();
+                  setEditVersion(null);
+                }}
+              >
+                Back to Draft
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+        <PlanCreationSummary model={model} answersOnly />
+      </section>
+    );
+  return (
+    <>
+      {editingKey !== null || model.openQuestion !== null ? (
+        <PlanCreationSummary model={model} answersOnly />
+      ) : null}
+      <PlanCreationDraftCards
+        model={model}
+        draft={model.draft}
+        onEditAnswers={() => setEditVersion(model.version)}
+      />
+    </>
+  );
 }
 
 export function PlanCreationDiscardConsequence(props: { readonly eventId: string }): ReactElement {

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
@@ -1,0 +1,257 @@
+import type {
+  PlanCreationAnswerSummary,
+  PlanCreationCardModel,
+  PlanCreationDraft,
+} from "@enduragent/coach-contract";
+import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent } from "../../components/ui/card";
+import { useEnduragentStore } from "../../state/store";
+
+const answerLabels: ReadonlyArray<readonly [PlanCreationAnswerSummary["answerKey"], string]> = [
+  ["goal", "Main Goal"],
+  ["plan-length", "Plan length"],
+  ["schedule-mode", "Schedule mode"],
+  ["availability", "Availability"],
+  ["start-timing", "Start timing"],
+  ["commitments", "Commitments"],
+  ["baseline", "Recent training"],
+  ["success", "Success"],
+  ["restriction", "Training restriction"],
+];
+
+function dateLabel(value: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T12:00:00Z`));
+}
+
+function Fact(props: { readonly label: string; readonly children: ReactNode }): ReactElement {
+  return (
+    <div
+      role="row"
+      className="grid grid-cols-[minmax(104px,0.72fr)_minmax(0,1.28fr)] gap-4 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-1 max-[560px]:gap-1"
+    >
+      <span role="rowheader" className="text-xs leading-4 text-ink-2">
+        {props.label}
+      </span>
+      <strong
+        role="cell"
+        className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left"
+      >
+        {props.children}
+      </strong>
+    </div>
+  );
+}
+
+function AnswerFacts(props: {
+  readonly summaries: readonly PlanCreationAnswerSummary[];
+  readonly current?: boolean;
+  readonly omitGoal?: boolean;
+}): ReactElement {
+  return (
+    <>
+      {answerLabels.map(([key, label]) => {
+        const summary = props.summaries.find((answer) => answer.answerKey === key);
+        if (summary === undefined || (props.omitGoal && key === "goal")) return null;
+        const source = props.current
+          ? "current answer"
+          : summary.source.kind === "athlete"
+            ? "your answer"
+            : summary.source.label;
+        return (
+          <Fact key={key} label={`${label} · ${source}`}>
+            {summary.detail}
+          </Fact>
+        );
+      })}
+    </>
+  );
+}
+
+function ReviewCard(props: {
+  readonly eyebrow?: string;
+  readonly title: string;
+  readonly status?: string;
+  readonly summary?: string;
+  readonly children: ReactNode;
+}): ReactElement {
+  return (
+    <Card
+      size="sm"
+      className="min-w-0"
+      role="region"
+      aria-label={props.eyebrow === "Draft inputs" ? "Draft inputs" : props.title}
+    >
+      <CardContent className="grid gap-inset">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
+          <div className="grid gap-[calc(var(--inset)/2)] min-w-0">
+            {props.eyebrow ? (
+              <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+                {props.eyebrow}
+              </p>
+            ) : null}
+            <h3 className="m-0 text-base leading-6 font-semibold break-words">{props.title}</h3>
+          </div>
+          {props.status ? (
+            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+              {props.status}
+            </span>
+          ) : null}
+        </div>
+        {props.summary ? <p className="m-0 text-sm leading-5 text-ink-2">{props.summary}</p> : null}
+        {props.children}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PlanCreationDraftCards(props: {
+  readonly model: PlanCreationCardModel;
+  readonly draft: PlanCreationDraft;
+  readonly onEditAnswers: () => void;
+}): ReactElement {
+  const actions = useEnduragentStore((state) => state.chatActions);
+  const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
+  const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
+  const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
+  const discardButton = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (focusRequest?.target === "discard") queueMicrotask(() => discardButton.current?.focus());
+  }, [focusRequest?.revision, focusRequest?.target]);
+  const draft = props.draft;
+  const stale = props.model.draftStale;
+  const workouts = draft.weeks.flatMap((week) => week.workouts);
+  const goal = draft.answeredSummaries.find((answer) => answer.answerKey === "goal");
+  const title =
+    draft.goal.kind === "event" ? draft.goal.name : (draft.goal.outcome ?? "Improve fitness");
+  return (
+    <section className="grid min-w-0 gap-inset" aria-label="Plan Draft review">
+      {stale ? (
+        <ReviewCard title="Changed answers">
+          <div role="table" aria-label="Changed answers">
+            <AnswerFacts summaries={props.model.answeredSummaries} current />
+          </div>
+        </ReviewCard>
+      ) : null}
+      <ReviewCard
+        eyebrow="Draft inputs"
+        title={title}
+        status={stale ? "Stale" : "Needs review"}
+        summary={
+          stale
+            ? "This Draft preserves the earlier answers and Workouts. Rebuild before activation."
+            : "Review the whole Draft before activating."
+        }
+      >
+        <div role="table" aria-label="Draft inputs">
+          <Fact
+            label={`Main Goal · ${goal?.source.kind === "derived" ? goal.source.label : "your answer"}`}
+          >
+            {draft.goal.kind === "event"
+              ? `${draft.goal.name} · ${dateLabel(draft.goal.date)}`
+              : title}
+          </Fact>
+          <Fact label="Calendar">Local review only</Fact>
+          <Fact label="Plan span">
+            {dateLabel(draft.start)} to {dateLabel(draft.end)} · {draft.weeks.length} weeks ·{" "}
+            {draft.spanKind}
+          </Fact>
+          <AnswerFacts summaries={draft.answeredSummaries} omitGoal />
+        </div>
+        <details className="border-t border-line pt-3">
+          <summary className="cursor-pointer text-sm font-medium">How this Plan was built</summary>
+          <div role="table" aria-label="How this Plan was built">
+            <Fact label="Guidance">Heart rate or perceived effort. No FTP test.</Fact>
+            <Fact label="Training approach">Balanced · default</Fact>
+            {draft.notes.map((note, index) => (
+              <Fact key={`${index}:${note}`} label="Confirmed limits">
+                {note}
+              </Fact>
+            ))}
+          </div>
+        </details>
+      </ReviewCard>
+      <ReviewCard
+        eyebrow="Training outline"
+        title="Every week and Workout"
+        status={stale ? "Out of date" : "Draft"}
+        summary={`${draft.weeks.length} weeks · ${workouts.length} Workouts · ${workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min`}
+      >
+        {draft.weeks.map((week) => (
+          <div key={week.number} className="grid min-w-0 gap-inset">
+            <p className="m-0 text-xs font-semibold text-ink-2">
+              Week {week.number} · {dateLabel(week.start)} to {dateLabel(week.end)} ·{" "}
+              {week.workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min
+            </p>
+            <div role="list" aria-label={`Week ${week.number} Workouts`}>
+              {week.workouts.length === 0 ? (
+                <p className="m-0 text-sm leading-5 text-ink-2">No Workouts this week.</p>
+              ) : (
+                week.workouts.map((workout, index) => (
+                  <div
+                    key={workout.id}
+                    role="listitem"
+                    className="grid grid-cols-[minmax(0,0.6fr)_minmax(0,1.4fr)_auto] items-start gap-3 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-[minmax(0,1fr)_auto]"
+                  >
+                    <span className="text-xs leading-4 text-ink-2 max-[560px]:col-span-2">
+                      {workout.date === null
+                        ? `Priority ${index + 1} · Undated`
+                        : dateLabel(workout.date)}
+                    </span>
+                    <strong className="text-sm leading-5 font-medium [overflow-wrap:anywhere]">
+                      {workout.name} · {workout.minutes} min · {workout.guidance}
+                    </strong>
+                    <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+                      planned{workout.pinned ? " · Pinned" : ""}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+            {week.notes.map((note, index) => (
+              <p key={`${index}:${note}`} className="m-0 text-sm leading-5 text-ink-2">
+                {note}
+              </p>
+            ))}
+          </div>
+        ))}
+        <div className="mt-inset flex flex-wrap gap-inset">
+          <Button
+            ref={discardButton}
+            variant="destructive"
+            data-plan-creation-discard={props.model.creationId}
+            aria-haspopup="dialog"
+            disabled={busy || actions === null}
+            onClick={() => actions?.openPlanCreationDiscard()}
+          >
+            Discard
+          </Button>
+          <Button
+            variant="outline"
+            disabled={busy || actions === null || editingKey !== null}
+            onClick={props.onEditAnswers}
+          >
+            Edit answers
+          </Button>
+          {stale ? (
+            <Button
+              disabled={
+                busy || actions === null || props.model.readiness !== "ready" || editingKey !== null
+              }
+              onClick={() => actions?.buildPlanCreationDraft()}
+            >
+              Rebuild Draft
+            </Button>
+          ) : (
+            <Button disabled>Activate Plan</Button>
+          )}
+        </div>
+      </ReviewCard>
+    </section>
+  );
+}

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
@@ -7,6 +7,7 @@ import { useEnduragentStore } from "../../state/store";
 
 export function PlanCreationSummary(props: {
   readonly model: PlanCreationCardModel;
+  readonly answersOnly?: boolean;
 }): ReactElement {
   const actions = useEnduragentStore((state) => state.chatActions);
   const paused = useEnduragentStore((state) => state.chat.planCreationPaused);
@@ -76,58 +77,68 @@ export function PlanCreationSummary(props: {
           ))}
         </ul>
       )}
-      <Card size="sm" className="min-w-0" data-parity="progress.card">
-        <CardContent className="grid gap-inset">
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-inset">
-            <div className="grid gap-[calc(var(--inset)/2)]">
-              <p
-                className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2"
-                data-parity="progress.eyebrow"
-              >
-                Plan creation
-              </p>
-              <strong data-parity="progress.title">New Plan</strong>
+      {props.answersOnly ? null : (
+        <Card size="sm" className="min-w-0" data-parity="progress.card">
+          <CardContent className="grid gap-inset">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-inset">
+              <div className="grid gap-[calc(var(--inset)/2)]">
+                <p
+                  className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2"
+                  data-parity="progress.eyebrow"
+                >
+                  Plan creation
+                </p>
+                <strong data-parity="progress.title">New Plan</strong>
+              </div>
+              <div className="flex items-center gap-inset self-start">
+                <span
+                  className="rounded-full bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2"
+                  data-parity="progress.status"
+                >
+                  {ready ? "Ready" : "In progress"}
+                </span>
+                <Button
+                  ref={discardButton}
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  data-plan-creation-discard={props.model.creationId}
+                  aria-haspopup="dialog"
+                  disabled={busy || actions === null}
+                  onClick={() => actions?.openPlanCreationDiscard()}
+                >
+                  Discard
+                </Button>
+              </div>
             </div>
-            <div className="flex items-center gap-inset self-start">
-              <span
-                className="rounded-full bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2"
-                data-parity="progress.status"
-              >
-                {ready ? "Ready" : "In progress"}
-              </span>
-              <Button
-                ref={discardButton}
-                type="button"
-                variant="destructive"
-                size="sm"
-                data-plan-creation-discard={props.model.creationId}
-                aria-haspopup="dialog"
-                disabled={busy || actions === null}
-                onClick={() => actions?.openPlanCreationDiscard()}
-              >
-                Discard
-              </Button>
+            <p className="m-0 text-xs text-ink-2" data-parity="progress.summary">
+              {ready
+                ? "The essentials are complete."
+                : `${props.model.answeredSummaries.length} of ${total} answered.`}
+            </p>
+            <div className="flex flex-wrap gap-inset" data-parity="progress.actions">
+              {ready && props.model.draft === null ? (
+                <Button
+                  disabled={actions === null || busy || editingKey !== null}
+                  onClick={() => actions?.buildPlanCreationDraft()}
+                >
+                  Build Draft
+                </Button>
+              ) : null}
+              {canContinue ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={actions === null || busy}
+                  onClick={() => actions?.continuePlanCreation()}
+                >
+                  Continue
+                </Button>
+              ) : null}
             </div>
-          </div>
-          <p className="m-0 text-xs text-ink-2" data-parity="progress.summary">
-            {ready
-              ? "The essentials are complete. Draft preview arrives in a later update."
-              : `${props.model.answeredSummaries.length} of ${total} answered.`}
-          </p>
-          <div className="flex justify-end" data-parity="progress.actions">
-            {canContinue ? (
-              <Button
-                type="button"
-                variant="outline"
-                disabled={actions === null || busy}
-                onClick={() => actions?.continuePlanCreation()}
-              >
-                Continue
-              </Button>
-            ) : null}
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
     </section>
   );
 }

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -46,6 +46,7 @@ function chatActions(): ChatActions {
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
     startPlanCreation: vi.fn(),
+    buildPlanCreationDraft: vi.fn(),
     answerPlanCreation: vi.fn(),
     pausePlanCreation: vi.fn(),
     continuePlanCreation: vi.fn(),

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -21,6 +21,8 @@ import type {
   PlanCreationCardModel,
   PlanCreationDiscardRpcParams,
   PlanCreationDiscardRpcResult,
+  PlanCreationPreviewRpcParams,
+  PlanCreationPreviewRpcResult,
   PlanCreationStartRpcParams,
   PlanCreationStartRpcResult,
   QueuedChatMessage,
@@ -40,6 +42,7 @@ import {
 } from "../src/chat/controller";
 import { COACH_RESPONSE_CODE_UNIT_LIMIT, COACH_TURN_EVENT_LIMIT } from "../src/chat/limits";
 import type { DesktopCoachClientProvider } from "../src/coach-client";
+import { planCreationDraft } from "./plan-creation-draft-fixtures";
 import { CHAT_WORKING_COPY, EMPTY_CHAT_STATE, type ChatState } from "../src/turn-state";
 
 const questionStep = { current: 1, total: 9 } as const;
@@ -366,6 +369,9 @@ function client(
       | { readonly status: "found"; readonly delivery: PlanningRequestDelivery }
       | { readonly status: "missing" }
     >;
+    readonly previewPlanCreation?: (
+      request: PlanCreationPreviewRpcParams,
+    ) => Promise<PlanCreationPreviewRpcResult>;
     readonly startPlanCreation?: (
       request: PlanCreationStartRpcParams,
     ) => Promise<PlanCreationStartRpcResult>;
@@ -452,6 +458,14 @@ function client(
     }
     if (method === "retryPlanningRequest") {
       return (sessions.retryPlanningRequest?.() ?? Promise.resolve({ status: "missing" })) as never;
+    }
+    if (method === "plan_creation.preview") {
+      return (sessions.previewPlanCreation?.(request as PlanCreationPreviewRpcParams) ??
+        Promise.resolve({
+          status: "rejected",
+          reason: "no-unfinished-creation",
+          planCreation: null,
+        })) as never;
     }
     if (method === "plan_creation.start") {
       return (sessions.startPlanCreation?.(request as PlanCreationStartRpcParams) ??
@@ -2301,6 +2315,92 @@ describe("chat controller", () => {
     expect(chatMessages(fake)).toEqual(["Chat continues"]);
   });
 
+  it("retries Draft preview with a stable command and restores review on relaunch", async () => {
+    const ready: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 10,
+      status: "in-progress",
+      readiness: "ready",
+      answeredSummaries: [planLengthSummary(4)],
+      openQuestion: null,
+      draft: null,
+      draftStale: false,
+    };
+    const review: PlanCreationCardModel = {
+      ...ready,
+      version: 11,
+      status: "review",
+      draft: planCreationDraft(ready.answeredSummaries),
+    };
+    const previewPlanCreation = vi
+      .fn<(request: PlanCreationPreviewRpcParams) => Promise<PlanCreationPreviewRpcResult>>()
+      .mockRejectedValueOnce(new Error("interrupted"))
+      .mockResolvedValue({ status: "previewed", planCreation: review });
+    const fake = client(replies(), {
+      listPlanningRequests: async () => ({ deliveries: [], planCreation: ready }),
+      previewPlanCreation,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    await controller.buildPlanCreationDraft();
+    expect(controls.at(-1)?.planCreation?.value).toEqual(ready);
+    await controller.buildPlanCreationDraft();
+    expect(previewPlanCreation).toHaveBeenCalledTimes(2);
+    expect(previewPlanCreation.mock.calls[0]?.[0]).toEqual({
+      commandId: expect.any(String),
+      creationId: ready.creationId,
+      expectedVersion: ready.version,
+    });
+    expect(previewPlanCreation.mock.calls[1]?.[0]).toEqual(previewPlanCreation.mock.calls[0]?.[0]);
+    expect(controls.at(-1)?.planCreation?.value).toEqual(review);
+    await expect(controller.submit("Chat continues during review")).resolves.toBe(true);
+
+    const relaunched = subject(
+      client(replies(), {
+        listPlanningRequests: async () => ({ deliveries: [], planCreation: review }),
+      }),
+    );
+    await relaunched.controller.start();
+    expect(relaunched.controls.at(-1)?.planCreation?.value).toEqual(review);
+  });
+
+  it("retains the previous stale Draft when no Workouts fit a rebuild", async () => {
+    const draft = planCreationDraft([planLengthSummary(4)]);
+    const review: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 12,
+      status: "review",
+      readiness: "ready",
+      answeredSummaries: [planLengthSummary(8)],
+      openQuestion: null,
+      draft,
+      draftStale: true,
+    };
+    const previewPlanCreation = vi
+      .fn<(request: PlanCreationPreviewRpcParams) => Promise<PlanCreationPreviewRpcResult>>()
+      .mockResolvedValue({
+        status: "rejected",
+        reason: "no-workouts",
+        explanation: "Confirmed limits leave no Workouts.",
+        planCreation: review,
+      });
+    const { controller, controls } = subject(
+      client(replies(), {
+        listPlanningRequests: async () => ({ deliveries: [], planCreation: review }),
+        previewPlanCreation,
+      }),
+    );
+    await controller.start();
+    await controller.buildPlanCreationDraft();
+    expect(controls.at(-1)?.planCreation).toMatchObject({
+      value: review,
+      notice:
+        "No Workouts fit anywhere in this Plan under your confirmed limits. Edit those limits to continue.",
+      busy: false,
+    });
+    expect(controls.at(-1)?.planCreation?.value?.draft).toEqual(draft);
+  });
+
   it("submits an edited answer at the current version and closes the editor", async () => {
     const ready: PlanCreationCardModel = {
       draft: null,
@@ -2342,6 +2442,47 @@ describe("chat controller", () => {
       paused: false,
       editingKey: null,
     });
+  });
+
+  it("installs changed review answers without changing the Draft snapshot", async () => {
+    const originalAnswers = [planLengthSummary(4)];
+    const review: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 11,
+      status: "review",
+      readiness: "ready",
+      answeredSummaries: originalAnswers,
+      openQuestion: null,
+      draft: planCreationDraft(originalAnswers),
+      draftStale: false,
+    };
+    const changed: PlanCreationCardModel = {
+      ...review,
+      version: 12,
+      answeredSummaries: [planLengthSummary(8)],
+      draftStale: true,
+    };
+    const answerPlanCreation = vi
+      .fn<(request: PlanCreationAnswerRpcParams) => Promise<PlanCreationAnswerRpcResult>>()
+      .mockResolvedValue({ status: "answered", planCreation: changed });
+    const { controller, controls } = subject(
+      client(replies(), {
+        listPlanningRequests: async () => ({ deliveries: [], planCreation: review }),
+        answerPlanCreation,
+      }),
+    );
+    await controller.start();
+    controller.editPlanCreation("plan-length");
+    await controller.answerPlanCreation({ kind: "plan-length", weeks: 8 });
+
+    expect(answerPlanCreation).toHaveBeenCalledWith({
+      commandId: expect.any(String),
+      creationId: review.creationId,
+      expectedVersion: review.version,
+      answer: { kind: "plan-length", weeks: 8 },
+    });
+    expect(controls.at(-1)?.planCreation).toMatchObject({ value: changed, editingKey: null });
+    expect(controls.at(-1)?.planCreation?.value?.draft?.answeredSummaries).toEqual(originalAnswers);
   });
 
   it("preserves Edit and focus state when an identical Plan Creation model is restored", async () => {

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -26,6 +26,7 @@ import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice";
 import { useEnduragentStore } from "../src/state/store";
 import { SLASH_COMMANDS } from "../src/chat/commands";
 import { ChatView } from "../src/ui/chat/ChatView";
+import { planCreationDraft } from "./plan-creation-draft-fixtures";
 
 function stubActions(): ChatActions {
   return {
@@ -44,6 +45,7 @@ function stubActions(): ChatActions {
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
     startPlanCreation: vi.fn(),
+    buildPlanCreationDraft: vi.fn(),
     answerPlanCreation: vi.fn(),
     pausePlanCreation: vi.fn(),
     continuePlanCreation: vi.fn(),
@@ -2824,11 +2826,137 @@ describe("chat surface", () => {
         timeline: [{ kind: "plan-creation", model: ready }],
         sendDisabled: false,
       });
-      expect(
-        screen.getByText("The essentials are complete. Draft preview arrives in a later update."),
-      ).toBeVisible();
+      expect(screen.getByText("The essentials are complete.")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Build Draft" })).toBeVisible();
       expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
+      await user.click(screen.getByRole("button", { name: "Build Draft" }));
+      expect(actions.buildPlanCreationDraft).toHaveBeenCalledOnce();
       expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+    });
+
+    it("renders the whole Draft with closed builder details and separate review actions", async () => {
+      const draft = planCreationDraft();
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null),
+        status: "review",
+        draft,
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+
+      expect(screen.getByText("Review the whole Draft before activating.")).toBeVisible();
+      expect(screen.getByRole("heading", { name: "Every week and Workout" })).toBeVisible();
+      expect(screen.getByText("4 weeks · 3 Workouts · 180 min")).toBeVisible();
+      expect(screen.getAllByText("Priority 1 · Undated")).toHaveLength(3);
+      expect(screen.getByText("No Workouts this week.")).toBeVisible();
+      expect(screen.getByText("Confirmed limits leave no Workouts in this week.")).toBeVisible();
+      for (const week of draft.weeks) {
+        expect(screen.getByText(new RegExp(`Week ${week.number} ·`))).toBeVisible();
+      }
+      const disclosure = screen.getByText("How this Plan was built").closest("details");
+      expect(disclosure).not.toHaveAttribute("open");
+      await userEvent.click(screen.getByText("How this Plan was built"));
+      expect(disclosure).toHaveAttribute("open");
+      expect(
+        screen.getByText("Endurance ride limited to 60 minutes by your confirmed limits."),
+      ).toBeVisible();
+      const discard = screen.getByRole("button", { name: "Discard" });
+      const edit = screen.getByRole("button", { name: "Edit answers" });
+      const activate = screen.getByRole("button", { name: "Activate Plan" });
+      expect(activate).toBeDisabled();
+      expect(discard.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(
+        edit.compareDocumentPosition(activate) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      await userEvent.click(discard);
+      expect(actions.openPlanCreationDiscard).toHaveBeenCalledOnce();
+      expect(composer()).toBeEnabled();
+    });
+
+    it("keeps fixed Workout dates and pinned status visible during Draft review", () => {
+      const draft = planCreationDraft();
+      draft.mode = "fixed";
+      for (const week of draft.weeks) {
+        for (const workout of week.workouts) {
+          workout.date = week.start;
+          workout.pinned = true;
+        }
+      }
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null),
+        status: "review",
+        draft,
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+
+      expect(screen.queryByText("Priority 1 · Undated")).toBeNull();
+      expect(screen.getAllByText("planned · Pinned")).toHaveLength(3);
+      for (const date of ["7 Sept 1998", "21 Sept 1998", "28 Sept 1998"]) {
+        expect(screen.getByText(date, { exact: true })).toBeVisible();
+      }
+    });
+
+    it("preserves Draft inputs below changed answers and rebuilds with the current card", async () => {
+      const original = planCreationModel(null, {
+        answeredSummaries: [
+          {
+            answerKey: "plan-length",
+            title: "Plan length",
+            detail: "4 weeks",
+            question: planLengthQuestion("How long should this Fitness Plan be?"),
+            answer: { kind: "plan-length", weeks: 4 },
+          },
+        ],
+      });
+      const model: PlanCreationCardModel = {
+        ...original,
+        version: 3,
+        status: "review",
+        draft: planCreationDraft(original.answeredSummaries),
+        draftStale: true,
+        answeredSummaries: original.answeredSummaries.map((summary) => ({
+          ...summary,
+          detail: "8 weeks",
+          answer: { kind: "plan-length", weeks: 8 },
+        })),
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+
+      const changed = screen.getByRole("heading", { name: "Changed answers" });
+      const outline = screen.getByRole("heading", { name: "Every week and Workout" });
+      expect(
+        changed.compareDocumentPosition(outline) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(screen.getByText("4 weeks", { exact: true })).toBeVisible();
+      expect(screen.getByText("8 weeks", { exact: true })).toBeVisible();
+      expect(screen.getByText("Plan length · current answer")).toBeVisible();
+      expect(
+        screen.getByText(
+          "This Draft preserves the earlier answers and Workouts. Rebuild before activation.",
+        ),
+      ).toBeVisible();
+      expect(screen.queryByRole("button", { name: "Activate Plan" })).toBeNull();
+      await userEvent.click(screen.getByRole("button", { name: "Rebuild Draft" }));
+      expect(actions.buildPlanCreationDraft).toHaveBeenCalledOnce();
+      await userEvent.click(screen.getByRole("button", { name: "Edit answers" }));
+      expect(screen.getByText("A changed answer makes the Draft stale.")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Edit Plan length" })).toBeEnabled();
+      await userEvent.click(screen.getByRole("button", { name: "Back to Draft" }));
+      expect(screen.getByRole("heading", { name: "Every week and Workout" })).toBeVisible();
     });
 
     it("keeps summaries in the conversation and submits authored success", async () => {

--- a/apps/desktop-renderer/tests/plan-creation-draft-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-creation-draft-fixtures.ts
@@ -1,0 +1,44 @@
+import type { PlanCreationAnswerSummary, PlanCreationDraft } from "@enduragent/coach-contract";
+
+export function planCreationDraft(
+  answeredSummaries: PlanCreationAnswerSummary[] = [],
+): PlanCreationDraft {
+  return {
+    kind: "draft",
+    answeredSummaries,
+    goal: { kind: "fitness", outcome: "Build steady power", weeks: 4 },
+    mode: "flexible",
+    start: "1998-09-07",
+    end: "1998-10-04",
+    spanKind: "Fitness Plan",
+    computedWeeks: 4,
+    weeks: [1, 2, 3, 4].map((number) => ({
+      number,
+      start: `1998-09-${String(7 * number).padStart(2, "0")}`,
+      end: number === 4 ? "1998-10-04" : `1998-09-${String(7 * number + 6).padStart(2, "0")}`,
+      workouts:
+        number === 2
+          ? []
+          : [
+              {
+                id: `workout-${number}`,
+                name: "Endurance ride",
+                kind: "endurance",
+                date: null,
+                minutes: 60,
+                pinned: false,
+                guidance: "Use comfortable perceived effort or your known heart-rate guidance",
+                power: null,
+              },
+            ],
+      notes: number === 2 ? ["Confirmed limits leave no Workouts in this week."] : [],
+    })),
+    notes: ["Endurance ride limited to 60 minutes by your confirmed limits."],
+    guidance: "Use comfortable perceived effort or your known heart-rate guidance",
+    ftp: null,
+    builderId: "cycling",
+    builderVersion: "1",
+    inputFingerprint: "a".repeat(64),
+    outputFingerprint: "b".repeat(64),
+  };
+}

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -115,6 +115,7 @@ function stubActions(): ChatActions {
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
     startPlanCreation: vi.fn(),
+    buildPlanCreationDraft: vi.fn(),
     answerPlanCreation: vi.fn(),
     pausePlanCreation: vi.fn(),
     continuePlanCreation: vi.fn(),

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -33,6 +33,7 @@ function stubActions(): ChatActions {
     retryPlanningRequestLoad: vi.fn(),
     clearPlanningRequestFocus: vi.fn(),
     startPlanCreation: vi.fn(),
+    buildPlanCreationDraft: vi.fn(),
     answerPlanCreation: vi.fn(),
     pausePlanCreation: vi.fn(),
     continuePlanCreation: vi.fn(),

--- a/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
@@ -198,10 +198,11 @@ async function choose(page: Page, backend: PlanCreationBackend, version: number,
     ).toBeVisible();
   } else {
     await expect(
-      page.getByText("The essentials are complete. Draft preview arrives in a later update.", {
+      page.getByText("The essentials are complete.", {
         exact: true,
       }),
     ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Build Draft", exact: true })).toBeVisible();
   }
   await test.info().attach(`answer-${version}-timing`, {
     body: JSON.stringify({
@@ -288,10 +289,11 @@ test("completes the Fitness Goal with an authored success answer", async ({ play
     await completeFitnessGoal(scenario);
     const progress = scenario.page.getByRole("region", { name: "Plan Creation progress" });
     await expect(
-      progress.getByText("The essentials are complete. Draft preview arrives in a later update.", {
+      progress.getByText("The essentials are complete.", {
         exact: true,
       }),
     ).toBeVisible();
+    await expect(progress.getByRole("button", { name: "Build Draft", exact: true })).toBeVisible();
     await expect(scenario.page.getByRole("button", { name: "Send message" })).toBeEnabled();
     const answers = await scenario.backend.answers();
     expect(answers.map((answer) => answer.answer_key)).toEqual([
@@ -582,10 +584,10 @@ for (const appearance of [
       expect(await requireCard(scenario.backend)).toEqual(card);
       expect(await scenario.backend.answers()).toEqual(answers);
       await expect(
-        scenario.page.getByText(
-          "The essentials are complete. Draft preview arrives in a later update.",
-          { exact: true },
-        ),
+        scenario.page.getByText("The essentials are complete.", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        scenario.page.getByRole("button", { name: "Build Draft", exact: true }),
       ).toBeVisible();
     } finally {
       await close(scenario);

--- a/apps/desktop/tests/e2e/plan-creation-slice4.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice4.spec.ts
@@ -1,0 +1,361 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import type { PlanCreationCardModel } from "@enduragent/coach-contract";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Creation renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-draft-review-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"));
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    await backend.seedUnrelatedPlans();
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    return { backend, fixture, scratch, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function relaunch(scenario: Scenario, playwright: Playwright): Promise<void> {
+  await scenario.browser.close();
+  await scenario.fixture.relaunch(() => scenario.backend.reopen());
+  await scenario.fixture.setViewport(scenario.width, 820);
+  Object.assign(scenario, await connect(playwright, scenario.fixture, scenario.colorScheme));
+  expect(await scenario.page.evaluate(() => innerWidth)).toBe(scenario.width);
+  await expect(
+    scenario.page.getByRole("heading", { name: "Every week and Workout", exact: true }),
+  ).toBeVisible();
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  const screenshotPath = test.info().outputPath(`${name}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  if (name === "review" || name === "stale" || name === "rebuilt" || name === "restored") {
+    for (const title of ["Draft inputs", "Every week and Workout"]) {
+      const region = scenario.page.getByRole("region", { name: title, exact: true });
+      await region.getByRole("heading").scrollIntoViewIfNeeded();
+      const path = test.info().outputPath(`${name}-${title}.png`);
+      await scenario.page.screenshot({ path });
+      await test.info().attach(`${name}-${title}`, { path, contentType: "image/png" });
+    }
+    await scenario.page
+      .getByRole("button", { name: "Edit answers", exact: true })
+      .scrollIntoViewIfNeeded();
+    const path = test.info().outputPath(`${name}-actions.png`);
+    await scenario.page.screenshot({ path });
+    await test.info().attach(`${name}-actions`, { path, contentType: "image/png" });
+  }
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-creation", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        drafts: await scenario.backend.inspectDrafts(),
+        requests: scenario.backend.creationRequests,
+        unrelated: await scenario.backend.inspectUnrelated(),
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+async function card(backend: PlanCreationBackend): Promise<PlanCreationCardModel> {
+  const value = await backend.card();
+  if (value === null) throw new TypeError("Plan Creation is unavailable");
+  return value;
+}
+
+async function choose(scenario: Scenario, answer: string): Promise<void> {
+  const before = await card(scenario.backend);
+  await scenario.page.locator(`[data-parity="choice.row"][data-answer="${answer}"]`).click();
+  await expect.poll(async () => (await scenario.backend.card())?.version).toBe(before.version + 1);
+}
+
+async function continueAnswer(scenario: Scenario): Promise<void> {
+  const before = await card(scenario.backend);
+  await scenario.page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect.poll(async () => (await scenario.backend.card())?.version).toBe(before.version + 1);
+}
+
+async function completeFitness(scenario: Scenario): Promise<void> {
+  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await expect.poll(async () => (await scenario.backend.card())?.version).toBe(1);
+  await choose(scenario, "fitness");
+  await choose(scenario, "4");
+  await choose(scenario, "flexible");
+  await scenario.page.locator('[data-answer="hours-6"]').click();
+  await scenario.page.locator('[data-parity="availability.longest"]').fill("2");
+  await continueAnswer(scenario);
+  await choose(scenario, "asap");
+  await choose(scenario, "none");
+  await choose(scenario, "regular");
+  await scenario.page.locator('[data-parity="choice.custom"][data-answer="custom"]').click();
+  await scenario.page.locator('[data-parity="custom.textarea"]').fill("Ride four steady hours");
+  await continueAnswer(scenario);
+  await choose(scenario, "none");
+  await expect(
+    scenario.page.getByText("The essentials are complete.", { exact: true }),
+  ).toBeVisible();
+}
+
+async function build(scenario: Scenario, rebuild = false): Promise<PlanCreationCardModel> {
+  const before = await card(scenario.backend);
+  await scenario.page
+    .getByRole("button", {
+      name: rebuild ? "Rebuild Draft" : "Build Draft",
+      exact: true,
+    })
+    .click();
+  await expect.poll(async () => (await scenario.backend.card())?.version).toBe(before.version + 1);
+  const current = await card(scenario.backend);
+  expect(current).toMatchObject({ status: "review", draftStale: false });
+  expect(scenario.backend.creationRequests.at(-1)).toMatchObject({
+    method: "plan_creation.preview",
+    params: { creationId: before.creationId, expectedVersion: before.version },
+  });
+  await expect(
+    scenario.page.getByRole("heading", { name: "Every week and Workout", exact: true }),
+  ).toBeVisible();
+  await expect(
+    scenario.page.getByRole("button", { name: "Activate Plan", exact: true }),
+  ).toBeDisabled();
+  return current;
+}
+
+for (const appearance of [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const) {
+  test(`reviews, rebuilds, and restores a Draft at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    const scenario = await launch(playwright, appearance);
+    try {
+      const unrelated = await scenario.backend.inspectUnrelated();
+      await completeFitness(scenario);
+      await capture(scenario, "ready");
+      const first = await build(scenario);
+      if (first.draft === null) throw new TypeError("Built Draft is unavailable");
+      const stored = await scenario.backend.inspectDrafts();
+      expect(stored.revisions).toHaveLength(1);
+      expect(stored.revisions[0]).toMatchObject({
+        revision_number: 1,
+        parent_revision_number: null,
+      });
+      expect(stored.creations[0]).toMatchObject({
+        status: "review",
+        current_draft_revision_number: 1,
+      });
+      await expect(
+        scenario.page.getByText("Review the whole Draft before activating.", { exact: true }),
+      ).toBeVisible();
+      await expect(scenario.page.getByText("Local review only", { exact: true })).toBeVisible();
+      await expect(
+        scenario.page
+          .getByRole("table", { name: "Draft inputs", exact: true })
+          .getByRole("row")
+          .filter({ hasText: "Main Goal" })
+          .getByRole("cell"),
+      ).toHaveText("Improve fitness");
+      const disclosure = scenario.page
+        .locator("details")
+        .filter({ has: scenario.page.locator("summary", { hasText: "How this Plan was built" }) });
+      await expect(disclosure).not.toHaveAttribute("open", "");
+      await disclosure.locator("summary").click();
+      await expect(disclosure).toContainText("Heart rate or perceived effort. No FTP test.");
+      await disclosure.locator("summary").click();
+      for (const week of first.draft.weeks) {
+        await expect(scenario.page.getByText(new RegExp(`^Week ${week.number} ·`))).toHaveCount(1);
+        const rows = scenario.page
+          .getByRole("list", { name: `Week ${week.number} Workouts`, exact: true })
+          .getByRole("listitem");
+        await expect(rows).toHaveCount(week.workouts.length);
+        for (const [index, workout] of week.workouts.entries()) {
+          await expect(rows.nth(index)).toContainText(
+            `${workout.name} · ${workout.minutes} min · ${workout.guidance}`,
+          );
+        }
+      }
+      await expect(scenario.page.getByText("Priority 1 · Undated", { exact: true })).toHaveCount(4);
+      await capture(scenario, "review");
+      await scenario.page.getByRole("button", { name: "Edit answers", exact: true }).click();
+      await scenario.page.getByRole("button", { name: "Edit Plan length", exact: true }).click();
+      await choose(scenario, "8");
+      await expect(
+        scenario.page.getByRole("heading", { name: "Changed answers", exact: true }),
+      ).toBeVisible();
+      const stale = await card(scenario.backend);
+      expect(stale.draftStale).toBe(true);
+      expect(stale.draft).toEqual(first.draft);
+      expect((await scenario.backend.inspectDrafts()).revisions).toEqual(stored.revisions);
+      await capture(scenario, "stale");
+      await relaunch(scenario, playwright);
+      expect(await card(scenario.backend)).toEqual(stale);
+      await expect(
+        scenario.page.getByRole("button", { name: "Rebuild Draft", exact: true }),
+      ).toBeVisible();
+      const rebuilt = await build(scenario, true);
+      expect(rebuilt.draft?.weeks).toHaveLength(8);
+      expect(rebuilt.draft?.answeredSummaries).toEqual(rebuilt.answeredSummaries);
+      const revised = await scenario.backend.inspectDrafts();
+      expect(revised.revisions).toHaveLength(2);
+      expect(revised.revisions[0]).toEqual(stored.revisions[0]);
+      expect(revised.revisions[1]).toMatchObject({ revision_number: 2, parent_revision_number: 1 });
+      await expect(
+        scenario.page.getByRole("heading", { name: "Changed answers", exact: true }),
+      ).toHaveCount(0);
+      await capture(scenario, "rebuilt");
+      await relaunch(scenario, playwright);
+      expect(await card(scenario.backend)).toEqual(rebuilt);
+      expect(await scenario.backend.inspectDrafts()).toEqual(revised);
+      expect(await scenario.backend.inspectUnrelated()).toEqual(unrelated);
+      await expect(
+        scenario.page.getByRole("button", { name: "Activate Plan", exact: true }),
+      ).toBeDisabled();
+      await capture(scenario, "restored");
+    } finally {
+      await close(scenario);
+    }
+  });
+}
+
+test("preserves the earlier Draft when changed limits leave no Workouts", async ({
+  playwright,
+}) => {
+  const scenario = await launch(playwright, { width: 1180, colorScheme: "light" });
+  try {
+    await completeFitness(scenario);
+    const original = await build(scenario);
+    const stored = await scenario.backend.inspectDrafts();
+    await scenario.page.getByRole("button", { name: "Edit answers", exact: true }).click();
+    await scenario.page
+      .getByRole("button", { name: "Edit Training Restriction", exact: true })
+      .click();
+    await scenario.page.locator('[data-answer="no-training"]').click();
+    await continueAnswer(scenario);
+    await scenario.page.getByRole("button", { name: "Rebuild Draft", exact: true }).click();
+    await expect(
+      scenario.page.getByText(
+        "No Workouts fit anywhere in this Plan under your confirmed limits. Edit those limits to continue.",
+        { exact: true },
+      ),
+    ).toBeVisible();
+    expect((await card(scenario.backend)).draft).toEqual(original.draft);
+    expect((await card(scenario.backend)).draftStale).toBe(true);
+    expect((await scenario.backend.inspectDrafts()).revisions).toEqual(stored.revisions);
+    await expect(
+      scenario.page.getByRole("heading", { name: "Every week and Workout", exact: true }),
+    ).toBeVisible();
+    await capture(scenario, "no-workouts");
+  } finally {
+    await close(scenario);
+  }
+});

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -1,4 +1,7 @@
-import type { PlanCreationCardModel } from "@enduragent/coach-contract";
+import {
+  PlanCreationPreviewRpcParamsSchema,
+  type PlanCreationCardModel,
+} from "@enduragent/coach-contract";
 import {
   createPlanCreationRepository,
   type PlanCreationRepository,
@@ -178,6 +181,13 @@ export class PlanCreationBackend {
             ),
           );
         }
+        if (request.method === "plan_creation.preview") {
+          return response(
+            await this.requireHost()["plan_creation.preview"](
+              PlanCreationPreviewRpcParamsSchema.parse(request.params),
+            ),
+          );
+        }
         if (request.method === "plan_creation.discard") {
           return response(
             await this.requireHost()["plan_creation.discard"](
@@ -238,6 +248,21 @@ export class PlanCreationBackend {
       ),
       commands: await store.all(
         "SELECT command_name,status FROM planning_command WHERE command_name IN ('plan_creation.start','plan_creation.answer') ORDER BY created_at_ms,command_id",
+      ),
+    };
+  }
+
+  async inspectDrafts() {
+    const store = this.requireStore();
+    return {
+      creations: await store.all(
+        "SELECT id,status,version,current_draft_revision_number FROM plan_creation ORDER BY created_at_ms,id",
+      ),
+      revisions: await store.all(
+        "SELECT * FROM plan_creation_draft_revision ORDER BY creation_id,revision_number",
+      ),
+      commands: await store.all(
+        "SELECT * FROM planning_command WHERE command_name='plan_creation.preview' ORDER BY created_at_ms,command_id",
       ),
     };
   }


### PR DESCRIPTION
## Summary

Stacked on #899. Plan creation in Chat now shows a `Build Draft` action once the essentials are complete, and renders the Draft for review: the `Draft inputs` card (goal, calendar, Plan span, then every answer with its source), the `Every week and Workout` outline (one block per week, dated rows or `Priority n · Undated`, builder notes, `No Workouts this week.`), and a closed-by-default `How this Plan was built` disclosure. Actions, left to right: `Discard`, `Edit answers`, then `Activate Plan` (disabled until activation ships) or the primary `Rebuild Draft` when the Draft is stale. A changed answer marks the Draft stale and shows the `Changed answers` card above it. A build that fits no Workouts shows the confirmed-limits notice and keeps any previous Draft. Relaunch restores the review from the store.

## Verification

- Astra high verifier: pass, no blocking findings.
- Desktop E2E: all 29 cases pass on macOS, including the new `plan-creation-slice4` spec (build, review, edit-to-stale, rebuild, relaunch, no-workouts) at 1180 and 720 in light and dark. Screenshots compared against the approved prototype `draft-review` and stale scenarios.
- Root `pnpm check` clean; renderer unit tests 653 passed; oxlint clean; fixture privacy clean.

| Limit | Value |
|---|---|
| Review widths covered | 1180, 720 |
| Themes covered | light, dark |
| Action order | Discard · Edit answers · Activate Plan / Rebuild Draft |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
