### PR TITLE
feat(coach): list the Plan library in one read

### DIFF
--- a/.changeset/list-plans-for-library.md
+++ b/.changeset/list-plans-for-library.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/coach-contract": patch
+"@enduragent/coach": patch
+"@enduragent/coach-client": patch
+"@enduragent/kernel": patch
+---
+
+User-facing: The Plan page can now read your unfinished Plan creation, your active Plan, and your closed Plans together.

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
+import { ListPlansResultSchema } from "@enduragent/coach-contract";
 import type {
   CoachEngine,
   CoachOperations,
@@ -12,6 +13,7 @@ import type {
   OperationProgressEvent,
   PlanCreationOperations,
   PlanningOperations,
+  PlanningReadOperations,
   PlanningRequestOperations,
   PlanProgressEvent,
   TelegramControlSnapshot,
@@ -387,6 +389,7 @@ export async function launchDesktopFixture(input: {
   };
   const operations: CoachOperations &
     PlanningOperations &
+    PlanningReadOperations &
     PlanningRequestOperations &
     PlanCreationOperations = {
     async importFiles(request, onEvent) {
@@ -558,6 +561,9 @@ export async function launchDesktopFixture(input: {
       return finalFrame(await invoke("listPlanningRequests", request)) as Awaited<
         ReturnType<NonNullable<PlanningRequestOperations["listPlanningRequests"]>>
       >;
+    },
+    async "plan.list"(request) {
+      return ListPlansResultSchema.parse(finalFrame(await invoke("plan.list", request)));
     },
     async "plan_creation.start"(request) {
       return finalFrame(await invoke("plan_creation.start", request)) as Awaited<

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -1,4 +1,5 @@
 import {
+  ListPlansParamsSchema,
   PlanCreationActivateRpcParamsSchema,
   PlanCreationPreviewRpcParamsSchema,
   type CoachEngine,
@@ -128,7 +129,8 @@ export class PlanCreationBackend {
     this.script = {
       onRequest: async (value) => {
         const request = value as ScriptRequest;
-        if (request.method.startsWith("plan_creation.")) this.creationRequests.push(request);
+        if (request.method.startsWith("plan_creation.") || request.method === "plan.list")
+          this.creationRequests.push(request);
         if (coexistence && request.method === "listArchivedConversations") {
           return response({
             schemaVersion: 1,
@@ -205,6 +207,11 @@ export class PlanCreationBackend {
         if (readStoredPlans && request.method === "getPlanState") {
           return response(await this.planState());
         }
+        if (request.method === "plan.list") {
+          return response(
+            await this.requireHost()["plan.list"](ListPlansParamsSchema.parse(request.params)),
+          );
+        }
         if (request.method === "plan_creation.activate") {
           return response(
             await this.requireHost()["plan_creation.activate"](
@@ -272,6 +279,7 @@ export class PlanCreationBackend {
       { todayDateKey: () => 19980101 },
     );
     this.host = createPlanCreationOperations({
+      store: this.store,
       repository: this.repository,
       identity,
       crypto: globalThis.crypto,

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -143,6 +143,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   getArchivedTranscriptPage: 30_000,
   getAthleteState: 30_000,
   getPlanningReadModel: 30_000,
+  "plan.list": 30_000,
   getActivityAnalysis: 90_000,
   exportTrainingFile: 120_000,
   importFiles: 60 * 60_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -124,6 +124,7 @@ const rpcDeadlineCases = [
   ["getArchivedTranscriptPage", { boundaryRef: "a".repeat(64), cursor: null, limit: 25 }, 30_000],
   ["getAthleteState", {}, 30_000],
   ["getPlanningReadModel", {}, 30_000],
+  ["plan.list", {}, 30_000],
   [
     "getActivityAnalysis",
     { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
@@ -1029,6 +1030,7 @@ describe("RPC receive and observers", () => {
           plannedWorkouts: [],
           wellness: {},
         },
+        "plan.list": { creation: null, active: null, closed: [] },
         getPlanningReadModel: {
           schemaVersion: 1,
           status: "no-plan",

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PlanCreationCardModelSchema } from "./plan-creation.js";
 
 export const PlanDateKeySchema = z.number().int().min(1_000_101).max(99_991_231);
 
@@ -92,7 +93,31 @@ export type GetPlanningReadModelRpcParams = z.infer<typeof GetPlanningReadModelR
 export const GetPlanningReadModelRpcResultSchema = PlanningReadModelSchema;
 export type GetPlanningReadModelRpcResult = z.infer<typeof GetPlanningReadModelRpcResultSchema>;
 
+export const PlanSummarySchema = z.object({
+  planId: z.string().min(1),
+  name: z.string().min(1),
+  start: z.iso.date(),
+  end: z.iso.date(),
+  weeks: z.number().int().positive(),
+  status: z.enum(["active", "closed"]),
+  closeReason: z.enum(["stopped", "completed", "legacy-unclassified"]).nullable(),
+  closedAt: z.iso.date().nullable(),
+  activatedAt: z.iso.date().nullable(),
+  creationId: z.string().min(1).nullable(),
+}).strict();
+export type PlanSummary = z.infer<typeof PlanSummarySchema>;
+
+export const ListPlansParamsSchema = z.object({}).strict();
+export type ListPlansParams = z.infer<typeof ListPlansParamsSchema>;
+export const ListPlansResultSchema = z.object({
+  creation: PlanCreationCardModelSchema.nullable(),
+  active: PlanSummarySchema.extend({ status: z.literal("active") }).nullable(),
+  closed: z.array(PlanSummarySchema.extend({ status: z.literal("closed") })),
+}).strict();
+export type ListPlansResult = z.infer<typeof ListPlansResultSchema>;
+
 export interface PlanningReadOperations {
+  "plan.list"?(request: ListPlansParams): Promise<ListPlansResult>;
   getPlanningReadModel?(
     request: GetPlanningReadModelRpcParams,
   ): Promise<GetPlanningReadModelRpcResult>;

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -122,6 +122,8 @@ import {
 import {
   GetPlanningReadModelRpcParamsSchema,
   GetPlanningReadModelRpcResultSchema,
+  ListPlansParamsSchema,
+  ListPlansResultSchema,
   type PlanningReadOperations,
 } from "./planning-read.js";
 import {
@@ -272,6 +274,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "getArchivedTranscriptPage",
   "getAthleteState",
   "getPlanningReadModel",
+  "plan.list",
   "getActivityAnalysis",
   "exportTrainingFile",
   "importFiles",
@@ -1571,6 +1574,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
     .object({
       jsonrpc: z.literal("2.0"),
       id: JsonRpcIdSchema,
+      method: z.literal("plan.list"),
+      params: ListPlansParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
       method: z.literal("getActivityAnalysis"),
       params: ActivityAnalysisRequestSchema,
     })
@@ -2205,6 +2216,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "getPlanningReadModel",
     requestSchema: GetPlanningReadModelRpcParamsSchema,
     responseSchema: GetPlanningReadModelRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  "plan.list": {
+    wireName: "plan.list",
+    requestSchema: ListPlansParamsSchema,
+    responseSchema: ListPlansResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   getActivityAnalysis: {

--- a/packages/coach-contract/tests/planning-read-contract.test.ts
+++ b/packages/coach-contract/tests/planning-read-contract.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   GetPlanningReadModelRpcParamsSchema,
   PlanningReadModelSchema,
+  ListPlansParamsSchema,
+  ListPlansResultSchema,
+  PlanSummarySchema,
 } from "../src/index.js";
 
 describe("Planning read contract", () => {
@@ -49,5 +52,58 @@ describe("Planning read contract", () => {
       },
     };
     expect(PlanningReadModelSchema.safeParse(value).success).toBe(false);
+  });
+});
+
+describe("Plan library contract", () => {
+  const active = {
+    planId: "plan-active",
+    name: "Build fitness",
+    start: "1998-12-21",
+    end: "1999-01-17",
+    weeks: 4,
+    status: "active",
+    closeReason: null,
+    closedAt: null,
+    activatedAt: "1998-12-20",
+    creationId: "creation-active",
+  };
+
+  it("accepts the empty library and strict empty params", () => {
+    const empty = { creation: null, active: null, closed: [] };
+    expect(ListPlansParamsSchema.parse({})).toEqual({});
+    expect(ListPlansResultSchema.parse(empty)).toEqual(empty);
+    expect(ListPlansParamsSchema.safeParse({ planId: "extra" }).success).toBe(false);
+    expect(ListPlansResultSchema.safeParse({ ...empty, extra: true }).success).toBe(false);
+  });
+
+  it.each(["stopped", "completed", "legacy-unclassified"])("accepts %s closed history", (closeReason) => {
+    const closed = {
+      ...active,
+      planId: "plan-closed",
+      status: "closed",
+      closeReason,
+      closedAt: "1999-01-18",
+      activatedAt: null,
+      creationId: null,
+    };
+    const library = { creation: null, active, closed: [closed] };
+    expect(ListPlansResultSchema.parse(library)).toEqual(library);
+    expect(ListPlansResultSchema.safeParse({ ...library, active: closed }).success).toBe(false);
+    expect(ListPlansResultSchema.safeParse({ ...library, closed: [active] }).success).toBe(false);
+  });
+
+  it.each([
+    { start: 19981221 },
+    { end: "1999-02-30" },
+    { closedAt: "1999-01-18T12:00:00Z" },
+    { activatedAt: "1998-1-1" },
+    { weeks: 0 },
+    { status: "draft" },
+    { closeReason: "unknown" },
+    { creationId: "" },
+    { calendarStatus: "healthy" },
+  ])("rejects invalid summary fields %j", (fields) => {
+    expect(PlanSummarySchema.safeParse({ ...active, ...fields }).success).toBe(false);
   });
 });

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1325,6 +1325,7 @@ describe("coach request and event projection", () => {
         asOfDateKey: 20260826,
         plan: null,
       }),
+      "plan.list": async () => ({ creation: null, active: null, closed: [] }),
       getActivityAnalysis: async () => {
         throw new Error("not exercised by registry exhaustiveness");
       },

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -873,6 +873,7 @@ export async function createLocalCoachComposition(
   const planningIdentity = createAuthoredIdentity(input.home.configDir, { now });
   const planningTimezone = resolveUserTimezone(input.config.session.timezone);
   const planCreationOperations = createPlanCreationOperations({
+    store: input.context.store,
     repository: createPlanCreationRepository(input.context.store),
     identity: planningIdentity,
     crypto: globalThis.crypto,
@@ -2248,6 +2249,7 @@ export async function createLocalCoachComposition(
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
       ...planningRequestOperations,
+      "plan.list": planCreationOperations["plan.list"],
       "plan_creation.start": planCreationOperations["plan_creation.start"],
       "plan_creation.answer": planCreationOperations["plan_creation.answer"],
       "plan_creation.preview": planCreationOperations["plan_creation.preview"],

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -528,6 +528,7 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "getArchivedTranscriptPage",
   "getAthleteState",
   "getPlanningReadModel",
+  "plan.list",
   "getActivityAnalysis",
   "importFiles",
   "sync",
@@ -1346,6 +1347,19 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 throw new TypeError("Planning read operation is unavailable.");
               }
               result = await input.operations.getPlanningReadModel(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "plan.list":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY["plan.list"].requestSchema.parse(
+                generic.data.params,
+              );
+              if (input.operations["plan.list"] === undefined) {
+                throw new TypeError("Plan library operation is unavailable.");
+              }
+              result = await input.operations["plan.list"](request);
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import {
+  ListPlansParamsSchema,
+  ListPlansResultSchema,
+  type ListPlansParams,
+  type ListPlansResult,
   PlanCreationActivateRpcParamsSchema,
   PlanCreationActivateRpcResultSchema,
   PlanCreationAnswerRpcParamsSchema,
@@ -17,6 +21,8 @@ import {
 import { buildCreationDraft } from "@enduragent/sport-cycling";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import {
+  addCivilDays,
+  createPlanRepository,
   dateKeyFromText,
   inclusiveCivilDays,
   MIN_FULL_PLAN_DAYS,
@@ -25,6 +31,7 @@ import {
   type PlanCreationRepository,
   type PlanCreationSnapshot,
 } from "@enduragent/kernel/planning";
+import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import {
   encodePlanCreationAnswer,
@@ -54,6 +61,7 @@ export function expectedPlanCreationAnswerKind(
 }
 
 export interface PlanCreationHost extends PlanCreationOperations {
+  "plan.list"(request: ListPlansParams): Promise<ListPlansResult>;
   readCard(): Promise<PlanCreationCardModel | null>;
 }
 
@@ -70,6 +78,7 @@ const PreviewInputDateSchema = z.object({ today: z.iso.date() });
 const defaultBaselineEvidence: BaselineEvidenceSource = { read: async () => undefined };
 
 export function createPlanCreationOperations(input: {
+  store: SqlStore & Pick<MigratorStore, "transaction">;
   repository: PlanCreationRepository;
   identity: AuthoredIdentity;
   crypto: Crypto;
@@ -77,6 +86,7 @@ export function createPlanCreationOperations(input: {
   baselineEvidence?: BaselineEvidenceSource;
   today?: () => string;
 }): PlanCreationHost {
+  const plans = createPlanRepository(input.store);
   const baselineEvidence = input.baselineEvidence ?? defaultBaselineEvidence;
   const today = input.today ?? (() => new Date().toISOString().slice(0, 10));
   const stamp = async (commandId: string, digest: string) => {
@@ -140,6 +150,37 @@ export function createPlanCreationOperations(input: {
     return snapshot === undefined ? null : project(snapshot);
   };
   return {
+    async "plan.list"(request) {
+      ListPlansParamsSchema.parse(request);
+      return input.store.transaction(async () => {
+        const creation = await input.repository.readUnfinished();
+        const records = await plans.listPlans();
+        const dateText = (dateKey: number): string => {
+          const digits = String(dateKey).padStart(8, "0");
+          return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+        };
+        const timestampDate = (value: number | null): string | null =>
+          value === null ? null : new Date(value).toISOString().slice(0, 10);
+        const summaries = records.map((plan) => ({
+          planId: plan.planId,
+          name: plan.name,
+          start: dateText(plan.startDateKey),
+          end: dateText(addCivilDays(plan.startDateKey, plan.totalWeeks * 7 - 1)),
+          weeks: plan.totalWeeks,
+          status: plan.status,
+          closeReason: plan.closeReason,
+          closedAt: timestampDate(plan.closedAtMs),
+          activatedAt: timestampDate(plan.activatedAtMs),
+          creationId: plan.creationId,
+        }));
+        return ListPlansResultSchema.parse({
+          creation:
+            creation === undefined ? null : projectPlanCreationCard(creation, { today: today() }),
+          active: summaries.find((plan) => plan.status === "active") ?? null,
+          closed: summaries.filter((plan) => plan.status === "closed"),
+        });
+      });
+    },
     async "plan_creation.start"(request) {
       const parsed = PlanCreationStartRpcParamsSchema.parse(request);
       const current = await input.repository.readUnfinished();

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -209,6 +209,7 @@ const operations: CoachOperations & PlanningReadOperations & PlanCreationOperati
     turns: [],
     nextCursor: null,
   }),
+  "plan.list": async () => ({ creation: null, active: null, closed: [] }),
   getPlanningReadModel: async () => ({
     schemaVersion: 1,
     status: "no-plan",
@@ -848,6 +849,10 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       }),
       operations: {
         ...operations,
+        "plan.list": async () => {
+          calls.push("plan.list");
+          return { creation: null, active: null, closed: [] };
+        },
         getPlanningReadModel: async () => {
           calls.push("getPlanningReadModel");
           return { schemaVersion: 1, status: "no-plan", asOfDateKey: 20260826, plan: null };
@@ -938,6 +943,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       { id: 40, method: "retryQueuedTurn", params: { chatId: "chat", claimId: "claim-1" } },
       { id: 4, method: "getAthleteState", params: {} },
       { id: 41, method: "getPlanningReadModel", params: {} },
+      { id: 42, method: "plan.list", params: {} },
       {
         id: 5,
         method: "getActivityAnalysis",
@@ -975,6 +981,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       "retryQueuedTurn:chat",
       "getAthleteState",
       "getPlanningReadModel",
+      "plan.list",
       "getActivityAnalysis",
       "exportTrainingFile",
     ]);
@@ -2264,7 +2271,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     },
   );
 
-  it("dispatches strict Plan Creation operations for the renderer", async () => {
+  it("dispatches strict Plan library and creation operations for the renderer", async () => {
     const token = "x".repeat(43);
     const creationId = "01J00000000000000000000000";
     const startedCard: PlanCreationCardModel = {
@@ -2393,6 +2400,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       closedPlanId: null,
       activatedAt: "1998-09-07",
     };
+    const listPlans = vi.fn(async () => ({ creation: startedCard, active: null, closed: [] }));
     const activatePlanCreation = vi.fn<PlanCreationOperations["plan_creation.activate"]>(
       async () => activationResult,
     );
@@ -2400,6 +2408,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       engine: engine(),
       operations: {
         ...operations,
+        "plan.list": listPlans,
         "plan_creation.start": startPlanCreation,
         "plan_creation.answer": answerPlanCreation,
         "plan_creation.preview": previewPlanCreation,
@@ -2457,6 +2466,12 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         params: activateParams,
         result: activationResult,
       },
+      {
+        id: "list",
+        method: "plan.list",
+        params: {},
+        result: { creation: startedCard, active: null, closed: [] },
+      },
     ]) {
       renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
       expect(parseCoachRpcEnvelope(await renderer.frames.next())).toEqual({
@@ -2470,6 +2485,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(previewPlanCreation).toHaveBeenCalledWith(previewParams);
     expect(discardPlanCreation).toHaveBeenCalledWith(discardParams);
     expect(activatePlanCreation).toHaveBeenCalledWith(activateParams);
+    expect(listPlans).toHaveBeenCalledWith({});
 
     for (const request of [
       {
@@ -2496,6 +2512,11 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         id: "invalid-activate",
         method: "plan_creation.activate",
         params: { ...activateParams, extra: true },
+      },
+      {
+        id: "invalid-list",
+        method: "plan.list",
+        params: { extra: true },
       },
     ]) {
       renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -27,6 +27,12 @@ import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import { createPlanningReadService } from "../src/planning-read-service.js";
 import { readPlanCreationAnswers } from "../src/plan-creation-answers.js";
 
+const unusedStore = () => {
+  const store = openSqliteStorage(":memory:");
+  onTestFinished(() => store.close());
+  return store;
+};
+
 const id = (value: string) => `${"0".repeat(26 - value.length)}${value}`;
 const today = "1998-09-02";
 const eventCandidate = {
@@ -172,6 +178,7 @@ function harness(
     },
   };
   const host = createPlanCreationOperations({
+    store: unusedStore(),
     repository,
     identity: {
       deviceId: async () => "test-device",
@@ -660,6 +667,7 @@ describe("Plan Creation operations", () => {
     });
     let sequence = 8;
     const host = createPlanCreationOperations({
+      store: unusedStore(),
       repository: {
         activate: async () => {
           throw new Error("unused");
@@ -758,6 +766,7 @@ describe("Plan Creation operations", () => {
       return { outcome: "discarded" };
     });
     const host = createPlanCreationOperations({
+      store: unusedStore(),
       repository: {
         activate: async () => {
           throw new Error("unused");
@@ -853,6 +862,7 @@ async function previewHarness() {
   const repository = createPlanCreationRepository(store);
   let sequence = 100;
   const host = createPlanCreationOperations({
+    store,
     repository,
     identity: {
       deviceId: async () => "preview-test-device",
@@ -1084,6 +1094,94 @@ describe("Plan Creation activation", () => {
       },
     };
   };
+
+  it("reads one snapshot while replacing the active Plan", async () => {
+    const test = await review();
+    const incumbentId = id("800");
+    await createPlanRepository(test.store).replace({
+      id: incumbentId,
+      originId: null,
+      name: "Earlier Plan",
+      primaryGoal: "Build fitness",
+      startDateKey: 19971222,
+      targetDateKey: 19980118,
+      status: "active",
+      kind: "short_race_preparation",
+      totalWeeks: 4,
+      weekStartDay: 1,
+      structureJson: "{}",
+      createdAtMs: 882_748_800_000,
+      updatedAtMs: 882_748_800_000,
+      deviceId: "test-device",
+      hlcPhysicalMs: 882_748_800_000,
+      hlcCounter: 0,
+    }, []);
+    await test.store.run(
+      `INSERT INTO planning_plan
+(plan_id,status,version,current_revision_number,activated_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
+      [incumbentId],
+    );
+    const transaction = vi.spyOn(test.store, "transaction");
+    const readUnfinished = test.repository.readUnfinished.bind(test.repository);
+    let signalEntered = () => {};
+    let releaseRead = () => {};
+    const entered = new Promise<void>((resolve) => {
+      signalEntered = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const reader = vi.spyOn(test.repository, "readUnfinished").mockImplementationOnce(async () => {
+      const creation = await readUnfinished();
+      signalEntered();
+      await released;
+      return creation;
+    });
+    const before = test.host["plan.list"]({});
+    await entered;
+    expect(transaction).toHaveBeenCalledTimes(1);
+    const activation = test.host["plan_creation.activate"](test.request);
+    await vi.waitFor(() => expect(transaction).toHaveBeenCalledTimes(2));
+    releaseRead();
+    await expect(before).resolves.toMatchObject({
+      creation: { creationId: test.request.creationId, status: "review" },
+      active: { planId: incumbentId, start: "1997-12-22", end: "1998-01-18", creationId: null },
+      closed: [],
+    });
+    const activated = await activation;
+    reader.mockRestore();
+    transaction.mockClear();
+    const after = await test.host["plan.list"]({});
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(after).toEqual({
+      creation: null,
+      active: {
+        planId: activated.planId,
+        name: "Improve fitness",
+        start: test.draft.start,
+        end: test.draft.end,
+        weeks: 4,
+        status: "active",
+        closeReason: null,
+        closedAt: null,
+        activatedAt: "1998-01-01",
+        creationId: test.request.creationId,
+      },
+      closed: [{
+        planId: incumbentId,
+        name: "Earlier Plan",
+        start: "1997-12-22",
+        end: "1998-01-18",
+        weeks: 4,
+        status: "closed",
+        closeReason: "stopped",
+        closedAt: "1998-01-01",
+        activatedAt: "1997-12-22",
+        creationId: null,
+      }],
+    });
+  });
 
   it("activates dated Workouts, removes the Chat card, and exposes the Plan to readers", async () => {
     const test = await review();

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -256,6 +256,7 @@ describe("Plan operations", () => {
       hlcStamp: () => ({ physicalMs: 904_780_800_000, counter: 0 }),
     };
     const creation = createPlanCreationOperations({
+      store,
       repository: createPlanCreationRepository(store),
       identity: authored,
       crypto: globalThis.crypto,

--- a/packages/engine/tests/planning/workout-drift.test.ts
+++ b/packages/engine/tests/planning/workout-drift.test.ts
@@ -130,6 +130,7 @@ function planRepository(): PlanRepository {
     read: vi.fn(async () => plan),
     readByOriginId: vi.fn(),
     readLatest: vi.fn(async () => plan),
+    listPlans: vi.fn(async () => []),
     readWorkouts: vi.fn(async () => [workout]),
     count: vi.fn(async () => 1),
     delete: vi.fn(),

--- a/packages/kernel-node/tests/plan-library-repository.test.ts
+++ b/packages/kernel-node/tests/plan-library-repository.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPlanRepository, type PlanSummaryRecord } from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const id = (value: string) => value.padStart(26, "0");
+const activatedAtMs = 883_612_800_000;
+
+describe("Plan library repository", () => {
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => store.close());
+
+  async function seed(input: {
+    key: string;
+    closeReason?: Exclude<PlanSummaryRecord["closeReason"], null>;
+    closedAtMs?: number;
+    revisionKind?: "activation" | "migration";
+  }): Promise<PlanSummaryRecord> {
+    const planId = id(input.key);
+    const closeReason = input.closeReason ?? null;
+    const closedAtMs = input.closedAtMs ?? null;
+    const status = closeReason === null ? "active" : "closed";
+    await createPlanRepository(store).replace(
+      {
+        id: planId,
+        originId: null,
+        name: `Endurance Plan ${input.key}`,
+        primaryGoal: "Build endurance",
+        startDateKey: 19980101,
+        targetDateKey: null,
+        status: status === "active" ? "active" : "ended",
+        kind: "full_plan",
+        totalWeeks: 12,
+        weekStartDay: 4,
+        structureJson: "{}",
+        createdAtMs: activatedAtMs,
+        updatedAtMs: closedAtMs ?? activatedAtMs,
+        deviceId: "test-device",
+        hlcPhysicalMs: activatedAtMs,
+        hlcCounter: 0,
+      },
+      [],
+    );
+    await store.run(
+      `INSERT INTO planning_plan (plan_id,status,version,current_revision_number,
+       activated_at_ms,closed_at_ms,close_reason,close_actor,updated_at_ms,
+       device_id,hlc_physical_ms,hlc_counter) VALUES (?,?,1,1,?,?,?,?,?,'test-device',?,0)`,
+      [
+        planId,
+        status,
+        activatedAtMs,
+        closedAtMs,
+        closeReason,
+        closeReason === "completed"
+          ? "system:plan-completion"
+          : closeReason === "stopped"
+            ? "athlete"
+            : null,
+        closedAtMs ?? activatedAtMs,
+        activatedAtMs,
+      ],
+    );
+    const creationId = input.revisionKind === "activation" ? id(`C${input.key}`) : null;
+    if (input.revisionKind !== undefined) {
+      await store.run(
+        `INSERT INTO plan_revision (id,plan_id,revision_number,parent_revision_number,
+         source_kind,source_id,snapshot_json,fingerprint,created_at_ms,
+         device_id,hlc_physical_ms,hlc_counter) VALUES (?,?,1,NULL,?,?,'{}',?,?,'test-device',?,0)`,
+        [
+          id(`R${input.key}`),
+          planId,
+          input.revisionKind,
+          creationId,
+          "f".repeat(64),
+          activatedAtMs,
+          activatedAtMs,
+        ],
+      );
+    }
+    return {
+      planId,
+      name: `Endurance Plan ${input.key}`,
+      startDateKey: 19980101,
+      totalWeeks: 12,
+      status,
+      closeReason,
+      closedAtMs,
+      activatedAtMs,
+      creationId,
+    };
+  }
+
+  it("returns no summaries when no Plans exist", async () => {
+    await expect(createPlanRepository(store).listPlans()).resolves.toEqual([]);
+  });
+
+  it("reads one active Plan with its activation creation lineage", async () => {
+    const active = await seed({ key: "1", revisionKind: "activation" });
+    await expect(createPlanRepository(store).listPlans()).resolves.toEqual([active]);
+  });
+
+  it("orders closed Plans by closure date with stable ties and preserves missing activation lineage", async () => {
+    const oldest = await seed({
+      key: "3",
+      closeReason: "legacy-unclassified",
+      closedAtMs: activatedAtMs + 86_400_000,
+      revisionKind: "migration",
+    });
+    const stopped = await seed({
+      key: "2",
+      closeReason: "stopped",
+      closedAtMs: activatedAtMs + 172_800_000,
+      revisionKind: "activation",
+    });
+    const completed = await seed({
+      key: "1",
+      closeReason: "completed",
+      closedAtMs: activatedAtMs + 172_800_000,
+    });
+    const repository = createPlanRepository(store);
+    await expect(repository.listPlans()).resolves.toEqual([completed, stopped, oldest]);
+    const active = await seed({ key: "4" });
+    const queries = vi.spyOn(store, "all");
+    const individualReads = vi.spyOn(store, "get");
+    await expect(repository.listPlans()).resolves.toEqual([active, completed, stopped, oldest]);
+    expect(queries).toHaveBeenCalledTimes(1);
+    expect(individualReads).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kernel/src/planning/repository.ts
+++ b/packages/kernel/src/planning/repository.ts
@@ -46,6 +46,18 @@ export interface PlanWorkoutRecord {
   readonly hlcCounter: number;
 }
 
+export interface PlanSummaryRecord {
+  readonly planId: string;
+  readonly name: string;
+  readonly startDateKey: number;
+  readonly totalWeeks: number;
+  readonly status: "active" | "closed";
+  readonly closeReason: "stopped" | "completed" | "legacy-unclassified" | null;
+  readonly closedAtMs: number | null;
+  readonly activatedAtMs: number | null;
+  readonly creationId: string | null;
+}
+
 export type PlanValidationErrorCode =
   | "invalid-id"
   | "invalid-origin-id"
@@ -86,6 +98,7 @@ export interface PlanRepository {
   read(id: string): Promise<PlanRecord | undefined>;
   readByOriginId(originId: string): Promise<PlanRecord | undefined>;
   readLatest(): Promise<PlanRecord | undefined>;
+  listPlans(): Promise<readonly PlanSummaryRecord[]>;
   readWorkouts(planId: string): Promise<readonly PlanWorkoutRecord[]>;
   endActive(input: EndActivePlanInput): Promise<EndActivePlanResult>;
   count(): Promise<number>;
@@ -273,6 +286,33 @@ function workoutFromRow(row: Row): PlanWorkoutRecord {
   });
 }
 
+function planSummaryFromRow(row: Row): PlanSummaryRecord {
+  const status = text(row, "status");
+  const closeReason = nullableText(row, "close_reason");
+  if (status !== "active" && status !== "closed") {
+    throw new PlanValidationError("invalid-status");
+  }
+  if (
+    closeReason !== null &&
+    closeReason !== "stopped" &&
+    closeReason !== "completed" &&
+    closeReason !== "legacy-unclassified"
+  ) {
+    throw new PlanValidationError("invalid-json");
+  }
+  return Object.freeze({
+    planId: text(row, "plan_id"),
+    name: text(row, "name"),
+    startDateKey: integer(row, "start_date_key"),
+    totalWeeks: integer(row, "total_weeks"),
+    status,
+    closeReason,
+    closedAtMs: nullableInteger(row, "closed_at_ms"),
+    activatedAtMs: nullableInteger(row, "activated_at_ms"),
+    creationId: nullableText(row, "creation_id"),
+  });
+}
+
 export function createPlanRepository(store: PlanningStore): PlanRepository {
   const replace = async (
     plan: PlanRecord,
@@ -373,6 +413,20 @@ ON CONFLICT (id) DO UPDATE SET
         "SELECT * FROM plan ORDER BY updated_at_ms DESC, hlc_physical_ms DESC, hlc_counter DESC, id DESC LIMIT 1",
       );
       return row === undefined ? undefined : planFromRow(row);
+    },
+    async listPlans() {
+      const rows = await store.all(
+        `SELECT planning_plan.plan_id, plan.name, plan.start_date_key, plan.total_weeks,
+                planning_plan.status, planning_plan.close_reason, planning_plan.closed_at_ms,
+                planning_plan.activated_at_ms, plan_revision.source_id AS creation_id
+         FROM planning_plan
+         JOIN plan ON plan.id = planning_plan.plan_id
+         LEFT JOIN plan_revision ON plan_revision.plan_id = planning_plan.plan_id
+           AND plan_revision.source_kind = 'activation'
+         ORDER BY planning_plan.status = 'active' DESC,
+                  planning_plan.closed_at_ms DESC, planning_plan.plan_id ASC`,
+      );
+      return rows.map(planSummaryFromRow);
     },
     async readWorkouts(planId: string) {
       if (!ULID.test(planId)) throw new PlanValidationError("invalid-id");


### PR DESCRIPTION
## Summary

Adds `plan.list`, one read that returns the unfinished Plan creation card, the active Plan summary, and closed Plan summaries (name, start, end, weeks, status, close reason, closed date, activation date, originating creation) from a single transaction, so the Plan page can render the library without a request per row. The Plans come from one query joining `planning_plan` to the legacy `plan` row and the activation revision, active first, then closed by close time.

Out of scope, deferred inside the same issue: calendar status per Plan, closed-Plan detail, pagination, the renderer.

## Verification

- Astra high verifier: pass, no findings.
- Root `pnpm check` clean; workspace tests for coach-contract, coach, coach-client, kernel, kernel-node: 2608 passed, 1 skipped; oxlint clean.

| Limit | Value |
|---|---|
| Queries per `plan.list` | 1 for Plans plus the creation read, one transaction |
| Client timeout | 30000 ms |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
