### PR TITLE
feat(coach): activate a reviewed Plan Draft locally

### DIFF
--- a/.changeset/activate-plan-draft-in-chat.md
+++ b/.changeset/activate-plan-draft-in-chat.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/coach": patch
+"@enduragent/coach-client": patch
+"@enduragent/kernel": patch
+---
+
+User-facing: A reviewed Draft can now become your active Plan. Activating closes any Plan that was running and keeps your answers with the new Plan.

--- a/.changeset/activate-plan-draft-in-chat.md
+++ b/.changeset/activate-plan-draft-in-chat.md
@@ -1,4 +1,5 @@
 ---
+"@enduragent/desktop": patch
 "@enduragent/coach-contract": patch
 "@enduragent/coach": patch
 "@enduragent/coach-client": patch

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -579,6 +579,11 @@ export async function launchDesktopFixture(input: {
         ReturnType<PlanCreationOperations["plan_creation.discard"]>
       >;
     },
+    async "plan_creation.activate"(request) {
+      return finalFrame(await invoke("plan_creation.activate", request)) as Awaited<
+        ReturnType<PlanCreationOperations["plan_creation.activate"]>
+      >;
+    },
     async getPlanState(request) {
       return finalFrame(await invoke("getPlanState", request)) as Awaited<
         ReturnType<NonNullable<PlanningOperations["getPlanState"]>>

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -187,6 +187,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   "plan_creation.answer": 30_000,
   "plan_creation.preview": 30_000,
   "plan_creation.discard": 30_000,
+  "plan_creation.activate": 30_000,
 };
 
 function positiveSafeInteger(value: unknown): value is number {

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -250,6 +250,15 @@ const rpcDeadlineCases = [
     },
     30_000,
   ],
+  [
+    "plan_creation.activate",
+    {
+      commandId: "plan-activate",
+      creationId: "00000000000000000000000000",
+      expectedVersion: 1,
+    },
+    30_000,
+  ],
 ] as const satisfies ReadonlyArray<readonly [CoachRpcMethodName, unknown, number]>;
 
 class ControllableSocket extends EventTarget {
@@ -1214,6 +1223,12 @@ describe("RPC receive and observers", () => {
           planCreation: null,
         },
         "plan_creation.discard": { status: "discarded" },
+        "plan_creation.activate": {
+          creationId: "01J00000000000000000000000",
+          planId: "01J00000000000000000000001",
+          closedPlanId: null,
+          activatedAt: "1998-09-07",
+        },
       };
       socket.emitMessage(
         serializeCoachRpcEnvelope({

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -671,7 +671,23 @@ export const PlanCreationPreviewRpcResultSchema = z.discriminatedUnion("status",
 ]);
 export type PlanCreationPreviewRpcResult = z.infer<typeof PlanCreationPreviewRpcResultSchema>;
 
+export const PlanCreationActivateRpcParamsSchema = PlanCreationDiscardRpcParamsSchema;
+export type PlanCreationActivateRpcParams = z.infer<typeof PlanCreationActivateRpcParamsSchema>;
+
+export const PlanCreationActivateRpcResultSchema = z
+  .object({
+    creationId: PlanCreationUlidSchema,
+    planId: PlanCreationUlidSchema,
+    closedPlanId: PlanCreationUlidSchema.nullable(),
+    activatedAt: PlanCreationCivilDateSchema,
+  })
+  .strict();
+export type PlanCreationActivateRpcResult = z.infer<typeof PlanCreationActivateRpcResultSchema>;
+
 export interface PlanCreationOperations {
+  "plan_creation.activate"(
+    request: PlanCreationActivateRpcParams,
+  ): Promise<PlanCreationActivateRpcResult>;
   "plan_creation.preview"(
     request: PlanCreationPreviewRpcParams,
   ): Promise<PlanCreationPreviewRpcResult>;

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -140,6 +140,8 @@ import {
   type PlanningRequestOperations,
 } from "./planning-request.js";
 import {
+  PlanCreationActivateRpcParamsSchema,
+  PlanCreationActivateRpcResultSchema,
   PlanCreationAnswerRpcParamsSchema,
   PlanCreationAnswerRpcResultSchema,
   PlanCreationPreviewRpcParamsSchema,
@@ -314,6 +316,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "plan_creation.answer",
   "plan_creation.preview",
   "plan_creation.discard",
+  "plan_creation.activate",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
 export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
@@ -1916,6 +1919,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       params: PlanCreationDiscardRpcParamsSchema,
     })
     .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("plan_creation.activate"),
+      params: PlanCreationActivateRpcParamsSchema,
+    })
+    .strict(),
 ]);
 export type CoachRpcRequestEnvelope = z.infer<typeof CoachRpcRequestEnvelopeSchema>;
 
