### PR TITLE
ci: drop the Linux desktop E2E step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,22 +108,6 @@ jobs:
           else
             echo "::warning::No changeset found for this PR. Behavioral/user-facing changes should ship a .changeset/*.md (see .changeset/README.md). chore:/ci: PRs are exempt."
           fi
-      - id: desktop_e2e
-        name: Test Desktop E2E on Linux
-        if: needs.desktop-scope.outputs.native == 'true'
-        continue-on-error: true
-        run: |
-          pnpm --filter @enduragent/desktop exec playwright install-deps chromium
-          xvfb-run -a pnpm --filter @enduragent/desktop test:e2e
-      - name: Upload Desktop E2E artifacts
-        if: steps.desktop_e2e.outcome == 'failure'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: desktop-e2e-linux-artifacts
-          path: |
-            apps/desktop/playwright-report/
-            apps/desktop/test-results/
-          if-no-files-found: warn
 
   test:
     needs: check

--- a/apps/desktop/tests/ci-cost-contract.test.ts
+++ b/apps/desktop/tests/ci-cost-contract.test.ts
@@ -30,7 +30,8 @@ describe("CI cost contract", () => {
     expect(check).toContain("pnpm exec vitest run --shard=2/2");
     expect(check).toContain("run: pnpm s8a");
     expect(check).toContain("Pack and smoke cycling-coach");
-    expect(check).toContain("xvfb-run -a pnpm --filter @enduragent/desktop test:e2e");
+    expect(check).not.toContain("Test Desktop E2E on Linux");
+    expect(check).not.toContain("xvfb-run");
     expect(ci).not.toContain("test_shards:");
     expect(ci).not.toMatch(/^  s8a:/mu);
   });


### PR DESCRIPTION
## Summary

Removes `Test Desktop E2E on Linux` and its failure-only artifact upload from the `check` job.

- The step has never passed in the visible CI history. Every run where it executed also ran the failure-only artifact upload.
- Each case waited 45 s for a renderer that never appeared, then retried once. Past 23 cases the step overran the 40-minute job limit, cancelled `check`, and failed `test` and `smoke` as dependents, so every desktop PR showed red with green real gates.
- Enduragent desktop ships on macOS and Windows. The macOS `desktop-packaged-native` job runs the same Playwright suite against the packaged app on the same desktop-scope trigger and remains the desktop E2E gate.

#905 fixes the two Linux startup defects behind the failures (they also affected the published CLI on Linux) and stands on its own; this PR is independent of it.

Workflow change: operator merge only.

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
