### PR TITLE
feat(desktop): show the Plan library and route into Main Chat

### DIFF
--- a/.changeset/tender-papayas-train.md
+++ b/.changeset/tender-papayas-train.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Find your unfinished Plan creation, active Plan, and closed Plans together on the Plan page. Start or continue creating a Plan and return to Chat from there.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -14,7 +14,7 @@ import { createArchiveViewAdapter } from "./state/adapters/archive";
 import { createChatViewAdapter } from "./state/adapters/chat";
 import { createFirstSyncViewAdapter } from "./state/adapters/first-sync";
 import { createOnboardingViewAdapter } from "./state/adapters/onboarding";
-import { createPlanViewAdapter } from "./state/adapters/plan";
+import { createPlanViewAdapter, listPlans } from "./state/adapters/plan";
 import { createRideImportAdapter } from "./state/adapters/ride-import";
 import {
   createAthleteSettingsAdapter,
@@ -56,6 +56,7 @@ import { createRideImportController, subscribeToDroppedRideImports } from "./rid
 import { createTrainingExportController } from "./training-export/controller";
 import { settleInitialSetupStatus } from "./initial-setup-status";
 import { createPlanController } from "./plan/controller";
+import { subscribePlanLibraryRefresh } from "./plan/library-refresh";
 
 export type Disposer = () => void;
 
@@ -75,6 +76,19 @@ export function onboardingCredentialMutationsBlocked(
 
 export function bootRenderer(): Disposer {
   const store = useEnduragentStore;
+  const planReturnStorageKey = "enduragent.plan.return-on-launch";
+  try {
+    if (window.localStorage.getItem(planReturnStorageKey) === "true") {
+      store.getState().setActiveView("plan");
+    }
+  } catch {}
+  const disposePlanReturn = store.subscribe((state, previousState) => {
+    if (state.activeView === previousState.activeView) return;
+    try {
+      if (state.activeView === "plan") window.localStorage.setItem(planReturnStorageKey, "true");
+      else window.localStorage.removeItem(planReturnStorageKey);
+    } catch {}
+  });
   const platform = rendererPlatformProjection(window.enduragentAuth.platform);
   store.getState().setOnboardingStartupSettled(false);
   const onLifecycle = (event: WindowEventMap["enduragent-lifecycle"]): void => {
@@ -133,6 +147,8 @@ export function bootRenderer(): Disposer {
     view: trainingAdapter.view,
   });
   const planController = createPlanController({
+    listPlans: () => listPlans(clients),
+    renderLibrary: (next) => store.getState().setPlanLibrary(next),
     read: () => window.enduragentAuth.getPlanningReadModel(),
     render: (next) => store.getState().setPlanSurface(next),
     navigate: (view) => store.getState().setActiveView(view),
@@ -177,12 +193,13 @@ export function bootRenderer(): Disposer {
   const chatController = createChatController({
     clients,
     view: chatAdapter.view,
+    openChat: () => store.getState().setActiveView("chat"),
     refreshTrainingContext: async () => {
       await Promise.all([trainingContextController.refresh(), planController.refresh()]);
     },
     refreshSpend: () => spendController.refresh(),
     refreshPlan: async () => {
-      await planController.refresh();
+      await planController.refresh(true);
       try {
         const hydration = await window.enduragentAuth.getPlanState();
         store.getState().setPlanHydration(hydration);
@@ -211,6 +228,22 @@ export function bootRenderer(): Disposer {
   const disposeSetupReadiness = store.subscribe((state, previousState) => {
     if (!setupReady(previousState) && setupReady(state)) void chatController.resume();
   });
+  store.getState().bindPlanLibraryActions({
+    startCreation: () => {
+      chatController.resumeCreation(store.getState().planLibrary.value?.creation ?? null);
+      store.getState().setActiveView("chat");
+      void chatController.startPlanCreation();
+    },
+    continueCreation: (creation) => {
+      void chatController.continueCreationFromLibrary(creation.creationId);
+    },
+    changeInChat: () => {
+      chatController.pausePlanCreation();
+      store.getState().setActiveView("chat");
+      requestAnimationFrame(focusComposer);
+    },
+  });
+  const disposePlanLibraryRefresh = subscribePlanLibraryRefresh(planController);
   const disposePlanToChatRefresh = store.subscribe((state, previousState) => {
     if (previousState.activeView === "plan" && state.activeView === "chat") {
       chatController.refreshPlanningRequests();
@@ -659,7 +692,10 @@ export function bootRenderer(): Disposer {
     store.getState().bindOnboardingActions(null);
     disposeRideAnalysisSelection();
     disposeSetupReadiness();
+    disposePlanReturn();
     disposePlanToChatRefresh();
+    disposePlanLibraryRefresh();
+    store.getState().bindPlanLibraryActions(null);
     window.removeEventListener("enduragent-lifecycle", onLifecycle);
     window.removeEventListener("pagehide", dispose);
     desktopUpdateController.dispose();

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -54,6 +54,8 @@ export type ActivePlanKnowledge =
   | { readonly kind: "none" }
   | { readonly kind: "active"; readonly name: string };
 
+export const CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY =
+  "This creation is no longer unfinished. Open the Plan library for its current result.";
 export const CHAT_CONNECTION_INTERRUPTED_COPY =
   "Connection interrupted. Your partial response is preserved.";
 export const CHAT_RESPONSE_STOPPED_COPY = "Response stopped. Your partial response is preserved.";
@@ -237,6 +239,8 @@ export interface ChatController {
   refreshPlanningRequests(): void;
   focusPlanningRequest(requestId: string): void;
   clearPlanningRequestFocus(): void;
+  resumeCreation(model: PlanCreationCardModel | null): void;
+  continueCreationFromLibrary(creationId: string): Promise<void>;
   startPlanCreation(): Promise<void>;
   answerPlanCreation(answer: PlanCreationAnswerInput): Promise<void>;
   buildPlanCreationDraft(): Promise<void>;
@@ -316,6 +320,7 @@ export function createChatController(input: {
   readonly refreshTrainingContext: () => Promise<void>;
   readonly refreshSpend: () => Promise<void>;
   readonly refreshPlan?: () => Promise<void>;
+  readonly openChat?: () => void;
   readonly readTranscriptPage?: (request: {
     readonly cursor: string | null;
     readonly limit: number;
@@ -2020,6 +2025,57 @@ export function createChatController(input: {
       planningRequestFocusId = null;
       render();
     },
+    resumeCreation(model) {
+      if (disposed || planCreationBusy) return;
+      installPlanCreation(model);
+      planCreationLoaded = true;
+      planCreationEditingKey = null;
+      clearPlanCreationPause();
+      planCreationPaused = false;
+      planCreationFocusRevision += 1;
+      if (planCreation?.draft !== null && planCreation?.draft !== undefined) {
+        requestPlanCreationFocus("activate");
+      }
+      render();
+    },
+    async continueCreationFromLibrary(creationId) {
+      if (disposed || planCreationBusy) return;
+      planCreationBusy = true;
+      planCreationError = null;
+      planCreationNotice = null;
+      render();
+      try {
+        const result = await (
+          await input.clients.getClient()
+        ).call("listPlanningRequests", {
+          chatId: DESKTOP_CHAT_ID,
+        });
+        if (disposed) return;
+        if (result.planCreation?.creationId !== creationId) {
+          planCreationNotice = CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY;
+          render();
+          await input.refreshPlan?.();
+          if (disposed) return;
+          installPlanCreation(result.planCreation);
+          planCreationLoaded = true;
+          return;
+        }
+        input.openChat?.();
+        installPlanCreation(result.planCreation);
+        planCreationLoaded = true;
+        planCreationEditingKey = null;
+        clearPlanCreationPause();
+        planCreationPaused = false;
+        planCreationFocusRevision += 1;
+        if (result.planCreation.draft !== null) requestPlanCreationFocus("activate");
+        render();
+      } catch {
+        planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
+      } finally {
+        planCreationBusy = false;
+        render();
+      }
+    },
     async startPlanCreation() {
       if (
         disposed ||
@@ -2257,6 +2313,7 @@ export function createChatController(input: {
         pendingPlanCreationCommand = null;
         planCreationDiscardConfirmationOpen = false;
         if (result.status === "discarded") {
+          input.openChat?.();
           installPlanCreation(null, "start");
           if (!planCreationDiscardEvents.some((event) => event.eventId === target.creationId)) {
             planCreationDiscardEvents = [

--- a/apps/desktop-renderer/src/plan/controller.ts
+++ b/apps/desktop-renderer/src/plan/controller.ts
@@ -1,15 +1,21 @@
-import type { PlanNavigationTarget, PlanningReadModel } from "@enduragent/coach-contract";
-import type { PlanReadSurfaceState } from "../state/plan-slice";
+import type {
+  ListPlansResult,
+  PlanNavigationTarget,
+  PlanningReadModel,
+} from "@enduragent/coach-contract";
+import type { PlanLibraryState, PlanReadSurfaceState } from "../state/plan-slice";
 
 export interface PlanController {
   start(): Promise<void>;
-  refresh(): Promise<void>;
+  refresh(afterPending?: boolean): Promise<void>;
   openFromChat(target: PlanNavigationTarget): void;
   backToChat(): void;
   dispose(): void;
 }
 
 export function createPlanController(input: {
+  readonly listPlans: () => Promise<ListPlansResult>;
+  readonly renderLibrary: (state: PlanLibraryState) => void;
   readonly read: () => Promise<PlanningReadModel>;
   readonly render: (state: PlanReadSurfaceState) => void;
   readonly navigate: (view: "chat" | "plan") => void;
@@ -17,12 +23,24 @@ export function createPlanController(input: {
 }): PlanController {
   let disposed = false;
   let value: PlanningReadModel | null = null;
+  let library: ListPlansResult | null = null;
   let pending: Promise<void> | undefined;
 
-  const refresh = (): Promise<void> => {
-    if (pending !== undefined) return pending;
+  const refresh = (afterPending = false): Promise<void> => {
+    if (disposed) return Promise.resolve();
+    if (pending !== undefined) return afterPending ? pending.then(() => refresh()) : pending;
     input.render(value === null ? { status: "loading", value: null } : { status: "ready", value });
-    const task = input
+    const list = input
+      .listPlans()
+      .then((next) => {
+        if (disposed) return;
+        library = next;
+        input.renderLibrary({ status: "ready", value: next });
+      })
+      .catch(() => {
+        if (!disposed) input.renderLibrary({ status: "unavailable", value: library });
+      });
+    const read = input
       .read()
       .then((next) => {
         if (disposed) return;
@@ -31,7 +49,9 @@ export function createPlanController(input: {
       })
       .catch(() => {
         if (!disposed) input.render({ status: "unavailable", value });
-      })
+      });
+    const task = Promise.all([read, list])
+      .then(() => undefined)
       .finally(() => {
         if (pending === task) pending = undefined;
       });

--- a/apps/desktop-renderer/src/plan/library-refresh.ts
+++ b/apps/desktop-renderer/src/plan/library-refresh.ts
@@ -1,0 +1,34 @@
+import { planReadModel } from "../state/plan-slice";
+import { useEnduragentStore } from "../state/store";
+import type { PlanController } from "./controller";
+
+export function subscribePlanLibraryRefresh(controller: PlanController): () => void {
+  return useEnduragentStore.subscribe((state, previousState) => {
+    const creation = state.chat.planCreation;
+    const previousCreation = previousState.chat.planCreation;
+    const creationChanged =
+      creation?.creationId !== previousCreation?.creationId ||
+      creation?.version !== previousCreation?.version;
+    const plan = planReadModel(state.plan);
+    const previousPlan = planReadModel(previousState.plan);
+    const activePlanId = plan?.lifecycle === "active" ? plan.planId : null;
+    const previousActivePlanId = previousPlan?.lifecycle === "active" ? previousPlan.planId : null;
+    const library = state.planLibrary.value;
+    const creationNeedsRefresh =
+      creationChanged &&
+      (library === null ||
+        creation?.creationId !== library.creation?.creationId ||
+        creation?.version !== library.creation?.version);
+    const activePlanNeedsRefresh =
+      activePlanId !== previousActivePlanId && activePlanId !== (library?.active?.planId ?? null);
+    if (
+      (state.activeView === "plan" && previousState.activeView !== "plan") ||
+      creationNeedsRefresh ||
+      activePlanNeedsRefresh
+    )
+      void controller.refresh(
+        (creationNeedsRefresh && previousState.chat.planCreationLoaded) ||
+          (activePlanNeedsRefresh && previousPlan !== null),
+      );
+  });
+}

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -7,6 +7,7 @@ import {
   type ExecutePlanTransitionRpcResult,
   type GetPlanStateRpcResult,
   type PlanError,
+  type ListPlansResult,
   type PlanHydrationState,
   type PlanProgressEvent,
   type PlanReadModel,
@@ -23,6 +24,10 @@ import type { ChatSurfaceState } from "../chat-slice";
 import type { PlanSurfaceState, PlanTransitionState } from "../plan-slice";
 import { planReadModel } from "../plan-slice";
 import { createChatViewAdapter } from "./chat";
+
+export async function listPlans(clients: DesktopCoachClientProvider): Promise<ListPlansResult> {
+  return (await clients.getClient()).call("plan.list", {});
+}
 
 export interface PlanBridge {
   getPlanState(): Promise<GetPlanStateRpcResult>;

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -1,5 +1,7 @@
 import type {
   CoachDecisionAnswer,
+  ListPlansResult,
+  PlanCreationCardModel,
   PlanError,
   PlanHydrationState,
   PlanNavigationTarget,
@@ -52,6 +54,17 @@ export type PlanReadSurfaceState =
   | { readonly status: "loading"; readonly value: null }
   | { readonly status: "ready"; readonly value: PlanningReadModel }
   | { readonly status: "unavailable"; readonly value: PlanningReadModel | null };
+
+export type PlanLibraryState =
+  | { readonly status: "loading"; readonly value: null }
+  | { readonly status: "ready"; readonly value: ListPlansResult }
+  | { readonly status: "unavailable"; readonly value: ListPlansResult | null };
+
+export interface PlanLibraryActions {
+  startCreation(): void;
+  continueCreation(creation: PlanCreationCardModel): void;
+  changeInChat(): void;
+}
 
 export interface PlanningReadActions {
   refresh(): void;
@@ -144,6 +157,10 @@ export interface PlanActions {
 export interface PlanSlice {
   readonly plan: PlanSurfaceState;
   readonly planSurface: PlanReadSurfaceState;
+  readonly planLibrary: PlanLibraryState;
+  readonly planLibraryActions: PlanLibraryActions | null;
+  setPlanLibrary: (value: PlanLibraryState) => void;
+  bindPlanLibraryActions: (actions: PlanLibraryActions | null) => void;
   readonly planFocus: PlanNavigationTarget | null;
   readonly planReturnToChat: boolean;
   readonly planActions: PlanActions | null;
@@ -187,6 +204,14 @@ export function planAttentionCount(plan: PlanSurfaceState): number {
 
 export const createPlanSlice: StateCreator<EnduragentState, [], [], PlanSlice> = (set) => ({
   plan: EMPTY_PLAN_SURFACE,
+  planLibrary: { status: "loading", value: null },
+  planLibraryActions: null,
+  setPlanLibrary(value) {
+    set({ planLibrary: value });
+  },
+  bindPlanLibraryActions(actions) {
+    set({ planLibraryActions: actions });
+  },
   planSurface: { status: "loading", value: null },
   planFocus: null,
   planReturnToChat: false,

--- a/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
@@ -1,0 +1,172 @@
+import type {
+  ListPlansResult,
+  PlanCreationCardModel,
+  PlanSummary,
+} from "@enduragent/coach-contract";
+import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import { CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY } from "../../chat/controller";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent } from "../../components/ui/card";
+import { useEnduragentStore } from "../../state/store";
+
+function dateLabel(value: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T12:00:00Z`));
+}
+
+function LibraryCard(props: {
+  readonly eyebrow?: string;
+  readonly title: string;
+  readonly status?: string;
+  readonly summary: string;
+  readonly children?: ReactNode;
+}): ReactElement {
+  return (
+    <Card size="sm" className="min-w-0" role="region" aria-label={props.eyebrow ?? props.title}>
+      <CardContent className="grid gap-inset">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
+          <div className="grid min-w-0 gap-[calc(var(--inset)/2)]">
+            {props.eyebrow ? (
+              <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+                {props.eyebrow}
+              </p>
+            ) : null}
+            <h3 className="m-0 text-base leading-6 font-semibold break-words">{props.title}</h3>
+          </div>
+          {props.status ? (
+            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+              {props.status}
+            </span>
+          ) : null}
+        </div>
+        <p className="m-0 text-sm leading-5 text-ink-2">{props.summary}</p>
+        {props.children}
+      </CardContent>
+    </Card>
+  );
+}
+
+function creationTitle(creation: PlanCreationCardModel): string {
+  const summary = creation.answeredSummaries.find((answer) => answer.answerKey === "goal");
+  if (summary?.answer.kind !== "goal") return "New Plan";
+  const goal = summary.answer.goal;
+  if (goal.kind === "fitness") return goal.outcome ?? "Improve fitness";
+  if (goal.kind === "event-manual") return `${goal.name} · ${dateLabel(goal.date)}`;
+  const candidate =
+    summary.question.kind === "goal-question"
+      ? summary.question.candidates.find((item) => item.candidateId === goal.candidateId)
+      : undefined;
+  return candidate === undefined
+    ? summary.detail
+    : `${candidate.name} · ${dateLabel(candidate.date)}`;
+}
+
+function spanLabel(plan: PlanSummary): string {
+  return `${dateLabel(plan.start)} to ${dateLabel(plan.end)} · ${plan.weeks} weeks`;
+}
+
+export function PlanLibrary(props: {
+  readonly library: ListPlansResult;
+  readonly readDetails: () => void;
+}): ReactElement {
+  const actions = useEnduragentStore((state) => state.planLibraryActions);
+  const chatActions = useEnduragentStore((state) => state.chatActions);
+  const chatCreation = useEnduragentStore((state) => state.chat.planCreation);
+  const notice = useEnduragentStore((state) => state.chat.notice);
+  const error = useEnduragentStore((state) => state.chat.planCreationError);
+  const paused = useEnduragentStore((state) => state.chat.planCreationPaused);
+  const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
+  const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
+  const discard = useRef<HTMLButtonElement>(null);
+  const { creation, active, closed } = props.library;
+  const total =
+    creation?.openQuestion?.step.total ??
+    creation?.answeredSummaries[0]?.question.step.total ??
+    creation?.answeredSummaries.length ??
+    0;
+  useEffect(() => {
+    if (focusRequest?.target === "discard") {
+      queueMicrotask(() => discard.current?.focus());
+    }
+  }, [focusRequest]);
+  return (
+    <section aria-label="Plan library" className="grid min-w-0 gap-inset">
+      {notice !== CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY ? null : (
+        <p role="status" className="m-0 text-sm text-ink-2">
+          {notice}
+        </p>
+      )}
+      {error === null ? null : (
+        <p role="alert" className="m-0 text-sm text-danger">
+          {error}
+        </p>
+      )}
+      {creation === null ? null : (
+        <LibraryCard
+          eyebrow="Plan creation"
+          title={creationTitle(creation)}
+          status={
+            creation.draft !== null
+              ? "Draft"
+              : paused && chatCreation?.creationId === creation.creationId
+                ? "Paused"
+                : "In progress"
+          }
+          summary={`${creation.answeredSummaries.length} of ${total} answered. ${active === null ? "No Plan is active." : `${active.name} keeps running.`}`}
+        >
+          <div className="flex flex-wrap gap-inset">
+            <Button
+              ref={discard}
+              variant="destructive"
+              aria-haspopup="dialog"
+              disabled={
+                busy || chatActions === null || chatCreation?.creationId !== creation.creationId
+              }
+              onClick={() => chatActions?.openPlanCreationDiscard()}
+            >
+              Discard
+            </Button>
+            <Button
+              disabled={busy || actions === null}
+              onClick={() => actions?.continueCreation(creation)}
+            >
+              Continue in Chat
+            </Button>
+          </div>
+        </LibraryCard>
+      )}
+      {active === null ? (
+        <LibraryCard title="No active Plan" summary="Create a Plan when you are ready." />
+      ) : (
+        <LibraryCard
+          eyebrow="Active Plan"
+          title={active.name}
+          status="Active"
+          summary={spanLabel(active)}
+        >
+          <div className="flex flex-wrap gap-inset">
+            <Button variant="outline" onClick={props.readDetails}>
+              Read Plan details
+            </Button>
+            <Button disabled={actions === null} onClick={() => actions?.changeInChat()}>
+              Change in Chat
+            </Button>
+          </div>
+        </LibraryCard>
+      )}
+      {closed.map((plan) => (
+        <LibraryCard
+          key={plan.planId}
+          eyebrow="Closed Plan"
+          title={plan.name}
+          status="Closed"
+          summary={`${spanLabel(plan)} · ${plan.closeReason === "stopped" ? "Stopped" : plan.closeReason === "completed" ? "Completed" : "Unknown reason"}`}
+        />
+      ))}
+    </section>
+  );
+}

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -53,6 +53,7 @@ import { useEnduragentStore } from "../../state/store";
 import { CoachDecisionPanel } from "../chat/CoachDecisionPanel";
 import { Composer, type ComposerHandle } from "../chat/Composer";
 import { ConversationTranscript } from "../chat/Transcript";
+import { PlanLibrary } from "./PlanLibrary";
 import { Page } from "../shared/Page";
 import { WorkoutArchiveExportControl } from "../training/TrainingExportControls";
 
@@ -4583,6 +4584,15 @@ function ReadyProjection(): ReactElement {
 }
 
 export function PlanView(): ReactElement {
+  const library = useEnduragentStore((state) => state.planLibrary);
+  const libraryActions = useEnduragentStore((state) => state.planLibraryActions);
+  const planningActions = useEnduragentStore((state) => state.planningReadActions);
+  const creationFocus = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
+  const details = useRef<HTMLDivElement>(null);
+  const startButton = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (creationFocus?.target === "start") startButton.current?.focus();
+  }, [creationFocus, library.value?.creation]);
   const plan = useEnduragentStore((state) => state.plan);
   const actions = useEnduragentStore((state) => state.planActions);
   const model = planReadModel(plan);
@@ -4626,7 +4636,18 @@ export function PlanView(): ReactElement {
       subtitle={subtitle}
       busy={loading}
       action={
-        coachWorkspace ? (
+        library.value !== null && !coachWorkspace && !historyPage ? (
+          library.value.creation === null ? (
+            <Button
+              ref={startButton}
+              id="start-plan"
+              disabled={libraryActions === null}
+              onClick={() => libraryActions?.startCreation()}
+            >
+              {library.value.active === null ? "Start a Plan" : "Start a new Plan"}
+            </Button>
+          ) : undefined
+        ) : coachWorkspace ? (
           <Button
             id="plan-coach-close"
             type="button"
@@ -4656,27 +4677,63 @@ export function PlanView(): ReactElement {
       contentMode={coachWorkspace ? "workspace" : "scroll"}
     >
       <div className={coachWorkspace ? "h-full min-h-0" : "grid gap-6"}>
-        {plan.hydration.status === "stale" ? (
-          <StaleNotice message={plan.hydration.error.message} />
+        {library.status === "unavailable" ? (
+          <div role="alert" className="grid gap-inset">
+            <StaleNotice message="Plan library could not load. Try again." />
+            <Button variant="outline" onClick={() => planningActions?.refresh()}>
+              Try again
+            </Button>
+          </div>
         ) : null}
-        {plan.hydration.status === "loading" ? (
-          <p className="m-0 text-ink-2" role="status" aria-live="polite">
-            Loading your Plan…
-          </p>
-        ) : plan.hydration.status === "failed" ? (
-          <StatusCard
-            title="Plan could not load"
-            support={plan.hydration.error.message}
-            retry={plan.hydration.error.retryable}
+        {library.value !== null && !coachWorkspace && !historyPage ? (
+          <PlanLibrary
+            library={library.value}
+            readDetails={() => {
+              details.current?.scrollIntoView({ block: "start", behavior: "instant" });
+              details.current?.focus({ preventScroll: true });
+            }}
           />
-        ) : plan.hydration.status === "unsupported-capability" ? (
-          <StatusCard
-            title="Plan is not available yet"
-            support="Update Enduragent and its local service to use Plan."
-          />
-        ) : (
-          <ReadyProjection />
-        )}
+        ) : null}
+        <div
+          ref={details}
+          tabIndex={-1}
+          className={coachWorkspace ? "h-full min-h-0" : "grid gap-6"}
+        >
+          {library.value !== null && activeOverview ? (
+            <div className="flex justify-end">
+              <Button
+                id="plan-history-trigger"
+                type="button"
+                variant="outline"
+                onClick={() => actions?.openHistory()}
+              >
+                <History className="size-4" aria-hidden="true" />
+                Plan history
+              </Button>
+            </div>
+          ) : null}
+          {plan.hydration.status === "stale" ? (
+            <StaleNotice message={plan.hydration.error.message} />
+          ) : null}
+          {plan.hydration.status === "loading" ? (
+            <p className="m-0 text-ink-2" role="status" aria-live="polite">
+              Loading your Plan…
+            </p>
+          ) : plan.hydration.status === "failed" ? (
+            <StatusCard
+              title="Plan could not load"
+              support={plan.hydration.error.message}
+              retry={plan.hydration.error.retryable}
+            />
+          ) : plan.hydration.status === "unsupported-capability" ? (
+            <StatusCard
+              title="Plan is not available yet"
+              support="Update Enduragent and its local service to use Plan."
+            />
+          ) : (
+            <ReadyProjection />
+          )}
+        </div>
         <CoursePickerDialog />
       </div>
     </Page>

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -688,6 +688,7 @@ function subject(
   const refresh = vi.fn(refreshImplementation);
   const refreshSpend = vi.fn(spendRefreshImplementation);
   const refreshPlan = vi.fn(async () => {});
+  const openChat = vi.fn();
   const provider: DesktopCoachClientProvider = {
     getClient: vi.fn(async () => first),
     reconnect: vi.fn(async () => reconnected),
@@ -712,6 +713,7 @@ function subject(
     },
     refreshTrainingContext: refresh,
     refreshPlan,
+    openChat,
     refreshSpend,
     canChat,
     initialQueueSnapshot,
@@ -742,6 +744,7 @@ function subject(
     refresh,
     refreshSpend,
     refreshPlan,
+    openChat,
     openPlanningRequest,
   };
 }
@@ -2145,7 +2148,7 @@ describe("chat controller", () => {
         planCreation: nextCard,
       }),
     });
-    const { controller, controls } = subject(fake);
+    const { controller, controls, openChat } = subject(fake);
     await controller.start();
 
     controller.openPlanCreationDiscard();
@@ -2165,8 +2168,14 @@ describe("chat controller", () => {
       discardConfirmationOpen: true,
     });
 
+    expect(openChat).not.toHaveBeenCalled();
+    const focusRequest = controls.at(-1)?.planCreation?.focusRequest;
+    openChat.mockImplementation(() => {
+      expect(controls.at(-1)?.planCreation?.focusRequest).toEqual(focusRequest);
+    });
     finishDiscard({ status: "discarded" });
     await Promise.all([first, second]);
+    expect(openChat).toHaveBeenCalledOnce();
 
     expect(controls.at(-1)?.planCreation).toMatchObject({
       value: null,
@@ -3598,5 +3607,122 @@ describe("chat controller", () => {
     expect(
       vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession"),
     ).toHaveLength(1);
+  });
+});
+
+describe("Plan library Chat entry", () => {
+  const creation: PlanCreationCardModel = {
+    creationId: "library-creation",
+    version: 1,
+    status: "in-progress",
+    readiness: "incomplete",
+    answeredSummaries: [planLengthSummary(12)],
+    openQuestion: goalQuestion("Goal?"),
+    draft: null,
+    draftStale: false,
+  };
+
+  it.each([null, { ...creation, creationId: "replacement-creation" }])(
+    "keeps a stale library entry out of Chat and refreshes its result",
+    async (current) => {
+      const fake = client(replies(), {
+        listPlanningRequests: async () => ({ deliveries: [], planCreation: current }),
+      });
+      const { controller, controls, openChat, refreshPlan } = subject(fake);
+      controller.resumeCreation(creation);
+      await controller.continueCreationFromLibrary(creation.creationId);
+      expect(openChat).not.toHaveBeenCalled();
+      expect(refreshPlan).toHaveBeenCalledOnce();
+      expect(controls.at(-1)?.planCreation).toMatchObject({
+        value: current,
+        busy: false,
+        notice:
+          "This creation is no longer unfinished. Open the Plan library for its current result.",
+      });
+      controller.dispose();
+    },
+  );
+
+  it("opens Chat only after checking the unfinished creation and uses its current version", async () => {
+    let resolve!: (value: { deliveries: []; planCreation: PlanCreationCardModel }) => void;
+    const pending = new Promise<{ deliveries: []; planCreation: PlanCreationCardModel }>((done) => {
+      resolve = done;
+    });
+    const fake = client(replies(), { listPlanningRequests: () => pending });
+    const { controller, controls, openChat } = subject(fake);
+    controller.resumeCreation(creation);
+    const focusRevision = controls.at(-1)?.planCreation?.focusRevision;
+    openChat.mockImplementation(() => {
+      expect(controls.at(-1)?.planCreation?.focusRevision).toBe(focusRevision);
+    });
+    const continuing = controller.continueCreationFromLibrary(creation.creationId);
+    expect(openChat).not.toHaveBeenCalled();
+    const current = { ...creation, version: 2 };
+    resolve({ deliveries: [], planCreation: current });
+    await continuing;
+    expect(openChat).toHaveBeenCalledOnce();
+    expect(controls.at(-1)?.planCreation).toMatchObject({
+      value: current,
+      paused: false,
+      busy: false,
+    });
+    controller.dispose();
+  });
+
+  it("installs a library creation before Chat hydration and focuses its open question", () => {
+    const { controller, controls } = subject(client(replies()));
+    controller.resumeCreation(creation);
+    const resumed = controls.at(-1)?.planCreation;
+    expect(resumed).toMatchObject({
+      loaded: true,
+      value: creation,
+      paused: false,
+      editingKey: null,
+    });
+    expect(resumed?.focusRevision).toBeGreaterThan(0);
+    controller.editPlanCreation("plan-length");
+    controller.pausePlanCreation();
+    controller.resumeCreation(creation);
+    expect(controls.at(-1)?.planCreation).toMatchObject({
+      value: creation,
+      paused: false,
+      editingKey: null,
+    });
+    expect(controls.at(-1)?.planCreation?.focusRevision).toBeGreaterThan(
+      resumed?.focusRevision ?? 0,
+    );
+    controller.dispose();
+  });
+
+  it("focuses Activate when the resumed creation already has a Draft", () => {
+    const { controller, controls } = subject(client(replies()));
+    const draft = { ...creation, draft: planCreationDraft(), openQuestion: null };
+    controller.resumeCreation(draft);
+    expect(controls.at(-1)?.planCreation).toMatchObject({
+      value: draft,
+      focusRequest: { target: "activate" },
+    });
+    controller.dispose();
+  });
+
+  it("prepares an empty library entry to start before Chat hydration", async () => {
+    const start = vi.fn(
+      async (): Promise<PlanCreationStartRpcResult> => ({
+        status: "started",
+        outcome: "created",
+        planCreation: creation,
+      }),
+    );
+    const fake = client(replies(), { startPlanCreation: start });
+    const { controller, controls } = subject(fake);
+    controller.resumeCreation(null);
+    expect(controls.at(-1)?.planCreation).toMatchObject({
+      loaded: true,
+      value: null,
+      paused: false,
+    });
+    await controller.startPlanCreation();
+    expect(start).toHaveBeenCalledOnce();
+    controller.dispose();
   });
 });

--- a/apps/desktop-renderer/tests/plan-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ListPlansResult, PlanningReadModel } from "@enduragent/coach-contract";
 import type { PlanReadSurfaceState } from "../src/state/plan-slice";
 import { createPlanController } from "../src/plan/controller";
 
@@ -14,6 +15,8 @@ describe("Plan controller", () => {
     let fail = false;
     const states: PlanReadSurfaceState[] = [];
     const controller = createPlanController({
+      listPlans: async () => ({ creation: null, active: null, closed: [] }),
+      renderLibrary: vi.fn(),
       read: vi.fn(async () => {
         if (fail) throw new Error("offline");
         return model;
@@ -32,6 +35,8 @@ describe("Plan controller", () => {
     const navigate = vi.fn();
     const focus = vi.fn();
     const controller = createPlanController({
+      listPlans: async () => ({ creation: null, active: null, closed: [] }),
+      renderLibrary: vi.fn(),
       read: vi.fn(async () => model),
       render: vi.fn(),
       navigate,
@@ -48,5 +53,97 @@ describe("Plan controller", () => {
     controller.backToChat();
     expect(focus).toHaveBeenLastCalledWith(null, false);
     expect(navigate).toHaveBeenLastCalledWith("chat");
+  });
+});
+
+function deferredLibrary() {
+  let resolve!: (value: ListPlansResult) => void;
+  const promise = new Promise<ListPlansResult>((accept) => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}
+
+describe("Plan library refresh", () => {
+  const library: ListPlansResult = { creation: null, active: null, closed: [] };
+
+  function subject(
+    listPlans: () => Promise<ListPlansResult>,
+    read: () => Promise<PlanningReadModel> = async () => model,
+  ) {
+    const renderLibrary = vi.fn();
+    const render = vi.fn();
+    const controller = createPlanController({
+      listPlans,
+      read,
+      renderLibrary,
+      render,
+      navigate: vi.fn(),
+      focus: vi.fn(),
+    });
+    return { controller, renderLibrary, render };
+  }
+
+  it("retains the last good library when a later list fails independently of the projection", async () => {
+    const listPlans = vi
+      .fn<() => Promise<ListPlansResult>>()
+      .mockResolvedValueOnce(library)
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(library);
+    const { controller, renderLibrary, render } = subject(listPlans);
+    await controller.start();
+    await controller.refresh();
+    expect(renderLibrary).toHaveBeenLastCalledWith({ status: "unavailable", value: library });
+    expect(render).toHaveBeenLastCalledWith({ status: "ready", value: model });
+    await controller.refresh();
+    expect(renderLibrary).toHaveBeenLastCalledWith({ status: "ready", value: library });
+  });
+
+  it("coalesces page reads and queues a fresh list after a Chat mutation", async () => {
+    const pending = deferredLibrary();
+    const updated: ListPlansResult = {
+      ...library,
+      closed: [
+        {
+          planId: "closed-plan",
+          name: "Fitness",
+          start: "1998-09-07",
+          end: "1998-10-04",
+          weeks: 4,
+          status: "closed",
+          closeReason: "completed",
+          closedAt: "1998-10-04",
+          activatedAt: "1998-09-07",
+          creationId: null,
+        },
+      ],
+    };
+    const listPlans = vi
+      .fn<() => Promise<ListPlansResult>>()
+      .mockImplementationOnce(() => pending.promise)
+      .mockResolvedValueOnce(updated);
+    const { controller, renderLibrary } = subject(listPlans);
+    const initial = controller.start();
+    expect(controller.refresh()).toBe(initial);
+    const mutation = controller.refresh(true);
+    expect(listPlans).toHaveBeenCalledOnce();
+    pending.resolve(library);
+    await mutation;
+    expect(listPlans).toHaveBeenCalledTimes(2);
+    expect(renderLibrary).toHaveBeenLastCalledWith({ status: "ready", value: updated });
+  });
+
+  it("ignores pending results and queued mutation refreshes after disposal", async () => {
+    const pending = deferredLibrary();
+    const listPlans = vi.fn(() => pending.promise);
+    const { controller, renderLibrary } = subject(listPlans);
+    const initial = controller.start();
+    const mutation = controller.refresh(true);
+    controller.dispose();
+    pending.resolve(library);
+    await Promise.all([initial, mutation]);
+    await controller.refresh();
+    expect(renderLibrary).not.toHaveBeenCalled();
+    expect(listPlans).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -1,0 +1,685 @@
+import type { ListPlansResult, PlanCreationCardModel } from "@enduragent/coach-contract";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { lazy, Suspense } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPlanController } from "../src/plan/controller";
+import { subscribePlanLibraryRefresh } from "../src/plan/library-refresh";
+import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice";
+import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice";
+import { useEnduragentStore } from "../src/state/store";
+import { PlanLibrary } from "../src/ui/plan/PlanLibrary";
+import { PlanView } from "../src/ui/plan/PlanView";
+import { planCreationDraft } from "./plan-creation-draft-fixtures";
+import { planReadModel } from "./plan-fixtures";
+
+function stubActions(): ChatActions {
+  return {
+    submit: vi.fn(async () => true),
+    chooseAttachments: vi.fn(),
+    pasteAttachment: vi.fn(),
+    receiveAttachmentAdmissions: vi.fn(),
+    saveAttachmentDraftText: vi.fn(),
+    removeAttachment: vi.fn(),
+    retryAttachment: vi.fn(),
+    selectAttachmentWorkout: vi.fn(),
+    reviewAttachmentInPlan: vi.fn(),
+    continueMessageInPlan: vi.fn(),
+    openPlanningRequest: vi.fn(),
+    retryPlanningRequest: vi.fn(),
+    retryPlanningRequestLoad: vi.fn(),
+    clearPlanningRequestFocus: vi.fn(),
+    startPlanCreation: vi.fn(),
+    buildPlanCreationDraft: vi.fn(),
+    answerPlanCreation: vi.fn(),
+    pausePlanCreation: vi.fn(),
+    continuePlanCreation: vi.fn(),
+    editPlanCreation: vi.fn(),
+    cancelPlanCreationEdit: vi.fn(),
+    openPlanCreationDiscard: vi.fn(),
+    cancelPlanCreationDiscard: vi.fn(),
+    confirmPlanCreationDiscard: vi.fn(),
+    openPlanCreationActivate: vi.fn(),
+    cancelPlanCreationActivate: vi.fn(),
+    confirmPlanCreationActivate: vi.fn(),
+    stop: vi.fn(),
+    removeQueued: vi.fn(),
+    runQueuedCommand: vi.fn(),
+    retryQueuedTurn: vi.fn(),
+    retry: vi.fn(),
+    loadEarlier: vi.fn(),
+    retryHydration: vi.fn(),
+    retryDecision: vi.fn(),
+    openNewConversation: vi.fn(),
+    cancelNewConversation: vi.fn(),
+    confirmNewConversation: vi.fn(),
+    retryFirstSync: vi.fn(),
+    answerDecision: vi.fn(),
+    skipDecision: vi.fn(),
+  };
+}
+
+function stubPlanActions(): PlanActions {
+  return {
+    open: vi.fn(),
+    startPlan: vi.fn(),
+    closeCoach: vi.fn(),
+    submitCoach: vi.fn(async () => true),
+    stopCoach: vi.fn(),
+    removeQueuedCoachMessage: vi.fn(),
+    retryQueuedCoachTurn: vi.fn(),
+    answerCoachDecision: vi.fn(),
+    skipCoachDecision: vi.fn(),
+    saveFtp: vi.fn(),
+    refreshFtp: vi.fn(),
+    backToCoachInterview: vi.fn(),
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    openDiscardConfirmation: vi.fn(),
+    closeDiscardConfirmation: vi.fn(),
+    discardDraft: vi.fn(),
+    openRevisionComposer: vi.fn(),
+    closeRevisionComposer: vi.fn(),
+    openCoursePicker: vi.fn(),
+    closeCoursePicker: vi.fn(),
+    chooseCourseFile: vi.fn(),
+    continueWithoutCourse: vi.fn(),
+    useCourseWithoutElevation: vi.fn(),
+    removeCourse: vi.fn(),
+    openDatePicker: vi.fn(),
+    closeDatePicker: vi.fn(),
+    recalculateStartDate: vi.fn(),
+    approveDraft: vi.fn(),
+    openReplacement: vi.fn(),
+    closeReplacementConfirmation: vi.fn(),
+    confirmReplacement: vi.fn(),
+    retryReplacementCleanup: vi.fn(),
+    verifyReplacementCleanup: vi.fn(),
+    writeReplacementMirror: vi.fn(),
+    openReplacementActivePlan: vi.fn(),
+    reconcilePlan: vi.fn(),
+    verifyReconciliation: vi.fn(),
+    openSeason: vi.fn(),
+    openReadiness: vi.fn(),
+    closeReadiness: vi.fn(),
+    refreshReadiness: vi.fn(),
+    closeSeason: vi.fn(),
+    openRaceWeek: vi.fn(),
+    closeRaceWeek: vi.fn(),
+    openWorkout: vi.fn(),
+    closeWorkout: vi.fn(),
+    resolveWorkoutMatch: vi.fn(),
+    resolveWorkoutDrift: vi.fn(),
+    openProposal: vi.fn(),
+    closeProposal: vi.fn(),
+    reviseProposal: vi.fn(),
+    approveProposal: vi.fn(),
+    rejectProposal: vi.fn(),
+    openHistory: vi.fn(),
+    closeHistory: vi.fn(),
+    undoPlanChange: vi.fn(),
+    openPlanSettings: vi.fn(),
+    closePlanSettings: vi.fn(),
+    setPlanSetting: vi.fn(),
+    openEndConfirmation: vi.fn(),
+    closeEndConfirmation: vi.fn(),
+    confirmEndPlan: vi.fn(),
+    retryPlanCleanup: vi.fn(),
+    verifyPlanCleanup: vi.fn(),
+    openRaceOutcome: vi.fn(),
+    recordRaceOutcome: vi.fn(),
+    openEndedConversation: vi.fn(),
+    closeEndedConversation: vi.fn(),
+    openAttention: vi.fn(),
+    resolvePlanningRequestDate: vi.fn(),
+    returnToCoach: vi.fn(),
+    retry: vi.fn(),
+  };
+}
+
+const creation: PlanCreationCardModel = {
+  creationId: "creation-library",
+  version: 1,
+  status: "in-progress",
+  readiness: "incomplete",
+  draft: null,
+  draftStale: false,
+  answeredSummaries: [],
+  openQuestion: {
+    kind: "goal-question",
+    step: { current: 1, total: 9 },
+    prompt: "What are you training for?",
+    candidates: [],
+    eventNotListedOption: {
+      label: "Event not listed",
+      detail: "Add your event.",
+      editorLabel: "Event",
+      placeholder: "Event name",
+      nameLabel: "Name",
+      dateLabel: "Date",
+    },
+    fitnessOption: { label: "General fitness", detail: "Build fitness." },
+    authoredOption: {
+      label: "Something else",
+      detail: "Name an event.",
+      editorLabel: "Event",
+      placeholder: "Event name",
+    },
+  },
+};
+const active: NonNullable<ListPlansResult["active"]> = {
+  planId: "active-library",
+  name: "Build steady power",
+  start: "1998-09-07",
+  end: "1998-10-04",
+  weeks: 4,
+  status: "active",
+  closeReason: null,
+  closedAt: null,
+  activatedAt: "1998-09-07",
+  creationId: null,
+};
+const closed: ListPlansResult["closed"] = [
+  {
+    ...active,
+    planId: "closed-recent",
+    name: "Summer fitness",
+    status: "closed",
+    closedAt: "1998-09-06",
+    closeReason: "completed",
+  },
+  {
+    ...active,
+    planId: "closed-older",
+    name: "Spring fitness",
+    status: "closed",
+    closedAt: "1998-08-01",
+    closeReason: "stopped",
+  },
+];
+const combinations = [false, true].flatMap((hasCreation) =>
+  [false, true].flatMap((hasActive) =>
+    [false, true].map((hasClosed) => ({ hasCreation, hasActive, hasClosed })),
+  ),
+);
+
+beforeEach(() => {
+  useEnduragentStore.setState({
+    chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation },
+    chatActions: stubActions(),
+    plan: EMPTY_PLAN_SURFACE,
+    planActions: null,
+    planLibrary: { status: "loading", value: null },
+    planLibraryActions: {
+      startCreation: vi.fn(),
+      continueCreation: vi.fn(),
+      changeInChat: vi.fn(),
+    },
+    planningReadActions: null,
+  });
+});
+
+describe("Plan library", () => {
+  it("shows the stale creation notice on the library", () => {
+    const notice =
+      "This creation is no longer unfinished. Open the Plan library for its current result.";
+    useEnduragentStore.setState({
+      chat: { ...EMPTY_CHAT_SURFACE, notice },
+      planLibrary: { status: "ready", value: { creation: null, active, closed } },
+    });
+    render(<PlanView />);
+    expect(screen.getByText(notice, { exact: true })).toBeVisible();
+    expect(screen.getByRole("region", { name: "Plan library" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Continue in Chat" })).toBeNull();
+  });
+
+  it.each(combinations)(
+    "renders creation=$hasCreation active=$hasActive closed=$hasClosed in library order",
+    ({ hasCreation, hasActive, hasClosed }) => {
+      const library: ListPlansResult = {
+        creation: hasCreation ? creation : null,
+        active: hasActive ? active : null,
+        closed: hasClosed ? closed : [],
+      };
+      useEnduragentStore.setState({ planLibrary: { status: "ready", value: library } });
+      render(<PlanView />);
+      const section = screen.getByRole("region", { name: "Plan library" });
+      expect(
+        within(section)
+          .getAllByRole("heading")
+          .map((heading) => heading.textContent),
+      ).toEqual([
+        ...(hasCreation ? ["New Plan"] : []),
+        hasActive ? "Build steady power" : "No active Plan",
+        ...(hasClosed ? ["Summer fitness", "Spring fitness"] : []),
+      ]);
+      if (hasCreation) {
+        const card = within(section).getByRole("region", { name: "Plan creation" });
+        expect(within(card).getByText("In progress")).toBeVisible();
+        expect(
+          within(card).getByText(
+            `0 of 9 answered. ${hasActive ? "Build steady power keeps running." : "No Plan is active."}`,
+          ),
+        ).toBeVisible();
+        expect(
+          within(card)
+            .getAllByRole("button")
+            .map((button) => button.textContent),
+        ).toEqual(["Discard", "Continue in Chat"]);
+        expect(screen.queryByRole("button", { name: /^Start a (new )?Plan$/ })).toBeNull();
+      } else {
+        const start = screen.getByRole("button", {
+          name: hasActive ? "Start a new Plan" : "Start a Plan",
+        });
+        fireEvent.click(start);
+        expect(
+          useEnduragentStore.getState().planLibraryActions?.startCreation,
+        ).toHaveBeenCalledOnce();
+      }
+      if (hasActive) {
+        const card = within(section).getByRole("region", { name: "Active Plan" });
+        expect(within(card).getByText("7 Sept 1998 to 4 Oct 1998 · 4 weeks")).toBeVisible();
+        expect(within(card).getByText("Active", { exact: true })).toBeVisible();
+        expect(
+          within(card)
+            .getAllByRole("button")
+            .map((button) => button.textContent),
+        ).toEqual(["Read Plan details", "Change in Chat"]);
+      } else {
+        expect(within(section).getByText("Create a Plan when you are ready.")).toBeVisible();
+      }
+      if (hasClosed) {
+        const cards = within(section).getAllByRole("region", { name: "Closed Plan" });
+        expect(
+          within(cards[0]!).getByText("7 Sept 1998 to 4 Oct 1998 · 4 weeks · Completed"),
+        ).toBeVisible();
+        expect(
+          within(cards[1]!).getByText("7 Sept 1998 to 4 Oct 1998 · 4 weeks · Stopped"),
+        ).toBeVisible();
+        for (const card of cards) expect(within(card).queryByRole("button")).toBeNull();
+      }
+      expect(screen.queryByRole("button", { name: "Read final details" })).toBeNull();
+    },
+  );
+
+  it("dispatches each library action with the current creation", () => {
+    const readDetails = vi.fn();
+    render(<PlanLibrary library={{ creation, active, closed }} readDetails={readDetails} />);
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    expect(
+      useEnduragentStore.getState().chatActions?.openPlanCreationDiscard,
+    ).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole("button", { name: "Continue in Chat" }));
+    expect(useEnduragentStore.getState().planLibraryActions?.continueCreation).toHaveBeenCalledWith(
+      creation,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Change in Chat" }));
+    expect(useEnduragentStore.getState().planLibraryActions?.changeInChat).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole("button", { name: "Read Plan details" }));
+    expect(readDetails).toHaveBeenCalledOnce();
+  });
+
+  it("shows Paused only for the matching creation and Draft takes precedence", () => {
+    useEnduragentStore.setState({
+      chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation, planCreationPaused: true },
+    });
+    const view = render(
+      <PlanLibrary library={{ creation, active: null, closed: [] }} readDetails={vi.fn()} />,
+    );
+    expect(screen.getByText("Paused")).toBeVisible();
+    view.rerender(
+      <PlanLibrary
+        library={{
+          creation: { ...creation, draft: planCreationDraft() },
+          active: null,
+          closed: [],
+        }}
+        readDetails={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Draft")).toBeVisible();
+    expect(screen.queryByText("Paused")).toBeNull();
+  });
+
+  it("preserves readable cards with an explicit retry on failure", () => {
+    const refresh = vi.fn();
+    const library: ListPlansResult = { creation: null, active, closed };
+    useEnduragentStore.setState({
+      planLibrary: { status: "ready", value: library },
+      planningReadActions: {
+        refresh,
+        openFromChat: vi.fn(),
+        backToChat: vi.fn(),
+        returnToChatRequest: vi.fn(),
+      },
+    });
+    render(<PlanView />);
+    expect(refresh).not.toHaveBeenCalled();
+    act(() =>
+      useEnduragentStore.setState({ planLibrary: { status: "unavailable", value: library } }),
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Plan library could not load. Try again.");
+    expect(screen.getByRole("heading", { name: "Summer fitness" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it.each(["navigation", "relaunch"] as const)(
+    "lists once on %s before a lazy mount, then once per refresh and reopen",
+    async (entry) => {
+      const store = useEnduragentStore;
+      store.setState({ activeView: entry === "relaunch" ? "plan" : "chat" });
+      const listPlans = vi.fn(
+        async (): Promise<ListPlansResult> => ({
+          creation,
+          active,
+          closed,
+        }),
+      );
+      const controller = createPlanController({
+        listPlans,
+        read: async () => ({
+          schemaVersion: 1,
+          status: "no-plan",
+          asOfDateKey: 19980907,
+          plan: null,
+        }),
+        renderLibrary: (next) => store.getState().setPlanLibrary(next),
+        render: (next) => store.getState().setPlanSurface(next),
+        navigate: (view) => store.getState().setActiveView(view),
+        focus: (target, returnToChat) => store.getState().setPlanFocus(target, returnToChat),
+      });
+      store.getState().bindPlanningReadActions({
+        refresh: () => void controller.refresh(),
+        openFromChat: controller.openFromChat,
+        backToChat: controller.backToChat,
+        returnToChatRequest: vi.fn(),
+      });
+      const unsubscribe = subscribePlanLibraryRefresh(controller);
+      let mountView!: (module: { default: typeof PlanView }) => void;
+      const viewModule = new Promise<{ default: typeof PlanView }>((resolve) => {
+        mountView = resolve;
+      });
+      const LazyPlanView = lazy(() => viewModule);
+      try {
+        if (entry === "relaunch") await controller.start();
+        else {
+          store.getState().setActiveView("plan");
+          await vi.waitFor(() => expect(store.getState().planLibrary.status).toBe("ready"));
+        }
+        expect(listPlans).toHaveBeenCalledOnce();
+        const view = render(
+          <Suspense fallback={<div>Loading Plan view</div>}>
+            <LazyPlanView />
+          </Suspense>,
+        );
+        expect(screen.getByText("Loading Plan view")).toBeVisible();
+        await act(async () => mountView({ default: PlanView }));
+        expect(screen.getByRole("region", { name: "Plan library" })).toBeVisible();
+        expect(listPlans).toHaveBeenCalledOnce();
+        await act(async () =>
+          store.setState({
+            chat: {
+              ...store.getState().chat,
+              planCreation: structuredClone(creation),
+              planCreationLoaded: true,
+            },
+          }),
+        );
+        expect(listPlans).toHaveBeenCalledOnce();
+
+        await act(async () => store.getState().planningReadActions?.refresh());
+        expect(listPlans).toHaveBeenCalledTimes(2);
+
+        view.unmount();
+        store.getState().setActiveView("chat");
+        await act(async () => store.getState().setActiveView("plan"));
+        render(<PlanView />);
+        expect(listPlans).toHaveBeenCalledTimes(3);
+      } finally {
+        unsubscribe();
+        controller.dispose();
+      }
+    },
+  );
+});
+
+describe("Plan library refresh subscription", () => {
+  function watchRefresh() {
+    const refresh = vi.fn(async () => {});
+    const unsubscribe = subscribePlanLibraryRefresh({
+      refresh,
+      start: vi.fn(async () => {}),
+      openFromChat: vi.fn(),
+      backToChat: vi.fn(),
+      dispose: vi.fn(),
+    });
+    return { refresh, unsubscribe };
+  }
+
+  it("does not reread when Chat hydrates the creation already in the library", () => {
+    useEnduragentStore.setState({
+      chat: { ...EMPTY_CHAT_SURFACE, planCreation: null },
+      planLibrary: { status: "ready", value: { creation, active, closed } },
+    });
+    const { refresh, unsubscribe } = watchRefresh();
+    try {
+      useEnduragentStore.setState({
+        chat: {
+          ...EMPTY_CHAT_SURFACE,
+          planCreation: structuredClone(creation),
+          planCreationLoaded: true,
+        },
+      });
+      expect(refresh).not.toHaveBeenCalled();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("ignores cloned creation objects with the same id and version", () => {
+    useEnduragentStore.setState({
+      chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation, planCreationLoaded: true },
+    });
+    const { refresh, unsubscribe } = watchRefresh();
+    try {
+      useEnduragentStore.setState({
+        chat: { ...useEnduragentStore.getState().chat, planCreation: structuredClone(creation) },
+      });
+      expect(refresh).not.toHaveBeenCalled();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it.each([
+    { ...creation, version: creation.version + 1 },
+    { ...creation, creationId: "replacement-creation" },
+  ])("refreshes once when creation identity changes to $creationId version $version", (next) => {
+    useEnduragentStore.setState({
+      chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation, planCreationLoaded: true },
+      planLibrary: { status: "ready", value: { creation, active, closed } },
+    });
+    const { refresh, unsubscribe } = watchRefresh();
+    try {
+      useEnduragentStore.setState({
+        chat: { ...useEnduragentStore.getState().chat, planCreation: next },
+      });
+      expect(refresh).toHaveBeenCalledExactlyOnceWith(true);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("ignores active Plan hydration and clones but refreshes once for a different Plan id", () => {
+    const model = planReadModel({ lifecycle: "active", planId: active.planId });
+    useEnduragentStore.setState({
+      planLibrary: { status: "ready", value: { creation, active, closed } },
+    });
+    const { refresh, unsubscribe } = watchRefresh();
+    try {
+      useEnduragentStore.setState({
+        plan: {
+          ...EMPTY_PLAN_SURFACE,
+          hydration: { status: "ready", state: model },
+          lastReady: model,
+        },
+      });
+      useEnduragentStore.setState({ plan: structuredClone(useEnduragentStore.getState().plan) });
+      expect(refresh).not.toHaveBeenCalled();
+      const next = { ...model, planId: "replacement-active-plan" };
+      useEnduragentStore.setState({
+        plan: {
+          ...EMPTY_PLAN_SURFACE,
+          hydration: { status: "ready", state: next },
+          lastReady: next,
+        },
+      });
+      expect(refresh).toHaveBeenCalledExactlyOnceWith(true);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("joins the pending startup read when Chat hydrates instead of queuing another read", async () => {
+    const store = useEnduragentStore;
+    store.setState({
+      activeView: "plan",
+      chat: { ...EMPTY_CHAT_SURFACE, planCreation: null },
+    });
+    let resolveResult: (value: ListPlansResult) => void = () => {};
+    const result = {
+      promise: new Promise<ListPlansResult>((resolve) => {
+        resolveResult = resolve;
+      }),
+      resolve: (value: ListPlansResult) => resolveResult(value),
+    };
+    const listPlans = vi.fn(() => result.promise);
+    const controller = createPlanController({
+      listPlans,
+      read: async () => ({
+        schemaVersion: 1,
+        status: "no-plan",
+        asOfDateKey: 19980907,
+        plan: null,
+      }),
+      renderLibrary: (next) => store.getState().setPlanLibrary(next),
+      render: (next) => store.getState().setPlanSurface(next),
+      navigate: (view) => store.getState().setActiveView(view),
+      focus: (target, returnToChat) => store.getState().setPlanFocus(target, returnToChat),
+    });
+    const refresh = vi.spyOn(controller, "refresh");
+    const unsubscribe = subscribePlanLibraryRefresh(controller);
+    try {
+      const started = controller.start();
+      store.setState({
+        chat: {
+          ...EMPTY_CHAT_SURFACE,
+          planCreation: structuredClone(creation),
+          planCreationLoaded: true,
+        },
+      });
+      expect(refresh).toHaveBeenCalledExactlyOnceWith(false);
+      result.resolve({ creation, active, closed });
+      await started;
+      await Promise.all(refresh.mock.results.map((call) => call.value));
+      expect(listPlans).toHaveBeenCalledOnce();
+      expect(store.getState().planLibrary).toEqual({
+        status: "ready",
+        value: { creation, active, closed },
+      });
+    } finally {
+      unsubscribe();
+      controller.dispose();
+    }
+  });
+});
+
+describe("Plan creation title", () => {
+  it.each(["manual", "candidate", "fitness"] as const)(
+    "formats the %s goal from its typed answer",
+    (kind) => {
+      const candidate = {
+        candidateId: "01J00000000000000000000000",
+        name: "Autumn Hills Ride",
+        date: "1998-10-04",
+        sourceLabel: "Calendar",
+      };
+      const question = creation.openQuestion;
+      if (question?.kind !== "goal-question") throw new Error("Goal question required");
+      const answered: PlanCreationCardModel = {
+        ...creation,
+        answeredSummaries: [
+          {
+            answerKey: "goal",
+            title: "Goal",
+            detail: "Autumn Hills Ride · 1998-10-04",
+            source: { kind: "athlete" },
+            question: { ...question, candidates: [candidate] },
+            answer: {
+              kind: "goal",
+              goal:
+                kind === "fitness"
+                  ? { kind: "fitness", outcome: "Build lasting fitness" }
+                  : kind === "manual"
+                    ? { kind: "event-manual", name: candidate.name, date: candidate.date }
+                    : { kind: "event-candidate", candidateId: candidate.candidateId },
+            },
+          },
+        ],
+      };
+      render(
+        <PlanLibrary
+          library={{ creation: answered, active: null, closed: [] }}
+          readDetails={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByRole("heading", {
+          name: kind === "fitness" ? "Build lasting fitness" : "Autumn Hills Ride · 4 Oct 1998",
+        }),
+      ).toBeVisible();
+      expect(screen.getByText("1 of 9 answered. No Plan is active.")).toBeVisible();
+    },
+  );
+});
+
+it("keeps Plan history below the library while a creation occupies the header", () => {
+  const planActions = stubPlanActions();
+  const model = planReadModel({
+    lifecycle: "active",
+    scenarioId: "PL-S004",
+    projection: "active",
+    planId: active.planId,
+    data: {
+      plan: {
+        id: active.planId,
+        name: active.name,
+        primaryGoal: "Build steady power",
+        startDate: active.start,
+        targetDate: active.end,
+        kind: "full-plan",
+        totalWeeks: active.weeks,
+        weekStartDay: 1,
+        workoutCount: 0,
+        plannedDurationS: 0,
+      },
+      today: "1998-09-07",
+      weekIndex: 1,
+      todayWorkout: null,
+      workouts: [],
+    },
+  });
+  useEnduragentStore.setState({
+    plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state: model }, lastReady: model },
+    planActions,
+    planLibrary: { status: "ready", value: { creation, active, closed: [] } },
+  });
+  render(<PlanView />);
+  const library = screen.getByRole("region", { name: "Plan library" });
+  const history = screen.getByRole("button", { name: "Plan history" });
+  expect(within(library).queryByRole("button", { name: "Plan history" })).toBeNull();
+  expect(library.compareDocumentPosition(history) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /^Start a (new )?Plan$/ })).toBeNull();
+  fireEvent.click(history);
+  expect(planActions.openHistory).toHaveBeenCalledOnce();
+});

--- a/apps/desktop/tests/e2e/plan-library.spec.ts
+++ b/apps/desktop/tests/e2e/plan-library.spec.ts
@@ -1,0 +1,410 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Creation renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+  presence: Parameters<PlanCreationBackend["seedLibrary"]>[0],
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-library-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    await backend.seedLibrary(presence);
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    expect(backend.planListRequests).toHaveLength(1);
+    return { backend, fixture, scratch, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function relaunch(scenario: Scenario, playwright: Playwright): Promise<void> {
+  await scenario.browser.close();
+  await scenario.fixture.relaunch(() => scenario.backend.reopen());
+  await scenario.fixture.setViewport(scenario.width, 820);
+  Object.assign(scenario, await connect(playwright, scenario.fixture, scenario.colorScheme));
+  expect(await scenario.page.evaluate(() => innerWidth)).toBe(scenario.width);
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  const screenshotPath = test.info().outputPath(`${name}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-creation", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        library: await scenario.backend.library(),
+        requests: scenario.backend.creationRequests,
+        planListRequests: scenario.backend.planListRequests,
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+async function openLibrary(scenario: Scenario): Promise<void> {
+  await scenario.page
+    .getByRole("navigation", { name: "Main navigation" })
+    .getByRole("button", { name: "Plan", exact: true })
+    .click();
+  await expect(
+    scenario.page.getByRole("region", { name: "Plan library", exact: true }),
+  ).toBeVisible();
+  await expect(scenario.page.locator("#message")).not.toBeVisible();
+}
+
+async function assertMixedLibrary(scenario: Scenario): Promise<void> {
+  const library = scenario.page.getByRole("region", { name: "Plan library", exact: true });
+  await expect(library.getByRole("heading")).toHaveText([
+    "Improve fitness",
+    "Active endurance Plan",
+    "Recent endurance Plan",
+    "Closed base Plan",
+    "Earlier fitness Plan",
+  ]);
+  await expect(library.getByRole("button")).toHaveText([
+    "Discard",
+    "Continue in Chat",
+    "Read Plan details",
+    "Change in Chat",
+  ]);
+  await expect(library).toContainText("1 of 9 answered. Active endurance Plan keeps running.");
+  await expect(library).toContainText("1 Jan 1998 to 28 Jan 1998 · 4 weeks");
+  await expect(library).toContainText("1 Nov 1997 to 28 Nov 1997 · 4 weeks · Completed");
+  await expect(library).toContainText("1 Oct 1997 to 28 Oct 1997 · 4 weeks · Stopped");
+  await expect(library).toContainText("1 Aug 1997 to 28 Aug 1997 · 4 weeks · Unknown reason");
+  await expect(scenario.page.getByRole("button", { name: /^Start a (new )?Plan$/ })).toHaveCount(0);
+}
+
+for (const appearance of [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const) {
+  test(`restores a mixed Plan library and opens Chat actions at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance, {
+      creation: true,
+      active: true,
+      closed: true,
+    });
+    try {
+      const readsBeforeNavigation = scenario.backend.planListRequests.length;
+      await openLibrary(scenario);
+      await assertMixedLibrary(scenario);
+      expect(scenario.backend.planListRequests.length - readsBeforeNavigation).toBe(1);
+      const before = await scenario.backend.library();
+      await capture(scenario, "mixed-library");
+      const readsBeforeRelaunch = scenario.backend.planListRequests.length;
+      await relaunch(scenario, playwright);
+      await assertMixedLibrary(scenario);
+      expect(await scenario.backend.library()).toEqual(before);
+      await capture(scenario, "restored-library");
+      expect(scenario.backend.planListRequests.length - readsBeforeRelaunch).toBe(1);
+      await scenario.page.getByRole("button", { name: "Continue in Chat", exact: true }).click();
+      await expect(
+        scenario.page
+          .locator('[data-parity="question.card"][data-question="plan-length"]')
+          .getByRole("heading"),
+      ).toBeFocused();
+      await capture(scenario, "continue-in-chat");
+      await openLibrary(scenario);
+      await scenario.page.getByRole("button", { name: "Change in Chat", exact: true }).click();
+      await expect(scenario.page.locator("#message")).toBeFocused();
+      expect(await scenario.backend.library()).toEqual(before);
+      await capture(scenario, "change-in-chat");
+      await openLibrary(scenario);
+      await scenario.page.getByRole("button", { name: "Read Plan details", exact: true }).click();
+      await expect(
+        scenario.page.getByRole("heading", { name: "Plan active · week 1 of 4", exact: true }),
+      ).toBeInViewport();
+      await capture(scenario, "active-details");
+      const discard = scenario.page.getByRole("button", { name: "Discard", exact: true });
+      await discard.click();
+      const dialog = scenario.page.getByRole("dialog", {
+        name: "Discard this Plan creation?",
+        exact: true,
+      });
+      await expect(
+        dialog.getByRole("button", { name: "Keep creating", exact: true }),
+      ).toBeFocused();
+      await capture(scenario, "discard-confirmation");
+      await dialog.getByRole("button", { name: "Keep creating", exact: true }).click();
+      await expect(discard).toBeFocused();
+      expect(await scenario.backend.library()).toEqual(before);
+      await discard.click();
+      await dialog.getByRole("button", { name: "Discard creation", exact: true }).click();
+      await expect.poll(async () => (await scenario.backend.library()).creation).toBeNull();
+      await expect(
+        scenario.page.getByRole("region", { name: "Plan library", exact: true }),
+      ).not.toBeVisible();
+      await expect(scenario.page.locator("#message")).toBeVisible();
+      await expect(
+        scenario.page.getByText("Plan creation discarded", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
+      ).toBeFocused();
+      await expect(
+        scenario.page.getByRole("button", { name: "Continue in Chat", exact: true }),
+      ).toHaveCount(0);
+      const after = await scenario.backend.library();
+      expect(after.active).toEqual(before.active);
+      expect(after.closed).toEqual(before.closed);
+      await capture(scenario, "creation-discarded");
+      await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+      await expect(
+        scenario.page
+          .locator('[data-parity="question.card"][data-question="goal"]')
+          .getByRole("heading"),
+      ).toBeFocused();
+      expect((await scenario.backend.library()).active).toEqual(before.active);
+      await capture(scenario, "start-new-plan");
+    } finally {
+      await close(scenario);
+    }
+  });
+
+  test(`starts from an empty Plan library at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance, {
+      creation: false,
+      active: false,
+      closed: false,
+    });
+    try {
+      await openLibrary(scenario);
+      const library = () =>
+        scenario.page.getByRole("region", { name: "Plan library", exact: true });
+      await expect(library().getByRole("heading")).toHaveText(["No active Plan"]);
+      await expect(library()).toContainText("Create a Plan when you are ready.");
+      await capture(scenario, "empty-library");
+      await relaunch(scenario, playwright);
+      await expect(library().getByRole("heading")).toHaveText(["No active Plan"]);
+      await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+      await expect(
+        scenario.page
+          .locator('[data-parity="question.card"][data-question="goal"]')
+          .getByRole("heading"),
+      ).toBeFocused();
+      await scenario.page.locator('[data-parity="choice.row"][data-answer="fitness"]').click();
+      await expect.poll(async () => (await scenario.backend.card())?.version).toBe(2);
+      await openLibrary(scenario);
+      await expect(library().getByRole("heading")).toHaveText([
+        "Improve fitness",
+        "No active Plan",
+      ]);
+      await expect(library()).toContainText("1 of 9 answered. No Plan is active.");
+      await expect(
+        scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
+      ).toHaveCount(0);
+      await capture(scenario, "creation-without-active-plan");
+    } finally {
+      await close(scenario);
+    }
+  });
+}
+
+test("keeps the last library after a failed read and retries", async ({ playwright }) => {
+  test.setTimeout(120_000);
+  const scenario = await launch(
+    playwright,
+    { width: 1180, colorScheme: "light" },
+    { creation: true, active: true, closed: true },
+  );
+  try {
+    const readsBeforeNavigation = scenario.backend.planListRequests.length;
+    await openLibrary(scenario);
+    await assertMixedLibrary(scenario);
+    expect(scenario.backend.planListRequests.length - readsBeforeNavigation).toBe(1);
+    const before = await scenario.backend.library();
+    await scenario.page
+      .getByRole("navigation", { name: "Main navigation" })
+      .getByRole("button", { name: "Chat", exact: true })
+      .click();
+    scenario.backend.planListReadFails = true;
+    await openLibrary(scenario);
+    await expect(
+      scenario.page.getByText("Plan library could not load. Try again.", { exact: true }),
+    ).toBeVisible();
+    await assertMixedLibrary(scenario);
+    expect(await scenario.backend.library()).toEqual(before);
+    await capture(scenario, "library-read-failed");
+    expect(scenario.backend.planListRequests.length - readsBeforeNavigation).toBe(2);
+    scenario.backend.planListReadFails = false;
+    await scenario.page.getByRole("button", { name: "Try again", exact: true }).click();
+    await expect(
+      scenario.page.getByText("Plan library could not load. Try again.", { exact: true }),
+    ).toHaveCount(0);
+    await assertMixedLibrary(scenario);
+    await capture(scenario, "library-read-recovered");
+    expect(scenario.backend.planListRequests.length - readsBeforeNavigation).toBe(3);
+  } finally {
+    await close(scenario);
+  }
+});
+
+test("refreshes a stale creation without leaving the library when Continue in Chat is clicked", async ({
+  playwright,
+}) => {
+  test.setTimeout(120_000);
+  const scenario = await launch(
+    playwright,
+    { width: 1180, colorScheme: "light" },
+    { creation: true, active: true, closed: true },
+  );
+  try {
+    await openLibrary(scenario);
+    await assertMixedLibrary(scenario);
+    const before = await scenario.backend.library();
+    const creation = before.creation;
+    if (creation === null) throw new TypeError("Plan creation is unavailable");
+    await scenario.backend.script.onRequest({
+      method: "plan_creation.discard",
+      params: {
+        commandId: "discard-visible-library-creation",
+        creationId: creation.creationId,
+        expectedVersion: creation.version,
+      },
+    });
+    expect((await scenario.backend.library()).creation).toBeNull();
+    const readsBeforeContinue = scenario.backend.planListRequests.length;
+    await scenario.page.getByRole("button", { name: "Continue in Chat", exact: true }).click();
+    await expect(
+      scenario.page.getByRole("region", { name: "Plan library", exact: true }),
+    ).toBeVisible();
+    await expect(scenario.page.locator("#message")).not.toBeVisible();
+    await expect(
+      scenario.page
+        .getByRole("region", { name: "Plan library", exact: true })
+        .getByText(
+          "This creation is no longer unfinished. Open the Plan library for its current result.",
+          { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(
+      scenario.page.getByRole("button", { name: "Continue in Chat", exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      scenario.page.getByRole("heading", { name: "Improve fitness", exact: true }),
+    ).toHaveCount(0);
+    const after = await scenario.backend.library();
+    expect(after.active).toEqual(before.active);
+    expect(after.closed).toEqual(before.closed);
+    await capture(scenario, "stale-creation-refreshed");
+    expect(scenario.backend.planListRequests.length - readsBeforeContinue).toBe(1);
+  } finally {
+    await close(scenario);
+  }
+});

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -109,11 +109,13 @@ const response = (value: unknown): readonly string[] => [JSON.stringify(value)];
 export class PlanCreationBackend {
   readonly script: DesktopFixtureScript;
   readonly creationRequests: ScriptRequest[] = [];
+  readonly planListRequests: ScriptRequest[] = [];
   private store: (SqlStore & MigratorStore) | undefined;
   private repository: PlanCreationRepository | undefined;
   private host: PlanCreationHost | undefined;
   private planning: PlanningOperations | undefined;
   planStateReadFails = false;
+  planListReadFails = false;
   private sequence = 0;
   private instant = 883_612_800_000;
   private queueRevision = 0;
@@ -129,8 +131,7 @@ export class PlanCreationBackend {
     this.script = {
       onRequest: async (value) => {
         const request = value as ScriptRequest;
-        if (request.method.startsWith("plan_creation.") || request.method === "plan.list")
-          this.creationRequests.push(request);
+        if (request.method.startsWith("plan_creation.")) this.creationRequests.push(request);
         if (coexistence && request.method === "listArchivedConversations") {
           return response({
             schemaVersion: 1,
@@ -208,6 +209,8 @@ export class PlanCreationBackend {
           return response(await this.planState());
         }
         if (request.method === "plan.list") {
+          this.planListRequests.push(request);
+          if (this.planListReadFails) throw new Error("Synthetic Plan library read failure");
           return response(
             await this.requireHost()["plan.list"](ListPlansParamsSchema.parse(request.params)),
           );
@@ -309,6 +312,121 @@ export class PlanCreationBackend {
     if (this.planning?.getPlanState === undefined)
       throw new TypeError("Plan inspection is unavailable");
     return this.planning.getPlanState({});
+  }
+
+  async library() {
+    return this.requireHost()["plan.list"]({});
+  }
+
+  async seedLibrary(presence: {
+    readonly creation: boolean;
+    readonly active: boolean;
+    readonly closed: boolean;
+  }): Promise<void> {
+    const store = this.requireStore();
+    const insertPlan = async (plan: {
+      readonly id: string;
+      readonly name: string;
+      readonly start: number;
+      readonly end: number;
+      readonly weekStartDay: number;
+      readonly closedAt: number | null;
+      readonly reason: "stopped" | "completed" | "legacy-unclassified" | null;
+    }) => {
+      const updatedAt = plan.closedAt ?? 883_612_800_000;
+      await store.run(
+        `INSERT INTO plan (
+id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,total_weeks,
+week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?,NULL,?,'Improve fitness',?,?,?,'short_race_preparation',4,?,'{}',850000000000,?,'fixture-device',?,0)`,
+        [
+          plan.id,
+          plan.name,
+          plan.start,
+          plan.end,
+          plan.closedAt === null ? "active" : "ended",
+          plan.weekStartDay,
+          updatedAt,
+          updatedAt,
+        ],
+      );
+      await store.run(
+        `INSERT INTO planning_plan (
+plan_id,status,version,current_revision_number,activated_at_ms,closed_at_ms,close_reason,close_actor,
+updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?,?,1,1,850000000000,?,?,?,?,'fixture-device',?,0)`,
+        [
+          plan.id,
+          plan.closedAt === null ? "active" : "closed",
+          plan.closedAt,
+          plan.reason,
+          plan.reason === "completed"
+            ? "system:plan-completion"
+            : plan.reason === "stopped"
+              ? "athlete"
+              : null,
+          updatedAt,
+          updatedAt,
+        ],
+      );
+    };
+    if (presence.active) {
+      await insertPlan({
+        id: activePlanId,
+        name: "Active endurance Plan",
+        start: 19980101,
+        end: 19980128,
+        weekStartDay: 4,
+        closedAt: null,
+        reason: null,
+      });
+    }
+    if (presence.closed) {
+      for (const plan of [
+        {
+          id: closedPlanId,
+          name: "Closed base Plan",
+          start: 19971001,
+          end: 19971028,
+          weekStartDay: 3,
+          closedAt: 879_292_800_000,
+          reason: "stopped",
+        },
+        {
+          id: fixtureId("F"),
+          name: "Earlier fitness Plan",
+          start: 19970801,
+          end: 19970828,
+          weekStartDay: 5,
+          closedAt: 873_158_400_000,
+          reason: "legacy-unclassified",
+        },
+        {
+          id: fixtureId("G"),
+          name: "Recent endurance Plan",
+          start: 19971101,
+          end: 19971128,
+          weekStartDay: 6,
+          closedAt: 881_971_200_000,
+          reason: "completed",
+        },
+      ] as const)
+        await insertPlan(plan);
+    }
+    if (presence.creation) {
+      const started = await this.requireHost()["plan_creation.start"]({
+        commandId: "seed-library-creation",
+      });
+      if (started.status !== "started") throw new TypeError("Plan Creation seed was rejected");
+      const answered = await this.requireHost()["plan_creation.answer"]({
+        commandId: "seed-library-goal",
+        creationId: started.planCreation.creationId,
+        expectedVersion: started.planCreation.version,
+        answer: { kind: "goal", goal: { kind: "fitness" } },
+      });
+      if (answered.status !== "answered")
+        throw new TypeError("Plan Creation goal seed was rejected");
+    }
   }
 
   async inspectActivation() {


### PR DESCRIPTION
## Summary

Stacked on #903. The Plan page now shows the Plan library from one `plan.list` read: the unfinished Plan creation card (`Discard`, `Continue in Chat`), the active Plan card (`Read Plan details`, `Change in Chat`) or the `No active Plan` card, and one card per closed Plan with its close reason. The header offers `Start a Plan` or `Start a new Plan` only while no creation exists. `Start` and `Continue in Chat` switch to Chat with the open question focused; a creation that is no longer unfinished keeps the athlete on the library with the prototype's notice. `Change in Chat` switches to Chat with the composer focused. `Discard` reuses the existing confirmation and returns to Chat with `Plan creation discarded`. A failed read keeps the last good library; startup, relaunch, navigation, and explicit refresh each issue one read.

Deferred inside the same issue: calendar status per Plan, `Stop Plan`, closed-Plan detail, legacy recovery, pagination, and the legacy coach intake workspace which still hides the library until legacy retirement.

## Verification

- Astra high verifier over three rounds. It found a possible duplicate read on open, a stale `Continue in Chat` that left Chat empty, `Discard` staying on the Plan page, and a second read on relaunch; all fixed. Its final pass ran every gate green; the one remaining note was a `Promise.withResolvers` use in a new test that the test tsconfig does not type, replaced here.
- Desktop E2E: 49 of 49 pass on macOS, including the new `plan-library` spec (mixed and empty libraries, the three Chat routes, stale Continue, discard, failed read and retry, relaunch) at 1180 and 720 in light and dark. Screenshots compared against the prototype library.
- Renderer tests: 1273 passed across both projects. Root `pnpm check` clean on the rebased head. Lint clean.

| Limit | Value |
|---|---|
| `plan.list` calls per open, relaunch, refresh | 1 |
| Widths and themes covered | 1180, 720 · light, dark |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