@@ -2458,6 +2469,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "plan_creation.discard",
     requestSchema: PlanCreationDiscardRpcParamsSchema,
     responseSchema: PlanCreationDiscardRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  "plan_creation.activate": {
+    wireName: "plan_creation.activate",
+    requestSchema: PlanCreationActivateRpcParamsSchema,
+    responseSchema: PlanCreationActivateRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
 } as const satisfies CoachRpcMethodRegistryShape;

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -4,6 +4,8 @@ import {
   COACH_RPC_METHOD_REGISTRY,
   CoachRpcRequestEnvelopeSchema,
   PLAN_CREATION_ANSWER_KEYS,
+  PlanCreationActivateRpcParamsSchema,
+  PlanCreationActivateRpcResultSchema,
   PlanCreationAnswerInputSchema,
   PlanCreationAnswerRpcParamsSchema,
   PlanCreationAnswerRpcResultSchema,
@@ -688,7 +690,51 @@ describe("Plan Creation contract", () => {
       "plan_creation.answer",
       "plan_creation.preview",
       "plan_creation.discard",
+      "plan_creation.activate",
     ]);
+  });
+
+  it("validates activation identity, command boundaries, and civil dates", () => {
+    const request = { commandId: "activate", creationId, expectedVersion: 2 };
+    expect(PlanCreationActivateRpcParamsSchema.parse(request)).toEqual(request);
+    for (const extra of [
+      { expectedVersion: 0 },
+      { commandId: "" },
+      { creationId: "invalid" },
+      { activatedAt: "1998-09-07" },
+      { planId: creationId },
+    ]) {
+      expect(PlanCreationActivateRpcParamsSchema.safeParse({ ...request, ...extra }).success).toBe(
+        false,
+      );
+    }
+    const result = {
+      creationId,
+      planId: "01J00000000000000000000001",
+      closedPlanId: null,
+      activatedAt: "1998-09-07",
+    };
+    expect(PlanCreationActivateRpcResultSchema.parse(result)).toEqual(result);
+    expect(
+      PlanCreationActivateRpcResultSchema.parse({ ...result, closedPlanId: creationId }),
+    ).toEqual({ ...result, closedPlanId: creationId });
+    for (const extra of [
+      { activatedAt: "1998-02-30" },
+      { activatedAt: "1998-09-07T00:00:00Z" },
+      { planId: "invalid" },
+      { closedPlanId: "invalid" },
+      { status: "activated" },
+    ]) {
+      expect(PlanCreationActivateRpcResultSchema.safeParse({ ...result, ...extra }).success).toBe(
+        false,
+      );
+    }
+    expect(COACH_RPC_METHOD_REGISTRY["plan_creation.activate"]).toEqual({
+      wireName: "plan_creation.activate",
+      requestSchema: PlanCreationActivateRpcParamsSchema,
+      responseSchema: PlanCreationActivateRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
   });
 
   it("registers strict Plan Creation envelopes without events", () => {
@@ -706,6 +752,10 @@ describe("Plan Creation contract", () => {
         method: "plan_creation.discard",
         params: { commandId: "discard", creationId, expectedVersion: 1 },
       },
+      {
+        method: "plan_creation.activate",
+        params: { commandId: "activate", creationId, expectedVersion: 1 },
+      },
     ] as const;
     requests.forEach((request, id) =>
       expect(CoachRpcRequestEnvelopeSchema.parse({ jsonrpc: "2.0", id, ...request }).method).toBe(
@@ -717,6 +767,7 @@ describe("Plan Creation contract", () => {
       "plan_creation.answer",
       "plan_creation.preview",
       "plan_creation.discard",
+      "plan_creation.activate",
     ] as const) {
       expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse({}).success).toBe(false);
     }

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1464,6 +1464,12 @@ describe("coach request and event projection", () => {
         planCreation: null,
       }),
       "plan_creation.discard": async () => ({ status: "discarded" }),
+      "plan_creation.activate": async () => ({
+        creationId: "01J00000000000000000000000",
+        planId: "01J00000000000000000000001",
+        closedPlanId: null,
+        activatedAt: "1998-09-07",
+      }),
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
     expect(COACH_RPC_METHOD_NAMES).toEqual(Object.keys(fake));

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -2252,6 +2252,7 @@ export async function createLocalCoachComposition(
       "plan_creation.answer": planCreationOperations["plan_creation.answer"],
       "plan_creation.preview": planCreationOperations["plan_creation.preview"],
       "plan_creation.discard": planCreationOperations["plan_creation.discard"],
+      "plan_creation.activate": planCreationOperations["plan_creation.activate"],
       ...planningOperations,
     } satisfies CoachOperations &
       PlanningReadOperations &

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -47,6 +47,7 @@ import {
   type SetDailySpendCapRpcParams,
   type SpendSummary,
 } from "@enduragent/coach-contract";
+import { PlanCreationStoreError } from "@enduragent/kernel/planning";
 import { unavailableChatAttachmentAdmission } from "../attachment-operations.js";
 import type { WriterProtocolHandlers } from "@enduragent/kernel-node/lock";
 import WebSocket, { WebSocketServer, type RawData } from "ws";
@@ -551,6 +552,7 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "plan_creation.answer",
   "plan_creation.preview",
   "plan_creation.discard",
+  "plan_creation.activate",
 ]);
 
 const PLAN_CHAT_RENDERER_METHODS = new Set<CoachRpcMethodName>([
@@ -1867,6 +1869,39 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 ),
               );
             } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "plan_creation.activate":
+            try {
+              result = await input.operations["plan_creation.activate"](
+                COACH_RPC_METHOD_REGISTRY["plan_creation.activate"].requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              if (
+                error instanceof PlanCreationStoreError &&
+                (error.code === "not-ready" ||
+                  error.code === "version-conflict" ||
+                  error.code === "command-conflict")
+              ) {
+                await enqueueSerialized(
+                  state,
+                  serializeCoachRpcEnvelope(
+                    JsonRpcErrorResponseEnvelopeSchema.parse({
+                      jsonrpc: "2.0",
+                      id: generic.data.id,
+                      error: {
+                        code: -32000,
+                        message: new PlanCreationStoreError(error.code).message,
+                        data: { code: error.code },
+                      },
+                    }),
+                  ),
+                );
+                return;
+              }
               invocationFailure = { error };
             }
             break;

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import {
+  PlanCreationActivateRpcParamsSchema,
+  PlanCreationActivateRpcResultSchema,
   PlanCreationAnswerRpcParamsSchema,
   PlanCreationAnswerRpcResultSchema,
   PlanCreationDiscardRpcParamsSchema,
@@ -15,6 +17,10 @@ import {
 import { buildCreationDraft } from "@enduragent/sport-cycling";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import {
+  dateKeyFromText,
+  inclusiveCivilDays,
+  MIN_FULL_PLAN_DAYS,
+  weekdayForDateKey,
   PlanCreationStoreError,
   type PlanCreationRepository,
   type PlanCreationSnapshot,
@@ -321,6 +327,85 @@ export function createPlanCreationOperations(input: {
         }
         throw error;
       }
+    },
+    async "plan_creation.activate"(request) {
+      const parsed = PlanCreationActivateRpcParamsSchema.parse(request);
+      const command = await stamp(parsed.commandId, await requestDigest(input.crypto, parsed));
+      const result = await input.repository.activate({
+        command,
+        creationId: parsed.creationId,
+        expectedVersion: parsed.expectedVersion,
+        activatedAt: today(),
+        revisionId: input.identity.newUlid(),
+        materialize(snapshot) {
+          if (snapshot.currentDraft === null || resolvePlanCreationDraftAnswers(snapshot) === null)
+            throw new PlanCreationStoreError("not-ready");
+          const draft = PlanCreationDraftSchema.parse(
+            JSON.parse(snapshot.currentDraft.outputSnapshotJson),
+          );
+          const planId = input.identity.newUlid();
+          const startDateKey = dateKeyFromText(draft.start);
+          const targetDateKey = dateKeyFromText(draft.end);
+          const name = draft.goal.kind === "event" ? draft.goal.name : "Improve fitness";
+          const primaryGoal =
+            draft.answeredSummaries.find((answer) => answer.answerKey === "success")?.detail ??
+            name;
+          const totalWeeks = draft.weeks.length;
+          const kind =
+            inclusiveCivilDays(startDateKey, targetDateKey) >= MIN_FULL_PLAN_DAYS
+              ? "full_plan"
+              : "short_race_preparation";
+          const authored = {
+            deviceId: command.deviceId,
+            hlcPhysicalMs: command.hlcPhysicalMs,
+            hlcCounter: command.hlcCounter,
+          };
+          return {
+            plan: {
+              id: planId,
+              originId: null,
+              name,
+              primaryGoal,
+              startDateKey,
+              targetDateKey,
+              status: "active",
+              kind,
+              totalWeeks,
+              weekStartDay: weekdayForDateKey(startDateKey),
+              structureJson: canonicalJson({
+                source: "plan-creation",
+                creationId: snapshot.id,
+                draftRevisionNumber: snapshot.currentDraft.revisionNumber,
+                spanKind: draft.spanKind,
+                mode: draft.mode,
+              }),
+              createdAtMs: command.nowMs,
+              updatedAtMs: command.nowMs,
+              ...authored,
+            },
+            workouts: draft.weeks.flatMap((week) =>
+              week.workouts.flatMap((workout) =>
+                workout.date === null
+                  ? []
+                  : [
+                      {
+                        id: input.identity.newUlid(),
+                        planId,
+                        dateKey: dateKeyFromText(workout.date),
+                        sport: "Ride",
+                        name: workout.name,
+                        durationS: Math.round(workout.minutes * 60),
+                        structureJson: canonicalJson(workout),
+                        origin: "coach" as const,
+                        ...authored,
+                      },
+                    ],
+              ),
+            ),
+          };
+        },
+      });
+      return PlanCreationActivateRpcResultSchema.parse(result);
     },
     async "plan_creation.discard"(request) {
       const parsed = PlanCreationDiscardRpcParamsSchema.parse(request);

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { Duplex } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
+import { PlanCreationStoreError } from "@enduragent/kernel/planning";
 import {
   WindowsPrivatePathPolicyError,
   type CreateTelegramChannelInput,
@@ -2215,6 +2216,54 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     await client.close();
   });
 
+  it.each([
+    ["not-ready", "Build a current complete Draft and resolve pending answers before activation."],
+    ["version-conflict", "version-conflict"],
+    ["command-conflict", "command-conflict"],
+  ] as const)(
+    "preserves the safe activation %s rejection for the renderer",
+    async (code, message) => {
+      const failure = new PlanCreationStoreError(code);
+      failure.message = "Private unexpected error text";
+      const rpc = createCoachRpcServer({
+        engine: engine(),
+        operations: {
+          ...operations,
+          "plan_creation.activate": async () => {
+            throw failure;
+          },
+        },
+        token: "x".repeat(43),
+        owner: "app-supervised",
+      });
+      const renderer = await openSocket(rpc);
+      renderer.ws.send(
+        JSON.stringify(
+          createClientHandshakeFrame(TEST_RENDERER_CAPABILITY_BYTES.toString("base64url")),
+        ),
+      );
+      await renderer.frames.next();
+      renderer.ws.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "activate",
+          method: "plan_creation.activate",
+          params: {
+            commandId: "activate",
+            creationId: "01J00000000000000000000000",
+            expectedVersion: 2,
+          },
+        }),
+      );
+      expect(parseCoachRpcEnvelope(await renderer.frames.next())).toEqual({
+        jsonrpc: "2.0",
+        id: "activate",
+        error: { code: -32000, message, data: { code } },
+      });
+      await renderer.close();
+    },
+  );
+
   it("dispatches strict Plan Creation operations for the renderer", async () => {
     const token = "x".repeat(43);
     const creationId = "01J00000000000000000000000";
@@ -2338,6 +2387,15 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     const discardPlanCreation = vi.fn<PlanCreationOperations["plan_creation.discard"]>(
       async () => ({ status: "discarded" }),
     );
+    const activationResult = {
+      creationId,
+      planId: "01J00000000000000000000001",
+      closedPlanId: null,
+      activatedAt: "1998-09-07",
+    };
+    const activatePlanCreation = vi.fn<PlanCreationOperations["plan_creation.activate"]>(
+      async () => activationResult,
+    );
     const rpc = createCoachRpcServer({
       engine: engine(),
       operations: {
@@ -2346,6 +2404,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         "plan_creation.answer": answerPlanCreation,
         "plan_creation.preview": previewPlanCreation,
         "plan_creation.discard": discardPlanCreation,
+        "plan_creation.activate": activatePlanCreation,
       },
       token,
       owner: "app-supervised",
@@ -2366,6 +2425,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     };
     const previewParams = { commandId: "preview-1", creationId, expectedVersion: 2 };
     const discardParams = { commandId: "discard-1", creationId, expectedVersion: 2 };
+    const activateParams = { commandId: "activate-1", creationId, expectedVersion: 2 };
     for (const { result, ...request } of [
       {
         id: "start",
@@ -2391,6 +2451,12 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         params: discardParams,
         result: { status: "discarded" },
       },
+      {
+        id: "activate",
+        method: "plan_creation.activate",
+        params: activateParams,
+        result: activationResult,
+      },
     ]) {
       renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
       expect(parseCoachRpcEnvelope(await renderer.frames.next())).toEqual({
@@ -2403,6 +2469,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(answerPlanCreation).toHaveBeenCalledWith(answerParams);
     expect(previewPlanCreation).toHaveBeenCalledWith(previewParams);
     expect(discardPlanCreation).toHaveBeenCalledWith(discardParams);
+    expect(activatePlanCreation).toHaveBeenCalledWith(activateParams);
 
     for (const request of [
       {
@@ -2425,6 +2492,11 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         method: "plan_creation.discard",
         params: { ...discardParams, extra: true },
       },
+      {
+        id: "invalid-activate",
+        method: "plan_creation.activate",
+        params: { ...activateParams, extra: true },
+      },
     ]) {
       renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
       expect(parseCoachRpcEnvelope(await renderer.frames.next())).toMatchObject({
@@ -2436,6 +2508,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(answerPlanCreation).toHaveBeenCalledOnce();
     expect(previewPlanCreation).toHaveBeenCalledOnce();
     expect(discardPlanCreation).toHaveBeenCalledOnce();
+    expect(activatePlanCreation).toHaveBeenCalledOnce();
     await renderer.close();
   });
 

--- a/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
+++ b/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
@@ -20,4 +20,7 @@ export const planCreationOperationStubs = {
     reason: "no-unfinished-creation",
     planCreation: null,
   }),
+  "plan_creation.activate": async () => {
+    throw new Error("No unfinished creation");
+  },
 } satisfies PlanCreationOperations;

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@enduragent/coach-contract";
 import {
   createPlanCreationRepository,
+  createPlanRepository,
   PlanCreationStoreError,
   type PlanCreationAnswerRecord,
   type PlanCreationRepository,
@@ -23,6 +24,7 @@ import {
 import { runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanningReadService } from "../src/planning-read-service.js";
 import { readPlanCreationAnswers } from "../src/plan-creation-answers.js";
 
 const id = (value: string) => `${"0".repeat(26 - value.length)}${value}`;
@@ -155,6 +157,9 @@ function harness(
     return { outcome: "recorded", snapshot: current };
   });
   const repository: PlanCreationRepository = {
+    activate: async () => {
+      throw new Error("unused");
+    },
     replayDraft: async () => undefined,
     recordDraft: async () => {
       throw new Error("unused");
@@ -656,6 +661,9 @@ describe("Plan Creation operations", () => {
     let sequence = 8;
     const host = createPlanCreationOperations({
       repository: {
+        activate: async () => {
+          throw new Error("unused");
+        },
         replayDraft: async () => undefined,
         recordDraft: async () => {
           throw new Error("unused");
@@ -751,6 +759,9 @@ describe("Plan Creation operations", () => {
     });
     const host = createPlanCreationOperations({
       repository: {
+        activate: async () => {
+          throw new Error("unused");
+        },
         replayDraft: async () => undefined,
         recordDraft: async () => {
           throw new Error("unused");
@@ -866,12 +877,12 @@ async function previewHarness() {
     );
     return card;
   };
-  const ready = async () => {
+  const ready = async (mode: "fixed" | "flexible" = "flexible") => {
     for (const value of [
       fitnessGoal,
       { kind: "plan-length", weeks: 4 } as const,
-      flexibleMode,
-      flexibleAvailability,
+      mode === "fixed" ? fixedMode : flexibleMode,
+      mode === "fixed" ? fixedAvailability : flexibleAvailability,
       startTiming,
       noCommitments,
       regularBaseline,
@@ -1049,5 +1060,185 @@ describe("Plan Creation preview", () => {
     test.advanceDay();
     await expect(test.host["plan_creation.preview"](request)).resolves.toEqual(first);
     await expect(test.host.readCard()).resolves.toBeNull();
+  });
+});
+
+describe("Plan Creation activation", () => {
+  const review = async (mode: "fixed" | "flexible" = "fixed") => {
+    const test = await previewHarness();
+    const card = await test.ready(mode);
+    const result = await test.host["plan_creation.preview"]({
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    });
+    if (result.status !== "previewed" || result.planCreation.draft === null)
+      throw new Error("Expected current Draft");
+    return {
+      ...test,
+      draft: result.planCreation.draft,
+      request: {
+        commandId: "activate",
+        creationId: card.creationId,
+        expectedVersion: result.planCreation.version,
+      },
+    };
+  };
+
+  it("activates dated Workouts, removes the Chat card, and exposes the Plan to readers", async () => {
+    const test = await review();
+    const result = await test.host["plan_creation.activate"](test.request);
+    expect(result).toEqual({
+      creationId: test.request.creationId,
+      planId: expect.any(String),
+      closedPlanId: null,
+      activatedAt: today,
+    });
+    await expect(test.host.readCard()).resolves.toBeNull();
+    await expect(test.repository.readUnfinished()).resolves.toBeUndefined();
+    const plans = createPlanRepository(test.store);
+    await expect(plans.readLatest()).resolves.toMatchObject({
+      id: result.planId,
+      name: "Improve fitness",
+      primaryGoal: "Climb stronger",
+      status: "active",
+      startDateKey: Number(test.draft.start.replaceAll("-", "")),
+      targetDateKey: Number(test.draft.end.replaceAll("-", "")),
+    });
+    const draftWorkouts = test.draft.weeks.flatMap((week) => week.workouts);
+    const workouts = await plans.readWorkouts(result.planId);
+    expect(workouts).toHaveLength(draftWorkouts.length);
+    expect(workouts.map((workout) => JSON.parse(workout.structureJson))).toEqual(draftWorkouts);
+    const model = await createPlanningReadService({
+      store: test.store,
+      timezone: "UTC",
+      now: () => Date.parse(`${test.draft.start}T12:00:00Z`),
+    }).getPlanningReadModel({});
+    expect(model).toMatchObject({
+      status: "ready",
+      plan: { id: result.planId, currentWeek: 1, totalWeeks: 4, phase: null },
+    });
+    if (model.status !== "ready") throw new Error("Expected active Plan");
+    expect(model.plan.workouts.map((workout) => workout.name)).toEqual(
+      test.draft.weeks[0]?.workouts.map((workout) => workout.name),
+    );
+  });
+
+  it("activates a Base Plan within its window and retains the later Event Goal in its snapshot", async () => {
+    const test = await previewHarness();
+    for (const answer of [
+      { kind: "goal", goal: { kind: "event-manual", name: "Spring Tour", date: "1999-05-16" } },
+      fixedMode,
+      fixedAvailability,
+      startTiming,
+      noCommitments,
+      regularBaseline,
+      eventSuccess,
+      noRestriction,
+    ] satisfies readonly PlanCreationAnswerInput[])
+      await test.answer(answer);
+    const card = test.card();
+    const reviewed = await test.host["plan_creation.preview"]({
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    });
+    if (reviewed.status !== "previewed" || reviewed.planCreation.draft === null)
+      throw new Error("Expected Base Plan Draft");
+    const draft = reviewed.planCreation.draft;
+    expect(draft).toMatchObject({
+      spanKind: "Base Plan",
+      goal: { name: "Spring Tour", date: "1999-05-16" },
+    });
+    expect(draft.weeks).toHaveLength(12);
+    const activated = await test.host["plan_creation.activate"]({
+      commandId: "activate",
+      creationId: card.creationId,
+      expectedVersion: reviewed.planCreation.version,
+    });
+    await expect(createPlanRepository(test.store).readLatest()).resolves.toMatchObject({
+      id: activated.planId,
+      name: "Spring Tour",
+      targetDateKey: Number(draft.end.replaceAll("-", "")),
+      kind: "full_plan",
+      totalWeeks: 12,
+    });
+    expect(Number(draft.end.replaceAll("-", ""))).toBeLessThan(19990516);
+    expect(
+      await test.store.all("SELECT snapshot_json FROM plan_revision WHERE plan_id = ?", [
+        activated.planId,
+      ]),
+    ).toEqual([{ snapshot_json: canonicalJson(draft) }]);
+  });
+
+  it("keeps undated flexible Workouts in the revision snapshot", async () => {
+    const test = await review("flexible");
+    const result = await test.host["plan_creation.activate"](test.request);
+    expect(test.draft.weeks.flatMap((week) => week.workouts).length).toBeGreaterThan(0);
+    expect(await test.store.all("SELECT * FROM plan_workout")).toEqual([]);
+    expect(
+      await test.store.all("SELECT snapshot_json FROM plan_revision WHERE plan_id = ?", [
+        result.planId,
+      ]),
+    ).toEqual([{ snapshot_json: canonicalJson(test.draft) }]);
+    await expect(test.host.readCard()).resolves.toBeNull();
+  });
+
+  it("replays the original Plan and host date and rejects changed command input", async () => {
+    const test = await review();
+    const first = await test.host["plan_creation.activate"](test.request);
+    const plans = await test.store.all("SELECT * FROM plan");
+    const workouts = await test.store.all("SELECT * FROM plan_workout");
+    test.advanceDay();
+    await expect(test.host["plan_creation.activate"](test.request)).resolves.toEqual(first);
+    await expect(
+      test.host["plan_creation.activate"]({
+        ...test.request,
+        expectedVersion: test.request.expectedVersion + 1,
+      }),
+    ).rejects.toMatchObject({ code: "command-conflict" });
+    expect(await test.store.all("SELECT * FROM plan")).toEqual(plans);
+    expect(await test.store.all("SELECT * FROM plan_workout")).toEqual(workouts);
+    await expect(test.host.readCard()).resolves.toBeNull();
+  });
+
+  it("rejects missing Drafts and stale versions without creating a Plan", async () => {
+    const test = await previewHarness();
+    const card = await test.ready();
+    const request = {
+      commandId: "activate",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    };
+    await expect(test.host["plan_creation.activate"](request)).rejects.toMatchObject({
+      code: "not-ready",
+      message: "Build a current complete Draft and resolve pending answers before activation.",
+    });
+    await expect(
+      test.host["plan_creation.activate"]({ ...request, expectedVersion: card.version - 1 }),
+    ).rejects.toMatchObject({
+      code: "version-conflict",
+    });
+    expect(await test.store.all("SELECT * FROM plan")).toEqual([]);
+    await expect(test.host.readCard()).resolves.toEqual(card);
+  });
+
+  it("rejects an edited Draft and preserves its current card", async () => {
+    const test = await review();
+    const edited = await answered(
+      test.host["plan_creation.answer"]({
+        ...test.request,
+        commandId: "edit",
+        answer: { kind: "plan-length", weeks: 8 },
+      }),
+    );
+    await expect(
+      test.host["plan_creation.activate"]({ ...test.request, expectedVersion: edited.version }),
+    ).rejects.toMatchObject({
+      code: "not-ready",
+      message: "Build a current complete Draft and resolve pending answers before activation.",
+    });
+    expect(await test.store.all("SELECT * FROM plan")).toEqual([]);
+    await expect(test.host.readCard()).resolves.toEqual(edited);
   });
 });

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ChatQueueSnapshot,
+  PlanCreationAnswerInput,
   CoachEngine,
   PlanProgressEvent,
   TurnEvent,
 } from "@enduragent/coach-contract";
 import {
   createPlanConversationRepository,
+  createPlanCreationRepository,
   createPlanReconciliationRepository,
   createPlanRepository,
   createPlanSettingsRepository,
@@ -41,6 +43,7 @@ import {
   type PlanMirrorCalendarPort,
 } from "@enduragent/engine";
 import { createPlanningOperations, type PlanDraftBuilder } from "../src/planning-operations.js";
+import { createPlanCreationOperations } from "../src/plan-creation-operations.js";
 import type { PlanRaceCourseAdapter } from "../src/planning-race-course.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 
@@ -243,6 +246,90 @@ describe("Plan operations", () => {
 
   afterEach(async () => {
     await store.close();
+  });
+
+  it("reads an activated creation and its dated Workouts without legacy phases", async () => {
+    let sequence = 100;
+    const authored: AuthoredIdentity = {
+      deviceId: async () => "activation-test-device",
+      newUlid: () => `${"0".repeat(23)}${++sequence}`,
+      hlcStamp: () => ({ physicalMs: 904_780_800_000, counter: 0 }),
+    };
+    const creation = createPlanCreationOperations({
+      repository: createPlanCreationRepository(store),
+      identity: authored,
+      crypto: globalThis.crypto,
+      eventCandidates: { read: async () => [] },
+      today: () => "1998-09-02",
+    });
+    const started = await creation["plan_creation.start"]({ commandId: "start" });
+    if (started.status !== "started") throw new Error("Expected creation");
+    let card = started.planCreation;
+    const answers: readonly PlanCreationAnswerInput[] = [
+      { kind: "goal", goal: { kind: "fitness" } },
+      { kind: "plan-length", weeks: 4 },
+      { kind: "schedule-mode", mode: "fixed" },
+      {
+        kind: "availability",
+        mode: "fixed",
+        weeklyHoursLimit: 8,
+        longestWorkoutHours: 3,
+        usableWeekdays: [2, 4, 6],
+      },
+      { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
+      { kind: "commitments", commitments: { kind: "none" } },
+      { kind: "baseline", baseline: "regular" },
+      { kind: "success", success: { kind: "fitness-choice", choice: "climb-stronger" } },
+      { kind: "restriction", restriction: { kind: "none" } },
+    ];
+    for (const answer of answers) {
+      const result = await creation["plan_creation.answer"]({
+        commandId: `answer-${++sequence}`,
+        creationId: card.creationId,
+        expectedVersion: card.version,
+        answer,
+      });
+      if (result.status !== "answered") throw new Error("Expected confirmed answer");
+      card = result.planCreation;
+    }
+    const reviewed = await creation["plan_creation.preview"]({
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    });
+    if (reviewed.status !== "previewed" || reviewed.planCreation.draft === null)
+      throw new Error("Expected Draft");
+    const activated = await creation["plan_creation.activate"]({
+      commandId: "activate",
+      creationId: card.creationId,
+      expectedVersion: reviewed.planCreation.version,
+    });
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      { todayDateKey: () => 19980902 },
+    );
+    const result = await operations.getPlanState?.({});
+    expect(result).toMatchObject({
+      status: "ready",
+      state: {
+        projection: "active",
+        data: {
+          plan: { id: activated.planId, name: "Improve fitness" },
+          workouts: expect.any(Array),
+        },
+      },
+    });
+    if (result?.status !== "ready") throw new Error("Expected active Plan state");
+    const draftWorkouts = reviewed.planCreation.draft.weeks[0]?.workouts ?? [];
+    expect(result.state.data.workouts).toEqual(
+      draftWorkouts.map((workout) =>
+        expect.objectContaining({
+          date: workout.date,
+          name: workout.name,
+          durationS: workout.minutes * 60,
+        }),
+      ),
+    );
   });
 
   it("persists and relaunches a dedicated streamed Plan conversation", async () => {

--- a/packages/kernel-node/tests/plan-creation-activation.test.ts
+++ b/packages/kernel-node/tests/plan-creation-activation.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createPlanCreationRepository,
+  type PlanCreationCommandStamp,
+  type PlanCreationRepository,
+} from "@enduragent/kernel/planning";
+import {
+  dumpStore,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const id = (value: string) => value.padStart(26, "0");
+const nowMs = 883_612_800_000;
+const fingerprint = "f".repeat(64);
+const stamp = (commandId: string, offset = 0): PlanCreationCommandStamp => ({
+  commandId,
+  requestDigest: "a".repeat(64),
+  nowMs: nowMs + offset,
+  deviceId: "test-device-1998",
+  hlcPhysicalMs: nowMs + offset,
+  hlcCounter: 0,
+});
+const datedWorkout = { name: "Endurance ride", date: "1998-01-01" };
+const poolWorkout = { name: "Flexible ride", date: null };
+const draft = {
+  outputFingerprint: fingerprint,
+  weeks: [{ workouts: [datedWorkout, poolWorkout] }, { workouts: [] }],
+};
+
+const activationInput = (key = "1") => {
+  const command = stamp(`activate-${key}`, Number(key) * 10 + 2);
+  const planId = id(`1${key}`);
+  return {
+    command,
+    creationId: id(key),
+    expectedVersion: 2,
+    activatedAt: "1998-01-01",
+    revisionId: id(`2${key}`),
+    materialize: () => ({
+      plan: {
+        id: planId,
+        originId: null,
+        name: "Improve fitness",
+        primaryGoal: "Ride well",
+        startDateKey: 19980101,
+        targetDateKey: 19980114,
+        status: "active" as const,
+        kind: "short_race_preparation" as const,
+        totalWeeks: 2,
+        weekStartDay: 4,
+        structureJson: JSON.stringify({ source: "plan-creation", creationId: id(key) }),
+        createdAtMs: command.nowMs,
+        updatedAtMs: command.nowMs,
+        deviceId: command.deviceId,
+        hlcPhysicalMs: command.hlcPhysicalMs,
+        hlcCounter: command.hlcCounter,
+      },
+      workouts: [
+        {
+          id: id(`3${key}`),
+          planId,
+          dateKey: 19980101,
+          sport: "Ride",
+          name: datedWorkout.name,
+          durationS: 3600,
+          structureJson: JSON.stringify(datedWorkout),
+          origin: "coach" as const,
+          deviceId: command.deviceId,
+          hlcPhysicalMs: command.hlcPhysicalMs,
+          hlcCounter: command.hlcCounter,
+        },
+      ],
+    }),
+  } satisfies Parameters<PlanCreationRepository["activate"]>[0];
+};
+
+describe("Plan Creation activation repository", () => {
+  let store: SqlStore & MigratorStore;
+  let repository: PlanCreationRepository;
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    repository = createPlanCreationRepository(store);
+  });
+  afterEach(async () => store.close());
+  const start = (key = "1") =>
+    repository.start({
+      command: stamp(`start-${key}`, Number(key) * 10),
+      creationId: id(key),
+      seed: { schemaVersion: 1, eventCandidates: [] },
+    });
+  const review = async (key = "1", output = draft) => {
+    await start(key);
+    await repository.recordDraft({
+      command: stamp(`preview-${key}`, Number(key) * 10 + 1),
+      creationId: id(key),
+      expectedVersion: 1,
+      draftId: id(`4${key}`),
+      inputSnapshotJson: "{}",
+      inputFingerprint: "e".repeat(64),
+      outputSnapshotJson: JSON.stringify(output),
+      builderId: "cycling",
+      builderVersion: "1",
+      activationFingerprint: fingerprint,
+    });
+  };
+
+  it("activates a reviewed Draft and retains undated Workouts only in its immutable revision", async () => {
+    await review();
+    const input = activationInput();
+    await expect(repository.activate(input)).resolves.toEqual({
+      creationId: id("1"),
+      planId: id("11"),
+      closedPlanId: null,
+      activatedAt: "1998-01-01",
+    });
+    await expect(repository.readUnfinished()).resolves.toBeUndefined();
+    expect(
+      await store.get("SELECT status,version,activated_plan_id,terminal_at_ms FROM plan_creation"),
+    ).toEqual({
+      status: "activated",
+      version: 3,
+      activated_plan_id: id("11"),
+      terminal_at_ms: input.command.nowMs,
+    });
+    expect(
+      await store.get(
+        "SELECT status,version,current_revision_number,activated_at_ms FROM planning_plan",
+      ),
+    ).toEqual({
+      status: "active",
+      version: 1,
+      current_revision_number: 1,
+      activated_at_ms: input.command.nowMs,
+    });
+    expect(await store.all("SELECT id,status FROM plan")).toEqual([
+      { id: id("11"), status: "active" },
+    ]);
+    expect(await store.all("SELECT date_key,origin,structure_json FROM plan_workout")).toEqual([
+      { date_key: 19980101, origin: "coach", structure_json: JSON.stringify(datedWorkout) },
+    ]);
+    expect(
+      await store.get(
+        "SELECT revision_number,parent_revision_number,source_kind,source_id,snapshot_json,fingerprint FROM plan_revision",
+      ),
+    ).toEqual({
+      revision_number: 1,
+      parent_revision_number: null,
+      source_kind: "activation",
+      source_id: id("1"),
+      snapshot_json: JSON.stringify(draft),
+      fingerprint,
+    });
+    await expect(
+      store.run("UPDATE plan_revision SET fingerprint=?", ["e".repeat(64)]),
+    ).rejects.toThrow();
+    expect(
+      await store.all(
+        "SELECT status FROM planning_command WHERE command_name='plan_creation.activate'",
+      ),
+    ).toEqual([{ status: "succeeded" }]);
+  });
+
+  it("closes both incumbent rows and replays the original result after another activation", async () => {
+    await review();
+    const first = await repository.activate(activationInput());
+    await review("2");
+    const second = await repository.activate(activationInput("2"));
+    expect(second.closedPlanId).toBe(first.planId);
+    expect(
+      await store.get(
+        "SELECT status,version,close_reason,close_actor,closed_at_ms FROM planning_plan WHERE plan_id=?",
+        [first.planId],
+      ),
+    ).toEqual({
+      status: "closed",
+      version: 2,
+      close_reason: "stopped",
+      close_actor: "test-device-1998",
+      closed_at_ms: nowMs + 22,
+    });
+    expect(await store.all("SELECT id,status FROM plan ORDER BY id")).toEqual([
+      { id: first.planId, status: "ended" },
+      { id: second.planId, status: "active" },
+    ]);
+    const before = await dumpStore(store);
+    await expect(
+      createPlanCreationRepository(store).activate({
+        ...activationInput(),
+        materialize: () => {
+          throw new Error("Replay must not materialize again");
+        },
+      }),
+    ).resolves.toEqual(first);
+    expect(await dumpStore(store)).toBe(before);
+    await expect(
+      repository.activate({
+        ...activationInput(),
+        command: { ...activationInput().command, requestDigest: "b".repeat(64) },
+      }),
+    ).rejects.toMatchObject({ code: "command-conflict" });
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it.each(["missing", "stale", "version", "empty", "fingerprint"])(
+    "rejects %s Draft admission without changing any stored row",
+    async (kind) => {
+      await review();
+      await repository.activate(activationInput());
+      if (kind === "missing") await start("2");
+      else
+        await review(
+          "2",
+          kind === "empty"
+            ? { ...draft, weeks: [{ workouts: [] }] }
+            : kind === "fingerprint"
+              ? { ...draft, outputFingerprint: "d".repeat(64) }
+              : draft,
+        );
+      if (kind === "stale")
+        await repository.recordAnswer({
+          command: stamp("edited-answer", 23),
+          creationId: id("2"),
+          expectedVersion: 2,
+          answerId: id("8"),
+          answerKey: "success",
+          valueJson: "{}",
+        });
+      const before = await dumpStore(store);
+      await expect(
+        repository.activate({
+          ...activationInput("2"),
+          expectedVersion: kind === "stale" ? 3 : kind === "missing" || kind === "version" ? 1 : 2,
+        }),
+      ).rejects.toMatchObject({
+        code:
+          kind === "version"
+            ? "version-conflict"
+            : kind === "fingerprint"
+              ? "corrupt-record"
+              : "not-ready",
+      });
+      expect(await dumpStore(store)).toBe(before);
+    },
+  );
+
+  it("rejects activation when no unfinished creation exists", async () => {
+    const before = await dumpStore(store);
+    await expect(repository.activate(activationInput())).rejects.toMatchObject({
+      code: "not-ready",
+    });
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it("rolls back incumbent closure and every new row when the activation ledger fails", async () => {
+    await review();
+    await repository.activate(activationInput());
+    await review("2");
+    const before = await dumpStore(store);
+    let closureObserved = false;
+    const failing = createPlanCreationRepository({
+      exec: (sql) => store.exec(sql),
+      async run(sql, params) {
+        if (sql.includes("INSERT INTO planning_command")) {
+          expect(
+            await store.get("SELECT status,close_reason FROM planning_plan WHERE plan_id=?", [
+              id("11"),
+            ]),
+          ).toEqual({ status: "closed", close_reason: "stopped" });
+          expect(await store.get("SELECT status FROM plan WHERE id=?", [id("11")])).toEqual({
+            status: "ended",
+          });
+          expect(await store.get("SELECT status FROM plan_creation WHERE id=?", [id("2")])).toEqual(
+            { status: "activated" },
+          );
+          closureObserved = true;
+          throw new Error("Synthetic activation ledger failure");
+        }
+        return store.run(sql, params);
+      },
+      get: (sql, params) => store.get(sql, params),
+      all: (sql, params) => store.all(sql, params),
+      close: () => store.close(),
+      transaction: (operation) => store.transaction(operation),
+    });
+    await expect(failing.activate(activationInput("2"))).rejects.toThrow(
+      "Synthetic activation ledger failure",
+    );
+    expect(closureObserved).toBe(true);
+    expect(await dumpStore(store)).toBe(before);
+    await expect(repository.activate(activationInput("2"))).resolves.toMatchObject({
+      closedPlanId: id("11"),
+    });
+  });
+});

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -1,3 +1,9 @@
+import {
+  validatePlanRecord,
+  validatePlanWorkoutRecord,
+  type PlanRecord,
+  type PlanWorkoutRecord,
+} from "./repository.js";
 import { canonicalJson } from "../archive/canonical.js";
 import type { MigratorStore } from "../store/migrator.js";
 import type { Row, SqlStore } from "../store/ports.js";
@@ -9,11 +15,17 @@ export type PlanCreationErrorCode =
   | "stale-version"
   | "missing-creation"
   | "no-unfinished-creation"
-  | "corrupt-record";
+  | "corrupt-record"
+  | "version-conflict"
+  | "not-ready";
 
 export class PlanCreationStoreError extends Error {
   constructor(readonly code: PlanCreationErrorCode) {
-    super(code);
+    super(
+      code === "not-ready"
+        ? "Build a current complete Draft and resolve pending answers before activation."
+        : code,
+    );
     this.name = "PlanCreationStoreError";
   }
 }
@@ -124,7 +136,35 @@ export interface DiscardPlanCreationInput {
   readonly expectedVersion: number;
 }
 
+export const PlanCreationActivationResultSchema = z
+  .object({
+    creationId: z.string().regex(/^[0-9A-HJKMNP-TV-Z]{26}$/u),
+    planId: z.string().regex(/^[0-9A-HJKMNP-TV-Z]{26}$/u),
+    closedPlanId: z
+      .string()
+      .regex(/^[0-9A-HJKMNP-TV-Z]{26}$/u)
+      .nullable(),
+    activatedAt: z.iso.date(),
+  })
+  .strict();
+export type PlanCreationActivationResult = z.infer<typeof PlanCreationActivationResultSchema>;
+
+export interface ActivatePlanCreationInput extends DiscardPlanCreationInput {
+  readonly activatedAt: string;
+  readonly revisionId: string;
+  readonly materialize: (snapshot: PlanCreationSnapshot) => {
+    readonly plan: PlanRecord;
+    readonly workouts: readonly PlanWorkoutRecord[];
+  };
+}
+
+const ActivationDraftSchema = z.object({
+  weeks: z.array(z.object({ workouts: z.array(z.unknown()) })),
+  outputFingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+});
+
 export interface PlanCreationRepository {
+  activate(input: ActivatePlanCreationInput): Promise<PlanCreationActivationResult>;
   readUnfinished(): Promise<PlanCreationSnapshot | undefined>;
   start(input: StartPlanCreationInput): Promise<{
     outcome: "created" | "resumed" | "replayed";
@@ -241,7 +281,8 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
       | "plan_creation.start"
       | "plan_creation.answer"
       | "plan_creation.discard"
-      | "plan_creation.preview",
+      | "plan_creation.preview"
+      | "plan_creation.activate",
     command: PlanCreationCommandStamp,
   ) => {
     const row = await store.get(
@@ -269,7 +310,8 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
       | "plan_creation.start"
       | "plan_creation.answer"
       | "plan_creation.discard"
-      | "plan_creation.preview",
+      | "plan_creation.preview"
+      | "plan_creation.activate",
     command: PlanCreationCommandStamp,
     creationId: string,
     result: unknown,
@@ -435,6 +477,159 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
           throw new PlanCreationStoreError("stale-version");
         await recordCommand("plan_creation.preview", command, creationId, snapshot);
         return { outcome: "recorded", snapshot };
+      });
+    },
+    async activate({ command, creationId, expectedVersion, activatedAt, revisionId, materialize }) {
+      return store.transaction(async () => {
+        const prior = await hasReplay("plan_creation.activate", command);
+        if (prior !== undefined) {
+          const parsed = PlanCreationActivationResultSchema.safeParse(
+            json(text(prior, "result_json")),
+          );
+          return parsed.success ? parsed.data : fail();
+        }
+        const current = await readUnfinished();
+        if (current === undefined || current.id !== creationId)
+          throw new PlanCreationStoreError("not-ready");
+        if (current.version !== expectedVersion)
+          throw new PlanCreationStoreError("version-conflict");
+        const revision = current.currentDraft;
+        if (
+          current.status !== "review" ||
+          revision === null ||
+          revision.inputVersion + 1 !== current.version
+        )
+          throw new PlanCreationStoreError("not-ready");
+        const draft = ActivationDraftSchema.safeParse(json(revision.outputSnapshotJson));
+        if (!draft.success || !draft.data.weeks.some((week) => week.workouts.length > 0))
+          throw new PlanCreationStoreError("not-ready");
+        if (draft.data.outputFingerprint !== revision.activationFingerprint) return fail();
+        const { plan, workouts } = materialize(current);
+        validatePlanRecord(plan);
+        for (const workout of workouts) validatePlanWorkoutRecord(plan, workout);
+        if (plan.status !== "active") return fail();
+        const incumbent = await store.get(
+          "SELECT plan_id FROM planning_plan WHERE status='active'",
+        );
+        const closedPlanId = incumbent === undefined ? null : text(incumbent, "plan_id");
+        const result = PlanCreationActivationResultSchema.parse({
+          creationId,
+          planId: plan.id,
+          closedPlanId,
+          activatedAt,
+        });
+        if (closedPlanId !== null) {
+          await store.run(
+            `UPDATE planning_plan SET status='closed',close_reason='stopped',close_actor=?,closed_at_ms=?,
+version=version+1,updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=? WHERE plan_id=? AND status='active'`,
+            [
+              command.deviceId,
+              command.nowMs,
+              command.nowMs,
+              command.deviceId,
+              command.hlcPhysicalMs,
+              command.hlcCounter,
+              closedPlanId,
+            ],
+          );
+          await store.run(
+            `UPDATE plan SET status='ended',updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=? WHERE id=?`,
+            [
+              command.nowMs,
+              command.deviceId,
+              command.hlcPhysicalMs,
+              command.hlcCounter,
+              closedPlanId,
+            ],
+          );
+        }
+        await store.run(
+          `INSERT INTO plan (id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,
+total_weeks,week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          [
+            plan.id,
+            plan.originId,
+            plan.name,
+            plan.primaryGoal,
+            plan.startDateKey,
+            plan.targetDateKey,
+            plan.status,
+            plan.kind,
+            plan.totalWeeks,
+            plan.weekStartDay,
+            plan.structureJson,
+            plan.createdAtMs,
+            plan.updatedAtMs,
+            plan.deviceId,
+            plan.hlcPhysicalMs,
+            plan.hlcCounter,
+          ],
+        );
+        for (const workout of workouts) {
+          await store.run(
+            `INSERT INTO plan_workout (id,plan_id,date_key,sport,name,duration_s,structure_json,origin,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+            [
+              workout.id,
+              workout.planId,
+              workout.dateKey,
+              workout.sport,
+              workout.name,
+              workout.durationS,
+              workout.structureJson,
+              workout.origin,
+              workout.deviceId,
+              workout.hlcPhysicalMs,
+              workout.hlcCounter,
+            ],
+          );
+        }
+        await store.run(
+          `INSERT INTO planning_plan (plan_id,status,version,current_revision_number,activated_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,'active',1,1,?,?,?,?,?)`,
+          [
+            plan.id,
+            command.nowMs,
+            command.nowMs,
+            command.deviceId,
+            command.hlcPhysicalMs,
+            command.hlcCounter,
+          ],
+        );
+        await store.run(
+          `INSERT INTO plan_revision (id,plan_id,revision_number,parent_revision_number,source_kind,source_id,snapshot_json,fingerprint,created_at_ms,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,?,1,NULL,'activation',?,?,?,?,?,?,?)`,
+          [
+            revisionId,
+            plan.id,
+            creationId,
+            revision.outputSnapshotJson,
+            draft.data.outputFingerprint,
+            command.nowMs,
+            command.deviceId,
+            command.hlcPhysicalMs,
+            command.hlcCounter,
+          ],
+        );
+        const updated = await store.get(
+          `UPDATE plan_creation SET status='activated',activated_plan_id=?,terminal_at_ms=?,version=version+1,
+updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=? WHERE id=? AND status='review' AND version=? RETURNING version`,
+          [
+            plan.id,
+            command.nowMs,
+            command.nowMs,
+            command.deviceId,
+            command.hlcPhysicalMs,
+            command.hlcCounter,
+            creationId,
+            expectedVersion,
+          ],
+        );
+        if (updated === undefined || integer(updated, "version") !== expectedVersion + 1)
+          throw new PlanCreationStoreError("version-conflict");
+        await recordCommand("plan_creation.activate", command, creationId, result);
+        return result;
       });
     },
     async discard({ command, creationId, expectedVersion }) {


### PR DESCRIPTION
## Summary

Adds `plan_creation.activate`, the local half of turning a reviewed Draft into the athlete's active Plan. Inside one transaction it checks admission (creation in review, current Draft, at least one Workout, expected version), closes any active Plan (`planning_plan` closed as stopped, legacy `plan` ended), writes the legacy `plan` row plus one `plan_workout` per dated Draft Workout, inserts the active `planning_plan` with revision 1 (`source_kind = activation`, snapshot = the full Draft including undated pool Workouts), marks the creation activated, and records the command so an identical replay returns the original Plan id. After activation the Chat card is gone, the target resolves to the active Plan, and the Plan readers show the new Plan.

Out of scope, deferred inside the same issue: calendar mirroring and reconciliation, the legacy writer fence (an open legacy Plan conversation still hides the new Plan in `getPlanState`), undated Workouts in the legacy Workout table.

## Verification

- Astra high verifier: no defect in admission, atomicity, replay, registration, or readers in the normal path; its one blocking finding is the legacy-coexistence case above, deferred to the fence PR by the execution cut.
- Root `pnpm check` clean; workspace tests for coach-contract, coach, kernel, kernel-node: 2590 passed, 1 skipped; oxlint clean.

| Limit | Value |
|---|---|
| Active Plans at once | 1 (`idx_planning_plan_one_active`) |
| Activation revision | 1, `source_kind = activation` |
| Client timeout for activate | 30000 ms |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
