### PR TITLE
feat(desktop): stop a Plan and read its final history

### DIFF
--- a/.changeset/plan-close-renderer.md
+++ b/.changeset/plan-close-renderer.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Add the Stop Plan dialog, closed Plan history reading, and host-driven completion to the Plan page.
+
+User-facing: You can stop your active Plan from the Plan page, and every closed Plan keeps its final training readable in the library.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -14,7 +14,12 @@ import { createArchiveViewAdapter } from "./state/adapters/archive";
 import { createChatViewAdapter } from "./state/adapters/chat";
 import { createFirstSyncViewAdapter } from "./state/adapters/first-sync";
 import { createOnboardingViewAdapter } from "./state/adapters/onboarding";
-import { createPlanViewAdapter, listPlans } from "./state/adapters/plan";
+import {
+  closePlan,
+  createPlanViewAdapter,
+  listPlans,
+  readPlanHistory,
+} from "./state/adapters/plan";
 import { createRideImportAdapter } from "./state/adapters/ride-import";
 import {
   createAthleteSettingsAdapter,
@@ -229,6 +234,9 @@ export function bootRenderer(): Disposer {
     if (!setupReady(previousState) && setupReady(state)) void chatController.resume();
   });
   store.getState().bindPlanLibraryActions({
+    closePlan: (input) => closePlan(clients, input),
+    readPlanHistory: (planId) => readPlanHistory(clients, planId),
+    refresh: () => planController.refresh(true),
     startCreation: () => {
       chatController.resumeCreation(store.getState().planLibrary.value?.creation ?? null);
       store.getState().setActiveView("chat");

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -157,7 +157,7 @@ export function bootRenderer(): Disposer {
       const previous = store.getState().planLibrary;
       store.getState().setPlanLibrary(next);
       if (
-        previous.status === "ready" &&
+        previous.value !== null &&
         next.status === "ready" &&
         (previous.value.active?.planId ?? null) !== (next.value.active?.planId ?? null)
       ) {

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -153,7 +153,17 @@ export function bootRenderer(): Disposer {
   });
   const planController = createPlanController({
     listPlans: () => listPlans(clients),
-    renderLibrary: (next) => store.getState().setPlanLibrary(next),
+    renderLibrary: (next) => {
+      const previous = store.getState().planLibrary;
+      store.getState().setPlanLibrary(next);
+      if (
+        previous.status === "ready" &&
+        next.status === "ready" &&
+        (previous.value.active?.planId ?? null) !== (next.value.active?.planId ?? null)
+      ) {
+        planAdapter.reload();
+      }
+    },
     read: () => window.enduragentAuth.getPlanningReadModel(),
     render: (next) => store.getState().setPlanSurface(next),
     navigate: (view) => store.getState().setActiveView(view),
@@ -236,7 +246,10 @@ export function bootRenderer(): Disposer {
   store.getState().bindPlanLibraryActions({
     closePlan: (input) => closePlan(clients, input),
     readPlanHistory: (planId) => readPlanHistory(clients, planId),
-    refresh: () => planController.refresh(true),
+    refresh: () => {
+      planAdapter.reload();
+      return planController.refresh(true);
+    },
     startCreation: () => {
       chatController.resumeCreation(store.getState().planLibrary.value?.creation ?? null);
       store.getState().setActiveView("chat");

--- a/apps/desktop-renderer/src/plan/library-refresh.ts
+++ b/apps/desktop-renderer/src/plan/library-refresh.ts
@@ -21,13 +21,11 @@ export function subscribePlanLibraryRefresh(controller: PlanController): () => v
         creation?.version !== library.creation?.version);
     const activePlanNeedsRefresh =
       activePlanId !== previousActivePlanId && activePlanId !== (library?.active?.planId ?? null);
-    if (
-      (state.activeView === "plan" && previousState.activeView !== "plan") ||
-      creationNeedsRefresh ||
-      activePlanNeedsRefresh
-    )
+    const opened = state.activeView === "plan" && previousState.activeView !== "plan";
+    if (opened || creationNeedsRefresh || activePlanNeedsRefresh)
       void controller.refresh(
-        (creationNeedsRefresh && previousState.chat.planCreationLoaded) ||
+        opened ||
+          (creationNeedsRefresh && previousState.chat.planCreationLoaded) ||
           (activePlanNeedsRefresh && previousPlan !== null),
       );
   });

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -138,6 +138,7 @@ export interface PlanViewAdapter {
   closeEndedConversation(): void;
   openAttention(attentionId: string): void;
   returnToCoach(): void;
+  reload(): void;
   retry(): void;
   dispose(): void;
 }
@@ -1426,6 +1427,9 @@ export function createPlanViewAdapter(input: {
     returnToCoach() {
       if (active !== null) return;
       lastCommand = null;
+      void refresh(false);
+    },
+    reload() {
       void refresh(false);
     },
     retry() {

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -7,6 +7,9 @@ import {
   type ExecutePlanTransitionRpcResult,
   type GetPlanStateRpcResult,
   type PlanError,
+  type PlanCloseRpcParams,
+  type PlanCloseResult,
+  type PlanHistoryResult,
   type ListPlansResult,
   type PlanHydrationState,
   type PlanProgressEvent,
@@ -27,6 +30,23 @@ import { createChatViewAdapter } from "./chat";
 
 export async function listPlans(clients: DesktopCoachClientProvider): Promise<ListPlansResult> {
   return (await clients.getClient()).call("plan.list", {});
+}
+
+export async function readPlanHistory(
+  clients: DesktopCoachClientProvider,
+  planId: string,
+): Promise<PlanHistoryResult> {
+  return (await clients.getClient()).call("plan.history", { planId });
+}
+
+export async function closePlan(
+  clients: DesktopCoachClientProvider,
+  input: Omit<PlanCloseRpcParams, "commandId">,
+): Promise<PlanCloseResult> {
+  return (await clients.getClient()).call("plan.close", {
+    ...input,
+    commandId: globalThis.crypto.randomUUID(),
+  });
 }
 
 export interface PlanBridge {
@@ -128,12 +148,6 @@ const UNAVAILABLE_ERROR: PlanError = Object.freeze({
   retryable: true,
 });
 
-function addCivilDate(value: string, days: number): string {
-  const date = new Date(`${value}T00:00:00.000Z`);
-  date.setUTCDate(date.getUTCDate() + days);
-  return date.toISOString().slice(0, 10);
-}
-
 function hydrationFromResult(result: GetPlanStateRpcResult): PlanHydrationState {
   return result;
 }
@@ -198,7 +212,6 @@ export function createPlanViewAdapter(input: {
   let autoResumingCleanupPlanId: string | null = null;
   let autoResumingReplacementId: string | null = null;
   let attemptedWeeklyReviewSyncAtMs: number | null = null;
-  let autoCompletingPlanId: string | null = null;
   let active: {
     readonly commandId: string;
     readonly transitionId: PlanTransitionId;
@@ -267,33 +280,6 @@ export function createPlanViewAdapter(input: {
     input.publishHydration(next);
     if (next.status === "ready" || next.status === "stale") {
       syncCoach(next.state);
-      const activeData = PlanActiveProjectionDataSchema.safeParse(next.state.data);
-      const finalPlanDate = activeData.success
-        ? (activeData.data.plan.targetDate ??
-          addCivilDate(activeData.data.plan.startDate, activeData.data.plan.totalWeeks * 7 - 1))
-        : null;
-      if (
-        next.state.lifecycle === "active" &&
-        next.state.planId !== null &&
-        activeData.success &&
-        finalPlanDate !== null &&
-        activeData.data.today > finalPlanDate &&
-        autoCompletingPlanId !== next.state.planId &&
-        active === null
-      ) {
-        const planId = next.state.planId;
-        autoCompletingPlanId = planId;
-        queueMicrotask(() => {
-          if (disposed || active !== null) return;
-          void execute({
-            transitionId: "PL-T29",
-            commandId: createCommandId(),
-            planId,
-            asOf: activeData.data.today,
-          });
-        });
-        return;
-      }
       if (
         (next.state.scenarioId === "PL-S037" || next.state.scenarioId === "PL-S042") &&
         next.state.planId !== null &&
@@ -446,23 +432,6 @@ export function createPlanViewAdapter(input: {
       active = null;
       if (command.transitionId === "PL-T22") input.publishSettingPending(null);
       input.publishTransition({ status: "idle" });
-      if (
-        command.transitionId === "PL-T29" &&
-        result.state.scenarioId === "PL-S094" &&
-        result.state.planId !== null
-      ) {
-        const planId = result.state.planId;
-        autoResumingCleanupPlanId = planId;
-        queueMicrotask(() => {
-          if (disposed || active !== null) return;
-          void execute({
-            transitionId: "PL-T24",
-            commandId: createCommandId(),
-            planId,
-            mode: "cleanup",
-          });
-        });
-      }
       if (command.transitionId === "PL-T24" && result.state.scenarioId === "PL-S056") {
         queueMicrotask(() => void refresh(false));
       }

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -2,6 +2,9 @@ import type {
   CoachDecisionAnswer,
   ListPlansResult,
   PlanCreationCardModel,
+  PlanCloseResult,
+  PlanCloseRpcParams,
+  PlanHistoryResult,
   PlanError,
   PlanHydrationState,
   PlanNavigationTarget,
@@ -61,6 +64,9 @@ export type PlanLibraryState =
   | { readonly status: "unavailable"; readonly value: ListPlansResult | null };
 
 export interface PlanLibraryActions {
+  closePlan(input: Omit<PlanCloseRpcParams, "commandId">): Promise<PlanCloseResult>;
+  readPlanHistory(planId: string): Promise<PlanHistoryResult>;
+  refresh(): Promise<void>;
   startCreation(): void;
   continueCreation(creation: PlanCreationCardModel): void;
   changeInChat(): void;

--- a/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
@@ -1,0 +1,173 @@
+import type { PlanCreationAnswerSummary, PlanHistoryResult } from "@enduragent/coach-contract";
+import type { ReactElement, ReactNode } from "react";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent } from "../../components/ui/card";
+
+const answerLabels: ReadonlyArray<readonly [PlanCreationAnswerSummary["answerKey"], string]> = [
+  ["plan-length", "Plan length"],
+  ["schedule-mode", "Schedule mode"],
+  ["availability", "Availability"],
+  ["start-timing", "Start timing"],
+  ["commitments", "Commitments"],
+  ["baseline", "Recent training"],
+  ["success", "Success"],
+  ["restriction", "Training restriction"],
+];
+
+const cleanupLabels = {
+  complete: "Cleanup complete",
+  pending: "Calendar cleanup pending",
+  failed: "Calendar cleanup pending",
+  none: "Final history",
+} satisfies Record<NonNullable<PlanHistoryResult>["cleanup"], string>;
+
+function dateLabel(value: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T12:00:00Z`));
+}
+
+function Fact(props: { readonly label: string; readonly children: ReactNode }): ReactElement {
+  return (
+    <div
+      role="row"
+      className="grid grid-cols-[minmax(104px,0.72fr)_minmax(0,1.28fr)] gap-4 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-1 max-[560px]:gap-1"
+    >
+      <span role="rowheader" className="text-xs leading-4 text-ink-2">
+        {props.label}
+      </span>
+      <strong
+        role="cell"
+        className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left"
+      >
+        {props.children}
+      </strong>
+    </div>
+  );
+}
+
+export function PlanFinalDetails(props: {
+  readonly history: NonNullable<PlanHistoryResult>;
+  readonly notice?: string | null;
+  readonly backToLibrary: () => void;
+}): ReactElement {
+  const { plan, revision, cleanup } = props.history;
+  const draft = revision.snapshot;
+  const goal = draft.answeredSummaries.find((answer) => answer.answerKey === "goal");
+  const reason =
+    plan.closeReason === "completed"
+      ? "Completed"
+      : plan.closeReason === "stopped"
+        ? "Stopped"
+        : "Unknown reason";
+  return (
+    <section aria-label="Final Plan history" className="grid min-w-0 gap-inset">
+      {props.notice ? (
+        <p role="status" className="m-0 text-sm leading-5 text-ink-2">
+          {props.notice}
+        </p>
+      ) : null}
+      <Card size="sm" className="min-w-0" role="region" aria-label="Closed Plan">
+        <CardContent className="grid gap-inset">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
+            <div className="grid min-w-0 gap-[calc(var(--inset)/2)]">
+              <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+                Closed Plan
+              </p>
+              <h3 className="m-0 text-base leading-6 font-semibold break-words">{plan.name}</h3>
+            </div>
+            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+              Closed
+            </span>
+          </div>
+          <p className="m-0 text-sm leading-5 text-ink-2">
+            {dateLabel(plan.start)} to {dateLabel(plan.end)} · {plan.weeks} weeks · {reason}
+          </p>
+          {draft.goal.kind === "event" && draft.goal.date > draft.end ? (
+            <p role="status" className="m-0 text-sm leading-5 text-ink-2">
+              Your Event Goal is still {dateLabel(draft.goal.date)}. Start a new Plan for event
+              preparation when it is within 24 weeks.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+      <Card size="sm" className="min-w-0" role="region" aria-label="Final Plan details">
+        <CardContent className="grid gap-inset">
+          <h3 className="m-0 text-base leading-6 font-semibold break-words">Final Plan details</h3>
+          <div role="table" aria-label="Draft inputs">
+            <Fact
+              label={`Main Goal · ${goal?.source.kind === "derived" ? goal.source.label : "your answer"}`}
+            >
+              {draft.goal.kind === "event"
+                ? `${draft.goal.name} · ${dateLabel(draft.goal.date)}`
+                : (draft.goal.outcome ?? "Improve fitness")}
+            </Fact>
+            <Fact label="Calendar">{cleanupLabels[cleanup]}</Fact>
+            <Fact label="Plan span">
+              {dateLabel(draft.start)} to {dateLabel(draft.end)} · {draft.weeks.length} weeks ·{" "}
+              {draft.spanKind}
+            </Fact>
+            {answerLabels.map(([key, label]) => {
+              const summary = draft.answeredSummaries.find((answer) => answer.answerKey === key);
+              if (summary === undefined) return null;
+              const source =
+                summary.source.kind === "athlete" ? "your answer" : summary.source.label;
+              return (
+                <Fact key={key} label={`${label} · ${source}`}>
+                  {summary.detail}
+                </Fact>
+              );
+            })}
+          </div>
+          {draft.weeks.map((week) => (
+            <div key={week.number} className="grid min-w-0 gap-inset">
+              <p className="m-0 text-xs font-semibold text-ink-2">
+                Week {week.number} · {dateLabel(week.start)} to {dateLabel(week.end)} ·{" "}
+                {week.workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min
+              </p>
+              <div role="list" aria-label={`Week ${week.number} Workouts`}>
+                {week.workouts.length === 0 ? (
+                  <p className="m-0 text-sm leading-5 text-ink-2">No Workouts this week.</p>
+                ) : (
+                  week.workouts.map((workout, index) => (
+                    <div
+                      key={workout.id}
+                      role="listitem"
+                      className="grid grid-cols-[minmax(0,0.6fr)_minmax(0,1.4fr)_auto] items-start gap-3 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-[minmax(0,1fr)_auto]"
+                    >
+                      <span className="text-xs leading-4 text-ink-2 max-[560px]:col-span-2">
+                        {workout.date === null
+                          ? `Priority ${index + 1} · Undated`
+                          : dateLabel(workout.date)}
+                      </span>
+                      <strong className="text-sm leading-5 font-medium [overflow-wrap:anywhere]">
+                        {workout.name} · {workout.minutes} min · {workout.guidance}
+                      </strong>
+                      <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+                        {workout.date === null && !workout.pinned ? "Not chosen" : "planned"}
+                        {workout.pinned ? " · Pinned" : ""}
+                      </span>
+                    </div>
+                  ))
+                )}
+              </div>
+              {week.notes.map((note, index) => (
+                <p key={`${index}:${note}`} className="m-0 text-sm leading-5 text-ink-2">
+                  {note}
+                </p>
+              ))}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+      <div className="flex flex-wrap gap-inset">
+        <Button variant="outline" onClick={props.backToLibrary}>
+          Back to library
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
@@ -3,10 +3,19 @@ import type {
   PlanCreationCardModel,
   PlanSummary,
 } from "@enduragent/coach-contract";
-import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
 import { CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY } from "../../chat/controller";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog";
 import { useEnduragentStore } from "../../state/store";
 
 function dateLabel(value: string): string {
@@ -72,6 +81,7 @@ function spanLabel(plan: PlanSummary): string {
 export function PlanLibrary(props: {
   readonly library: ListPlansResult;
   readonly readDetails: () => void;
+  readonly readFinalDetails: (planId: string, justClosed?: boolean) => void;
 }): ReactElement {
   const actions = useEnduragentStore((state) => state.planLibraryActions);
   const chatActions = useEnduragentStore((state) => state.chatActions);
@@ -82,6 +92,56 @@ export function PlanLibrary(props: {
   const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
   const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
   const discard = useRef<HTMLButtonElement>(null);
+  const stop = useRef<HTMLButtonElement>(null);
+  const cancel = useRef<HTMLButtonElement>(null);
+  const [closing, setClosing] = useState<PlanSummary | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [closeError, setCloseError] = useState<string | null>(null);
+  const savePending = useRef(false);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  const confirmClose = async (): Promise<void> => {
+    if (closing === null || actions === null || savePending.current) return;
+    savePending.current = true;
+    setSaving(true);
+    let result;
+    try {
+      result = await actions.closePlan({
+        planId: closing.planId,
+        expectedVersion: closing.version,
+      });
+    } catch {
+      if (mounted.current) {
+        setCloseError("Stopping could not be saved locally. Your Plan is unchanged.");
+        setClosing(null);
+        setSaving(false);
+      }
+      savePending.current = false;
+      return;
+    }
+    savePending.current = false;
+    if (!mounted.current) return;
+    setSaving(false);
+    if (result.status === "rejected") {
+      if (result.reason === "stale-version") {
+        setCloseError("The Plan changed. Review its current details before stopping.");
+        void actions.refresh();
+      } else {
+        setCloseError("Stopping could not be saved locally. Your Plan is unchanged.");
+        setClosing(null);
+      }
+      return;
+    }
+    setClosing(null);
+    setCloseError(null);
+    props.readFinalDetails(result.planId, true);
+    void actions.refresh();
+  };
   const { creation, active, closed } = props.library;
   const total =
     creation?.openQuestion?.step.total ??
@@ -95,6 +155,55 @@ export function PlanLibrary(props: {
   }, [focusRequest]);
   return (
     <section aria-label="Plan library" className="grid min-w-0 gap-inset">
+      {closeError === null || closing !== null ? null : (
+        <p role="alert" className="m-0 text-sm text-danger">
+          {closeError}
+        </p>
+      )}
+      <Dialog
+        open={closing !== null}
+        onOpenChange={(open) => {
+          if (!open && !saving) {
+            setClosing(null);
+            setCloseError(null);
+          }
+        }}
+      >
+        <DialogContent
+          className="w-[min(520px,calc(100vw-32px))] max-w-none gap-0 border-line p-5 shadow-elev-4 sm:max-w-none"
+          showCloseButton={false}
+          initialFocus={cancel}
+          finalFocus={stop}
+          aria-busy={saving ? "true" : undefined}
+        >
+          <DialogHeader className="gap-inset">
+            <DialogTitle className="m-0 text-lg font-semibold">Stop this Plan?</DialogTitle>
+            <DialogDescription className="m-0 leading-5">
+              Final training stays readable. Calendar cleanup can finish later.
+            </DialogDescription>
+          </DialogHeader>
+          {closeError === null ? null : (
+            <p className="mt-inset mb-0 text-xs text-danger" role="alert">
+              {closeError}
+            </p>
+          )}
+          <DialogFooter className="mx-0 mt-row mb-0 flex-row justify-end rounded-none border-0 bg-transparent p-0">
+            <DialogClose
+              render={<Button ref={cancel} variant="outline" size="lg" disabled={saving} />}
+            >
+              Cancel
+            </DialogClose>
+            <Button
+              variant="destructive-solid"
+              size="lg"
+              disabled={saving || actions === null || closeError !== null}
+              onClick={() => void confirmClose()}
+            >
+              Stop Plan
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       {notice !== CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY ? null : (
         <p role="status" className="m-0 text-sm text-ink-2">
           {notice}
@@ -149,6 +258,18 @@ export function PlanLibrary(props: {
           summary={spanLabel(active)}
         >
           <div className="flex flex-wrap gap-inset">
+            <Button
+              ref={stop}
+              variant="destructive"
+              aria-haspopup="dialog"
+              disabled={actions === null || saving}
+              onClick={() => {
+                setCloseError(null);
+                setClosing(active);
+              }}
+            >
+              Stop Plan
+            </Button>
             <Button variant="outline" onClick={props.readDetails}>
               Read Plan details
             </Button>
@@ -165,7 +286,17 @@ export function PlanLibrary(props: {
           title={plan.name}
           status="Closed"
           summary={`${spanLabel(plan)} · ${plan.closeReason === "stopped" ? "Stopped" : plan.closeReason === "completed" ? "Completed" : "Unknown reason"}`}
-        />
+        >
+          <div className="flex flex-wrap gap-inset">
+            <Button
+              variant="outline"
+              disabled={actions === null}
+              onClick={() => props.readFinalDetails(plan.planId)}
+            >
+              Read final details
+            </Button>
+          </div>
+        </LibraryCard>
       ))}
     </section>
   );

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -31,6 +31,7 @@ import {
   type PlanFtpProjection,
   type PlanFtpSourceValue,
   type PlanHistoryEntry,
+  type PlanHistoryResult,
   type PlanPlanningRequestContext,
   type PlanRaceCourseProjection,
   type PlanRaceCourseSummary,
@@ -54,6 +55,7 @@ import { CoachDecisionPanel } from "../chat/CoachDecisionPanel";
 import { Composer, type ComposerHandle } from "../chat/Composer";
 import { ConversationTranscript } from "../chat/Transcript";
 import { PlanLibrary } from "./PlanLibrary";
+import { PlanFinalDetails } from "./PlanFinalDetails";
 import { Page } from "../shared/Page";
 import { WorkoutArchiveExportControl } from "../training/TrainingExportControls";
 
@@ -4584,8 +4586,40 @@ function ReadyProjection(): ReactElement {
 }
 
 export function PlanView(): ReactElement {
+  const [finalDetails, setFinalDetails] = useState<
+    | { status: "library" }
+    | { status: "loading"; planId: string; justClosed: boolean }
+    | { status: "ready"; history: PlanHistoryResult; justClosed: boolean }
+    | { status: "unavailable"; planId: string; justClosed: boolean }
+  >({ status: "library" });
+  const historyRequest = useRef(0);
+  useEffect(
+    () => () => {
+      historyRequest.current += 1;
+    },
+    [],
+  );
   const library = useEnduragentStore((state) => state.planLibrary);
   const libraryActions = useEnduragentStore((state) => state.planLibraryActions);
+  const readFinalDetails = (planId: string, justClosed = false): void => {
+    if (libraryActions === null) return;
+    const request = ++historyRequest.current;
+    setFinalDetails({ status: "loading", planId, justClosed });
+    void libraryActions.readPlanHistory(planId).then(
+      (history) => {
+        if (request === historyRequest.current)
+          setFinalDetails({ status: "ready", history, justClosed });
+      },
+      () => {
+        if (request === historyRequest.current)
+          setFinalDetails({ status: "unavailable", planId, justClosed });
+      },
+    );
+  };
+  const backToLibrary = (): void => {
+    historyRequest.current += 1;
+    setFinalDetails({ status: "library" });
+  };
   const planningActions = useEnduragentStore((state) => state.planningReadActions);
   const creationFocus = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
   const details = useRef<HTMLDivElement>(null);
@@ -4626,9 +4660,59 @@ export function PlanView(): ReactElement {
           : undefined;
 
   useEffect(() => {
-    if (returnFocusId === null) return;
+    if (returnFocusId === null || finalDetails.status !== "library") return;
     requestAnimationFrame(() => document.getElementById(returnFocusId)?.focus());
-  }, [model?.scenarioId, returnFocusId]);
+  }, [model?.scenarioId, returnFocusId, finalDetails.status]);
+
+  if (finalDetails.status !== "library") {
+    const notice = finalDetails.justClosed
+      ? finalDetails.status === "ready" && finalDetails.history?.cleanup === "complete"
+        ? "Plan closed. Cleanup complete."
+        : "Plan closed. Calendar cleanup pending."
+      : null;
+    return (
+      <Page title="Plan" className="plan-view" busy={finalDetails.status === "loading"}>
+        {finalDetails.status === "ready" && finalDetails.history !== null ? (
+          <PlanFinalDetails
+            history={finalDetails.history}
+            notice={notice}
+            backToLibrary={backToLibrary}
+          />
+        ) : (
+          <div className="grid gap-inset">
+            {notice === null ? null : (
+              <p role="status" className="m-0 text-sm text-ink-2">
+                {notice}
+              </p>
+            )}
+            {finalDetails.status === "loading" ? (
+              <p role="status" className="m-0 text-sm text-ink-2">
+                Loading final Plan details…
+              </p>
+            ) : null}
+            {finalDetails.status === "unavailable" ? (
+              <>
+                <p role="alert" className="m-0 text-sm text-danger">
+                  Final Plan details could not load. Try again.
+                </p>
+                <Button
+                  variant="outline"
+                  onClick={() => readFinalDetails(finalDetails.planId, finalDetails.justClosed)}
+                >
+                  Try again
+                </Button>
+              </>
+            ) : null}
+            <div>
+              <Button variant="outline" onClick={backToLibrary}>
+                Back to library
+              </Button>
+            </div>
+          </div>
+        )}
+      </Page>
+    );
+  }
 
   return (
     <Page
@@ -4688,6 +4772,7 @@ export function PlanView(): ReactElement {
         {library.value !== null && !coachWorkspace && !historyPage ? (
           <PlanLibrary
             library={library.value}
+            readFinalDetails={readFinalDetails}
             readDetails={() => {
               details.current?.scrollIntoView({ block: "start", behavior: "instant" });
               details.current?.focus({ preventScroll: true });

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -2044,6 +2044,19 @@ describe("Plan view adapter", () => {
     expect(subject.disposeProgress).toHaveBeenCalledOnce();
     expect(subject.surface.hydration).toEqual({ status: "loading" });
   });
+
+  it("reloads the Plan state on demand", async () => {
+    const subject = harness();
+    subject.adapter.start();
+    await settle();
+    expect(subject.getPlanState).toHaveBeenCalledTimes(1);
+
+    subject.adapter.reload();
+    await settle();
+
+    expect(subject.getPlanState).toHaveBeenCalledTimes(2);
+    expect(subject.surface.hydration.status).toBe("ready");
+  });
 });
 
 describe("Plan library RPC adapters", () => {

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -4,9 +4,15 @@ import type {
   PlanHydrationState,
   PlanProgressEvent,
 } from "@enduragent/coach-contract";
+import type { CoachClient } from "@enduragent/coach-client";
 import type { DesktopCoachClientProvider } from "../src/coach-client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPlanViewAdapter, type PlanBridge } from "../src/state/adapters/plan";
+import {
+  closePlan,
+  createPlanViewAdapter,
+  readPlanHistory,
+  type PlanBridge,
+} from "../src/state/adapters/plan";
 import {
   EMPTY_PLAN_SURFACE,
   type PlanSurfaceState,
@@ -1708,7 +1714,7 @@ describe("Plan view adapter", () => {
     });
   });
 
-  it("ends an active Plan after its final civil date and resumes ordinary cleanup", async () => {
+  it("hydrates an expired active Plan without issuing a completion command", async () => {
     const planId = "00000000000000000000000003";
     const active = planReadModel({
       lifecycle: "active",
@@ -1734,66 +1740,17 @@ describe("Plan view adapter", () => {
         workouts: [],
       },
     });
-    const ended = planReadModel({
-      lifecycle: "ended",
-      scenarioId: "PL-S094",
-      projection: "ended",
-      planId,
-      reconciliation: {
-        status: "not-started",
-        created: 0,
-        pending: 0,
-        failed: 0,
-        total: 0,
-        currentThrough: null,
-        error: null,
-      },
-      data: {},
-    });
-    const cleaned = planReadModel({
-      lifecycle: "ended",
-      scenarioId: "PL-S056",
-      projection: "ended",
-      planId,
-      reconciliation: {
-        status: "verified",
-        created: 0,
-        pending: 0,
-        failed: 0,
-        total: 0,
-        currentThrough: "1998-10-06",
-        error: null,
-      },
-      data: {},
-    });
     const subject = harness({
-      ids: ["natural-completion", "natural-cleanup"],
       getPlanState: async () => ({ status: "ready", state: active }),
-      executePlanTransition: async (command) => ({
-        status: "completed",
-        state: command.transitionId === "PL-T29" ? ended : cleaned,
-      }),
     });
 
     subject.adapter.start();
     await settle();
-    await settle();
+    subject.adapter.open();
     await settle();
 
-    expect(subject.executePlanTransition.mock.calls.map(([command]) => command)).toEqual([
-      {
-        transitionId: "PL-T29",
-        commandId: "natural-completion",
-        planId,
-        asOf: "1998-10-05",
-      },
-      {
-        transitionId: "PL-T24",
-        commandId: "natural-cleanup",
-        planId,
-        mode: "cleanup",
-      },
-    ]);
+    expect(subject.surface.hydration).toEqual({ status: "ready", state: active });
+    expect(subject.executePlanTransition).not.toHaveBeenCalled();
   });
 
   it("opens and records the separate race outcome", async () => {
@@ -2086,5 +2043,53 @@ describe("Plan view adapter", () => {
 
     expect(subject.disposeProgress).toHaveBeenCalledOnce();
     expect(subject.surface.hydration).toEqual({ status: "loading" });
+  });
+});
+
+describe("Plan library RPC adapters", () => {
+  function clientProvider() {
+    const client: CoachClient = {
+      call: async () => {
+        throw new Error("Unexpected RPC call");
+      },
+      get handshake(): CoachClient["handshake"] {
+        throw new Error("Unexpected handshake read");
+      },
+      close: async () => undefined,
+    };
+    const clients: DesktopCoachClientProvider = {
+      getClient: async () => client,
+      reconnect: async () => client,
+      close: async () => undefined,
+    };
+    return { clients, call: vi.spyOn(client, "call") };
+  }
+
+  it("reads the final history for the selected Plan", async () => {
+    const { clients, call } = clientProvider();
+    call.mockResolvedValue(null);
+    expect(await readPlanHistory(clients, "00000000000000000000000003")).toBeNull();
+    expect(call).toHaveBeenCalledWith("plan.history", {
+      planId: "00000000000000000000000003",
+    });
+  });
+
+  it("closes the current version with a new command id", async () => {
+    const commandId = "12345678-1234-1234-1234-123456789012";
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(commandId);
+    const result = {
+      status: "closed" as const,
+      planId: "00000000000000000000000003",
+      closedAt: 907459200000,
+      cleanupJobId: "00000000000000000000000004",
+    };
+    const { clients, call } = clientProvider();
+    call.mockResolvedValue(result);
+    expect(await closePlan(clients, { planId: result.planId, expectedVersion: 7 })).toEqual(result);
+    expect(call).toHaveBeenCalledWith("plan.close", {
+      commandId,
+      planId: result.planId,
+      expectedVersion: 7,
+    });
   });
 });

--- a/apps/desktop-renderer/tests/plan-final-details.test.tsx
+++ b/apps/desktop-renderer/tests/plan-final-details.test.tsx
@@ -1,0 +1,210 @@
+import type { PlanHistoryResult } from "@enduragent/coach-contract";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlanFinalDetails } from "../src/ui/plan/PlanFinalDetails";
+import { planCreationDraft } from "./plan-creation-draft-fixtures";
+
+function history(): NonNullable<PlanHistoryResult> {
+  const draft = planCreationDraft([
+    {
+      answerKey: "plan-length",
+      title: "Plan length",
+      detail: "4 weeks",
+      source: { kind: "athlete" },
+      answer: { kind: "plan-length", weeks: 4 },
+      question: {
+        kind: "plan-length-question",
+        step: { current: 2, total: 9 },
+        prompt: "How long should this Plan be?",
+        options: ([4, 8, 12, 16] satisfies Array<4 | 8 | 12 | 16>).map((weeks) => ({
+          weeks,
+          label: `${weeks} weeks`,
+          detail: `${weeks} weeks of training`,
+        })),
+      },
+    },
+  ]);
+  return {
+    plan: {
+      planId: "closed-plan",
+      version: 2,
+      name: "Build steady power",
+      start: draft.start,
+      end: draft.end,
+      weeks: draft.weeks.length,
+      status: "closed",
+      closeReason: "stopped",
+      closedAt: "1998-09-14",
+      activatedAt: "1998-09-07",
+      creationId: "creation-closed",
+    },
+    closeActor: "fictional-device",
+    revision: { revisionNumber: 1, fingerprint: draft.outputFingerprint, snapshot: draft },
+    cleanup: "pending",
+  };
+}
+
+describe("final Plan details", () => {
+  it("renders the notice, closed summary, Draft facts and every week with only Back to library", () => {
+    const backToLibrary = vi.fn();
+    render(
+      <PlanFinalDetails
+        history={history()}
+        notice="Plan closed. Calendar cleanup pending."
+        backToLibrary={backToLibrary}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Plan closed. Calendar cleanup pending.");
+    const closed = screen.getByRole("region", { name: "Closed Plan" });
+    expect(within(closed).getByRole("heading", { name: "Build steady power" })).toBeVisible();
+    expect(within(closed).getByText("Closed")).toBeVisible();
+    expect(closed).toHaveTextContent("7 Sept 1998 to 4 Oct 1998 · 4 weeks · Stopped");
+    const details = screen.getByRole("region", { name: "Final Plan details" });
+    const facts = within(details).getByRole("table", { name: "Draft inputs" });
+    expect(
+      within(facts).getByRole("row", { name: /Main Goal · your answer.*Build steady power/ }),
+    ).toBeVisible();
+    expect(
+      within(facts).getByRole("row", { name: /Plan length · your answer.*4 weeks/ }),
+    ).toBeVisible();
+    expect(within(facts).getByRole("row", { name: /Plan span/ })).toHaveTextContent(
+      "7 Sept 1998 to 4 Oct 1998 · 4 weeks · Fitness Plan",
+    );
+    for (const number of [1, 2, 3, 4]) {
+      expect(within(details).getByRole("list", { name: `Week ${number} Workouts` })).toBeVisible();
+    }
+    expect(within(details).getByText("No Workouts this week.")).toBeVisible();
+    expect(
+      within(details).getByText("Confirmed limits leave no Workouts in this week."),
+    ).toBeVisible();
+    expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
+      "Back to library",
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "Back to library" }));
+    expect(backToLibrary).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["completed", "Completed"],
+    ["stopped", "Stopped"],
+    ["legacy-unclassified", "Unknown reason"],
+    [null, "Unknown reason"],
+  ] satisfies ReadonlyArray<
+    readonly [NonNullable<PlanHistoryResult>["plan"]["closeReason"], string]
+  >)("renders %s as %s", (closeReason, label) => {
+    const value = history();
+    value.plan.closeReason = closeReason;
+    render(<PlanFinalDetails history={value} backToLibrary={vi.fn()} />);
+    expect(screen.getByRole("region", { name: "Closed Plan" })).toHaveTextContent(
+      `7 Sept 1998 to 4 Oct 1998 · 4 weeks · ${label}`,
+    );
+  });
+
+  it.each([
+    ["complete", "Cleanup complete"],
+    ["pending", "Calendar cleanup pending"],
+    ["failed", "Calendar cleanup pending"],
+    ["none", "Final history"],
+  ] satisfies ReadonlyArray<readonly [NonNullable<PlanHistoryResult>["cleanup"], string]>)(
+    "renders the Calendar row for %s cleanup",
+    (cleanup, label) => {
+      const value = history();
+      value.cleanup = cleanup;
+      render(<PlanFinalDetails history={value} backToLibrary={vi.fn()} />);
+      expect(
+        within(screen.getByRole("row", { name: /^Calendar/ })).getByRole("cell", { name: label }),
+      ).toBeVisible();
+    },
+  );
+
+  it("retains undated Workouts as Not chosen and preserves dated and pinned Workouts", () => {
+    const value = history();
+    const firstWeek = value.revision.snapshot.weeks[0];
+    if (firstWeek === undefined) throw new Error("Missing first week");
+    firstWeek.workouts = [
+      {
+        id: "unchosen",
+        name: "Unchosen ride",
+        kind: "endurance",
+        date: null,
+        minutes: 60,
+        pinned: false,
+        guidance: "Comfortable effort",
+        power: null,
+      },
+      {
+        id: "dated",
+        name: "Dated ride",
+        kind: "endurance",
+        date: "1998-09-08",
+        minutes: 40,
+        pinned: false,
+        guidance: "Comfortable effort",
+        power: null,
+      },
+      {
+        id: "pinned",
+        name: "Pinned ride",
+        kind: "event",
+        date: "1998-09-12",
+        minutes: 90,
+        pinned: true,
+        guidance: "Comfortable effort",
+        power: null,
+      },
+      {
+        id: "undated-pinned",
+        name: "Undated pinned ride",
+        kind: "endurance",
+        date: null,
+        minutes: 20,
+        pinned: true,
+        guidance: "Comfortable effort",
+        power: null,
+      },
+    ];
+    render(<PlanFinalDetails history={value} backToLibrary={vi.fn()} />);
+    const rows = within(screen.getByRole("list", { name: "Week 1 Workouts" })).getAllByRole(
+      "listitem",
+    );
+    expect(rows[0]).toHaveTextContent("Priority 1 · Undated");
+    expect(rows[0]).toHaveTextContent("Not chosen");
+    expect(rows[1]).toHaveTextContent("8 Sept 1998");
+    expect(rows[1]).toHaveTextContent("planned");
+    expect(rows[2]).toHaveTextContent("12 Sept 1998");
+    expect(rows[2]).toHaveTextContent("planned · Pinned");
+    expect(rows[3]).toHaveTextContent("Priority 4 · Undated");
+    expect(rows[3]).toHaveTextContent("planned · Pinned");
+    expect(firstWeek.workouts.map((workout) => workout.date)).toEqual([
+      null,
+      "1998-09-08",
+      "1998-09-12",
+      null,
+    ]);
+  });
+
+  it("invites a new event preparation Plan when the Event Goal is beyond the Plan end", () => {
+    const value = history();
+    value.revision.snapshot.goal = { kind: "event", name: "Spring ride", date: "1999-02-14" };
+    value.revision.snapshot.spanKind = "Base Plan";
+    render(<PlanFinalDetails history={value} backToLibrary={vi.fn()} />);
+    expect(
+      within(screen.getByRole("region", { name: "Closed Plan" })).getByRole("status"),
+    ).toHaveTextContent(
+      "Your Event Goal is still 14 Feb 1999. Start a new Plan for event preparation when it is within 24 weeks.",
+    );
+    expect(
+      screen.getByRole("row", { name: /Main Goal · your answer.*Spring ride · 14 Feb 1999/ }),
+    ).toBeVisible();
+  });
+
+  it.each(["1998-10-03", "1998-10-04"])(
+    "omits the event invitation for Goal date %s within the Plan",
+    (date) => {
+      const value = history();
+      value.revision.snapshot.goal = { kind: "event", name: "Autumn ride", date };
+      render(<PlanFinalDetails history={value} backToLibrary={vi.fn()} />);
+      expect(screen.queryByText(/Your Event Goal is still/)).not.toBeInTheDocument();
+    },
+  );
+});

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -1,5 +1,11 @@
-import type { ListPlansResult, PlanCreationCardModel } from "@enduragent/coach-contract";
+import type {
+  ListPlansResult,
+  PlanCreationCardModel,
+  PlanHistoryResult,
+  PlanCloseResult,
+} from "@enduragent/coach-contract";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { lazy, Suspense } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPlanController } from "../src/plan/controller";
@@ -211,6 +217,16 @@ beforeEach(() => {
     planActions: null,
     planLibrary: { status: "loading", value: null },
     planLibraryActions: {
+      closePlan: vi.fn(
+        async (): Promise<PlanCloseResult> => ({
+          status: "closed",
+          planId: active.planId,
+          closedAt: 904435200000,
+          cleanupJobId: "cleanup-job",
+        }),
+      ),
+      readPlanHistory: vi.fn(async () => null),
+      refresh: vi.fn(async () => {}),
       startCreation: vi.fn(),
       continueCreation: vi.fn(),
       changeInChat: vi.fn(),
@@ -284,7 +300,7 @@ describe("Plan library", () => {
           within(card)
             .getAllByRole("button")
             .map((button) => button.textContent),
-        ).toEqual(["Read Plan details", "Change in Chat"]);
+        ).toEqual(["Stop Plan", "Read Plan details", "Change in Chat"]);
       } else {
         expect(within(section).getByText("Create a Plan when you are ready.")).toBeVisible();
       }
@@ -296,15 +312,24 @@ describe("Plan library", () => {
         expect(
           within(cards[1]!).getByText("7 Sept 1998 to 4 Oct 1998 · 4 weeks · Stopped"),
         ).toBeVisible();
-        for (const card of cards) expect(within(card).queryByRole("button")).toBeNull();
+        for (const card of cards)
+          expect(within(card).getByRole("button", { name: "Read final details" })).toBeVisible();
       }
-      expect(screen.queryByRole("button", { name: "Read final details" })).toBeNull();
+      expect(screen.queryAllByRole("button", { name: "Read final details" })).toHaveLength(
+        hasClosed ? closed.length : 0,
+      );
     },
   );
 
   it("dispatches each library action with the current creation", () => {
     const readDetails = vi.fn();
-    render(<PlanLibrary library={{ creation, active, closed }} readDetails={readDetails} />);
+    render(
+      <PlanLibrary
+        readFinalDetails={vi.fn()}
+        library={{ creation, active, closed }}
+        readDetails={readDetails}
+      />,
+    );
     fireEvent.click(screen.getByRole("button", { name: "Discard" }));
     expect(
       useEnduragentStore.getState().chatActions?.openPlanCreationDiscard,
@@ -324,11 +349,16 @@ describe("Plan library", () => {
       chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation, planCreationPaused: true },
     });
     const view = render(
-      <PlanLibrary library={{ creation, active: null, closed: [] }} readDetails={vi.fn()} />,
+      <PlanLibrary
+        readFinalDetails={vi.fn()}
+        library={{ creation, active: null, closed: [] }}
+        readDetails={vi.fn()}
+      />,
     );
     expect(screen.getByText("Paused")).toBeVisible();
     view.rerender(
       <PlanLibrary
+        readFinalDetails={vi.fn()}
         library={{
           creation: { ...creation, draft: planCreationDraft() },
           active: null,
@@ -630,6 +660,7 @@ describe("Plan creation title", () => {
       };
       render(
         <PlanLibrary
+          readFinalDetails={vi.fn()}
           library={{ creation: answered, active: null, closed: [] }}
           readDetails={vi.fn()}
         />,
@@ -683,4 +714,202 @@ it("keeps Plan history below the library while a creation occupies the header", 
   expect(screen.queryByRole("button", { name: /^Start a (new )?Plan$/ })).toBeNull();
   fireEvent.click(history);
   expect(planActions.openHistory).toHaveBeenCalledOnce();
+});
+
+describe("Stop Plan", () => {
+  function renderLibrary() {
+    const readFinalDetails = vi.fn();
+    render(
+      <PlanLibrary
+        library={{ creation: null, active, closed }}
+        readDetails={vi.fn()}
+        readFinalDetails={readFinalDetails}
+      />,
+    );
+    return readFinalDetails;
+  }
+
+  it("orders active card actions and closed card navigation", () => {
+    const readFinalDetails = renderLibrary();
+    expect(
+      within(screen.getByRole("region", { name: "Active Plan" }))
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["Stop Plan", "Read Plan details", "Change in Chat"]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Read final details" })[0]!);
+    expect(readFinalDetails).toHaveBeenCalledWith("closed-recent");
+  });
+
+  it.each(["Cancel", "Escape"])("focuses Cancel and returns focus after %s", async (method) => {
+    const user = userEvent.setup();
+    renderLibrary();
+    const stop = screen.getByRole("button", { name: "Stop Plan" });
+    await user.click(stop);
+    const dialog = await screen.findByRole("dialog", { name: "Stop this Plan?" });
+    expect(
+      within(dialog).getByText("Final training stays readable. Calendar cleanup can finish later."),
+    ).toBeVisible();
+    expect(
+      within(dialog)
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["Cancel", "Stop Plan"]);
+    await vi.waitFor(() =>
+      expect(within(dialog).getByRole("button", { name: "Cancel" })).toHaveFocus(),
+    );
+    if (method === "Escape") await user.keyboard("{Escape}");
+    else await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    await vi.waitFor(() => expect(stop).toHaveFocus());
+    expect(useEnduragentStore.getState().planLibraryActions?.closePlan).not.toHaveBeenCalled();
+  });
+
+  it("closes with the displayed version, refreshes and opens final details", async () => {
+    const readFinalDetails = renderLibrary();
+    fireEvent.click(screen.getByRole("button", { name: "Stop Plan" }));
+    fireEvent.click(
+      within(await screen.findByRole("dialog")).getByRole("button", { name: "Stop Plan" }),
+    );
+    await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    const actions = useEnduragentStore.getState().planLibraryActions;
+    expect(actions?.closePlan).toHaveBeenCalledExactlyOnceWith({
+      planId: active.planId,
+      expectedVersion: active.version,
+    });
+    expect(actions?.refresh).toHaveBeenCalledOnce();
+    expect(readFinalDetails).toHaveBeenCalledExactlyOnceWith(active.planId, true);
+  });
+
+  it("keeps stale rejection in the dialog until cancellation and review", async () => {
+    const actions = useEnduragentStore.getState().planLibraryActions;
+    if (actions === null) throw new Error("Missing library actions");
+    vi.mocked(actions.closePlan).mockResolvedValue({ status: "rejected", reason: "stale-version" });
+    const readFinalDetails = renderLibrary();
+    fireEvent.click(screen.getByRole("button", { name: "Stop Plan" }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Stop Plan" }));
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(
+      "The Plan changed. Review its current details before stopping.",
+    );
+    expect(dialog).toBeVisible();
+    expect(within(dialog).getByRole("button", { name: "Stop Plan" })).toBeDisabled();
+    expect(readFinalDetails).not.toHaveBeenCalled();
+    expect(actions.refresh).toHaveBeenCalledOnce();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it.each(["save", "no-active-plan", "command-conflict"])(
+    "closes the dialog after %s failure",
+    async (failure) => {
+      const actions = useEnduragentStore.getState().planLibraryActions;
+      if (actions === null) throw new Error("Missing library actions");
+      if (failure === "save") vi.mocked(actions.closePlan).mockRejectedValue(new Error("Offline"));
+      else
+        vi.mocked(actions.closePlan).mockResolvedValue({
+          status: "rejected",
+          reason: failure === "no-active-plan" ? "no-active-plan" : "command-conflict",
+        });
+      const readFinalDetails = renderLibrary();
+      const stop = screen.getByRole("button", { name: "Stop Plan" });
+      fireEvent.click(stop);
+      fireEvent.click(
+        within(await screen.findByRole("dialog")).getByRole("button", { name: "Stop Plan" }),
+      );
+      await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Stopping could not be saved locally. Your Plan is unchanged.",
+      );
+      await vi.waitFor(() => expect(stop).toHaveFocus());
+      expect(actions.refresh).not.toHaveBeenCalled();
+      expect(readFinalDetails).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["pending", "complete"] as const)(
+    "opens final history in the Plan page with %s cleanup notice",
+    async (cleanup) => {
+      const actions = useEnduragentStore.getState().planLibraryActions;
+      if (actions === null) throw new Error("Missing library actions");
+      const history: NonNullable<PlanHistoryResult> = {
+        plan: { ...active, status: "closed", closeReason: "stopped", closedAt: "1998-09-08" },
+        closeActor: "fictional-device",
+        revision: { revisionNumber: 1, fingerprint: "b".repeat(64), snapshot: planCreationDraft() },
+        cleanup,
+      };
+      vi.mocked(actions.readPlanHistory).mockResolvedValue(history);
+      vi.mocked(actions.refresh).mockImplementation(async () => {
+        useEnduragentStore.setState({
+          planLibrary: {
+            status: "ready",
+            value: {
+              creation: null,
+              active: null,
+              closed: [{ ...history.plan, status: "closed" }],
+            },
+          },
+        });
+      });
+      useEnduragentStore.setState({
+        planLibrary: { status: "ready", value: { creation: null, active, closed } },
+      });
+      render(<PlanView />);
+      fireEvent.click(screen.getByRole("button", { name: "Stop Plan" }));
+      fireEvent.click(
+        within(await screen.findByRole("dialog")).getByRole("button", { name: "Stop Plan" }),
+      );
+      expect(await screen.findByRole("heading", { name: "Final Plan details" })).toBeVisible();
+      expect(actions.readPlanHistory).toHaveBeenCalledExactlyOnceWith(active.planId);
+      expect(
+        screen.getByText(
+          cleanup === "complete"
+            ? "Plan closed. Cleanup complete."
+            : "Plan closed. Calendar cleanup pending.",
+        ),
+      ).toBeVisible();
+      expect(screen.queryByRole("button", { name: "Change in Chat" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Start a Plan" })).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Back to library" }));
+      expect(screen.getByRole("region", { name: "Plan library" })).toBeVisible();
+      expect(screen.getByRole("button", { name: "Read final details" })).toBeVisible();
+    },
+  );
+
+  it("queues a fresh library read when the Plan page opens during an earlier read", async () => {
+    const store = useEnduragentStore;
+    store.setState({ activeView: "chat" });
+    let finishRead: (value: ListPlansResult) => void = () => {};
+    const initial = new Promise<ListPlansResult>((resolve) => {
+      finishRead = resolve;
+    });
+    const listPlans = vi
+      .fn()
+      .mockReturnValueOnce(initial)
+      .mockResolvedValue({ creation: null, active: null, closed });
+    const controller = createPlanController({
+      listPlans,
+      read: async () => ({
+        schemaVersion: 1,
+        status: "no-plan",
+        asOfDateKey: 19981005,
+        plan: null,
+      }),
+      renderLibrary: (next) => store.getState().setPlanLibrary(next),
+      render: (next) => store.getState().setPlanSurface(next),
+      navigate: (view) => store.getState().setActiveView(view),
+      focus: vi.fn(),
+    });
+    const unsubscribe = subscribePlanLibraryRefresh(controller);
+    try {
+      const started = controller.start();
+      store.getState().setActiveView("plan");
+      finishRead({ creation: null, active, closed });
+      await started;
+      await vi.waitFor(() => expect(listPlans).toHaveBeenCalledTimes(2));
+      expect(store.getState().planLibrary.value?.active).toBeNull();
+    } finally {
+      unsubscribe();
+      controller.dispose();
+    }
+  });
 });

--- a/apps/desktop/tests/e2e/plan-close-history.spec.ts
+++ b/apps/desktop/tests/e2e/plan-close-history.spec.ts
@@ -230,8 +230,6 @@ for (const appearance of [
       await expect(dialog).not.toBeVisible();
       await expect(stop).toBeFocused();
       expect(await scenario.backend.inspectActivation()).toEqual(before);
-      await scenario.page.context().setOffline(true);
-      expect(await scenario.page.evaluate(() => navigator.onLine)).toBe(false);
       await stop.click();
       await dialog.getByRole("button", { name: "Stop Plan", exact: true }).click();
       await assertFinalDetails(scenario, "Stopped");

--- a/apps/desktop/tests/e2e/plan-close-history.spec.ts
+++ b/apps/desktop/tests/e2e/plan-close-history.spec.ts
@@ -1,0 +1,338 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Creation renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-close-history-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    await backend.seedLibrary({ creation: false, active: true, closed: false });
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    expect(backend.planListRequests).toHaveLength(1);
+    return { backend, fixture, scratch, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function relaunch(scenario: Scenario, playwright: Playwright): Promise<void> {
+  await scenario.browser.close();
+  await scenario.fixture.relaunch(() => scenario.backend.reopen());
+  await scenario.fixture.setViewport(scenario.width, 820);
+  Object.assign(scenario, await connect(playwright, scenario.fixture, scenario.colorScheme));
+  expect(await scenario.page.evaluate(() => innerWidth)).toBe(scenario.width);
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  const screenshotPath = test.info().outputPath(`${name}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-creation", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        library: await scenario.backend.library(),
+        stored: await scenario.backend.inspectActivation(),
+        planListRequests: scenario.backend.planListRequests,
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+async function openLibrary(scenario: Scenario): Promise<void> {
+  await scenario.page
+    .getByRole("navigation", { name: "Main navigation" })
+    .getByRole("button", { name: "Plan", exact: true })
+    .click();
+  await expect(
+    scenario.page.getByRole("region", { name: "Plan library", exact: true }),
+  ).toBeVisible();
+  await expect(scenario.page.locator("#message")).not.toBeVisible();
+}
+
+async function assertFinalDetails(scenario: Scenario, reason: "Stopped" | "Completed") {
+  const history = scenario.page.getByRole("region", { name: "Final Plan history", exact: true });
+  await expect(history).toBeVisible();
+  await expect(
+    history.getByRole("heading", { name: "Active endurance Plan", exact: true }),
+  ).toBeVisible();
+  await expect(
+    history.getByText(`1 Jan 1998 to 28 Jan 1998 · 4 weeks · ${reason}`, { exact: true }),
+  ).toBeVisible();
+  await expect(
+    history.getByRole("heading", { name: "Final Plan details", exact: true }),
+  ).toBeVisible();
+  await expect(
+    history.getByRole("row", { name: "Main Goal · your answer Improve fitness", exact: true }),
+  ).toBeVisible();
+  for (let week = 1; week <= 4; week += 1) {
+    const workouts = history.getByRole("list", { name: `Week ${week} Workouts`, exact: true });
+    const workout = workouts.getByRole("listitem");
+    await expect(workout).toHaveCount(1);
+    await expect(workout).toContainText(`${1 + (week - 1) * 7} Jan 1998`);
+    await expect(workout).toContainText(
+      "Endurance ride · 45 min · Keep the effort conversational.",
+    );
+    await expect(workout).toContainText("planned");
+  }
+  await expect(history.getByRole("button")).toHaveText(["Back to library"]);
+}
+
+async function assertClosedLibrary(scenario: Scenario, reason: "Stopped" | "Completed") {
+  const library = scenario.page.getByRole("region", { name: "Plan library", exact: true });
+  await expect(library.getByRole("heading")).toHaveText([
+    "No active Plan",
+    "Active endurance Plan",
+  ]);
+  const closed = library.getByRole("region", { name: "Closed Plan", exact: true });
+  await expect(
+    closed.getByText(`1 Jan 1998 to 28 Jan 1998 · 4 weeks · ${reason}`, { exact: true }),
+  ).toBeVisible();
+  await expect(library.getByRole("button", { name: "Stop Plan", exact: true })).toHaveCount(0);
+  await closed.getByRole("button", { name: "Read final details", exact: true }).click();
+  await assertFinalDetails(scenario, reason);
+}
+
+for (const appearance of [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const) {
+  test(`cancels and stops offline, then restores final history at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      await openLibrary(scenario);
+      const before = await scenario.backend.inspectActivation();
+      const stop = scenario.page
+        .getByRole("region", { name: "Active Plan", exact: true })
+        .getByRole("button", { name: "Stop Plan", exact: true });
+      const dialog = scenario.page.getByRole("dialog", { name: "Stop this Plan?", exact: true });
+      await stop.click();
+      await expect(dialog.getByRole("button")).toHaveText(["Cancel", "Stop Plan"]);
+      await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeFocused();
+      await expect(dialog).toContainText(
+        "Final training stays readable. Calendar cleanup can finish later.",
+      );
+      await capture(scenario, "stop-confirmation");
+      await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+      await expect(dialog).not.toBeVisible();
+      await expect(stop).toBeFocused();
+      expect(await scenario.backend.inspectActivation()).toEqual(before);
+      await scenario.page.context().setOffline(true);
+      expect(await scenario.page.evaluate(() => navigator.onLine)).toBe(false);
+      await stop.click();
+      await dialog.getByRole("button", { name: "Stop Plan", exact: true }).click();
+      await assertFinalDetails(scenario, "Stopped");
+      await expect(
+        scenario.page
+          .getByRole("status")
+          .filter({ hasText: "Plan closed. Calendar cleanup pending." }),
+      ).toBeVisible();
+      await expect(
+        scenario.page.getByRole("row", { name: "Calendar Calendar cleanup pending", exact: true }),
+      ).toBeVisible();
+      const after = await scenario.backend.inspectActivation();
+      expect(after.planningPlans).toEqual([
+        expect.objectContaining({
+          status: "closed",
+          close_reason: "stopped",
+          close_actor: "athlete",
+          version: 2,
+        }),
+      ]);
+      expect(after.plans).toEqual([expect.objectContaining({ status: "ended" })]);
+      expect(after.jobs).toEqual([expect.objectContaining({ kind: "cleanup", status: "pending" })]);
+      expect(after.commands).toEqual([expect.objectContaining({ command_name: "plan.close" })]);
+      expect(after.revisions).toEqual(before.revisions);
+      expect(after.workouts).toEqual(before.workouts);
+      await capture(scenario, "stopped-offline");
+      await scenario.page.getByRole("button", { name: "Back to library", exact: true }).click();
+      await assertClosedLibrary(scenario, "Stopped");
+      await scenario.page.getByRole("button", { name: "Back to library", exact: true }).click();
+      await relaunch(scenario, playwright);
+      await assertClosedLibrary(scenario, "Stopped");
+      expect(await scenario.backend.inspectActivation()).toEqual(after);
+      await capture(scenario, "restored-final-history");
+    } finally {
+      await close(scenario);
+    }
+  });
+
+  test(`rejects stale and failed stops, then completes after the final day at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      await openLibrary(scenario);
+      const stop = scenario.page
+        .getByRole("region", { name: "Active Plan", exact: true })
+        .getByRole("button", { name: "Stop Plan", exact: true });
+      const dialog = scenario.page.getByRole("dialog", { name: "Stop this Plan?", exact: true });
+      await stop.click();
+      await scenario.backend.bumpActivePlanVersion();
+      await dialog.getByRole("button", { name: "Stop Plan", exact: true }).click();
+      await expect(dialog.getByRole("alert")).toHaveText(
+        "The Plan changed. Review its current details before stopping.",
+      );
+      await expect(dialog.getByRole("button", { name: "Stop Plan", exact: true })).toBeDisabled();
+      const stale = await scenario.backend.inspectActivation();
+      expect(stale.planningPlans).toEqual([
+        expect.objectContaining({ status: "active", version: 2, close_reason: null }),
+      ]);
+      expect(stale.plans).toEqual([expect.objectContaining({ status: "active" })]);
+      expect(stale.jobs).toEqual([]);
+      await capture(scenario, "stale-stop");
+      await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+      await expect(stop).toBeFocused();
+      const navigation = scenario.page.getByRole("navigation", { name: "Main navigation" });
+      await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+      await openLibrary(scenario);
+      scenario.backend.failNextClose();
+      await stop.click();
+      await dialog.getByRole("button", { name: "Stop Plan", exact: true }).click();
+      await expect(dialog).not.toBeVisible();
+      await expect(scenario.page.getByRole("alert")).toHaveText(
+        "Stopping could not be saved locally. Your Plan is unchanged.",
+      );
+      expect(await scenario.backend.inspectActivation()).toEqual(stale);
+      await capture(scenario, "failed-stop");
+      await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+      scenario.backend.setCivilDate("1998-01-28");
+      await openLibrary(scenario);
+      await expect(stop).toBeVisible();
+      expect(await scenario.backend.inspectActivation()).toEqual(stale);
+      await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+      scenario.backend.setCivilDate("1998-01-29");
+      await openLibrary(scenario);
+      await assertClosedLibrary(scenario, "Completed");
+      const completed = await scenario.backend.inspectActivation();
+      expect(completed.planningPlans).toEqual([
+        expect.objectContaining({
+          status: "closed",
+          version: 3,
+          close_reason: "completed",
+          close_actor: "system:plan-completion",
+          closed_at_ms: Date.parse("1998-01-29T00:00:00.000Z"),
+        }),
+      ]);
+      expect(completed.plans).toEqual([expect.objectContaining({ status: "ended" })]);
+      expect(completed.revisions).toEqual(stale.revisions);
+      await capture(scenario, "completed-final-history");
+    } finally {
+      await close(scenario);
+    }
+  });
+}

--- a/apps/desktop/tests/e2e/plan-close-history.spec.ts
+++ b/apps/desktop/tests/e2e/plan-close-history.spec.ts
@@ -197,6 +197,7 @@ async function assertClosedLibrary(scenario: Scenario, reason: "Stopped" | "Comp
     closed.getByText(`1 Jan 1998 to 28 Jan 1998 · 4 weeks · ${reason}`, { exact: true }),
   ).toBeVisible();
   await expect(library.getByRole("button", { name: "Stop Plan", exact: true })).toHaveCount(0);
+  await expect(scenario.page.getByText(/^Plan active/)).toHaveCount(0);
   await closed.getByRole("button", { name: "Read final details", exact: true }).click();
   await assertFinalDetails(scenario, reason);
 }

--- a/apps/desktop/tests/e2e/plan-library.spec.ts
+++ b/apps/desktop/tests/e2e/plan-library.spec.ts
@@ -171,8 +171,12 @@ async function assertMixedLibrary(scenario: Scenario): Promise<void> {
   await expect(library.getByRole("button")).toHaveText([
     "Discard",
     "Continue in Chat",
+    "Stop Plan",
     "Read Plan details",
     "Change in Chat",
+    "Read final details",
+    "Read final details",
+    "Read final details",
   ]);
   await expect(library).toContainText("1 of 9 answered. Active endurance Plan keeps running.");
   await expect(library).toContainText("1 Jan 1998 to 28 Jan 1998 · 4 weeks");

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -1,5 +1,8 @@
 import {
   ListPlansParamsSchema,
+  PlanCloseRpcParamsSchema,
+  PlanHistoryParamsSchema,
+  PlanCreationDraftSchema,
   PlanCreationActivateRpcParamsSchema,
   PlanCreationPreviewRpcParamsSchema,
   type CoachEngine,
@@ -118,6 +121,8 @@ export class PlanCreationBackend {
   planListReadFails = false;
   private sequence = 0;
   private instant = 883_612_800_000;
+  private civilDate = "1998-01-01";
+  private closeFails = false;
   private queueRevision = 0;
   private queue: QueuedMessage[] = [];
   private transcript: TranscriptTurn[] = [];
@@ -215,6 +220,30 @@ export class PlanCreationBackend {
             await this.requireHost()["plan.list"](ListPlansParamsSchema.parse(request.params)),
           );
         }
+        if (request.method === "plan.close") {
+          const fail = this.closeFails;
+          this.closeFails = false;
+          if (fail) {
+            await this.requireStore()
+              .run(`CREATE TEMP TRIGGER reject_close BEFORE INSERT ON planning_command
+WHEN NEW.command_name='plan.close'
+BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
+          }
+          try {
+            return response(
+              await this.requireHost()["plan.close"](
+                PlanCloseRpcParamsSchema.parse(request.params),
+              ),
+            );
+          } finally {
+            if (fail) await this.requireStore().run("DROP TRIGGER reject_close");
+          }
+        }
+        if (request.method === "plan.history") {
+          return response(
+            await this.requireHost()["plan.history"](PlanHistoryParamsSchema.parse(request.params)),
+          );
+        }
         if (request.method === "plan_creation.activate") {
           return response(
             await this.requireHost()["plan_creation.activate"](
@@ -279,7 +308,7 @@ export class PlanCreationBackend {
         identity,
         engine: inspectionEngine,
       },
-      { todayDateKey: () => 19980101 },
+      { todayDateKey: () => Number(this.civilDate.replaceAll("-", "")) },
     );
     this.host = createPlanCreationOperations({
       store: this.store,
@@ -287,8 +316,25 @@ export class PlanCreationBackend {
       identity,
       crypto: globalThis.crypto,
       eventCandidates: { read: async () => [] },
-      today: () => "1998-01-01",
+      today: () => this.civilDate,
+      todayDateKey: () => Number(this.civilDate.replaceAll("-", "")),
+      now: () => Date.parse(`${this.civilDate}T00:00:00.000Z`),
     });
+  }
+
+  setCivilDate(date: string): void {
+    this.civilDate = date;
+    this.instant = Date.parse(`${date}T00:00:00.000Z`);
+  }
+
+  failNextClose(): void {
+    this.closeFails = true;
+  }
+
+  async bumpActivePlanVersion(): Promise<void> {
+    await this.requireStore().run("UPDATE planning_plan SET version=version+1 WHERE plan_id=?", [
+      activePlanId,
+    ]);
   }
 
   async reopen(): Promise<void> {
@@ -369,6 +415,62 @@ updated_at_ms,device_id,hlc_physical_ms,hlc_counter
           updatedAt,
         ],
       );
+      const dateText = (key: number) => String(key).replace(/^(\d{4})(\d{2})(\d{2})$/u, "$1-$2-$3");
+      const start = dateText(plan.start);
+      const end = dateText(plan.end);
+      const day = (offset: number) =>
+        new Date(Date.parse(`${start}T00:00:00.000Z`) + offset * 86_400_000)
+          .toISOString()
+          .slice(0, 10);
+      const snapshot = PlanCreationDraftSchema.parse({
+        kind: "draft",
+        answeredSummaries: [],
+        goal: { kind: "fitness", weeks: 4 },
+        mode: "fixed",
+        start,
+        end,
+        spanKind: "Fitness Plan",
+        computedWeeks: 4,
+        weeks: Array.from({ length: 4 }, (_, index) => ({
+          number: index + 1,
+          start: day(index * 7),
+          end: day(index * 7 + 6),
+          workouts: [
+            {
+              id: `${plan.id}-ride-${index + 1}`,
+              name: "Endurance ride",
+              kind: "endurance",
+              date: day(index * 7),
+              minutes: 45,
+              pinned: false,
+              guidance: "Keep the effort conversational.",
+              power: null,
+            },
+          ],
+          notes: [],
+        })),
+        notes: [],
+        guidance: "Build endurance steadily.",
+        ftp: null,
+        builderId: "fixture",
+        builderVersion: "1",
+        inputFingerprint: "a".repeat(64),
+        outputFingerprint: "b".repeat(64),
+      });
+      await store.run(
+        `INSERT INTO plan_revision (
+id,plan_id,revision_number,parent_revision_number,source_kind,source_id,snapshot_json,
+fingerprint,created_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?,?,1,NULL,'migration',NULL,?,?,?,'fixture-device',?,0)`,
+        [
+          fixtureId(`R${plan.id.slice(-1)}`),
+          plan.id,
+          JSON.stringify(snapshot),
+          snapshot.outputFingerprint,
+          updatedAt,
+          updatedAt,
+        ],
+      );
     };
     if (presence.active) {
       await insertPlan({
@@ -436,9 +538,10 @@ updated_at_ms,device_id,hlc_physical_ms,hlc_counter
       planningPlans: await store.all("SELECT * FROM planning_plan ORDER BY plan_id"),
       revisions: await store.all("SELECT * FROM plan_revision ORDER BY plan_id,revision_number"),
       creations: await store.all("SELECT * FROM plan_creation ORDER BY id"),
+      jobs: await store.all("SELECT * FROM plan_reconciliation_job ORDER BY id"),
       workouts: await store.all("SELECT * FROM plan_workout ORDER BY id"),
       commands: await store.all(
-        "SELECT * FROM planning_command WHERE command_name='plan_creation.activate' ORDER BY created_at_ms,command_id",
+        "SELECT * FROM planning_command WHERE command_name IN ('plan_creation.activate','plan.close') ORDER BY created_at_ms,command_id",
       ),
     };
   }

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1361,6 +1361,53 @@ describe("local coach composition", () => {
     await lifecycle.close();
   });
 
+  it.each([false, true])(
+    "retries Plan completion after initial refresh fails with deferInitialRefresh=%s",
+    async (deferInitialRefresh) => {
+      const home = await freshHome();
+      const context = fakeContext(home);
+      const trace: string[] = [];
+      const lifecycle = await compose(
+        home,
+        {
+          bootstrap: async () => reference(trace),
+          createRuntime: () => runtime(trace),
+          createBackend: () => backend(),
+          createRepository: () => ({
+            insertIfAbsent: async () => false,
+            readCurrent: async () => undefined,
+          }),
+          createResolver: () => missingResolver(),
+        },
+        context,
+        { apiKey: "", athleteId: "" },
+        undefined,
+        { ENDURAGENT_HOME: home.root },
+        deferInitialRefresh,
+      );
+      const failure = new Error("synthetic Plan completion storage failure");
+      const read = vi.spyOn(context.store, "get").mockRejectedValueOnce(failure);
+      try {
+        await expect(lifecycle.startInitialRefresh()).rejects.toBe(failure);
+        expect(read).toHaveBeenNthCalledWith(
+          1,
+          expect.stringContaining("WHERE planning_plan.status='active'"),
+        );
+        const windowsAfterFailure = trace.filter((entry) => entry === "run-window").length;
+
+        await expect(lifecycle.startInitialRefresh()).resolves.toBeUndefined();
+        expect(
+          read.mock.calls.filter(([sql]) => sql.includes("WHERE planning_plan.status='active'")),
+        ).toHaveLength(2);
+        expect(trace.filter((entry) => entry === "run-window")).toHaveLength(
+          windowsAfterFailure + (deferInitialRefresh ? 1 : 0),
+        );
+      } finally {
+        await lifecycle.close();
+      }
+    },
+  );
+
   it("defers the daemon refresh, tracks one start, and schedules retries after capture failure", async () => {
     const home = await freshHome();
     const failure = new Error("synthetic persistence failure");


### PR DESCRIPTION
## Summary

Renderer half of END-11 (close Plans and read their final history), stacked on #907.

- Active library card actions are `Stop Plan`, `Read Plan details`, `Change in Chat`. `Stop Plan` opens the production dialog (`Stop this Plan?`, Cancel focused first, Escape cancels, focus returns to the button). Confirm sends `plan.close` with the summary's current version; success shows `Plan closed. Calendar cleanup pending.` (or `Cleanup complete.` when the history reports it), refreshes the library and opens the closed detail. A stale version keeps the dialog open with review copy; a failed save closes it with the unchanged-Plan copy.
- Closed cards gain `Read final details`. The closed detail shows the closed card, the base-Plan invitation when the Goal is later than the Plan end, the `Final Plan details` facts table and every week's Workouts (undated unpinned as `Not chosen`), the calendar row from cleanup state, and `Back to library`. No edit, resume, change or undo controls.
- The renderer completion latch is removed; host completion in `plan.list` replaces it. The Plan page reloads its legacy projection whenever a library read changes the active Plan, so a stop or a host completion never leaves the old active view on screen.
- E2E `plan-close-history.spec.ts` at 1180 and 720, light and dark: cancel, stop, relaunch, stale version, forced ledger failure, host completion after the final day. The E2E backend fixture gains a mutable civil date, revision snapshots, close inspection and a one-shot ledger failure. The coach composition test covers a failed then retried startup completion.

## Verification

- Renderer typecheck and suites: 42 workspace files (679 tests) and the DOM project green; adapter tests cover the reload path.
- Desktop E2E on macOS: 18 of 18 across both specs. Screenshots compared against the prototype's stop-offline scenario (dialog, closed card, facts table, week list, Back to library).
- Astra high read-only verifier, three rounds: round 1 found the stale legacy projection after a stop, round 2 found the same gap when a failed library read recovers, round 3 `pass: true`.

| Limit | Value |
|---|---|
| MAX_ROUNDS | 3 (used 3) |
| BRIEF_BUDGET_MIN | 40 |
| INLINE_FIX_LINES | 5 |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
