### PR TITLE
fix(desktop): start the unpackaged desktop on Linux

### DIFF
--- a/.changeset/linux-desktop-e2e-startup.md
+++ b/.changeset/linux-desktop-e2e-startup.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: On Linux, Enduragent now starts its local service itself when none is running instead of reporting that it could not reach the service.
+
+Registration reads treat Linux like Windows: app-supervised with no launchd registration, unless a caller supplies an explicit registration state. The isolated development profile binding also accepts Linux, so the Linux desktop E2E job runs the same startup path as the packaged macOS fixture.

--- a/apps/desktop/src/main/development-user-data.ts
+++ b/apps/desktop/src/main/development-user-data.ts
@@ -32,7 +32,7 @@ export function decideDevelopmentUserDataBinding(
   const path = input.environment[DEVELOPMENT_USER_DATA_ENV];
   if (path === undefined) return Object.freeze({ kind: "no-op" });
   if (
-    input.platform !== "darwin" ||
+    (input.platform !== "darwin" && input.platform !== "linux") ||
     input.isPackaged ||
     input.environment.ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND !== "memory" ||
     input.environment.ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT !== "1" ||

--- a/apps/desktop/tests/development-user-data.test.ts
+++ b/apps/desktop/tests/development-user-data.test.ts
@@ -38,6 +38,16 @@ describe("isolated development user data binding", () => {
     expect(setPath).toHaveBeenCalledWith("userData", path);
   });
 
+  it("binds an unpackaged Linux app to the authorized disposable profile", () => {
+    expect(
+      decideDevelopmentUserDataBinding({
+        platform: "linux",
+        isPackaged: false,
+        environment: authorizedEnvironment,
+      }),
+    ).toEqual({ kind: "bind", path });
+  });
+
   it("does nothing when the isolated launcher did not request a profile", () => {
     const setPath = vi.fn();
     expect(
@@ -55,7 +65,7 @@ describe("isolated development user data binding", () => {
 
   it.each([
     ["a packaged app", { isPackaged: true }],
-    ["a non-macOS app", { platform: "linux" as const }],
+    ["a Windows app", { platform: "win32" as const }],
     [
       "a persistent credential context",
       {

--- a/packages/coach/src/desktop-registration.ts
+++ b/packages/coach/src/desktop-registration.ts
@@ -44,6 +44,9 @@ export async function readDesktopRegistration(
       registration: await dependencies.serviceRegistrationState(),
     };
   }
+  if (input.platform !== "darwin") {
+    return { source: "app-supervised", registration: "absent" };
+  }
   const status = await dependencies.readServiceStatus({
     home: input.home,
     executablePath: input.executablePath,

--- a/packages/coach/tests/desktop-registration.test.ts
+++ b/packages/coach/tests/desktop-registration.test.ts
@@ -64,10 +64,9 @@ describe("desktop registration", () => {
     expect(serviceRegistrationState).not.toHaveBeenCalled();
   });
 
-  it("keeps other platforms on the existing launchd observation path", async () => {
-    const failure = new UnsupportedLaunchdPlatformError();
+  it("classifies Linux as absent without invoking any launchd-shaped observer", async () => {
     const readServiceStatus = vi.fn(async () => {
-      throw failure;
+      throw new UnsupportedLaunchdPlatformError();
     });
 
     await expect(
@@ -75,7 +74,21 @@ describe("desktop registration", () => {
         { platform: "linux", home, executablePath: "/tmp/enduragent" },
         { readServiceStatus },
       ),
-    ).rejects.toBe(failure);
-    expect(readServiceStatus).toHaveBeenCalledOnce();
+    ).resolves.toEqual({ source: "app-supervised", registration: "absent" });
+    expect(readServiceStatus).not.toHaveBeenCalled();
+  });
+
+  it("honors an explicit registration override on Linux", async () => {
+    const readServiceStatus = vi.fn(async () => status);
+    const serviceRegistrationState = vi.fn(async () => "unknown" as const);
+
+    await expect(
+      readDesktopRegistration(
+        { platform: "linux", home, executablePath: "/tmp/enduragent" },
+        { readServiceStatus, serviceRegistrationState },
+      ),
+    ).resolves.toEqual({ source: "override", registration: "unknown" });
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(serviceRegistrationState).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

The Linux desktop E2E step in CI has never passed: every run where it executed also ran the failure-only artifact upload, and since the Plan-in-Chat suite grew to 23+ cases it overruns the 40-minute job limit and cancels `check`, which fails `test` and `smoke`. Reproduced in a Linux container from the epic head; two Linux-only startup defects, both present on `main`:

1. `readDesktopRegistration` only short-circuited `win32`. On Linux it called the launchd status reader, `/bin/launchctl` does not exist, `execFile` reported `spawn-failed`, the status became `unknown`, and `decideServiceAwareAutoStart({ registration: "unknown", peer: "absent" })` returned `refuse-daemon-unavailable`. The desktop exited 3 with `desktop-startup-refusal unavailable` and never opened a window. The published CLI took the same path on Linux and reported that it could not reach the local service instead of starting one.
2. `decideDevelopmentUserDataBinding` refused `ENDURAGENT_DEVELOPMENT_USER_DATA` on every platform except `darwin`, so the Playwright electron fixture threw `isolated development user data binding refused` before `app-ready`.

Linux is now app-supervised with registration `absent`, like Windows, unless a caller supplies an explicit registration state (the CLI tests inject one and keep their fail-closed and resume cases). Linux may bind the disposable development profile. No workflow change: the Linux step stays `continue-on-error`; removing or dropping it is a separate operator-approved workflow PR.

## Evidence

- Linux container (`node:24-bookworm-slim`, arm64, xvfb, Electron 43.1.1): both `desktop-launch.spec.ts` cases pass in 8 s after the fix; before it, one refused in under a second and the other timed out at 45 s.
- Root `pnpm check` passes on macOS; `desktop-registration.test.ts` and `development-user-data.test.ts` pass on macOS and Linux.
- The Linux `check` job on this PR is the real gate for this change.

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
