### PR TITLE
feat(coach): close Plans and read final history

### DIFF
--- a/.changeset/plan-close-backend.md
+++ b/.changeset/plan-close-backend.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Add Plan closure, automatic completion after the final day, and final history reads to the coach service.
+
+User-facing: Your Plan finishes on its own the day after its last week ends, and the coach keeps its final training readable.

--- a/apps/desktop-renderer/tests/plan-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-controller.test.ts
@@ -106,6 +106,7 @@ describe("Plan library refresh", () => {
       closed: [
         {
           planId: "closed-plan",
+          version: 2,
           name: "Fitness",
           start: "1998-09-07",
           end: "1998-10-04",

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -168,6 +168,7 @@ const creation: PlanCreationCardModel = {
 };
 const active: NonNullable<ListPlansResult["active"]> = {
   planId: "active-library",
+  version: 1,
   name: "Build steady power",
   start: "1998-09-07",
   end: "1998-10-04",

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import { ListPlansResultSchema } from "@enduragent/coach-contract";
+import {
+  ListPlansResultSchema,
+  PlanCloseResultSchema,
+  PlanHistoryResultSchema,
+} from "@enduragent/coach-contract";
 import type {
   CoachEngine,
   CoachOperations,
@@ -564,6 +568,12 @@ export async function launchDesktopFixture(input: {
     },
     async "plan.list"(request) {
       return ListPlansResultSchema.parse(finalFrame(await invoke("plan.list", request)));
+    },
+    async "plan.close"(request) {
+      return PlanCloseResultSchema.parse(finalFrame(await invoke("plan.close", request)));
+    },
+    async "plan.history"(request) {
+      return PlanHistoryResultSchema.parse(finalFrame(await invoke("plan.history", request)));
     },
     async "plan_creation.start"(request) {
       return finalFrame(await invoke("plan_creation.start", request)) as Awaited<

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -144,6 +144,8 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   getAthleteState: 30_000,
   getPlanningReadModel: 30_000,
   "plan.list": 30_000,
+  "plan.close": 30_000,
+  "plan.history": 30_000,
   getActivityAnalysis: 90_000,
   exportTrainingFile: 120_000,
   importFiles: 60 * 60_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -126,6 +126,12 @@ const rpcDeadlineCases = [
   ["getPlanningReadModel", {}, 30_000],
   ["plan.list", {}, 30_000],
   [
+    "plan.close",
+    { commandId: "close-1", planId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", expectedVersion: 1 },
+    30_000,
+  ],
+  ["plan.history", { planId: "01ARZ3NDEKTSV4RRFFQ69G5FAV" }, 30_000],
+  [
     "getActivityAnalysis",
     { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
     90_000,
@@ -1031,6 +1037,8 @@ describe("RPC receive and observers", () => {
           wellness: {},
         },
         "plan.list": { creation: null, active: null, closed: [] },
+        "plan.close": { status: "rejected", reason: "no-active-plan" },
+        "plan.history": null,
         getPlanningReadModel: {
           schemaVersion: 1,
           status: "no-plan",

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -684,7 +684,35 @@ export const PlanCreationActivateRpcResultSchema = z
   .strict();
 export type PlanCreationActivateRpcResult = z.infer<typeof PlanCreationActivateRpcResultSchema>;
 
+export const PlanCloseRpcParamsSchema = z
+  .object({
+    commandId: PlanCreationCommandIdSchema,
+    planId: PlanCreationUlidSchema,
+    expectedVersion: z.number().int().positive(),
+  })
+  .strict();
+export type PlanCloseRpcParams = z.infer<typeof PlanCloseRpcParamsSchema>;
+
+export const PlanCloseResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("closed"),
+      planId: PlanCreationUlidSchema,
+      closedAt: z.number().int().nonnegative(),
+      cleanupJobId: PlanCreationUlidSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("rejected"),
+      reason: z.enum(["stale-version", "no-active-plan", "command-conflict"]),
+    })
+    .strict(),
+]);
+export type PlanCloseResult = z.infer<typeof PlanCloseResultSchema>;
+
 export interface PlanCreationOperations {
+  "plan.close"(request: PlanCloseRpcParams): Promise<PlanCloseResult>;
   "plan_creation.activate"(
     request: PlanCreationActivateRpcParams,
   ): Promise<PlanCreationActivateRpcResult>;

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -96,6 +96,7 @@ export type GetPlanningReadModelRpcResult = z.infer<typeof GetPlanningReadModelR
 export const PlanSummarySchema = z
   .object({
     planId: z.string().min(1),
+    version: z.number().int().positive(),
     name: z.string().min(1),
     start: z.iso.date(),
     end: z.iso.date(),

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { PlanCreationCardModelSchema } from "./plan-creation.js";
+import { PlanCreationCardModelSchema, PlanCreationDraftSchema } from "./plan-creation.js";
 
 export const PlanDateKeySchema = z.number().int().min(1_000_101).max(99_991_231);
 
@@ -93,30 +93,54 @@ export type GetPlanningReadModelRpcParams = z.infer<typeof GetPlanningReadModelR
 export const GetPlanningReadModelRpcResultSchema = PlanningReadModelSchema;
 export type GetPlanningReadModelRpcResult = z.infer<typeof GetPlanningReadModelRpcResultSchema>;
 
-export const PlanSummarySchema = z.object({
-  planId: z.string().min(1),
-  name: z.string().min(1),
-  start: z.iso.date(),
-  end: z.iso.date(),
-  weeks: z.number().int().positive(),
-  status: z.enum(["active", "closed"]),
-  closeReason: z.enum(["stopped", "completed", "legacy-unclassified"]).nullable(),
-  closedAt: z.iso.date().nullable(),
-  activatedAt: z.iso.date().nullable(),
-  creationId: z.string().min(1).nullable(),
-}).strict();
+export const PlanSummarySchema = z
+  .object({
+    planId: z.string().min(1),
+    name: z.string().min(1),
+    start: z.iso.date(),
+    end: z.iso.date(),
+    weeks: z.number().int().positive(),
+    status: z.enum(["active", "closed"]),
+    closeReason: z.enum(["stopped", "completed", "legacy-unclassified"]).nullable(),
+    closedAt: z.iso.date().nullable(),
+    activatedAt: z.iso.date().nullable(),
+    creationId: z.string().min(1).nullable(),
+  })
+  .strict();
 export type PlanSummary = z.infer<typeof PlanSummarySchema>;
 
 export const ListPlansParamsSchema = z.object({}).strict();
 export type ListPlansParams = z.infer<typeof ListPlansParamsSchema>;
-export const ListPlansResultSchema = z.object({
-  creation: PlanCreationCardModelSchema.nullable(),
-  active: PlanSummarySchema.extend({ status: z.literal("active") }).nullable(),
-  closed: z.array(PlanSummarySchema.extend({ status: z.literal("closed") })),
-}).strict();
+export const ListPlansResultSchema = z
+  .object({
+    creation: PlanCreationCardModelSchema.nullable(),
+    active: PlanSummarySchema.extend({ status: z.literal("active") }).nullable(),
+    closed: z.array(PlanSummarySchema.extend({ status: z.literal("closed") })),
+  })
+  .strict();
 export type ListPlansResult = z.infer<typeof ListPlansResultSchema>;
 
+export const PlanHistoryParamsSchema = z.object({ planId: z.string().min(1) }).strict();
+export type PlanHistoryParams = z.infer<typeof PlanHistoryParamsSchema>;
+export const PlanHistoryResultSchema = z
+  .object({
+    plan: PlanSummarySchema,
+    closeActor: z.string().min(1).max(128).nullable(),
+    revision: z
+      .object({
+        revisionNumber: z.number().int().positive(),
+        fingerprint: z.string().min(1),
+        snapshot: PlanCreationDraftSchema,
+      })
+      .strict(),
+    cleanup: z.enum(["none", "pending", "complete", "failed"]),
+  })
+  .strict()
+  .nullable();
+export type PlanHistoryResult = z.infer<typeof PlanHistoryResultSchema>;
+
 export interface PlanningReadOperations {
+  "plan.history"?(request: PlanHistoryParams): Promise<PlanHistoryResult>;
   "plan.list"?(request: ListPlansParams): Promise<ListPlansResult>;
   getPlanningReadModel?(
     request: GetPlanningReadModelRpcParams,

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -123,6 +123,8 @@ import {
 import {
   GetPlanningReadModelRpcParamsSchema,
   GetPlanningReadModelRpcResultSchema,
+  PlanHistoryParamsSchema,
+  PlanHistoryResultSchema,
   ListPlansParamsSchema,
   ListPlansResultSchema,
   type PlanningReadOperations,
@@ -143,6 +145,8 @@ import {
   type PlanningRequestOperations,
 } from "./planning-request.js";
 import {
+  PlanCloseRpcParamsSchema,
+  PlanCloseResultSchema,
   PlanCreationActivateRpcParamsSchema,
   PlanCreationActivateRpcResultSchema,
   PlanCreationAnswerRpcParamsSchema,
@@ -276,6 +280,8 @@ export const COACH_RPC_METHOD_NAMES = [
   "getAthleteState",
   "getPlanningReadModel",
   "plan.list",
+  "plan.close",
+  "plan.history",
   "getActivityAnalysis",
   "exportTrainingFile",
   "importFiles",
@@ -1574,6 +1580,22 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
     .object({
       jsonrpc: z.literal("2.0"),
       id: JsonRpcIdSchema,
+      method: z.literal("plan.close"),
+      params: PlanCloseRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("plan.history"),
+      params: PlanHistoryParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
       method: z.literal("getActivityAnalysis"),
       params: ActivityAnalysisRequestSchema,
     })
@@ -2214,6 +2236,18 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "plan.list",
     requestSchema: ListPlansParamsSchema,
     responseSchema: ListPlansResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  "plan.close": {
+    wireName: "plan.close",
+    requestSchema: PlanCloseRpcParamsSchema,
+    responseSchema: PlanCloseResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  "plan.history": {
+    wireName: "plan.history",
+    requestSchema: PlanHistoryParamsSchema,
+    responseSchema: PlanHistoryResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   getActivityAnalysis: {

--- a/packages/coach-contract/tests/planning-read-contract.test.ts
+++ b/packages/coach-contract/tests/planning-read-contract.test.ts
@@ -28,7 +28,11 @@ describe("Planning read contract", () => {
       name: "Tempo",
       durationSeconds: 3600,
       origin: "coach" as const,
-      navigation: { destination: "plan" as const, focus: "workout" as const, entityId: "workout-1" },
+      navigation: {
+        destination: "plan" as const,
+        focus: "workout" as const,
+        entityId: "workout-1",
+      },
     };
     const value = {
       schemaVersion: 1,
@@ -66,6 +70,7 @@ describe("Plan library contract", () => {
     closeReason: null,
     closedAt: null,
     activatedAt: "1998-12-20",
+    version: 1,
     creationId: "creation-active",
   };
 
@@ -77,21 +82,24 @@ describe("Plan library contract", () => {
     expect(ListPlansResultSchema.safeParse({ ...empty, extra: true }).success).toBe(false);
   });
 
-  it.each(["stopped", "completed", "legacy-unclassified"])("accepts %s closed history", (closeReason) => {
-    const closed = {
-      ...active,
-      planId: "plan-closed",
-      status: "closed",
-      closeReason,
-      closedAt: "1999-01-18",
-      activatedAt: null,
-      creationId: null,
-    };
-    const library = { creation: null, active, closed: [closed] };
-    expect(ListPlansResultSchema.parse(library)).toEqual(library);
-    expect(ListPlansResultSchema.safeParse({ ...library, active: closed }).success).toBe(false);
-    expect(ListPlansResultSchema.safeParse({ ...library, closed: [active] }).success).toBe(false);
-  });
+  it.each(["stopped", "completed", "legacy-unclassified"])(
+    "accepts %s closed history",
+    (closeReason) => {
+      const closed = {
+        ...active,
+        planId: "plan-closed",
+        status: "closed",
+        closeReason,
+        closedAt: "1999-01-18",
+        activatedAt: null,
+        creationId: null,
+      };
+      const library = { creation: null, active, closed: [closed] };
+      expect(ListPlansResultSchema.parse(library)).toEqual(library);
+      expect(ListPlansResultSchema.safeParse({ ...library, active: closed }).success).toBe(false);
+      expect(ListPlansResultSchema.safeParse({ ...library, closed: [active] }).success).toBe(false);
+    },
+  );
 
   it.each([
     { start: 19981221 },
@@ -102,6 +110,7 @@ describe("Plan library contract", () => {
     { status: "draft" },
     { closeReason: "unknown" },
     { creationId: "" },
+    { version: 0 },
     { calendarStatus: "healthy" },
   ])("rejects invalid summary fields %j", (fields) => {
     expect(PlanSummarySchema.safeParse({ ...active, ...fields }).success).toBe(false);

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1326,6 +1326,8 @@ describe("coach request and event projection", () => {
         plan: null,
       }),
       "plan.list": async () => ({ creation: null, active: null, closed: [] }),
+      "plan.close": async () => ({ status: "rejected", reason: "no-active-plan" }),
+      "plan.history": async () => null,
       getActivityAnalysis: async () => {
         throw new Error("not exercised by registry exhaustiveness");
       },
@@ -2183,5 +2185,51 @@ describe("additive protocol signals", () => {
 
   it("uses protocol version 36", () => {
     expect(PROTOCOL_VERSION).toBe(36);
+  });
+});
+
+describe("Plan lifecycle wire contract", () => {
+  const closeParams = {
+    commandId: "close-1",
+    planId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    expectedVersion: 1,
+  };
+
+  it("accepts athlete closure and rejects public actor or completion claims", () => {
+    const schema = COACH_RPC_METHOD_REGISTRY["plan.close"].requestSchema;
+    expect(schema.parse(closeParams)).toEqual(closeParams);
+    for (const extra of [
+      { closeActor: "system:plan-completion" },
+      { closeReason: "completed" },
+      { closedAtMs: 904_953_600_000 },
+    ]) {
+      expect(schema.safeParse({ ...closeParams, ...extra }).success).toBe(false);
+    }
+    expect(schema.safeParse({ ...closeParams, expectedVersion: 0 }).success).toBe(false);
+  });
+
+  it("accepts closure results and every rejection reason", () => {
+    const schema = COACH_RPC_METHOD_REGISTRY["plan.close"].responseSchema;
+    expect(
+      schema.safeParse({
+        status: "closed",
+        planId: closeParams.planId,
+        closedAt: 904_953_600_000,
+        cleanupJobId: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+      }).success,
+    ).toBe(true);
+    for (const reason of ["stale-version", "no-active-plan", "command-conflict"]) {
+      expect(schema.parse({ status: "rejected", reason })).toEqual({ status: "rejected", reason });
+    }
+    expect(schema.safeParse({ status: "rejected", reason: "completed" }).success).toBe(false);
+  });
+
+  it("returns null for unavailable closed history and requires a Plan id", () => {
+    const method = COACH_RPC_METHOD_REGISTRY["plan.history"];
+    expect(method.requestSchema.parse({ planId: closeParams.planId })).toEqual({
+      planId: closeParams.planId,
+    });
+    expect(method.requestSchema.safeParse({ planId: "" }).success).toBe(false);
+    expect(method.responseSchema.parse(null)).toBeNull();
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -204,6 +204,7 @@ import { createPlanningRequestSourceCleanup } from "./planning-request-source-cl
 import {
   createPlanConversationRepository,
   createPlanCreationRepository,
+  createPlanLifecycleRepository,
   createPlanningRequestIntakeRepository,
   createPlanningRequestRepository,
   createPlanRepository,
@@ -871,6 +872,11 @@ export async function createLocalCoachComposition(
   const logger = createSubsystemLogger("agent", input.home.root);
   const planningIdentity = createAuthoredIdentity(input.home.configDir, { now });
   const planningTimezone = resolveUserTimezone(input.config.session.timezone);
+  const planningDateKey = (): number =>
+    Number(todayInTZ(planningTimezone, new Date(now())).replaceAll("-", ""));
+  const planLifecycle = createPlanLifecycleRepository(input.context.store, {
+    newId: () => planningIdentity.newUlid(),
+  });
   const planCreationOperations = createPlanCreationOperations({
     store: input.context.store,
     repository: createPlanCreationRepository(input.context.store),
@@ -879,10 +885,10 @@ export async function createLocalCoachComposition(
     eventCandidates: { read: async () => [] },
     baselineEvidence: { read: async () => undefined },
     today: () => todayInTZ(planningTimezone, new Date(now())),
+    todayDateKey: planningDateKey,
+    now,
   });
   const planningRepository = createLegacyPlanRepository(input.context.store);
-  const planningDateKey = (): number =>
-    Number(todayInTZ(planningTimezone, new Date(now())).replaceAll("-", ""));
   await importLegacyCurrentPlan({
     home: input.home,
     store: input.context.store,
@@ -1007,6 +1013,7 @@ export async function createLocalCoachComposition(
   let runtime: LocalStoreRuntime | undefined;
   let reference: LocalReferenceRuntime | undefined;
   let initialRefreshPromise: Promise<void> | undefined;
+  let initialPlanCompletion: Promise<unknown> | undefined;
   let initialRefreshRetryTimer: ReturnType<typeof setTimeout> | undefined;
   let initialRefreshFailedAttempts = 0;
   const initialRefreshController = new AbortController();
@@ -1709,8 +1716,12 @@ export async function createLocalCoachComposition(
     };
     const startInitialRefresh = (): Promise<void> => {
       if (initialRefreshPromise !== undefined) return initialRefreshPromise;
+      initialPlanCompletion ??= planLifecycle.completeExpired({
+        todayDateKey: planningDateKey(),
+        nowMs: now(),
+      });
       if (!input.deferInitialRefresh) {
-        initialRefreshPromise = Promise.resolve();
+        initialRefreshPromise = initialPlanCompletion.then(() => undefined);
         return initialRefreshPromise;
       }
       if (initialRefreshRetryTimer !== undefined) {
@@ -1720,36 +1731,38 @@ export async function createLocalCoachComposition(
       initialRefreshStarted = true;
       const refreshRevision = intervalsConfigRevision;
       let ownerSucceeded = false;
-      initialRefreshPromise = runtime!
-        .runWindowAfter(async (signal) => {
-          const initializationSignal = AbortSignal.any([signal, initialRefreshController.signal]);
-          initializationSignal.throwIfAborted();
-          initialRefreshConfigCaptured = true;
-          const initialConfig = copyConfig(unapprovedConfig);
-          if (initialConfig.intervals.apiKey.length > 0 && !intervalsOwnerReady) {
-            const ownerClaim = await assertIntervalsOwner(
-              initialConfig,
-              initialConfig,
-              initializationSignal,
+      initialRefreshPromise = initialPlanCompletion
+        .then(() =>
+          runtime!.runWindowAfter(async (signal) => {
+            const initializationSignal = AbortSignal.any([signal, initialRefreshController.signal]);
+            initializationSignal.throwIfAborted();
+            initialRefreshConfigCaptured = true;
+            const initialConfig = copyConfig(unapprovedConfig);
+            if (initialConfig.intervals.apiKey.length > 0 && !intervalsOwnerReady) {
+              const ownerClaim = await assertIntervalsOwner(
+                initialConfig,
+                initialConfig,
+                initializationSignal,
+              );
+              initializationSignal.throwIfAborted();
+              await ownerClaim?.claim();
+              initializationSignal.throwIfAborted();
+            }
+            await reconfigurable.replace(
+              () => {
+                initializationSignal.throwIfAborted();
+                return buildBundle(approvedRuntimeConfig(unapprovedConfig, true));
+              },
+              (replacement) => {
+                initializationSignal.throwIfAborted();
+                intervalsOwnerReady = true;
+                activeTimezone = replacement.timezone;
+                ownerSucceeded = true;
+                return replacement;
+              },
             );
-            initializationSignal.throwIfAborted();
-            await ownerClaim?.claim();
-            initializationSignal.throwIfAborted();
-          }
-          await reconfigurable.replace(
-            () => {
-              initializationSignal.throwIfAborted();
-              return buildBundle(approvedRuntimeConfig(unapprovedConfig, true));
-            },
-            (replacement) => {
-              initializationSignal.throwIfAborted();
-              intervalsOwnerReady = true;
-              activeTimezone = replacement.timezone;
-              ownerSucceeded = true;
-              return replacement;
-            },
-          );
-        })
+          }),
+        )
         .then(() => undefined)
         .finally(() => {
           if (ownerSucceeded && unapprovedConfig.intervals.apiKey.length > 0) {
@@ -2248,6 +2261,8 @@ export async function createLocalCoachComposition(
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
       ...planningRequestOperations,
       "plan.list": planCreationOperations["plan.list"],
+      "plan.close": planCreationOperations["plan.close"],
+      "plan.history": planCreationOperations["plan.history"],
       "plan_creation.start": planCreationOperations["plan_creation.start"],
       "plan_creation.answer": planCreationOperations["plan_creation.answer"],
       "plan_creation.preview": planCreationOperations["plan_creation.preview"],

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -913,8 +913,7 @@ export async function createLocalCoachComposition(
   let intervalsConfigRevision = 0;
   const ownerLookup = (config: Config) => ({
     apiKey: config.intervals.apiKey,
-    athleteId:
-      config.intervals.athleteId.length === 0 ? "0" : config.intervals.athleteId,
+    athleteId: config.intervals.athleteId.length === 0 ? "0" : config.intervals.athleteId,
     historyNewestDate: referencePlan(config).window.newest,
     clock: ownerClock,
   });
@@ -1716,12 +1715,19 @@ export async function createLocalCoachComposition(
     };
     const startInitialRefresh = (): Promise<void> => {
       if (initialRefreshPromise !== undefined) return initialRefreshPromise;
-      initialPlanCompletion ??= planLifecycle.completeExpired({
-        todayDateKey: planningDateKey(),
-        nowMs: now(),
-      });
+      initialPlanCompletion ??= planLifecycle
+        .completeExpired({ todayDateKey: planningDateKey(), nowMs: now() })
+        .catch((error: unknown) => {
+          initialPlanCompletion = undefined;
+          throw error;
+        });
       if (!input.deferInitialRefresh) {
-        initialRefreshPromise = initialPlanCompletion.then(() => undefined);
+        initialRefreshPromise = initialPlanCompletion
+          .then(() => undefined)
+          .catch((error: unknown) => {
+            initialRefreshPromise = undefined;
+            throw error;
+          });
         return initialRefreshPromise;
       }
       if (initialRefreshRetryTimer !== undefined) {
@@ -1875,8 +1881,7 @@ export async function createLocalCoachComposition(
         runtime,
         intervalsCredentials: options.liveIntervals,
         historyNewestDate: () => referencePlan(approvedConfig()).window.newest,
-        calendarTimeZone: () =>
-          resolveUserTimezone(approvedConfig().session.timezone),
+        calendarTimeZone: () => resolveUserTimezone(approvedConfig().session.timezone),
         readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
         readArchivedConversations: (request) => reconfigurable.listArchivedConversations(request),
         readArchivedTranscriptPage: (request) => reconfigurable.getArchivedTranscriptPage(request),

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -529,6 +529,8 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "getAthleteState",
   "getPlanningReadModel",
   "plan.list",
+  "plan.close",
+  "plan.history",
   "getActivityAnalysis",
   "importFiles",
   "sync",
@@ -1360,6 +1362,32 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 throw new TypeError("Plan library operation is unavailable.");
               }
               result = await input.operations["plan.list"](request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "plan.close":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY["plan.close"].requestSchema.parse(
+                generic.data.params,
+              );
+              if (input.operations["plan.close"] === undefined) {
+                throw new TypeError("Plan closure operation is unavailable.");
+              }
+              result = await input.operations["plan.close"](request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "plan.history":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY["plan.history"].requestSchema.parse(
+                generic.data.params,
+              );
+              if (input.operations["plan.history"] === undefined) {
+                throw new TypeError("Plan history operation is unavailable.");
+              }
+              result = await input.operations["plan.history"](request);
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 import {
+  PlanCloseRpcParamsSchema,
+  PlanCloseResultSchema,
+  PlanHistoryParamsSchema,
+  PlanHistoryResultSchema,
+  type PlanCloseRpcParams,
+  type PlanCloseResult,
+  type PlanHistoryParams,
+  type PlanHistoryResult,
   ListPlansParamsSchema,
   ListPlansResultSchema,
   type ListPlansParams,
@@ -22,6 +30,7 @@ import { buildCreationDraft } from "@enduragent/sport-cycling";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import {
   addCivilDays,
+  createPlanLifecycleRepository,
   createPlanRepository,
   dateKeyFromText,
   inclusiveCivilDays,
@@ -30,6 +39,7 @@ import {
   PlanCreationStoreError,
   type PlanCreationRepository,
   type PlanCreationSnapshot,
+  type PlanSummaryRecord,
 } from "@enduragent/kernel/planning";
 import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
@@ -62,6 +72,8 @@ export function expectedPlanCreationAnswerKind(
 
 export interface PlanCreationHost extends PlanCreationOperations {
   "plan.list"(request: ListPlansParams): Promise<ListPlansResult>;
+  "plan.close"(request: PlanCloseRpcParams): Promise<PlanCloseResult>;
+  "plan.history"(request: PlanHistoryParams): Promise<PlanHistoryResult>;
   readCard(): Promise<PlanCreationCardModel | null>;
 }
 
@@ -85,10 +97,17 @@ export function createPlanCreationOperations(input: {
   eventCandidates: GoalEventCandidateSource;
   baselineEvidence?: BaselineEvidenceSource;
   today?: () => string;
+  todayDateKey?: () => number;
+  now?: () => number;
 }): PlanCreationHost {
   const plans = createPlanRepository(input.store);
+  const lifecycle = createPlanLifecycleRepository(input.store, {
+    newId: () => input.identity.newUlid(),
+  });
   const baselineEvidence = input.baselineEvidence ?? defaultBaselineEvidence;
   const today = input.today ?? (() => new Date().toISOString().slice(0, 10));
+  const todayDateKey = input.todayDateKey ?? (() => dateKeyFromText(today()));
+  const now = input.now ?? Date.now;
   const stamp = async (commandId: string, digest: string) => {
     const clock = input.identity.hlcStamp();
     return {
@@ -149,30 +168,42 @@ export function createPlanCreationOperations(input: {
     const snapshot = await input.repository.readUnfinished();
     return snapshot === undefined ? null : project(snapshot);
   };
+  const dateText = (dateKey: number): string => {
+    const digits = String(dateKey).padStart(8, "0");
+    return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+  };
+  const timestampDate = (value: number | null): string | null =>
+    value === null ? null : new Date(value).toISOString().slice(0, 10);
+  const summarizePlan = (plan: PlanSummaryRecord) => ({
+    planId: plan.planId,
+    name: plan.name,
+    start: dateText(plan.startDateKey),
+    end: dateText(addCivilDays(plan.startDateKey, plan.totalWeeks * 7 - 1)),
+    weeks: plan.totalWeeks,
+    status: plan.status,
+    closeReason: plan.closeReason,
+    closedAt: timestampDate(plan.closedAtMs),
+    activatedAt: timestampDate(plan.activatedAtMs),
+    creationId: plan.creationId,
+  });
   return {
     async "plan.list"(request) {
       ListPlansParamsSchema.parse(request);
       return input.store.transaction(async () => {
+        await createPlanLifecycleRepository(
+          {
+            exec: (sql) => input.store.exec(sql),
+            get: (sql, params) => input.store.get(sql, params),
+            all: (sql, params) => input.store.all(sql, params),
+            run: (sql, params) => input.store.run(sql, params),
+            close: () => input.store.close(),
+            transaction: async (run) => run(),
+          },
+          { newId: () => input.identity.newUlid() },
+        ).completeExpired({ todayDateKey: todayDateKey(), nowMs: now() });
         const creation = await input.repository.readUnfinished();
         const records = await plans.listPlans();
-        const dateText = (dateKey: number): string => {
-          const digits = String(dateKey).padStart(8, "0");
-          return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
-        };
-        const timestampDate = (value: number | null): string | null =>
-          value === null ? null : new Date(value).toISOString().slice(0, 10);
-        const summaries = records.map((plan) => ({
-          planId: plan.planId,
-          name: plan.name,
-          start: dateText(plan.startDateKey),
-          end: dateText(addCivilDays(plan.startDateKey, plan.totalWeeks * 7 - 1)),
-          weeks: plan.totalWeeks,
-          status: plan.status,
-          closeReason: plan.closeReason,
-          closedAt: timestampDate(plan.closedAtMs),
-          activatedAt: timestampDate(plan.activatedAtMs),
-          creationId: plan.creationId,
-        }));
+        const summaries = records.map(summarizePlan);
         return ListPlansResultSchema.parse({
           creation:
             creation === undefined ? null : projectPlanCreationCard(creation, { today: today() }),
@@ -180,6 +211,32 @@ export function createPlanCreationOperations(input: {
           closed: summaries.filter((plan) => plan.status === "closed"),
         });
       });
+    },
+    async "plan.close"(request) {
+      const parsed = PlanCloseRpcParamsSchema.parse(request);
+      const command = await stamp(parsed.commandId, await requestDigest(input.crypto, parsed));
+      return PlanCloseResultSchema.parse(
+        await lifecycle.close({
+          command,
+          planId: parsed.planId,
+          expectedVersion: parsed.expectedVersion,
+          closedAtMs: now(),
+          todayDateKey: todayDateKey(),
+          cleanupJobId: input.identity.newUlid(),
+        }),
+      );
+    },
+    async "plan.history"(request) {
+      const parsed = PlanHistoryParamsSchema.parse(request);
+      const detail = await lifecycle.readClosedDetail(parsed.planId);
+      return PlanHistoryResultSchema.parse(
+        detail === null
+          ? null
+          : {
+              ...detail,
+              plan: summarizePlan(detail.plan),
+            },
+      );
     },
     async "plan_creation.start"(request) {
       const parsed = PlanCreationStartRpcParamsSchema.parse(request);

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -176,6 +176,7 @@ export function createPlanCreationOperations(input: {
     value === null ? null : new Date(value).toISOString().slice(0, 10);
   const summarizePlan = (plan: PlanSummaryRecord) => ({
     planId: plan.planId,
+    version: plan.version,
     name: plan.name,
     start: dateText(plan.startDateKey),
     end: dateText(addCivilDays(plan.startDateKey, plan.totalWeeks * 7 - 1)),

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -210,6 +210,8 @@ const operations: CoachOperations & PlanningReadOperations & PlanCreationOperati
     nextCursor: null,
   }),
   "plan.list": async () => ({ creation: null, active: null, closed: [] }),
+  "plan.close": async () => ({ status: "rejected", reason: "no-active-plan" }),
+  "plan.history": async () => null,
   getPlanningReadModel: async () => ({
     schemaVersion: 1,
     status: "no-plan",
@@ -853,6 +855,14 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
           calls.push("plan.list");
           return { creation: null, active: null, closed: [] };
         },
+        "plan.close": async () => {
+          calls.push("plan.close");
+          return { status: "rejected", reason: "no-active-plan" };
+        },
+        "plan.history": async () => {
+          calls.push("plan.history");
+          return null;
+        },
         getPlanningReadModel: async () => {
           calls.push("getPlanningReadModel");
           return { schemaVersion: 1, status: "no-plan", asOfDateKey: 20260826, plan: null };
@@ -945,6 +955,12 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       { id: 41, method: "getPlanningReadModel", params: {} },
       { id: 42, method: "plan.list", params: {} },
       {
+        id: 43,
+        method: "plan.close",
+        params: { commandId: "close-1", planId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", expectedVersion: 1 },
+      },
+      { id: 44, method: "plan.history", params: { planId: "01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
+      {
         id: 5,
         method: "getActivityAnalysis",
         params: { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
@@ -982,6 +998,8 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       "getAthleteState",
       "getPlanningReadModel",
       "plan.list",
+      "plan.close",
+      "plan.history",
       "getActivityAnalysis",
       "exportTrainingFile",
     ]);
@@ -2401,6 +2419,13 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       activatedAt: "1998-09-07",
     };
     const listPlans = vi.fn(async () => ({ creation: startedCard, active: null, closed: [] }));
+    const closePlan = vi.fn<PlanCreationOperations["plan.close"]>(async () => ({
+      status: "closed",
+      planId: activationResult.planId,
+      closedAt: 904_953_600_000,
+      cleanupJobId: "01J00000000000000000000002",
+    }));
+    const readHistory = vi.fn(async () => null);
     const activatePlanCreation = vi.fn<PlanCreationOperations["plan_creation.activate"]>(
       async () => activationResult,
     );
@@ -2409,6 +2434,8 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       operations: {
         ...operations,
         "plan.list": listPlans,
+        "plan.close": closePlan,
+        "plan.history": readHistory,
         "plan_creation.start": startPlanCreation,
         "plan_creation.answer": answerPlanCreation,
         "plan_creation.preview": previewPlanCreation,
@@ -2435,6 +2462,12 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     const previewParams = { commandId: "preview-1", creationId, expectedVersion: 2 };
     const discardParams = { commandId: "discard-1", creationId, expectedVersion: 2 };
     const activateParams = { commandId: "activate-1", creationId, expectedVersion: 2 };
+    const closeParams = {
+      commandId: "close-1",
+      planId: activationResult.planId,
+      expectedVersion: 1,
+    };
+    const historyParams = { planId: activationResult.planId };
     for (const { result, ...request } of [
       {
         id: "start",
@@ -2472,6 +2505,23 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         params: {},
         result: { creation: startedCard, active: null, closed: [] },
       },
+      {
+        id: "close",
+        method: "plan.close",
+        params: closeParams,
+        result: {
+          status: "closed",
+          planId: activationResult.planId,
+          closedAt: 904_953_600_000,
+          cleanupJobId: "01J00000000000000000000002",
+        },
+      },
+      {
+        id: "history",
+        method: "plan.history",
+        params: historyParams,
+        result: null,
+      },
     ]) {
       renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
       expect(parseCoachRpcEnvelope(await renderer.frames.next())).toEqual({
@@ -2486,6 +2536,8 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(discardPlanCreation).toHaveBeenCalledWith(discardParams);
     expect(activatePlanCreation).toHaveBeenCalledWith(activateParams);
     expect(listPlans).toHaveBeenCalledWith({});
+    expect(closePlan).toHaveBeenCalledWith(closeParams);
+    expect(readHistory).toHaveBeenCalledWith(historyParams);
 
     for (const request of [
       {
@@ -2517,6 +2569,21 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         id: "invalid-list",
         method: "plan.list",
         params: { extra: true },
+      },
+      {
+        id: "invalid-close",
+        method: "plan.close",
+        params: { ...closeParams, closeActor: "system:plan-completion" },
+      },
+      {
+        id: "invalid-completion",
+        method: "plan.close",
+        params: { ...closeParams, closeReason: "completed" },
+      },
+      {
+        id: "invalid-history",
+        method: "plan.history",
+        params: { ...historyParams, extra: true },
       },
     ]) {
       renderer.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));

--- a/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
+++ b/packages/coach/tests/helpers/plan-creation-operation-stubs.ts
@@ -1,6 +1,10 @@
 import type { PlanCreationOperations } from "@enduragent/coach-contract";
 
 export const planCreationOperationStubs = {
+  "plan.close": async () => ({
+    status: "rejected",
+    reason: "no-active-plan",
+  }),
   "plan_creation.start": async () => ({
     status: "rejected",
     reason: "command-conflict",

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1164,6 +1164,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
       creation: null,
       active: {
         planId: activated.planId,
+        version: 1,
         name: "Improve fitness",
         start: test.draft.start,
         end: test.draft.end,
@@ -1176,6 +1177,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
       },
       closed: [{
         planId: incumbentId,
+        version: 2,
         name: "Earlier Plan",
         start: "1997-12-22",
         end: "1998-01-18",
@@ -1186,6 +1188,33 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
         activatedAt: "1997-12-22",
         creationId: null,
       }],
+    });
+  });
+
+  it("exposes the active version for closure and rejects a stale version", async () => {
+    const test = await review();
+    const activated = await test.host["plan_creation.activate"](test.request);
+    const { active } = await test.host["plan.list"]({});
+    expect(active).toMatchObject({ planId: activated.planId, version: 1 });
+    if (active === null) throw new Error("Expected an active Plan");
+
+    await expect(
+      test.host["plan.close"]({
+        commandId: "stop-stale",
+        planId: active.planId,
+        expectedVersion: active.version + 1,
+      }),
+    ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+    await expect(
+      test.host["plan.close"]({
+        commandId: "stop-current",
+        planId: active.planId,
+        expectedVersion: active.version,
+      }),
+    ).resolves.toMatchObject({ status: "closed", planId: active.planId });
+    await expect(test.host["plan.list"]({})).resolves.toMatchObject({
+      active: null,
+      closed: [{ planId: active.planId, version: active.version + 1 }],
     });
   });
 

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -872,6 +872,8 @@ async function previewHarness() {
     crypto: globalThis.crypto,
     eventCandidates: { read: async () => [candidateSource] },
     today: () => currentToday,
+    todayDateKey: () => Number(currentToday.replaceAll("-", "")),
+    now: () => Date.parse(`${currentToday}T12:00:00Z`),
   });
   const started = await host["plan_creation.start"]({ commandId: "start" });
   if (started.status !== "started") throw new Error("Expected creation");
@@ -909,6 +911,9 @@ async function previewHarness() {
     ready,
     answer,
     card: () => card,
+    setToday: (value: string) => {
+      currentToday = value;
+    },
     advanceDay: () => {
       currentToday = "1998-09-03";
     },
@@ -1138,6 +1143,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
       await released;
       return creation;
     });
+    test.setToday("1998-01-01");
     const before = test.host["plan.list"]({});
     await entered;
     expect(transaction).toHaveBeenCalledTimes(1);
@@ -1181,6 +1187,64 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
         creationId: null,
       }],
     });
+  });
+
+  it("closes offline, replays the command, and reads the final snapshot", async () => {
+    const test = await review("flexible");
+    const activated = await test.host["plan_creation.activate"](test.request);
+    await expect(test.host["plan.history"]({ planId: activated.planId })).resolves.toBeNull();
+    const request = { commandId: "stop", planId: activated.planId, expectedVersion: 1 };
+    const result = await test.host["plan.close"](request);
+    expect(result).toMatchObject({ status: "closed", planId: activated.planId });
+    await expect(test.host["plan.close"](request)).resolves.toEqual(result);
+    await expect(test.host["plan.close"]({ ...request, expectedVersion: 2 })).resolves.toEqual({ status: "rejected", reason: "command-conflict" });
+    const detail = await test.host["plan.history"]({ planId: activated.planId });
+    expect(detail).toMatchObject({
+      plan: { planId: activated.planId, status: "closed", closeReason: "stopped" },
+      closeActor: "athlete",
+      revision: { revisionNumber: 1, snapshot: test.draft },
+      cleanup: "pending",
+    });
+    expect(detail?.revision.snapshot.weeks.flatMap((week) => week.workouts)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ date: null })]),
+    );
+    await expect(test.host["plan.list"]({})).resolves.toMatchObject({
+      active: null,
+      closed: [detail?.plan],
+    });
+    await expect(test.host["plan.history"]({ planId: id("999") })).resolves.toBeNull();
+  });
+
+  it("returns closure rejection reasons without changing an active Plan", async () => {
+    const test = await review();
+    const activated = await test.host["plan_creation.activate"](test.request);
+    await expect(
+      test.host["plan.close"]({ commandId: "stale", planId: activated.planId, expectedVersion: 2 }),
+    ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+    await expect(
+      test.host["plan.close"]({ commandId: "missing", planId: id("999"), expectedVersion: 1 }),
+    ).resolves.toEqual({ status: "rejected", reason: "no-active-plan" });
+    expect((await test.host["plan.list"]({})).active?.planId).toBe(activated.planId);
+  });
+
+  it("completes an expired Plan before listing and retains final history", async () => {
+    const test = await review();
+    const activated = await test.host["plan_creation.activate"](test.request);
+    test.setToday(test.draft.end);
+    expect((await test.host["plan.list"]({})).active?.planId).toBe(activated.planId);
+    test.setToday("1998-10-01");
+    await expect(test.host["plan.list"]({})).resolves.toMatchObject({
+      active: null,
+      closed: [{ planId: activated.planId, closeReason: "completed" }],
+    });
+    await expect(test.host["plan.history"]({ planId: activated.planId })).resolves.toMatchObject({
+      closeActor: "system:plan-completion",
+      cleanup: "pending",
+      revision: { snapshot: test.draft },
+    });
+    expect(
+      await test.store.all("SELECT * FROM planning_command WHERE command_name = 'plan.close'"),
+    ).toEqual([]);
   });
 
   it("activates dated Workouts, removes the Chat card, and exposes the Plan to readers", async () => {

--- a/packages/kernel-node/tests/plan-library-repository.test.ts
+++ b/packages/kernel-node/tests/plan-library-repository.test.ts
@@ -93,6 +93,7 @@ describe("Plan library repository", () => {
       closeReason,
       closedAtMs,
       activatedAtMs,
+      version: 1,
       creationId,
     };
   }

--- a/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
+++ b/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
@@ -1,0 +1,445 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createPlanCreationRepository,
+  createPlanLifecycleRepository,
+  type PlanLifecycleRepository,
+  type PlanCreationCommandStamp,
+  type PlanCreationRepository,
+} from "@enduragent/kernel/planning";
+import {
+  dumpStore,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const id = (value: string) => value.padStart(26, "0");
+const nowMs = 883_612_800_000;
+const fingerprint = "f".repeat(64);
+const stamp = (commandId: string, offset = 0): PlanCreationCommandStamp => ({
+  commandId,
+  requestDigest: "a".repeat(64),
+  nowMs: nowMs + offset,
+  deviceId: "test-device-1998",
+  hlcPhysicalMs: nowMs + offset,
+  hlcCounter: 0,
+});
+const datedWorkout = { name: "Endurance ride", date: "1998-01-01" };
+const poolWorkout = { name: "Flexible ride", date: null };
+const draft = {
+  outputFingerprint: fingerprint,
+  weeks: [{ workouts: [datedWorkout, poolWorkout] }, { workouts: [] }],
+};
+
+const activationInput = (key = "1") => {
+  const command = stamp(`activate-${key}`, Number(key) * 10 + 2);
+  const planId = id(`1${key}`);
+  return {
+    command,
+    creationId: id(key),
+    expectedVersion: 2,
+    activatedAt: "1998-01-01",
+    revisionId: id(`2${key}`),
+    materialize: () => ({
+      plan: {
+        id: planId,
+        originId: null,
+        name: "Improve fitness",
+        primaryGoal: "Ride well",
+        startDateKey: 19980101,
+        targetDateKey: 19980114,
+        status: "active" as const,
+        kind: "short_race_preparation" as const,
+        totalWeeks: 2,
+        weekStartDay: 4,
+        structureJson: JSON.stringify({ source: "plan-creation", creationId: id(key) }),
+        createdAtMs: command.nowMs,
+        updatedAtMs: command.nowMs,
+        deviceId: command.deviceId,
+        hlcPhysicalMs: command.hlcPhysicalMs,
+        hlcCounter: command.hlcCounter,
+      },
+      workouts: [
+        {
+          id: id(`3${key}`),
+          planId,
+          dateKey: 19980101,
+          sport: "Ride",
+          name: datedWorkout.name,
+          durationS: 3600,
+          structureJson: JSON.stringify(datedWorkout),
+          origin: "coach" as const,
+          deviceId: command.deviceId,
+          hlcPhysicalMs: command.hlcPhysicalMs,
+          hlcCounter: command.hlcCounter,
+        },
+      ],
+    }),
+  } satisfies Parameters<PlanCreationRepository["activate"]>[0];
+};
+
+describe("Plan lifecycle repository", () => {
+  let store: SqlStore & MigratorStore;
+  let repository: PlanCreationRepository;
+  let lifecycle: PlanLifecycleRepository;
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    repository = createPlanCreationRepository(store);
+    lifecycle = createPlanLifecycleRepository(store, { newId: () => id("99") });
+  });
+  afterEach(async () => store.close());
+  const start = (key = "1") =>
+    repository.start({
+      command: stamp(`start-${key}`, Number(key) * 10),
+      creationId: id(key),
+      seed: { schemaVersion: 1, eventCandidates: [] },
+    });
+  const review = async (key = "1", output = draft) => {
+    await start(key);
+    await repository.recordDraft({
+      command: stamp(`preview-${key}`, Number(key) * 10 + 1),
+      creationId: id(key),
+      expectedVersion: 1,
+      draftId: id(`4${key}`),
+      inputSnapshotJson: "{}",
+      inputFingerprint: "e".repeat(64),
+      outputSnapshotJson: JSON.stringify(output),
+      builderId: "cycling",
+      builderVersion: "1",
+      activationFingerprint: fingerprint,
+    });
+  };
+
+  const closeInput = () => ({
+    command: stamp("close-1", 50),
+    planId: id("11"),
+    expectedVersion: 1,
+    closedAtMs: nowMs + 50,
+    todayDateKey: 19980103,
+    cleanupJobId: id("91"),
+  });
+  const activate = async () => {
+    await review();
+    await repository.activate(activationInput());
+  };
+  const preview = () =>
+    store.run(
+      `INSERT INTO plan_change (
+    id,plan_id,status,version,base_revision_number,result_revision_number,
+    diff_json,rationale,premises_json,preview_fingerprint,reconciliation_effect_json,
+    created_at_ms,updated_at_ms,terminal_at_ms,device_id,hlc_physical_ms,hlc_counter
+    ) VALUES (?,?,'preview',1,1,NULL,'{}','Adjust training','[]',?,'{}',?,?,NULL,'test-device',?,3)`,
+      [id("81"), id("11"), fingerprint, nowMs + 60, nowMs + 60, nowMs + 60],
+    );
+
+  it("closes offline, records cleanup intent and preserves every revision and Workout", async () => {
+    await activate();
+    const revisions = await store.all("SELECT * FROM plan_revision");
+    const workouts = await store.all("SELECT * FROM plan_workout");
+    await expect(lifecycle.close(closeInput())).resolves.toEqual({
+      status: "closed",
+      planId: id("11"),
+      closedAt: nowMs + 50,
+      cleanupJobId: id("91"),
+    });
+    expect(
+      await store.get(`SELECT status,version,current_revision_number,close_actor,
+      close_reason,closed_at_ms FROM planning_plan`),
+    ).toEqual({
+      status: "closed",
+      version: 2,
+      current_revision_number: 1,
+      close_actor: "athlete",
+      close_reason: "stopped",
+      closed_at_ms: nowMs + 50,
+    });
+    expect(await store.get("SELECT status FROM plan")).toEqual({ status: "ended" });
+    expect(
+      await store.get(`SELECT kind,status,window_start_date_key,window_end_date_key
+      FROM plan_reconciliation_job`),
+    ).toEqual({
+      kind: "cleanup",
+      status: "pending",
+      window_start_date_key: 19980104,
+      window_end_date_key: 19980114,
+    });
+    expect(
+      await store.get(
+        "SELECT aggregate_refs_json FROM planning_command WHERE command_name='plan.close'",
+      ),
+    ).toEqual({ aggregate_refs_json: JSON.stringify({ planId: id("11") }, null, 2) });
+    expect(await store.all("SELECT * FROM plan_revision")).toEqual(revisions);
+    expect(await store.all("SELECT * FROM plan_workout")).toEqual(workouts);
+    await expect(store.run("UPDATE planning_plan SET version=version+1")).rejects.toThrow(
+      "immutable",
+    );
+  });
+
+  it("replays an already-closed Plan byte-identically, including after another activation", async () => {
+    await activate();
+    const result = await lifecycle.close(closeInput());
+    let before = await dumpStore(store);
+    await expect(lifecycle.close(closeInput())).resolves.toEqual(result);
+    expect(await dumpStore(store)).toBe(before);
+    await review("2");
+    await repository.activate(activationInput("2"));
+    before = await dumpStore(store);
+    await expect(lifecycle.close({ ...closeInput(), closedAtMs: nowMs + 100 })).resolves.toEqual(
+      result,
+    );
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it.each(["stale-version", "no-active-plan", "command-conflict"] as const)(
+    "rejects %s without any store changes",
+    async (reason) => {
+      await activate();
+      if (reason === "command-conflict") await lifecycle.close(closeInput());
+      const before = await dumpStore(store);
+      await expect(
+        lifecycle.close({
+          ...closeInput(),
+          expectedVersion: reason === "stale-version" ? 2 : 1,
+          planId: reason === "no-active-plan" ? id("88") : id("11"),
+          command: {
+            ...closeInput().command,
+            requestDigest: reason === "command-conflict" ? "b".repeat(64) : "a".repeat(64),
+          },
+        }),
+      ).resolves.toEqual({ status: "rejected", reason });
+      expect(await dumpStore(store)).toBe(before);
+    },
+  );
+
+  it("rejects when no active Plan exists, including a fresh command after closure", async () => {
+    await expect(lifecycle.close(closeInput())).resolves.toEqual({
+      status: "rejected",
+      reason: "no-active-plan",
+    });
+    await activate();
+    await lifecycle.close(closeInput());
+    const before = await dumpStore(store);
+    await expect(
+      lifecycle.close({ ...closeInput(), command: stamp("close-again", 70) }),
+    ).resolves.toEqual({ status: "rejected", reason: "no-active-plan" });
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it("bounds cleanup after the final Plan day", async () => {
+    await activate();
+    await lifecycle.close({ ...closeInput(), todayDateKey: 19980201 });
+    expect(
+      await store.get(
+        "SELECT window_start_date_key,window_end_date_key FROM plan_reconciliation_job",
+      ),
+    ).toEqual({ window_start_date_key: 19980202, window_end_date_key: 19980202 });
+  });
+
+  it("rolls back closure, cleanup and preview changes if the ledger write fails", async () => {
+    await activate();
+    await preview();
+    await store.exec(`CREATE TRIGGER fail_close_ledger BEFORE INSERT ON planning_command
+      WHEN NEW.command_name='plan.close' BEGIN SELECT RAISE(ABORT,'Synthetic ledger failure'); END;`);
+    const before = await dumpStore(store);
+    await expect(
+      lifecycle.close({ ...closeInput(), command: stamp("close-1", 70), closedAtMs: nowMs + 70 }),
+    ).rejects.toThrow("Synthetic ledger failure");
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it("enforces preview wall and logical clock ordering before staling the preview", async () => {
+    await activate();
+    await preview();
+    const before = await dumpStore(store);
+    for (const input of [
+      closeInput(),
+      { ...closeInput(), command: stamp("close-1", 60), closedAtMs: nowMs + 60 },
+      { ...closeInput(), command: stamp("close-1", 70), closedAtMs: nowMs + 50 },
+    ]) {
+      await expect(lifecycle.close(input)).rejects.toThrow("clock precedes preview");
+      expect(await dumpStore(store)).toBe(before);
+    }
+    await lifecycle.close({
+      ...closeInput(),
+      command: stamp("close-1", 70),
+      closedAtMs: nowMs + 70,
+    });
+    expect(await store.get("SELECT status,version,terminal_at_ms FROM plan_change")).toEqual({
+      status: "stale",
+      version: 2,
+      terminal_at_ms: nowMs + 70,
+    });
+    expect(await store.get("SELECT current_revision_number FROM planning_plan")).toEqual({
+      current_revision_number: 1,
+    });
+  });
+
+  it.each([19980113, 19980114])("keeps the Plan active on %s", async (todayDateKey) => {
+    await activate();
+    const before = await dumpStore(store);
+    await expect(lifecycle.completeExpired({ todayDateKey, nowMs: nowMs + 100 })).resolves.toEqual({
+      completedPlanId: null,
+    });
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it.each([false, true])(
+    "completes after its own final day with a later Goal=%s, once",
+    async (laterGoal) => {
+      const totalWeeks = laterGoal ? 12 : 2;
+      const finalDateKey = laterGoal ? 19980325 : 19980114;
+      const completionDay = laterGoal ? 19980326 : 19980115;
+      const snapshot = {
+        ...draft,
+        goal: { kind: "event", name: "Autumn ride", date: laterGoal ? "1998-12-31" : "1998-01-14" },
+        spanKind: laterGoal ? "Base Plan" : "Short block",
+        weeks: Array.from({ length: totalWeeks }, (_, index) => ({
+          workouts: index === 0 ? [datedWorkout, poolWorkout] : [],
+        })),
+      };
+      await review("1", snapshot);
+      const input = activationInput();
+      await repository.activate({
+        ...input,
+        materialize: () => {
+          const materialized = input.materialize();
+          return {
+            ...materialized,
+            plan: {
+              ...materialized.plan,
+              totalWeeks,
+              kind: laterGoal ? "full_plan" : materialized.plan.kind,
+              targetDateKey: finalDateKey,
+            },
+          };
+        },
+      });
+      await preview();
+      const commands = await store.all("SELECT * FROM planning_command");
+      const revisions = await store.all("SELECT * FROM plan_revision");
+      await expect(
+        lifecycle.completeExpired({ todayDateKey: completionDay, nowMs: nowMs + 100 }),
+      ).resolves.toEqual({ completedPlanId: id("11") });
+      expect(
+        await store.get("SELECT status,close_reason,close_actor,closed_at_ms FROM planning_plan"),
+      ).toEqual({
+        status: "closed",
+        close_reason: "completed",
+        close_actor: "system:plan-completion",
+        closed_at_ms: nowMs + 100,
+      });
+      expect(await store.get("SELECT status FROM plan")).toEqual({ status: "ended" });
+      expect(
+        await store.get(
+          "SELECT kind,status,window_start_date_key,window_end_date_key FROM plan_reconciliation_job",
+        ),
+      ).toEqual({
+        kind: "cleanup",
+        status: "pending",
+        window_start_date_key: completionDay,
+        window_end_date_key: completionDay,
+      });
+      expect(await store.all("SELECT * FROM planning_command")).toEqual(commands);
+      expect(await store.all("SELECT * FROM plan_revision")).toEqual(revisions);
+      expect((await lifecycle.readClosedDetail(id("11")))?.revision.snapshot).toEqual(snapshot);
+      const before = await dumpStore(store);
+      await expect(
+        lifecycle.completeExpired({ todayDateKey: 19990101, nowMs: nowMs + 200 }),
+      ).resolves.toEqual({ completedPlanId: null });
+      expect(await dumpStore(store)).toBe(before);
+    },
+  );
+
+  it("returns the final applied revision rather than the activation snapshot", async () => {
+    await activate();
+    await preview();
+    const finalSnapshot = {
+      ...draft,
+      weeks: [{ workouts: [{ ...poolWorkout, name: "Final flexible ride" }] }],
+    };
+    await store.run(
+      `INSERT INTO plan_revision (
+      id,plan_id,revision_number,parent_revision_number,source_kind,source_id,snapshot_json,
+      fingerprint,created_at_ms,device_id,hlc_physical_ms,hlc_counter
+      ) VALUES (?,?,2,1,'plan-change',?,?,?,?,'test-device',?,0)`,
+      [
+        id("82"),
+        id("11"),
+        id("81"),
+        JSON.stringify(finalSnapshot),
+        "e".repeat(64),
+        nowMs + 70,
+        nowMs + 70,
+      ],
+    );
+    await store.run(
+      `UPDATE planning_plan SET current_revision_number=2,version=2,
+      updated_at_ms=?,hlc_physical_ms=? WHERE plan_id=?`,
+      [nowMs + 70, nowMs + 70, id("11")],
+    );
+    await lifecycle.close({
+      ...closeInput(),
+      expectedVersion: 2,
+      command: stamp("close-1", 80),
+      closedAtMs: nowMs + 80,
+    });
+    const before = await dumpStore(store);
+    expect((await lifecycle.readClosedDetail(id("11")))?.revision).toEqual({
+      revisionNumber: 2,
+      fingerprint: "e".repeat(64),
+      snapshot: finalSnapshot,
+    });
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it("returns the existing cleanup job when its window is already recorded", async () => {
+    await activate();
+    await store.run(
+      `INSERT INTO plan_reconciliation_job (
+      id,plan_id,kind,status,window_start_date_key,window_end_date_key,created_at_ms,updated_at_ms
+      ) VALUES (?,?,'cleanup','pending',19980104,19980114,?,?)`,
+      [id("90"), id("11"), nowMs, nowMs],
+    );
+    await expect(lifecycle.close(closeInput())).resolves.toMatchObject({ cleanupJobId: id("90") });
+    expect(await store.all("SELECT id FROM plan_reconciliation_job")).toEqual([{ id: id("90") }]);
+  });
+
+  it("reads immutable closed details including undated Workouts and cleanup state", async () => {
+    await expect(lifecycle.readClosedDetail(id("11"))).resolves.toBeNull();
+    await activate();
+    await expect(lifecycle.readClosedDetail(id("11"))).resolves.toBeNull();
+    await lifecycle.close(closeInput());
+    const before = await dumpStore(store);
+    const detail = await lifecycle.readClosedDetail(id("11"));
+    expect(detail).toEqual({
+      plan: {
+        planId: id("11"),
+        name: "Improve fitness",
+        startDateKey: 19980101,
+        totalWeeks: 2,
+        status: "closed",
+        closeReason: "stopped",
+        closedAtMs: nowMs + 50,
+        activatedAtMs: nowMs + 12,
+        creationId: id("1"),
+      },
+      closeActor: "athlete",
+      revision: { revisionNumber: 1, fingerprint, snapshot: draft },
+      cleanup: "pending",
+    });
+    expect(await dumpStore(store)).toBe(before);
+    await store.run(
+      "UPDATE plan_reconciliation_job SET status='verified',completed_at_ms=updated_at_ms",
+    );
+    expect((await lifecycle.readClosedDetail(id("11")))?.cleanup).toBe("complete");
+    await store.run(
+      "UPDATE plan_reconciliation_job SET status='failed',completed_at_ms=NULL,last_error_code='calendar-delete-failed'",
+    );
+    expect((await lifecycle.readClosedDetail(id("11")))?.cleanup).toBe("failed");
+    await store.run("DELETE FROM plan_reconciliation_job");
+    expect((await lifecycle.readClosedDetail(id("11")))?.cleanup).toBe("none");
+  });
+});

--- a/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
+++ b/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createPlanCreationRepository,
+  createPlanRepository,
   createPlanLifecycleRepository,
   type PlanLifecycleRepository,
   type PlanCreationCommandStamp,
@@ -134,6 +135,22 @@ describe("Plan lifecycle repository", () => {
     ) VALUES (?,?,'preview',1,1,NULL,'{}','Adjust training','[]',?,'{}',?,?,NULL,'test-device',?,3)`,
       [id("81"), id("11"), fingerprint, nowMs + 60, nowMs + 60, nowMs + 60],
     );
+
+  it("lists the current Plan version before and after closure", async () => {
+    await activate();
+    const plans = createPlanRepository(store);
+    const [active] = await plans.listPlans();
+    expect(active).toMatchObject({ planId: id("11"), status: "active", version: 1 });
+    if (active === undefined) throw new Error("Expected an active Plan");
+
+    await expect(
+      lifecycle.close({ ...closeInput(), expectedVersion: active.version }),
+    ).resolves.toMatchObject({ status: "closed" });
+
+    await expect(plans.listPlans()).resolves.toMatchObject([
+      { planId: active.planId, status: "closed", version: active.version + 1 },
+    ]);
+  });
 
   it("closes offline, records cleanup intent and preserves every revision and Workout", async () => {
     await activate();
@@ -424,6 +441,7 @@ describe("Plan lifecycle repository", () => {
         closeReason: "stopped",
         closedAtMs: nowMs + 50,
         activatedAtMs: nowMs + 12,
+        version: 2,
         creationId: id("1"),
       },
       closeActor: "athlete",

--- a/packages/kernel/src/planning/command-ledger.ts
+++ b/packages/kernel/src/planning/command-ledger.ts
@@ -1,0 +1,86 @@
+import { canonicalJson } from "../archive/canonical.js";
+import type { SqlStore, Row } from "../store/ports.js";
+
+export type PlanCreationErrorCode =
+  | "command-conflict"
+  | "stale-version"
+  | "missing-creation"
+  | "no-unfinished-creation"
+  | "corrupt-record"
+  | "version-conflict"
+  | "not-ready";
+
+export class PlanCreationStoreError extends Error {
+  constructor(readonly code: PlanCreationErrorCode) {
+    super(
+      code === "not-ready"
+        ? "Build a current complete Draft and resolve pending answers before activation."
+        : code,
+    );
+    this.name = "PlanCreationStoreError";
+  }
+}
+
+export interface PlanCreationCommandStamp {
+  readonly commandId: string;
+  readonly requestDigest: string;
+  readonly nowMs: number;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+export type PlanningCommandName =
+  | "plan_creation.start"
+  | "plan_creation.answer"
+  | "plan_creation.discard"
+  | "plan_creation.preview"
+  | "plan_creation.activate"
+  | "plan.close";
+
+export const fail = (): never => {
+  throw new PlanCreationStoreError("corrupt-record");
+};
+const text = (row: Row, key: string): string => {
+  const value = row[key];
+  return typeof value === "string" ? value : fail();
+};
+
+export function createPlanningCommandLedger(store: SqlStore) {
+  const hasReplay = async (name: PlanningCommandName, command: PlanCreationCommandStamp) => {
+    const row = await store.get(
+      "SELECT request_digest,status,result_json FROM planning_command WHERE command_name=? AND command_id=?",
+      [name, command.commandId],
+    );
+    if (row === undefined) return undefined;
+    if (text(row, "request_digest") !== command.requestDigest)
+      throw new PlanCreationStoreError("command-conflict");
+    if (text(row, "status") !== "succeeded") fail();
+    return row;
+  };
+  const recordCommand = (
+    name: PlanningCommandName,
+    command: PlanCreationCommandStamp,
+    aggregateRefs: { readonly creationId: string } | { readonly planId: string },
+    result: unknown,
+  ) =>
+    store.run(
+      `INSERT INTO planning_command (
+command_name,command_id,request_digest,status,aggregate_refs_json,result_json,error_code,error_json,
+version,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?, ?, ?, 'succeeded', ?, ?, NULL, NULL, 2, ?, ?, ?, ?, ?)`,
+      [
+        name,
+        command.commandId,
+        command.requestDigest,
+        canonicalJson(aggregateRefs),
+        canonicalJson(result),
+        command.nowMs,
+        command.nowMs,
+        command.deviceId,
+        command.hlcPhysicalMs,
+        command.hlcCounter,
+      ],
+    );
+  return { hasReplay, recordCommand };
+}

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -4,32 +4,23 @@ import {
   type PlanRecord,
   type PlanWorkoutRecord,
 } from "./repository.js";
+import {
+  createPlanningCommandLedger,
+  fail,
+  PlanCreationStoreError,
+  type PlanCreationCommandStamp,
+} from "./command-ledger.js";
+export {
+  PlanCreationStoreError,
+  type PlanCreationErrorCode,
+  type PlanCreationCommandStamp,
+} from "./command-ledger.js";
 import { canonicalJson } from "../archive/canonical.js";
 import type { MigratorStore } from "../store/migrator.js";
 import type { Row, SqlStore } from "../store/ports.js";
 import { z } from "zod";
 
 export type PlanCreationStore = SqlStore & Pick<MigratorStore, "transaction">;
-export type PlanCreationErrorCode =
-  | "command-conflict"
-  | "stale-version"
-  | "missing-creation"
-  | "no-unfinished-creation"
-  | "corrupt-record"
-  | "version-conflict"
-  | "not-ready";
-
-export class PlanCreationStoreError extends Error {
-  constructor(readonly code: PlanCreationErrorCode) {
-    super(
-      code === "not-ready"
-        ? "Build a current complete Draft and resolve pending answers before activation."
-        : code,
-    );
-    this.name = "PlanCreationStoreError";
-  }
-}
-
 export const PlanCreationSeedV1Schema = z
   .object({
     schemaVersion: z.literal(1),
@@ -92,15 +83,6 @@ const PlanCreationSnapshotSchema = z
   })
   .readonly();
 export type PlanCreationSnapshot = z.infer<typeof PlanCreationSnapshotSchema>;
-
-export interface PlanCreationCommandStamp {
-  readonly commandId: string;
-  readonly requestDigest: string;
-  readonly nowMs: number;
-  readonly deviceId: string;
-  readonly hlcPhysicalMs: number;
-  readonly hlcCounter: number;
-}
 
 export interface StartPlanCreationInput {
   readonly command: PlanCreationCommandStamp;
@@ -184,9 +166,6 @@ export interface PlanCreationRepository {
   }>;
 }
 
-const fail = (): never => {
-  throw new PlanCreationStoreError("corrupt-record");
-};
 const text = (row: Row, key: string): string => {
   const value = row[key];
   return typeof value === "string" ? value : fail();
@@ -208,6 +187,7 @@ const parseSeed = (value: unknown): PlanCreationSeedV1 => {
 };
 
 export function createPlanCreationRepository(store: PlanCreationStore): PlanCreationRepository {
+  const { hasReplay, recordCommand } = createPlanningCommandLedger(store);
   const readUnfinished = async (): Promise<PlanCreationSnapshot | undefined> => {
     const rows = await store.all(
       "SELECT * FROM plan_creation WHERE status IN ('in-progress','review') ORDER BY created_at_ms,id",
@@ -276,25 +256,6 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
     if (snapshot === undefined) throw new PlanCreationStoreError("missing-creation");
     return snapshot;
   };
-  const hasReplay = async (
-    name:
-      | "plan_creation.start"
-      | "plan_creation.answer"
-      | "plan_creation.discard"
-      | "plan_creation.preview"
-      | "plan_creation.activate",
-    command: PlanCreationCommandStamp,
-  ) => {
-    const row = await store.get(
-      "SELECT request_digest,status,result_json FROM planning_command WHERE command_name=? AND command_id=?",
-      [name, command.commandId],
-    );
-    if (row === undefined) return undefined;
-    if (text(row, "request_digest") !== command.requestDigest)
-      throw new PlanCreationStoreError("command-conflict");
-    if (text(row, "status") !== "succeeded") fail();
-    return row;
-  };
   const replay = async (
     name: "plan_creation.start" | "plan_creation.answer",
     command: PlanCreationCommandStamp,
@@ -305,35 +266,6 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
     const parsed = PlanCreationSnapshotSchema.safeParse(json(text(row, "result_json")));
     return parsed.success ? parsed.data : fail();
   };
-  const recordCommand = (
-    name:
-      | "plan_creation.start"
-      | "plan_creation.answer"
-      | "plan_creation.discard"
-      | "plan_creation.preview"
-      | "plan_creation.activate",
-    command: PlanCreationCommandStamp,
-    creationId: string,
-    result: unknown,
-  ) =>
-    store.run(
-      `INSERT INTO planning_command (
-command_name,command_id,request_digest,status,aggregate_refs_json,result_json,error_code,error_json,
-version,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
-) VALUES (?, ?, ?, 'succeeded', ?, ?, NULL, NULL, 2, ?, ?, ?, ?, ?)`,
-      [
-        name,
-        command.commandId,
-        command.requestDigest,
-        canonicalJson({ creationId }),
-        canonicalJson(result),
-        command.nowMs,
-        command.nowMs,
-        command.deviceId,
-        command.hlcPhysicalMs,
-        command.hlcCounter,
-      ],
-    );
   return {
     readUnfinished,
     replayDraft,
@@ -361,10 +293,15 @@ terminal_at_ms,device_id,hlc_physical_ms,hlc_counter
           );
           snapshot = await requireUnfinished();
         }
-        await recordCommand("plan_creation.start", command, snapshot.id, {
-          creationId: snapshot.id,
-          outcome,
-        });
+        await recordCommand(
+          "plan_creation.start",
+          command,
+          { creationId: snapshot.id },
+          {
+            creationId: snapshot.id,
+            outcome,
+          },
+        );
         return { outcome, snapshot };
       });
     },
@@ -410,11 +347,16 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
         const snapshot = await requireUnfinished();
         if (snapshot.id !== creationId || snapshot.version !== version)
           throw new PlanCreationStoreError("stale-version");
-        await recordCommand("plan_creation.answer", command, creationId, {
-          creationId,
-          answerId,
-          version,
-        });
+        await recordCommand(
+          "plan_creation.answer",
+          command,
+          { creationId },
+          {
+            creationId,
+            answerId,
+            version,
+          },
+        );
         return { outcome: "recorded", snapshot };
       });
     },
@@ -475,7 +417,7 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
           snapshot.status !== "review"
         )
           throw new PlanCreationStoreError("stale-version");
-        await recordCommand("plan_creation.preview", command, creationId, snapshot);
+        await recordCommand("plan_creation.preview", command, { creationId }, snapshot);
         return { outcome: "recorded", snapshot };
       });
     },
@@ -628,7 +570,7 @@ updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=? WHERE id=? AND statu
         );
         if (updated === undefined || integer(updated, "version") !== expectedVersion + 1)
           throw new PlanCreationStoreError("version-conflict");
-        await recordCommand("plan_creation.activate", command, creationId, result);
+        await recordCommand("plan_creation.activate", command, { creationId }, result);
         return result;
       });
     },
@@ -659,11 +601,16 @@ RETURNING status,version`,
         if (text(updated, "status") !== "discarded" || integer(updated, "version") !== version) {
           fail();
         }
-        await recordCommand("plan_creation.discard", command, creationId, {
-          creationId,
-          outcome: "discarded",
-          version,
-        });
+        await recordCommand(
+          "plan_creation.discard",
+          command,
+          { creationId },
+          {
+            creationId,
+            outcome: "discarded",
+            version,
+          },
+        );
         return { outcome: "discarded" };
       });
     },

--- a/packages/kernel/src/planning/index.ts
+++ b/packages/kernel/src/planning/index.ts
@@ -17,3 +17,4 @@ export * from "./request-intake-repository.js";
 export * from "./intake-repository.js";
 export * from "./draft-build-repository.js";
 export * from "./creation-repository.js";
+export * from "./lifecycle-repository.js";

--- a/packages/kernel/src/planning/lifecycle-repository.ts
+++ b/packages/kernel/src/planning/lifecycle-repository.ts
@@ -1,0 +1,289 @@
+import { z } from "zod";
+import { createPlanningCommandLedger, fail, PlanCreationStoreError } from "./command-ledger.js";
+import type { PlanCreationCommandStamp, PlanCreationStore } from "./creation-repository.js";
+import { addCivilDays } from "./date-keys.js";
+import type { PlanSummaryRecord } from "./repository.js";
+
+const UlidSchema = z.string().regex(/^[0-9A-HJKMNP-TV-Z]{26}$/u);
+export const PlanCloseResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("closed"),
+      planId: UlidSchema,
+      closedAt: z.number().int().nonnegative(),
+      cleanupJobId: UlidSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("rejected"),
+      reason: z.enum(["stale-version", "no-active-plan", "command-conflict"]),
+    })
+    .strict(),
+]);
+export type PlanCloseResult = z.infer<typeof PlanCloseResultSchema>;
+
+export interface ClosePlanInput {
+  readonly command: PlanCreationCommandStamp;
+  readonly planId: string;
+  readonly expectedVersion: number;
+  readonly closedAtMs: number;
+  readonly todayDateKey: number;
+  readonly cleanupJobId: string;
+}
+
+export interface ClosedPlanDetail {
+  readonly plan: PlanSummaryRecord;
+  readonly closeActor: string | null;
+  readonly revision: {
+    readonly revisionNumber: number;
+    readonly fingerprint: string;
+    readonly snapshot: unknown;
+  };
+  readonly cleanup: "none" | "pending" | "complete" | "failed";
+}
+
+export interface PlanLifecycleRepository {
+  close(input: ClosePlanInput): Promise<PlanCloseResult>;
+  completeExpired(input: { readonly todayDateKey: number; readonly nowMs: number }): Promise<{
+    readonly completedPlanId: string | null;
+  }>;
+  readClosedDetail(planId: string): Promise<ClosedPlanDetail | null>;
+}
+
+const ActiveRowSchema = z.object({
+  plan_id: UlidSchema,
+  version: z.number().int().positive(),
+  start_date_key: z.number().int(),
+  total_weeks: z.number().int().positive(),
+  hlc_physical_ms: z.number().int().nonnegative(),
+  hlc_counter: z.number().int().nonnegative(),
+});
+const ClosedRowSchema = z.object({
+  plan_id: UlidSchema,
+  name: z.string(),
+  start_date_key: z.number().int(),
+  total_weeks: z.number().int().positive(),
+  status: z.literal("closed"),
+  close_reason: z.enum(["stopped", "completed", "legacy-unclassified"]),
+  closed_at_ms: z.number().int().nonnegative(),
+  activated_at_ms: z.number().int().nonnegative(),
+  creation_id: z.string().nullable(),
+  close_actor: z.string().nullable(),
+  cleanup_status: z.enum(["pending", "running", "retrying", "failed", "verified"]).nullable(),
+});
+const RevisionRowSchema = z.object({
+  revision_number: z.number().int().positive(),
+  fingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+  snapshot_json: z.string(),
+});
+
+export function createPlanLifecycleRepository(
+  store: PlanCreationStore,
+  identity: { readonly newId: () => string },
+): PlanLifecycleRepository {
+  const { hasReplay, recordCommand } = createPlanningCommandLedger(store);
+  const readActive = async () => {
+    const row = await store.get(`SELECT planning_plan.plan_id,planning_plan.version,
+      plan.start_date_key,plan.total_weeks,planning_plan.hlc_physical_ms,planning_plan.hlc_counter
+      FROM planning_plan JOIN plan ON plan.id=planning_plan.plan_id
+      WHERE planning_plan.status='active'`);
+    return row === undefined ? null : ActiveRowSchema.parse(row);
+  };
+  const persistClose = async (input: {
+    planId: string;
+    version: number;
+    reason: "stopped" | "completed";
+    actor: "athlete" | "system:plan-completion";
+    closedAtMs: number;
+    updatedAtMs: number;
+    deviceId: string;
+    hlcPhysicalMs: number;
+    hlcCounter: number;
+    cleanupJobId: string;
+    windowStart: number;
+    windowEnd: number;
+  }) => {
+    await store.run(
+      `UPDATE planning_plan SET status='closed',close_reason=?,close_actor=?,
+      closed_at_ms=?,version=version+1,updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=?
+      WHERE plan_id=? AND status='active' AND version=?`,
+      [
+        input.reason,
+        input.actor,
+        input.closedAtMs,
+        input.updatedAtMs,
+        input.deviceId,
+        input.hlcPhysicalMs,
+        input.hlcCounter,
+        input.planId,
+        input.version,
+      ],
+    );
+    await store.run(
+      `UPDATE plan SET status='ended',updated_at_ms=?,device_id=?,
+      hlc_physical_ms=?,hlc_counter=? WHERE id=?`,
+      [input.updatedAtMs, input.deviceId, input.hlcPhysicalMs, input.hlcCounter, input.planId],
+    );
+    await store.run(
+      `INSERT INTO plan_reconciliation_job (
+      id,plan_id,kind,status,window_start_date_key,window_end_date_key,
+      attempt_count,failure_count,resumed_count,last_resumed_attempt,last_error_code,
+      created_at_ms,updated_at_ms,completed_at_ms
+      ) VALUES (?,?,'cleanup','pending',?,?,0,0,0,NULL,NULL,?,?,NULL)
+      ON CONFLICT(plan_id,kind,window_start_date_key,window_end_date_key) DO NOTHING`,
+      [
+        input.cleanupJobId,
+        input.planId,
+        input.windowStart,
+        input.windowEnd,
+        input.updatedAtMs,
+        input.updatedAtMs,
+      ],
+    );
+    const job = await store.get(
+      `SELECT id FROM plan_reconciliation_job
+      WHERE plan_id=? AND kind='cleanup' AND window_start_date_key=? AND window_end_date_key=?`,
+      [input.planId, input.windowStart, input.windowEnd],
+    );
+    return z.object({ id: UlidSchema }).parse(job).id;
+  };
+  return {
+    async close(input) {
+      return store.transaction(async () => {
+        let prior;
+        try {
+          prior = await hasReplay("plan.close", input.command);
+        } catch (error) {
+          if (error instanceof PlanCreationStoreError && error.code === "command-conflict")
+            return { status: "rejected", reason: "command-conflict" };
+          throw error;
+        }
+        if (prior !== undefined) {
+          if (typeof prior.result_json !== "string") return fail();
+          return PlanCloseResultSchema.parse(JSON.parse(prior.result_json));
+        }
+        const active = await readActive();
+        if (active === null || active.plan_id !== input.planId)
+          return { status: "rejected", reason: "no-active-plan" };
+        if (active.version !== input.expectedVersion)
+          return { status: "rejected", reason: "stale-version" };
+        const windowStart = addCivilDays(input.todayDateKey, 1);
+        const finalDateKey = addCivilDays(active.start_date_key, active.total_weeks * 7 - 1);
+        const cleanupJobId = await persistClose({
+          planId: input.planId,
+          version: input.expectedVersion,
+          reason: "stopped",
+          actor: "athlete",
+          closedAtMs: input.closedAtMs,
+          updatedAtMs: Math.max(input.command.nowMs, input.closedAtMs),
+          deviceId: input.command.deviceId,
+          hlcPhysicalMs: input.command.hlcPhysicalMs,
+          hlcCounter: input.command.hlcCounter,
+          cleanupJobId: input.cleanupJobId,
+          windowStart,
+          windowEnd: Math.max(windowStart, finalDateKey),
+        });
+        const result = PlanCloseResultSchema.parse({
+          status: "closed",
+          planId: input.planId,
+          closedAt: input.closedAtMs,
+          cleanupJobId,
+        });
+        await recordCommand("plan.close", input.command, { planId: input.planId }, result);
+        return result;
+      });
+    },
+    async completeExpired({ todayDateKey, nowMs }) {
+      return store.transaction(async () => {
+        const active = await readActive();
+        if (active === null) return { completedPlanId: null };
+        const finalDateKey = addCivilDays(active.start_date_key, active.total_weeks * 7 - 1);
+        if (finalDateKey >= todayDateKey) return { completedPlanId: null };
+        const preview = await store.get(
+          `SELECT hlc_physical_ms,hlc_counter FROM plan_change
+          WHERE plan_id=? AND status='preview' ORDER BY hlc_physical_ms DESC,hlc_counter DESC LIMIT 1`,
+          [active.plan_id],
+        );
+        const clock = z
+          .object({
+            hlc_physical_ms: z.number().int().nonnegative(),
+            hlc_counter: z.number().int().nonnegative(),
+          })
+          .parse(preview ?? active);
+        const hlcPhysicalMs = Math.max(nowMs, active.hlc_physical_ms, clock.hlc_physical_ms);
+        const hlcCounter =
+          Math.max(
+            hlcPhysicalMs === active.hlc_physical_ms ? active.hlc_counter : 0,
+            hlcPhysicalMs === clock.hlc_physical_ms ? clock.hlc_counter : 0,
+          ) + 1;
+        const windowStart = addCivilDays(finalDateKey, 1);
+        await persistClose({
+          planId: active.plan_id,
+          version: active.version,
+          reason: "completed",
+          actor: "system:plan-completion",
+          closedAtMs: nowMs,
+          updatedAtMs: nowMs,
+          deviceId: "system:plan-completion",
+          hlcPhysicalMs,
+          hlcCounter,
+          cleanupJobId: identity.newId(),
+          windowStart,
+          windowEnd: windowStart,
+        });
+        return { completedPlanId: active.plan_id };
+      });
+    },
+    async readClosedDetail(planId) {
+      const row = await store.get(
+        `SELECT planning_plan.plan_id,plan.name,plan.start_date_key,plan.total_weeks,
+        planning_plan.status,planning_plan.close_reason,planning_plan.closed_at_ms,
+        planning_plan.activated_at_ms,planning_plan.close_actor,activation.source_id AS creation_id,
+        (SELECT status FROM plan_reconciliation_job WHERE plan_id=planning_plan.plan_id AND kind='cleanup'
+          ORDER BY updated_at_ms DESC,id DESC LIMIT 1) AS cleanup_status
+        FROM planning_plan JOIN plan ON plan.id=planning_plan.plan_id
+        LEFT JOIN plan_revision AS activation ON activation.plan_id=planning_plan.plan_id
+          AND activation.source_kind='activation'
+        WHERE planning_plan.plan_id=? AND planning_plan.status='closed'`,
+        [planId],
+      );
+      if (row === undefined) return null;
+      const closed = ClosedRowSchema.parse(row);
+      const revisionRow = await store.get(
+        `SELECT revision_number,fingerprint,snapshot_json
+        FROM plan_revision WHERE plan_id=? ORDER BY revision_number DESC LIMIT 1`,
+        [planId],
+      );
+      if (revisionRow === undefined) return null;
+      const revision = RevisionRowSchema.parse(revisionRow);
+      return {
+        plan: {
+          planId: closed.plan_id,
+          name: closed.name,
+          startDateKey: closed.start_date_key,
+          totalWeeks: closed.total_weeks,
+          status: closed.status,
+          closeReason: closed.close_reason,
+          closedAtMs: closed.closed_at_ms,
+          activatedAtMs: closed.activated_at_ms,
+          creationId: closed.creation_id,
+        },
+        closeActor: closed.close_actor,
+        revision: {
+          revisionNumber: revision.revision_number,
+          fingerprint: revision.fingerprint,
+          snapshot: JSON.parse(revision.snapshot_json),
+        },
+        cleanup:
+          closed.cleanup_status === null
+            ? "none"
+            : closed.cleanup_status === "verified"
+              ? "complete"
+              : closed.cleanup_status === "failed"
+                ? "failed"
+                : "pending",
+      };
+    },
+  };
+}

--- a/packages/kernel/src/planning/lifecycle-repository.ts
+++ b/packages/kernel/src/planning/lifecycle-repository.ts
@@ -68,6 +68,7 @@ const ClosedRowSchema = z.object({
   close_reason: z.enum(["stopped", "completed", "legacy-unclassified"]),
   closed_at_ms: z.number().int().nonnegative(),
   activated_at_ms: z.number().int().nonnegative(),
+  version: z.number().int().positive(),
   creation_id: z.string().nullable(),
   close_actor: z.string().nullable(),
   cleanup_status: z.enum(["pending", "running", "retrying", "failed", "verified"]).nullable(),
@@ -239,7 +240,7 @@ export function createPlanLifecycleRepository(
       const row = await store.get(
         `SELECT planning_plan.plan_id,plan.name,plan.start_date_key,plan.total_weeks,
         planning_plan.status,planning_plan.close_reason,planning_plan.closed_at_ms,
-        planning_plan.activated_at_ms,planning_plan.close_actor,activation.source_id AS creation_id,
+        planning_plan.activated_at_ms,planning_plan.version,planning_plan.close_actor,activation.source_id AS creation_id,
         (SELECT status FROM plan_reconciliation_job WHERE plan_id=planning_plan.plan_id AND kind='cleanup'
           ORDER BY updated_at_ms DESC,id DESC LIMIT 1) AS cleanup_status
         FROM planning_plan JOIN plan ON plan.id=planning_plan.plan_id
@@ -267,6 +268,7 @@ export function createPlanLifecycleRepository(
           closeReason: closed.close_reason,
           closedAtMs: closed.closed_at_ms,
           activatedAtMs: closed.activated_at_ms,
+          version: closed.version,
           creationId: closed.creation_id,
         },
         closeActor: closed.close_actor,

--- a/packages/kernel/src/planning/repository.ts
+++ b/packages/kernel/src/planning/repository.ts
@@ -48,6 +48,7 @@ export interface PlanWorkoutRecord {
 
 export interface PlanSummaryRecord {
   readonly planId: string;
+  readonly version: number;
   readonly name: string;
   readonly startDateKey: number;
   readonly totalWeeks: number;
@@ -302,6 +303,7 @@ function planSummaryFromRow(row: Row): PlanSummaryRecord {
   }
   return Object.freeze({
     planId: text(row, "plan_id"),
+    version: integer(row, "version"),
     name: text(row, "name"),
     startDateKey: integer(row, "start_date_key"),
     totalWeeks: integer(row, "total_weeks"),
@@ -416,7 +418,7 @@ ON CONFLICT (id) DO UPDATE SET
     },
     async listPlans() {
       const rows = await store.all(
-        `SELECT planning_plan.plan_id, plan.name, plan.start_date_key, plan.total_weeks,
+        `SELECT planning_plan.plan_id, planning_plan.version, plan.name, plan.start_date_key, plan.total_weeks,
                 planning_plan.status, planning_plan.close_reason, planning_plan.closed_at_ms,
                 planning_plan.activated_at_ms, plan_revision.source_id AS creation_id
          FROM planning_plan


### PR DESCRIPTION
## Summary

Backend half of END-11 (close Plans and read their final history) for the Plan-in-Chat epic.

- Kernel: new `lifecycle-repository.ts` with `close`, `completeExpired`, `readClosedDetail`; shared command ledger extracted to `command-ledger.ts`. Closing keeps revision rows untouched, sets the legacy `plan` row to ended, and records a pending cleanup job.
- Athlete stops record `close_actor='athlete'`. Completion runs when the athlete's civil today is later than the Plan's final day and records `system:plan-completion` with no ledger row. A base Plan completes on its own span, never its Event Goal.
- Coach hosts `plan.close` and `plan.history`; `plan.list` completes an expired Plan inside its transaction before listing, and the daemon runs completion once from initial refresh (with a transient failure cleared so retries recover).
- Contract: `PlanCloseRpcParams { commandId, planId, expectedVersion }`, `PlanCloseResult`, `PlanHistoryParams`, `PlanHistoryResult`; `PlanSummary` now exposes `version` so the renderer can send an authoritative expected version. RPC registry, daemon dispatch, client deadlines and lockstep stubs updated.
- No renderer UI, E2E specs or migrations; the renderer PR stacks on this branch.

## Verification

- Root `pnpm check` green.
- Backend suites: 320 tests across kernel-node lifecycle and library, coach hosts and daemon, contract, client; coach composition 126 tests.
- Astra high read-only verifier, two rounds: round 1 raised one blocking finding (cached rejected startup completion promise blocked retries), fixed in the last commit; round 2 `pass: true`, one non-blocking note (add a regression test for completion rejection followed by retry, tracked for the renderer PR).

| Limit | Value |
|---|---|
| MAX_ROUNDS | 3 (used 2 verifier rounds, 2 implementer launches) |
| BRIEF_BUDGET_MIN | 40 |
| INLINE_FIX_LINES | 5 |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
