### PR TITLE
feat(desktop): preview and apply Plan Schedule changes in Chat

### DIFF
--- a/.changeset/plan-change-renderer.md
+++ b/.changeset/plan-change-renderer.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Preview and apply Plan Schedule changes from Chat.
+
+User-facing: Ask for one schedule change to your active Plan, such as a shorter Wednesday or a free weekday, review the exact Workouts it would touch, and apply or cancel it.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -208,6 +208,12 @@ export function bootRenderer(): Disposer {
   const chatController = createChatController({
     clients,
     view: chatAdapter.view,
+    readPlanLibrary: () => store.getState().planLibrary.value,
+    readPlanChange: () => store.getState().planChange,
+    publishPlanChange: (next) => store.getState().setPlanChange(next),
+    refreshPlanLibrary: async () => {
+      await store.getState().planLibraryActions?.refresh();
+    },
     openChat: () => store.getState().setActiveView("chat"),
     refreshTrainingContext: async () => {
       await Promise.all([trainingContextController.refresh(), planController.refresh()]);
@@ -260,11 +266,30 @@ export function bootRenderer(): Disposer {
     },
     changeInChat: () => {
       chatController.pausePlanCreation();
+      const state = store.getState();
+      state.setPlanChange({
+        ...state.planChange,
+        open: true,
+        planId: state.planLibrary.value?.active?.planId ?? null,
+      });
       store.getState().setActiveView("chat");
       requestAnimationFrame(focusComposer);
     },
   });
   const disposePlanLibraryRefresh = subscribePlanLibraryRefresh(planController);
+  const disposePendingChangeRestore = store.subscribe((state, previousState) => {
+    const pending =
+      state.planLibrary.value?.changes.some((change) => change.status === "pending") ?? false;
+    const hadPending =
+      previousState.planLibrary.value?.changes.some((change) => change.status === "pending") ??
+      false;
+    if (
+      pending &&
+      (!hadPending || (!previousState.chat.planCreationLoaded && state.chat.planCreationLoaded))
+    ) {
+      chatController.pausePlanCreation();
+    }
+  });
   const disposePlanToChatRefresh = store.subscribe((state, previousState) => {
     if (previousState.activeView === "plan" && state.activeView === "chat") {
       chatController.refreshPlanningRequests();
@@ -411,6 +436,10 @@ export function bootRenderer(): Disposer {
     }).render,
   });
   store.getState().bindChatActions({
+    openPlanChangeEditor: () => chatController.openPlanChangeEditor(),
+    backFromPlanChangeEditor: () => chatController.backFromPlanChangeEditor(),
+    previewPlanChange: (intent) => void chatController.previewPlanChange(intent),
+    applyPlanChange: (decision) => void chatController.applyPlanChange(decision),
     submit: (message, attachmentIds) => chatController.submit(message, attachmentIds),
     chooseAttachments: () => chatController.chooseAttachments(),
     pasteAttachment: () => chatController.pasteAttachment(),
@@ -716,6 +745,7 @@ export function bootRenderer(): Disposer {
     disposePlanReturn();
     disposePlanToChatRefresh();
     disposePlanLibraryRefresh();
+    disposePendingChangeRestore();
     store.getState().bindPlanLibraryActions(null);
     window.removeEventListener("enduragent-lifecycle", onLifecycle);
     window.removeEventListener("pagehide", dispose);

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -32,6 +32,7 @@ import { createTelegramSettingsAdapter } from "./state/adapters/telegram";
 import { createManualSyncViewAdapter } from "./state/adapters/sync";
 import { createTrainingViewAdapter } from "./state/adapters/training";
 import { createUpdateSettingsAdapter } from "./state/adapters/update";
+import { EMPTY_PLAN_CHANGE_SURFACE } from "./state/chat-slice";
 import { credentialDrafts } from "./state/credential-drafts";
 import { restoreManualSyncFocus } from "./state/manual-sync-focus";
 import { useEnduragentStore, type EnduragentState } from "./state/store";
@@ -267,10 +268,11 @@ export function bootRenderer(): Disposer {
     changeInChat: () => {
       chatController.pausePlanCreation();
       const state = store.getState();
+      const planId = state.planLibrary.value?.active?.planId ?? null;
       state.setPlanChange({
-        ...state.planChange,
+        ...(state.planChange.planId === planId ? state.planChange : EMPTY_PLAN_CHANGE_SURFACE),
         open: true,
-        planId: state.planLibrary.value?.active?.planId ?? null,
+        planId,
       });
       store.getState().setActiveView("chat");
       requestAnimationFrame(focusComposer);
@@ -285,7 +287,12 @@ export function bootRenderer(): Disposer {
       false;
     if (
       pending &&
-      (!hadPending || (!previousState.chat.planCreationLoaded && state.chat.planCreationLoaded))
+      (!hadPending ||
+        (!previousState.chat.planCreationLoaded && state.chat.planCreationLoaded) ||
+        (previousState.chat.planCreationPaused && !state.chat.planCreationPaused) ||
+        (previousState.chat.planCreationBusy &&
+          !state.chat.planCreationBusy &&
+          !state.chat.planCreationPaused))
     ) {
       chatController.pausePlanCreation();
     }

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -11,6 +11,7 @@ import {
 } from "@enduragent/coach-client";
 import {
   PLAN_CREATION_ANSWER_KEYS,
+  PlanChangeIntentSchema,
   PlanActiveProjectionDataSchema,
   type AttachmentAdmissionReadModel,
   type ChatAttachmentComposerReadModel,
@@ -21,6 +22,8 @@ import {
   type CreatePlanningRequestRpcParams,
   type CreateWorkoutPlanningRequestRpcParams,
   type PlanHandoffSuggestion,
+  type ListPlansResult,
+  type PlanChangeIntent,
   type PlanCreationAnswerInput,
   type PlanCreationAnswerSummary,
   type PlanCreationCardModel,
@@ -29,6 +32,8 @@ import {
   type TranscriptPageEntry,
   type TurnEvent,
 } from "@enduragent/coach-contract";
+import { previewPlanChange, applyPlanChange } from "../state/adapters/plan";
+import { EMPTY_PLAN_CHANGE_SURFACE, type PlanChangeSurfaceState } from "../state/chat-slice";
 import type { DesktopCoachClientProvider } from "../coach-client";
 import {
   DESKTOP_CHAT_ID,
@@ -215,6 +220,10 @@ export interface ChatView {
 }
 
 export interface ChatController {
+  openPlanChangeEditor(): void;
+  backFromPlanChangeEditor(): void;
+  previewPlanChange(intent: PlanChangeIntent): Promise<void>;
+  applyPlanChange(decision: "apply" | "cancel"): Promise<void>;
   start(): Promise<void>;
   resume(): Promise<void>;
   refreshAttachments(): Promise<void>;
@@ -320,6 +329,10 @@ export function createChatController(input: {
   readonly refreshTrainingContext: () => Promise<void>;
   readonly refreshSpend: () => Promise<void>;
   readonly refreshPlan?: () => Promise<void>;
+  readonly readPlanLibrary?: () => ListPlansResult | null;
+  readonly readPlanChange?: () => PlanChangeSurfaceState;
+  readonly publishPlanChange?: (next: PlanChangeSurfaceState) => void;
+  readonly refreshPlanLibrary?: () => Promise<void>;
   readonly openChat?: () => void;
   readonly readTranscriptPage?: (request: {
     readonly cursor: string | null;
@@ -1731,8 +1744,136 @@ export function createChatController(input: {
     return task;
   };
 
+  const readChange = (): PlanChangeSurfaceState =>
+    input.readPlanChange?.() ?? EMPTY_PLAN_CHANGE_SURFACE;
+  const publishChange = (patch: Partial<PlanChangeSurfaceState>): void => {
+    if (!disposed) input.publishPlanChange?.({ ...readChange(), ...patch });
+  };
+  const changeFocus = (target: "editor" | "preview" | "change") => ({
+    target,
+    revision: (readChange().focusRequest?.revision ?? 0) + 1,
+  });
+
   render();
   return {
+    openPlanChangeEditor() {
+      const active = input.readPlanLibrary?.()?.active;
+      if (disposed || readChange().busy || !active) return;
+      publishChange({
+        open: true,
+        planId: active.planId,
+        editorOpen: true,
+        error: null,
+        focusRequest: changeFocus("editor"),
+      });
+    },
+    backFromPlanChangeEditor() {
+      if (disposed || readChange().busy) return;
+      publishChange({ editorOpen: false, error: null, focusRequest: changeFocus("change") });
+    },
+    async previewPlanChange(intent) {
+      const library = input.readPlanLibrary?.();
+      const active = library?.active;
+      if (disposed || readChange().busy || !active) return;
+      const parameterCopy =
+        intent.kind === "weekly-duration"
+          ? "Enter a weekly duration above zero."
+          : "day" in intent && (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
+            ? "Choose the weekday to change."
+            : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
+              ? "Choose the weekday to change."
+              : "Enter a duration above zero.";
+      if (!PlanChangeIntentSchema.safeParse(intent).success) {
+        publishChange({ error: parameterCopy });
+        return;
+      }
+      publishChange({ busy: true, error: null, notice: null });
+      try {
+        const result = await previewPlanChange(input.clients, {
+          planId: active.planId,
+          expectedVersion: active.version,
+          intent,
+        });
+        if (disposed) return;
+        if (result.status === "rejected") {
+          publishChange({
+            error:
+              result.reason === "stale-version"
+                ? "This request used an older Plan revision. Request a fresh preview."
+                : result.reason === "invalid-intent"
+                  ? parameterCopy
+                  : "This Change could not be previewed. Training is unchanged.",
+          });
+          return;
+        }
+        const superseded = library.changes.find(
+          (change) => change.changeId === result.change.supersedes,
+        );
+        publishChange({
+          open: true,
+          planId: active.planId,
+          editorOpen: false,
+          notice: superseded
+            ? `This preview supersedes “${superseded.title}”. Training is unchanged until confirmation.`
+            : "Review the exact changes before confirming.",
+        });
+        await input.refreshPlanLibrary?.();
+        publishChange({ focusRequest: changeFocus("preview") });
+      } catch {
+        publishChange({ error: "This Change could not be previewed. Training is unchanged." });
+      } finally {
+        publishChange({ busy: false });
+      }
+    },
+    async applyPlanChange(decision) {
+      const library = input.readPlanLibrary?.();
+      const active = library?.active;
+      if (disposed || readChange().busy || !active) return;
+      const pending = library.changes.find((change) => change.status === "pending");
+      if (!pending) {
+        publishChange({ notice: "This preview is no longer pending. Training is unchanged." });
+        return;
+      }
+      publishChange({ busy: true, error: null, notice: null });
+      try {
+        const result = await applyPlanChange(input.clients, {
+          planId: active.planId,
+          changeId: pending.changeId,
+          expectedVersion: active.version,
+          decision,
+        });
+        if (disposed) return;
+        if (result.status === "rejected") {
+          publishChange({
+            notice:
+              result.reason === "stale-version"
+                ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
+                : result.reason === "not-pending"
+                  ? "This preview is no longer pending. Training is unchanged."
+                  : "This Change could not be applied. Training and the pending preview are unchanged.",
+          });
+          return;
+        }
+        publishChange({
+          open: true,
+          planId: active.planId,
+          editorOpen: false,
+          notice:
+            result.status === "applied"
+              ? "Change applied locally. Training now matches the confirmed preview."
+              : "Change cancelled. Training is unchanged; the preview remains in history.",
+        });
+        await input.refreshPlanLibrary?.();
+        publishChange({ focusRequest: changeFocus("change") });
+      } catch {
+        publishChange({
+          notice:
+            "This Change could not be applied. Training and the pending preview are unchanged.",
+        });
+      } finally {
+        publishChange({ busy: false });
+      }
+    },
     start() {
       return start();
     },

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -1804,6 +1804,9 @@ export function createChatController(input: {
                   ? parameterCopy
                   : "This Change could not be previewed. Training is unchanged.",
           });
+          if (result.reason === "stale-version") {
+            await input.refreshPlanLibrary?.().catch(() => {});
+          }
           return;
         }
         const superseded = library.changes.find(
@@ -1852,6 +1855,9 @@ export function createChatController(input: {
                   ? "This preview is no longer pending. Training is unchanged."
                   : "This Change could not be applied. Training and the pending preview are unchanged.",
           });
+          if (result.reason === "stale-version" || result.reason === "not-pending") {
+            await input.refreshPlanLibrary?.().catch(() => {});
+          }
           return;
         }
         publishChange({

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -10,6 +10,8 @@ import {
   type PlanCloseRpcParams,
   type PlanCloseResult,
   type PlanHistoryResult,
+  type PlanChangePreviewRpcParams,
+  type PlanChangeApplyRpcParams,
   type ListPlansResult,
   type PlanHydrationState,
   type PlanProgressEvent,
@@ -44,6 +46,26 @@ export async function closePlan(
   input: Omit<PlanCloseRpcParams, "commandId">,
 ): Promise<PlanCloseResult> {
   return (await clients.getClient()).call("plan.close", {
+    ...input,
+    commandId: globalThis.crypto.randomUUID(),
+  });
+}
+
+export async function previewPlanChange(
+  clients: DesktopCoachClientProvider,
+  input: Omit<PlanChangePreviewRpcParams, "commandId">,
+) {
+  return (await clients.getClient()).call("plan_change.preview", {
+    ...input,
+    commandId: globalThis.crypto.randomUUID(),
+  });
+}
+
+export async function applyPlanChange(
+  clients: DesktopCoachClientProvider,
+  input: Omit<PlanChangeApplyRpcParams, "commandId">,
+) {
+  return (await clients.getClient()).call("plan_change.apply", {
     ...input,
     commandId: globalThis.crypto.randomUUID(),
   });

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -9,6 +9,7 @@ import type {
   PlanCreationAnswerSummary,
   PlanCreationCardModel,
   PlanHandoffSuggestion,
+  PlanChangeIntent,
 } from "@enduragent/coach-contract";
 import type { ActivePlanKnowledge } from "../chat/controller";
 import type { StateCreator } from "zustand";
@@ -108,6 +109,10 @@ export interface ChatSurfaceState {
 }
 
 export interface ChatActions {
+  openPlanChangeEditor(): void;
+  backFromPlanChangeEditor(): void;
+  previewPlanChange(intent: PlanChangeIntent): void;
+  applyPlanChange(decision: "apply" | "cancel"): void;
   submit(message: string, attachmentIds?: readonly string[]): Promise<boolean>;
   chooseAttachments(): Promise<void>;
   pasteAttachment(): Promise<void>;
@@ -203,7 +208,32 @@ export const EMPTY_CHAT_SURFACE: ChatSurfaceState = Object.freeze({
 
 export const IDLE_FIRST_SYNC: FirstSyncState = Object.freeze({ status: "idle" });
 
+export interface PlanChangeSurfaceState {
+  readonly open: boolean;
+  readonly planId: string | null;
+  readonly editorOpen: boolean;
+  readonly busy: boolean;
+  readonly error: string | null;
+  readonly notice: string | null;
+  readonly focusRequest: {
+    readonly target: "editor" | "preview" | "change";
+    readonly revision: number;
+  } | null;
+}
+
+export const EMPTY_PLAN_CHANGE_SURFACE: PlanChangeSurfaceState = Object.freeze({
+  open: false,
+  planId: null,
+  editorOpen: false,
+  busy: false,
+  error: null,
+  notice: null,
+  focusRequest: null,
+});
+
 export interface ChatSlice {
+  readonly planChange: PlanChangeSurfaceState;
+  setPlanChange: (next: PlanChangeSurfaceState) => void;
   readonly chat: ChatSurfaceState;
   readonly chatActions: ChatActions | null;
   readonly firstSync: FirstSyncState;
@@ -360,6 +390,10 @@ export function sameChatSurface(left: ChatSurfaceState, right: ChatSurfaceState)
 }
 
 export const createChatSlice: StateCreator<EnduragentState, [], [], ChatSlice> = (set) => ({
+  planChange: EMPTY_PLAN_CHANGE_SURFACE,
+  setPlanChange(next) {
+    set({ planChange: next });
+  },
   chat: EMPTY_CHAT_SURFACE,
   chatActions: null,
   firstSync: IDLE_FIRST_SYNC,

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -27,6 +27,7 @@ import { QueuedMessages } from "./QueuedMessages";
 import { SpendNotice } from "./SpendNotice";
 import { TrainingContextPanel } from "./TrainingContextPanel";
 import { Transcript } from "./Transcript";
+import { PlanChangeCards } from "./PlanChangeCards";
 import {
   PlanCreationActivateDialog,
   PlanCreationDiscardDialog,
@@ -68,6 +69,15 @@ export function ChatView(): ReactElement {
   const workBlocked = useEnduragentStore((state) => state.chat.workBlocked);
   const planningRequestFocusId = useEnduragentStore((state) => state.chat.planningRequestFocusId);
   const actions = useEnduragentStore((state) => state.chatActions);
+  const changeSurfaceVisible = useEnduragentStore((state) => {
+    const library = state.planLibrary.value;
+    return (
+      library?.active !== null &&
+      library?.active !== undefined &&
+      ((state.planChange.open && state.planChange.planId === library.active.planId) ||
+        library.changes.some((change) => change.status === "pending"))
+    );
+  });
   const mountedView = useRef(activeView);
 
   useLayoutEffect(() => {
@@ -200,6 +210,7 @@ export function ChatView(): ReactElement {
           >
             <div className="thread mx-auto w-[min(720px,calc(100%-48px))] max-[760px]:w-[calc(100%-32px)]">
               <Transcript />
+              <PlanChangeCards />
               <CoachProgress />
               <FirstSyncCard />
             </div>
@@ -228,7 +239,9 @@ export function ChatView(): ReactElement {
             {decisionCustomOpen || planCreationEditorOpen ? null : (
               <Composer handle={composer} draftMemory={composerDraft} />
             )}
-            <p className="mt-inset mb-0 text-center text-xs text-ink-3">{CHAT_DISCLAIMER}</p>
+            <p className="mt-inset mb-0 text-center text-xs text-ink-3">
+              {changeSurfaceVisible ? "Training changes need your confirmation." : CHAT_DISCLAIMER}
+            </p>
           </div>
         </div>
         {contextOpen && !compact ? <TrainingContextPanel /> : null}

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -1,0 +1,464 @@
+import type {
+  PlanChangeIntent,
+  PlanChangeModel,
+  PlanChangeWorkout,
+} from "@enduragent/coach-contract";
+import { useEffect, useRef, useState, type ReactElement, type ReactNode, type Ref } from "react";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent } from "../../components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
+import { useEnduragentStore } from "../../state/store";
+
+const changeOptions = [
+  { value: "weekday-duration", label: "Weekday duration cap" },
+  { value: "weekday-unavailable", label: "Weekday unavailable" },
+  { value: "hard-weekday", label: "No hard training on a weekday" },
+  { value: "weekly-duration", label: "Weekly duration cap" },
+  { value: "longest-workout", label: "Longest-Workout cap" },
+] satisfies Array<{ value: PlanChangeIntent["kind"]; label: string }>;
+const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const statusLabels = {
+  pending: "Pending",
+  applied: "Applied",
+  cancelled: "Cancelled",
+  superseded: "Superseded",
+  stale: "Stale",
+} satisfies Record<PlanChangeModel["status"], string>;
+
+function ChangeCard(props: {
+  eyebrow: string;
+  title: string;
+  status?: string;
+  summary?: string;
+  headingRef?: Ref<HTMLHeadingElement>;
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <Card size="sm" className="min-w-0" role="region" aria-label={props.title}>
+      <CardContent className="grid gap-inset">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
+          <div className="grid min-w-0 gap-[calc(var(--inset)/2)]">
+            <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+              {props.eyebrow}
+            </p>
+            <h3
+              ref={props.headingRef}
+              tabIndex={-1}
+              className="m-0 text-base leading-6 font-semibold break-words"
+            >
+              {props.title}
+            </h3>
+          </div>
+          {props.status ? (
+            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+              {props.status}
+            </span>
+          ) : null}
+        </div>
+        {props.summary ? <p className="m-0 text-sm leading-5 text-ink-2">{props.summary}</p> : null}
+        {props.children}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Fact(props: { label: string; children: ReactNode }): ReactElement {
+  return (
+    <div
+      role="row"
+      className="grid grid-cols-[minmax(104px,0.72fr)_minmax(0,1.28fr)] gap-4 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-1 max-[560px]:gap-1"
+    >
+      <span role="rowheader" className="text-xs leading-4 text-ink-2">
+        {props.label}
+      </span>
+      <strong
+        role="cell"
+        className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left"
+      >
+        {props.children}
+      </strong>
+    </div>
+  );
+}
+
+function workoutValue(workout: PlanChangeWorkout | null): string {
+  if (workout === null) return "Not in Plan";
+  const date =
+    workout.date === null
+      ? "Undated"
+      : new Intl.DateTimeFormat("en-GB", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+          timeZone: "UTC",
+        }).format(new Date(`${workout.date}T12:00:00Z`));
+  return `${date} · ${workout.minutes} min`;
+}
+
+function Difference({ change }: { change: PlanChangeModel }): ReactElement {
+  const weekNumbers = [
+    ...new Set(
+      [...change.totals.before.weeks, ...change.totals.after.weeks].map((week) => week.number),
+    ),
+  ];
+  return (
+    <>
+      <div role="table" aria-label="Affected individual Workouts">
+        {change.diff.map((row) => (
+          <Fact key={row.workoutId} label={row.before?.name ?? row.after?.name ?? "Workout"}>
+            {workoutValue(row.before)} → {workoutValue(row.after)}
+            {row.before && row.after && row.before.name !== row.after.name
+              ? ` · ${row.after.name}`
+              : ""}
+          </Fact>
+        ))}
+      </div>
+      <div role="table" aria-label="Before and after totals">
+        <Fact label="Plan totals">
+          {change.totals.before.plan} min → {change.totals.after.plan} min
+        </Fact>
+        {weekNumbers.map((number) => (
+          <Fact key={number} label={`Week ${number}`}>
+            {change.totals.before.weeks.find((week) => week.number === number)?.minutes ??
+              "Not in Plan"}{" "}
+            min →{" "}
+            {change.totals.after.weeks.find((week) => week.number === number)?.minutes ??
+              "Not in Plan"}{" "}
+            min
+          </Fact>
+        ))}
+      </div>
+      {change.diff.length === 0 ? (
+        <p className="m-0 text-sm text-ink-2">No Workout changes.</p>
+      ) : null}
+    </>
+  );
+}
+
+function premiseValue(intent: PlanChangeIntent): string {
+  switch (intent.kind) {
+    case "weekday-duration":
+      return `${days[intent.day - 1]} · ${intent.minutes} min`;
+    case "weekday-unavailable":
+      return `${days[intent.day - 1]} · Unavailable`;
+    case "hard-weekday":
+      return `${days[intent.day - 1]} · No hard training`;
+    case "weekly-duration":
+      return `${intent.hours} hours each week`;
+    case "longest-workout":
+      return `${intent.minutes} min`;
+  }
+}
+
+function ChangeEditor(): ReactElement {
+  const [kind, setKind] = useState<PlanChangeIntent["kind"]>("weekday-duration");
+  const [day, setDay] = useState(3);
+  const [minutes, setMinutes] = useState("30");
+  const [hours, setHours] = useState("3");
+  const state = useEnduragentStore((store) => store.planChange);
+  const actions = useEnduragentStore((store) => store.chatActions);
+  const firstControl = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    firstControl.current?.focus();
+  }, []);
+  const weekday =
+    kind === "weekday-duration" || kind === "weekday-unavailable" || kind === "hard-weekday";
+  return (
+    <ChangeCard eyebrow="Plan Change" title="What needs to change?">
+      <form
+        className="grid gap-inset"
+        noValidate
+        onSubmit={(event) => {
+          event.preventDefault();
+          let intent: PlanChangeIntent;
+          switch (kind) {
+            case "weekday-duration":
+              intent = { kind, day, minutes: Number(minutes) };
+              break;
+            case "weekday-unavailable":
+            case "hard-weekday":
+              intent = { kind, day };
+              break;
+            case "weekly-duration":
+              intent = { kind, hours: Number(hours) };
+              break;
+            case "longest-workout":
+              intent = { kind, minutes: Number(minutes) };
+              break;
+          }
+          actions?.previewPlanChange(intent);
+        }}
+      >
+        <div className="grid gap-[calc(var(--inset)/2)]">
+          <label htmlFor="plan-change-kind" className="text-xs text-ink-2">
+            Change
+          </label>
+          <Select
+            value={kind}
+            items={changeOptions}
+            disabled={state.busy}
+            onValueChange={(value) => {
+              const option = changeOptions.find((option) => option.value === value);
+              if (!option) return;
+              setKind(option.value);
+              setDay(option.value === "hard-weekday" ? 1 : 3);
+              setMinutes(option.value === "longest-workout" ? "60" : "30");
+              setHours("3");
+            }}
+          >
+            <SelectTrigger id="plan-change-kind" ref={firstControl} className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {changeOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {weekday ? (
+          <div className="grid gap-[calc(var(--inset)/2)]">
+            <label htmlFor="plan-change-day" className="text-xs text-ink-2">
+              Weekday
+            </label>
+            <Select
+              value={day}
+              items={days.map((label, index) => ({ value: index + 1, label }))}
+              disabled={state.busy}
+              onValueChange={(value) => {
+                if (value !== null) setDay(value);
+              }}
+            >
+              <SelectTrigger id="plan-change-day" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {days.map((label, index) => (
+                  <SelectItem key={label} value={index + 1}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+        {kind === "weekday-duration" || kind === "longest-workout" ? (
+          <div className="grid gap-[calc(var(--inset)/2)]">
+            <label htmlFor="plan-change-minutes" className="text-xs text-ink-2">
+              Duration limit in minutes
+            </label>
+            <input
+              className="min-h-[var(--ctl-h-lg)] rounded-ctl border border-line-2 bg-sunk px-ctl-px-sm py-2 text-sm font-normal leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20"
+              id="plan-change-minutes"
+              type="number"
+              min="1"
+              value={minutes}
+              disabled={state.busy}
+              onChange={(event) => setMinutes(event.target.value)}
+            />
+          </div>
+        ) : null}
+        {kind === "weekly-duration" ? (
+          <div className="grid gap-[calc(var(--inset)/2)]">
+            <label htmlFor="plan-change-hours" className="text-xs text-ink-2">
+              Weekly limit in hours
+            </label>
+            <input
+              className="min-h-[var(--ctl-h-lg)] rounded-ctl border border-line-2 bg-sunk px-ctl-px-sm py-2 text-sm font-normal leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20"
+              id="plan-change-hours"
+              type="number"
+              min="0"
+              step="any"
+              value={hours}
+              disabled={state.busy}
+              onChange={(event) => setHours(event.target.value)}
+            />
+          </div>
+        ) : null}
+        <p role="alert" className="m-0 text-xs text-danger">
+          {state.error}
+        </p>
+        <div className="mt-row flex flex-wrap gap-inset">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={state.busy}
+            onClick={() => actions?.backFromPlanChangeEditor()}
+          >
+            Back
+          </Button>
+          <Button type="submit" disabled={state.busy || actions === null}>
+            Preview change
+          </Button>
+        </div>
+      </form>
+    </ChangeCard>
+  );
+}
+
+export function PlanChangeCards(): ReactElement | null {
+  const library = useEnduragentStore((store) => store.planLibrary.value);
+  const state = useEnduragentStore((store) => store.planChange);
+  const actions = useEnduragentStore((store) => store.chatActions);
+  const setActiveView = useEnduragentStore((store) => store.setActiveView);
+  const activeView = useEnduragentStore((store) => store.activeView);
+  const [source, setSource] = useState<{ change: PlanChangeModel; difference: boolean } | null>(
+    null,
+  );
+  const sourceHeading = useRef<HTMLHeadingElement>(null);
+  const sourceOpener = useRef<HTMLButtonElement | null>(null);
+  const changeButton = useRef<HTMLButtonElement>(null);
+  const previewHeading = useRef<HTMLHeadingElement>(null);
+  const pending = library?.changes.find((change) => change.status === "pending");
+  useEffect(() => {
+    if (activeView !== "chat" || state.busy) return;
+    if (state.focusRequest?.target === "preview" && pending) previewHeading.current?.focus();
+    if (state.focusRequest?.target === "change") changeButton.current?.focus();
+  }, [state.focusRequest, state.busy, pending?.changeId, activeView]);
+  useEffect(() => {
+    if (source) sourceHeading.current?.focus();
+  }, [source]);
+  if (!library?.active || (!pending && !(state.open && state.planId === library.active.planId)))
+    return null;
+  const openSource = (
+    change: PlanChangeModel,
+    difference: boolean,
+    button: HTMLButtonElement,
+  ): void => {
+    sourceOpener.current = button;
+    setSource({ change, difference });
+  };
+  const notice = state.notice ?? (pending ? "Review the exact changes before confirming." : null);
+  return (
+    <section aria-label="Plan Changes" className="grid min-w-0 gap-inset">
+      {notice ? (
+        <p role="status" className="m-0 text-sm text-ink-2">
+          {notice}
+        </p>
+      ) : null}
+      <ChangeCard
+        eyebrow="Active Plan"
+        title={library.active.name}
+        summary={
+          library.creation
+            ? "Your separate Plan creation is still open."
+            : "Changes affect future, uncompleted training."
+        }
+      >
+        <div className="mt-row flex flex-wrap gap-inset">
+          <Button
+            ref={changeButton}
+            disabled={state.busy || actions === null}
+            onClick={() => actions?.openPlanChangeEditor()}
+          >
+            Change one thing
+          </Button>
+          <Button variant="outline" onClick={() => setActiveView("plan")}>
+            Open Plan
+          </Button>
+        </div>
+      </ChangeCard>
+      {state.editorOpen ? <ChangeEditor /> : null}
+      {pending ? (
+        <ChangeCard
+          eyebrow="Plan Change"
+          title={pending.title}
+          status="Pending"
+          headingRef={previewHeading}
+          summary="Review this exact difference. Training stays unchanged until you confirm."
+        >
+          <Difference change={pending} />
+          <div role="table" aria-label="Facts">
+            <Fact label="Main Goal">{library.active.name}</Fact>
+            <Fact label="Confidence">{pending.confidence}</Fact>
+          </div>
+          <div>
+            <Button
+              variant="outline"
+              onClick={(event) => openSource(pending, false, event.currentTarget)}
+            >
+              View evidence
+            </Button>
+          </div>
+          <div className="mt-row flex flex-wrap gap-inset">
+            <Button
+              variant="outline"
+              disabled={state.busy || actions === null}
+              onClick={() => actions?.applyPlanChange("cancel")}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={state.busy || actions === null}
+              onClick={() => actions?.applyPlanChange("apply")}
+            >
+              Apply to Plan
+            </Button>
+          </div>
+        </ChangeCard>
+      ) : null}
+      {library.changes
+        .filter((change) => change.status !== "pending")
+        .map((change) => (
+          <ChangeCard
+            key={change.changeId}
+            eyebrow="Plan Change history"
+            title={change.title}
+            status={statusLabels[change.status]}
+            summary="Earlier decisions remain readable."
+          >
+            <div className="mt-row flex flex-wrap gap-inset">
+              <Button
+                variant="outline"
+                onClick={(event) => openSource(change, false, event.currentTarget)}
+              >
+                Read historical evidence
+              </Button>
+              <Button
+                variant="outline"
+                onClick={(event) => openSource(change, true, event.currentTarget)}
+              >
+                Read this difference
+              </Button>
+            </div>
+          </ChangeCard>
+        ))}
+      {source ? (
+        <ChangeCard eyebrow="Evidence" title="Source details" headingRef={sourceHeading}>
+          {source.difference ? (
+            <>
+              <p className="m-0 text-sm text-ink-2">{statusLabels[source.change.status]}</p>
+              <Difference change={source.change} />
+            </>
+          ) : null}
+          <div role="table" aria-label="Source details">
+            {source.change.premises.map((premise) => (
+              <Fact key={premise.id} label={`${premise.label} · ${premise.source}`}>
+                {premiseValue(premise.value)}
+              </Fact>
+            ))}
+          </div>
+          <div className="mt-row flex flex-wrap gap-inset">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setSource(null);
+                sourceOpener.current?.focus();
+              }}
+            >
+              Back
+            </Button>
+          </div>
+        </ChangeCard>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -326,6 +326,10 @@ export function PlanChangeCards(): ReactElement | null {
   useEffect(() => {
     if (source) sourceHeading.current?.focus();
   }, [source]);
+  const activePlanId = library?.active?.planId ?? null;
+  useEffect(() => {
+    setSource(null);
+  }, [activePlanId]);
   if (!library?.active || (!pending && !(state.open && state.planId === library.active.planId)))
     return null;
   const openSource = (

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -31,6 +31,10 @@ function archiveActions(): ArchiveActions {
 
 function chatActions(): ChatActions {
   return {
+    openPlanChangeEditor: vi.fn(),
+    backFromPlanChangeEditor: vi.fn(),
+    previewPlanChange: vi.fn(),
+    applyPlanChange: vi.fn(),
     submit: vi.fn(),
     chooseAttachments: vi.fn(),
     pasteAttachment: vi.fn(),

--- a/apps/desktop-renderer/tests/boot-plan-change.test.ts
+++ b/apps/desktop-renderer/tests/boot-plan-change.test.ts
@@ -1,0 +1,292 @@
+import type { ListPlansResult, PlanCreationCardModel } from "@enduragent/coach-contract";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bootRenderer } from "../src/boot";
+import { createChatController } from "../src/chat/controller";
+import { EMPTY_PLAN_CHANGE_SURFACE } from "../src/state/chat-slice";
+import { useEnduragentStore as store } from "../src/state/store";
+
+const mocks = vi.hoisted(() => ({
+  reload: vi.fn(),
+  call: vi.fn(),
+  refresh: vi.fn(async () => {}),
+  idle: () => ({
+    start: vi.fn(),
+    dispose: vi.fn(),
+    activate: vi.fn(),
+    close: vi.fn(),
+    refresh: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock("../src/coach-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/coach-client")>()),
+  createDesktopCoachClientProvider: () => ({
+    getClient: async () => ({ call: mocks.call }),
+    close: async () => {},
+  }),
+}));
+vi.mock("../src/chat/controller", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/chat/controller")>();
+  return {
+    ...actual,
+    createChatController: vi.fn((input) => ({
+      ...actual.createChatController(input),
+      start: vi.fn(),
+      refreshPlanningRequests: vi.fn(),
+    })),
+  };
+});
+vi.mock("../src/plan/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/plan/controller")>()),
+  createPlanController: () => ({ ...mocks.idle(), refresh: mocks.refresh }),
+}));
+vi.mock("../src/state/adapters/plan", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state/adapters/plan")>()),
+  createPlanViewAdapter: () => ({ ...mocks.idle(), reload: mocks.reload }),
+  closePlan: vi.fn(),
+  readPlanHistory: vi.fn(),
+  listPlans: vi.fn(),
+}));
+vi.mock("../src/update/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/update/controller")>()),
+  createDesktopUpdateController: mocks.idle,
+}));
+vi.mock("../src/activity-analysis/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/activity-analysis/controller")>()),
+  createRideAnalysisController: mocks.idle,
+}));
+vi.mock("../src/training-export/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/training-export/controller")>()),
+  createTrainingExportController: mocks.idle,
+}));
+vi.mock("../src/training-context/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/training-context/controller")>()),
+  createTrainingContextController: mocks.idle,
+}));
+vi.mock("../src/training-sync", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/training-sync")>()),
+  createTrainingSyncCoordinator: mocks.idle,
+}));
+vi.mock("../src/training-context/manual-sync", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/training-context/manual-sync")>()),
+  createManualSyncController: mocks.idle,
+}));
+vi.mock("../src/spend-meter/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/spend-meter/controller")>()),
+  createSpendMeterController: mocks.idle,
+}));
+vi.mock("../src/archive/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/archive/controller")>()),
+  createArchiveController: mocks.idle,
+}));
+vi.mock("../src/first-sync", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/first-sync")>()),
+  createFirstSyncController: mocks.idle,
+}));
+vi.mock("../src/ride-import", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/ride-import")>()),
+  createRideImportController: mocks.idle,
+  subscribeToDroppedRideImports: () => vi.fn(),
+}));
+vi.mock("../src/state/adapters/ride-import", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state/adapters/ride-import")>()),
+  createRideImportAdapter: () => ({ port: {}, dispose: vi.fn() }),
+}));
+vi.mock("../src/onboarding/controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/onboarding/controller")>()),
+  createOnboardingController: mocks.idle,
+  onboardingCredentialMutationActive: () => false,
+}));
+vi.mock("../src/initial-setup-status", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/initial-setup-status")>()),
+  settleInitialSetupStatus: vi.fn(),
+}));
+vi.mock("../src/settings/session-controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/settings/session-controller")>()),
+  createSessionSettingsController: mocks.idle,
+}));
+vi.mock("../src/settings/credential-controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/settings/credential-controller")>()),
+  createCredentialSettingsController: mocks.idle,
+  credentialChangesBlocked: () => false,
+}));
+vi.mock("../src/settings/athlete-controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/settings/athlete-controller")>()),
+  createAthleteSettingsController: mocks.idle,
+}));
+vi.mock("../src/settings/provider-model-controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/settings/provider-model-controller")>()),
+  createProviderModelSettingsController: mocks.idle,
+}));
+vi.mock("../src/settings/telegram-controller", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/settings/telegram-controller")>()),
+  createTelegramSettingsController: mocks.idle,
+}));
+
+const creation: PlanCreationCardModel = {
+  creationId: "creation-draft",
+  version: 1,
+  status: "in-progress",
+  readiness: "incomplete",
+  draft: null,
+  draftStale: false,
+  answeredSummaries: [],
+  openQuestion: {
+    kind: "start-timing-question",
+    step: { current: 5, total: 9 },
+    prompt: "When could this Plan start?",
+    earliestAllowed: "1998-10-01",
+    options: [
+      {
+        timing: "as-soon-as-possible",
+        label: "As soon as possible",
+        detail: "Start at the earliest suitable week.",
+      },
+    ],
+    dateLabel: "Earliest start date",
+  },
+};
+
+function library(planId: string, pending = false): ListPlansResult {
+  return {
+    active: {
+      planId,
+      version: 2,
+      name: "Build fitness",
+      start: "1998-09-07",
+      end: "1998-10-04",
+      weeks: 4,
+      status: "active",
+      closeReason: null,
+      closedAt: null,
+      activatedAt: "1998-09-07",
+      creationId: null,
+    },
+    closed: [],
+    creation,
+    changes: pending
+      ? [
+          {
+            changeId: "change-pending",
+            planId,
+            baseRevisionNumber: 1,
+            status: "pending",
+            title: "Limit weekday duration",
+            intent: { kind: "weekday-duration", day: 2, minutes: 45 },
+            diff: [],
+            totals: {
+              before: { plan: 120, weeks: [{ number: 1, minutes: 120 }] },
+              after: { plan: 90, weeks: [{ number: 1, minutes: 90 }] },
+            },
+            supersedes: null,
+            supersededBy: null,
+            resultRevisionNumber: null,
+            confidence: "High",
+            premises: [],
+          },
+        ]
+      : [],
+  };
+}
+
+function controller() {
+  const result = vi.mocked(createChatController).mock.results.at(-1);
+  if (result?.type !== "return") throw new Error("Chat controller was not created");
+  return result.value;
+}
+
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.setState(store.getInitialState(), true);
+  vi.stubGlobal("window", {
+    localStorage: { getItem: () => null, setItem: vi.fn(), removeItem: vi.fn() },
+    enduragentAuth: { onDroppedChatAttachments: () => vi.fn() },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  vi.stubGlobal("document", { documentElement: { dataset: {} } });
+  vi.stubGlobal("requestAnimationFrame", vi.fn());
+  dispose = bootRenderer();
+});
+
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe("Plan Change boot wiring", () => {
+  it("reloads the Plan page and library through the chat refresh hook", async () => {
+    const input = vi.mocked(createChatController).mock.calls.at(-1)?.[0];
+    expect(input?.refreshPlanLibrary).toBeTypeOf("function");
+    await input?.refreshPlanLibrary?.();
+    expect(mocks.reload).toHaveBeenCalledOnce();
+    expect(mocks.refresh).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("resets Change interaction state when opening a different Plan", () => {
+    store.getState().setPlanLibrary({ status: "ready", value: library("plan-new") });
+    store.getState().setPlanChange({
+      ...EMPTY_PLAN_CHANGE_SURFACE,
+      planId: "plan-old",
+      editorOpen: true,
+      error: "Previous error",
+      notice: "Previous notice",
+      focusRequest: { target: "editor", revision: 4 },
+    });
+    store.getState().planLibraryActions?.changeInChat();
+    expect(store.getState().planChange).toEqual({
+      ...EMPTY_PLAN_CHANGE_SURFACE,
+      open: true,
+      planId: "plan-new",
+    });
+    expect(store.getState().activeView).toBe("chat");
+  });
+
+  it("retains Change interaction state when reopening the same Plan", () => {
+    store.getState().setPlanLibrary({ status: "ready", value: library("plan-active") });
+    const previous = {
+      ...EMPTY_PLAN_CHANGE_SURFACE,
+      planId: "plan-active",
+      editorOpen: true,
+      error: "Current error",
+      notice: "Current notice",
+      focusRequest: { target: "editor", revision: 4 } as const,
+    };
+    store.getState().setPlanChange(previous);
+    store.getState().planLibraryActions?.changeInChat();
+    expect(store.getState().planChange).toEqual({ ...previous, open: true });
+  });
+
+  it("pauses creation after Continue from the library finishes loading", async () => {
+    controller().resumeCreation(creation);
+    store.getState().setPlanLibrary({ status: "ready", value: library("plan-active", true) });
+    mocks.call.mockResolvedValueOnce({ deliveries: [], planCreation: creation });
+    store.getState().planLibraryActions?.continueCreation(creation);
+    await vi.waitFor(() => expect(store.getState().chat.planCreationBusy).toBe(false));
+    expect(mocks.call).toHaveBeenCalledExactlyOnceWith("listPlanningRequests", {
+      chatId: "desktop",
+    });
+    expect(store.getState().chat.planCreationError).toBeNull();
+    expect(store.getState().chat.planCreationPaused).toBe(true);
+  });
+
+  it.each(["creation-first", "change-first"])(
+    "keeps creation paused after Continue with a pending Change (%s)",
+    (order) => {
+      if (order === "creation-first") controller().resumeCreation(creation);
+      store.getState().setPlanLibrary({ status: "ready", value: library("plan-active", true) });
+      if (order === "change-first") controller().resumeCreation(creation);
+      expect(store.getState().chat.planCreationLoaded).toBe(true);
+      expect(store.getState().chat.planCreationPaused).toBe(true);
+      store.getState().chatActions?.continuePlanCreation();
+      expect(store.getState().chat.planCreationPaused).toBe(true);
+      expect(store.getState().planLibrary.value?.changes[0]?.status).toBe("pending");
+      store.getState().setPlanLibrary({ status: "ready", value: library("plan-active") });
+      store.getState().chatActions?.continuePlanCreation();
+      expect(store.getState().chat.planCreationPaused).toBe(false);
+    },
+  );
+});

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -32,6 +32,10 @@ import { EMPTY_PLAN_SURFACE } from "../src/state/plan-slice";
 
 function stubActions(): ChatActions {
   return {
+    openPlanChangeEditor: vi.fn(),
+    backFromPlanChangeEditor: vi.fn(),
+    previewPlanChange: vi.fn(),
+    applyPlanChange: vi.fn(),
     submit: vi.fn(async () => true),
     chooseAttachments: vi.fn(),
     pasteAttachment: vi.fn(),

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -11,6 +11,8 @@ import {
   closePlan,
   createPlanViewAdapter,
   readPlanHistory,
+  previewPlanChange,
+  applyPlanChange,
   type PlanBridge,
 } from "../src/state/adapters/plan";
 import {
@@ -2104,5 +2106,47 @@ describe("Plan library RPC adapters", () => {
       planId: result.planId,
       expectedVersion: 7,
     });
+  });
+});
+
+describe("Plan Change RPC adapters", () => {
+  it("generates unique command ids and preserves preview and decision payloads", async () => {
+    const call = vi.fn().mockResolvedValue({ status: "rejected", reason: "stale-version" });
+    const clients = { getClient: async () => ({ call }) } as unknown as DesktopCoachClientProvider;
+    const preview = {
+      planId: "plan-active",
+      expectedVersion: 4,
+      intent: { kind: "weekly-duration", hours: 6 },
+    } as const;
+    const decision = {
+      planId: "plan-active",
+      expectedVersion: 5,
+      changeId: "change-pending",
+      decision: "apply",
+    } as const;
+    expect(await previewPlanChange(clients, preview)).toEqual({
+      status: "rejected",
+      reason: "stale-version",
+    });
+    await applyPlanChange(clients, decision);
+    await applyPlanChange(clients, { ...decision, decision: "cancel" });
+    expect(call).toHaveBeenNthCalledWith(1, "plan_change.preview", {
+      ...preview,
+      commandId: expect.any(String),
+    });
+    expect(call).toHaveBeenNthCalledWith(2, "plan_change.apply", {
+      ...decision,
+      commandId: expect.any(String),
+    });
+    expect(call).toHaveBeenNthCalledWith(3, "plan_change.apply", {
+      ...decision,
+      decision: "cancel",
+      commandId: expect.any(String),
+    });
+    expect(new Set(call.mock.calls.map(([, request]) => request.commandId)).size).toBe(3);
+    for (const [, request] of call.mock.calls)
+      expect(request.commandId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+      );
   });
 });

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -1,0 +1,407 @@
+import type {
+  ListPlansResult,
+  PlanChangeModel,
+  PlanChangeWorkout,
+  PlanCreationCardModel,
+} from "@enduragent/coach-contract";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice";
+import { useEnduragentStore } from "../src/state/store";
+import { READY_ONBOARDING } from "../src/state/onboarding-slice";
+import { ChatView } from "../src/ui/chat/ChatView";
+import { PlanChangeCards } from "../src/ui/chat/PlanChangeCards";
+
+function stubActions(): ChatActions {
+  return {
+    openPlanChangeEditor: vi.fn(),
+    backFromPlanChangeEditor: vi.fn(),
+    previewPlanChange: vi.fn(),
+    applyPlanChange: vi.fn(),
+    submit: vi.fn(async () => true),
+    chooseAttachments: vi.fn(),
+    pasteAttachment: vi.fn(),
+    receiveAttachmentAdmissions: vi.fn(),
+    saveAttachmentDraftText: vi.fn(),
+    removeAttachment: vi.fn(),
+    retryAttachment: vi.fn(),
+    selectAttachmentWorkout: vi.fn(),
+    reviewAttachmentInPlan: vi.fn(),
+    continueMessageInPlan: vi.fn(),
+    openPlanningRequest: vi.fn(),
+    retryPlanningRequest: vi.fn(),
+    retryPlanningRequestLoad: vi.fn(),
+    clearPlanningRequestFocus: vi.fn(),
+    startPlanCreation: vi.fn(),
+    buildPlanCreationDraft: vi.fn(),
+    answerPlanCreation: vi.fn(),
+    pausePlanCreation: vi.fn(),
+    continuePlanCreation: vi.fn(),
+    editPlanCreation: vi.fn(),
+    cancelPlanCreationEdit: vi.fn(),
+    openPlanCreationDiscard: vi.fn(),
+    cancelPlanCreationDiscard: vi.fn(),
+    confirmPlanCreationDiscard: vi.fn(),
+    openPlanCreationActivate: vi.fn(),
+    cancelPlanCreationActivate: vi.fn(),
+    confirmPlanCreationActivate: vi.fn(),
+    stop: vi.fn(),
+    removeQueued: vi.fn(),
+    runQueuedCommand: vi.fn(),
+    retryQueuedTurn: vi.fn(),
+    retry: vi.fn(),
+    loadEarlier: vi.fn(),
+    retryHydration: vi.fn(),
+    retryDecision: vi.fn(),
+    openNewConversation: vi.fn(),
+    cancelNewConversation: vi.fn(),
+    confirmNewConversation: vi.fn(),
+    retryFirstSync: vi.fn(),
+    answerDecision: vi.fn(),
+    skipDecision: vi.fn(),
+  };
+}
+
+const active: NonNullable<ListPlansResult["active"]> = {
+  planId: "active-change",
+  version: 7,
+  name: "Build steady power",
+  start: "1998-09-07",
+  end: "1998-10-04",
+  weeks: 4,
+  status: "active",
+  closeReason: null,
+  closedAt: null,
+  activatedAt: "1998-09-07",
+  creationId: null,
+};
+const workout: PlanChangeWorkout = {
+  id: "workout-one",
+  name: "Endurance ride",
+  kind: "endurance",
+  date: "1998-09-09",
+  minutes: 60,
+  pinned: false,
+  guidance: "Ride comfortably",
+  power: null,
+};
+function change(patch: Partial<PlanChangeModel> = {}): PlanChangeModel {
+  return {
+    changeId: "change-pending",
+    planId: active.planId,
+    baseRevisionNumber: 1,
+    status: "pending",
+    title: "Limit Wednesday training",
+    intent: { kind: "weekday-duration", day: 3, minutes: 30 },
+    diff: [{ workoutId: workout.id, before: workout, after: { ...workout, minutes: 30 } }],
+    totals: {
+      before: { plan: 1234, weeks: [{ number: 1, minutes: 321 }] },
+      after: { plan: 1204, weeks: [{ number: 1, minutes: 291 }] },
+    },
+    supersedes: null,
+    supersededBy: null,
+    resultRevisionNumber: null,
+    confidence: "Confirmed schedule limits",
+    premises: [
+      {
+        id: "premise-one",
+        label: "Wednesday limit",
+        source: "Your confirmed request",
+        value: { kind: "weekday-duration", day: 3, minutes: 30 },
+      },
+    ],
+    ...patch,
+  };
+}
+function setChanges(changes: PlanChangeModel[]): void {
+  act(() =>
+    useEnduragentStore.setState({
+      planLibrary: { status: "ready", value: { active, creation: null, closed: [], changes } },
+    }),
+  );
+}
+function patchChange(
+  patch: Partial<ReturnType<typeof useEnduragentStore.getState>["planChange"]>,
+): void {
+  act(() =>
+    useEnduragentStore.setState({
+      planChange: { ...useEnduragentStore.getState().planChange, ...patch },
+    }),
+  );
+}
+
+beforeEach(() => {
+  useEnduragentStore.setState({
+    activeView: "chat",
+    chat: EMPTY_CHAT_SURFACE,
+    chatActions: stubActions(),
+    planChange: {
+      open: true,
+      planId: active.planId,
+      editorOpen: false,
+      busy: false,
+      error: null,
+      notice: null,
+      focusRequest: null,
+    },
+    planLibrary: { status: "ready", value: { active, creation: null, closed: [], changes: [] } },
+    planLibraryActions: null,
+  });
+});
+
+describe("Plan Change cards", () => {
+  it("restores pending Changes in Chat alongside separate creation and an enabled composer", async () => {
+    const creation: PlanCreationCardModel = {
+      creationId: "separate-creation",
+      version: 1,
+      status: "in-progress",
+      readiness: "incomplete",
+      draft: null,
+      draftStale: false,
+      answeredSummaries: [],
+      openQuestion: null,
+    };
+    useEnduragentStore.setState({
+      runtimeReady: true,
+      onboarding: READY_ONBOARDING,
+      chat: {
+        ...EMPTY_CHAT_SURFACE,
+        planCreation: creation,
+        planCreationLoaded: true,
+        planCreationPaused: true,
+        timeline: [{ kind: "plan-creation", model: creation }],
+      },
+      planLibrary: {
+        status: "ready",
+        value: { active, creation, closed: [], changes: [change()] },
+      },
+    });
+    patchChange({ open: false, planId: null });
+    render(<ChatView />);
+    expect(screen.getByRole("region", { name: "Plan Changes" })).toBeVisible();
+    expect(screen.getByRole("region", { name: "Plan Creation progress" })).toBeVisible();
+    expect(screen.getByText("Your separate Plan creation is still open.")).toBeVisible();
+    expect(screen.getByText("Training changes need your confirmation.")).toBeVisible();
+    const composer = screen.getByRole("combobox", { name: "Message your coach" });
+    expect(composer).toBeEnabled();
+    await userEvent.type(composer, "How should I pace tomorrow?");
+    expect(composer).toHaveValue("How should I pace tomorrow?");
+  });
+
+  it("shows the active Plan only after entry and restores a pending preview without entry", () => {
+    patchChange({ open: false, planId: null });
+    const view = render(<PlanChangeCards />);
+    expect(screen.queryByRole("region", { name: "Plan Changes" })).toBeNull();
+    setChanges([change()]);
+    expect(screen.getByRole("heading", { name: active.name })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Limit Wednesday training" })).toBeVisible();
+    expect(screen.getByText("Changes affect future, uncompleted training.")).toBeVisible();
+    view.unmount();
+    render(<PlanChangeCards />);
+    expect(screen.getByText("Pending", { exact: true })).toBeVisible();
+  });
+
+  it("orders notice, active Plan, editor, pending preview, then oldest to newest history", () => {
+    setChanges([
+      change({ changeId: "old", title: "Old decision", status: "applied" }),
+      change({ changeId: "new", title: "New decision", status: "cancelled" }),
+      change(),
+    ]);
+    patchChange({ editorOpen: true, notice: "Review the exact changes before confirming." });
+    render(<PlanChangeCards />);
+    const surface = screen.getByRole("region", { name: "Plan Changes" });
+    const headings = within(surface)
+      .getAllByRole("heading")
+      .map((heading) => heading.textContent);
+    expect(headings).toEqual([
+      active.name,
+      "What needs to change?",
+      "Limit Wednesday training",
+      "Old decision",
+      "New decision",
+    ]);
+    expect(
+      screen
+        .getByText("Review the exact changes before confirming.")
+        .compareDocumentPosition(screen.getByRole("heading", { name: active.name })),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(screen.getByText("Applied", { exact: true })).toBeVisible();
+    expect(screen.getByText("Cancelled", { exact: true })).toBeVisible();
+    expect(screen.queryByRole("button", { name: /Undo|Refresh preview/ })).toBeNull();
+  });
+
+  it("offers the five Schedule changes in order and submits their defaults", async () => {
+    patchChange({ editorOpen: true });
+    render(<PlanChangeCards />);
+    const actions = useEnduragentStore.getState().chatActions;
+    const select = screen.getByRole("combobox", { name: "Change" });
+    expect(screen.getByRole("combobox", { name: "Weekday" })).toHaveTextContent("Wed");
+    expect(screen.getByRole("spinbutton", { name: "Duration limit in minutes" })).toHaveValue(30);
+    await userEvent.click(screen.getByRole("button", { name: "Preview change" }));
+    expect(actions?.previewPlanChange).toHaveBeenLastCalledWith({
+      kind: "weekday-duration",
+      day: 3,
+      minutes: 30,
+    });
+    await userEvent.click(select);
+    expect((await screen.findAllByRole("option")).map((option) => option.textContent)).toEqual([
+      "Weekday duration cap",
+      "Weekday unavailable",
+      "No hard training on a weekday",
+      "Weekly duration cap",
+      "Longest-Workout cap",
+    ]);
+    await userEvent.click(await screen.findByRole("option", { name: "Weekday unavailable" }));
+    expect(screen.getByRole("combobox", { name: "Weekday" })).toHaveTextContent("Wed");
+    expect(screen.queryByRole("spinbutton")).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Preview change" }));
+    expect(actions?.previewPlanChange).toHaveBeenLastCalledWith({
+      kind: "weekday-unavailable",
+      day: 3,
+    });
+    await userEvent.click(select);
+    await userEvent.click(
+      await screen.findByRole("option", { name: "No hard training on a weekday" }),
+    );
+    expect(screen.getByRole("combobox", { name: "Weekday" })).toHaveTextContent("Mon");
+    await userEvent.click(screen.getByRole("button", { name: "Preview change" }));
+    expect(actions?.previewPlanChange).toHaveBeenLastCalledWith({ kind: "hard-weekday", day: 1 });
+    await userEvent.click(select);
+    await userEvent.click(await screen.findByRole("option", { name: "Weekly duration cap" }));
+    expect(screen.queryByRole("combobox", { name: "Weekday" })).toBeNull();
+    expect(screen.getByRole("spinbutton", { name: "Weekly limit in hours" })).toHaveValue(3);
+    await userEvent.click(screen.getByRole("button", { name: "Preview change" }));
+    expect(actions?.previewPlanChange).toHaveBeenLastCalledWith({
+      kind: "weekly-duration",
+      hours: 3,
+    });
+    await userEvent.click(select);
+    await userEvent.click(await screen.findByRole("option", { name: "Longest-Workout cap" }));
+    expect(screen.getByRole("spinbutton", { name: "Duration limit in minutes" })).toHaveValue(60);
+    await userEvent.click(screen.getByRole("button", { name: "Preview change" }));
+    expect(actions?.previewPlanChange).toHaveBeenLastCalledWith({
+      kind: "longest-workout",
+      minutes: 60,
+    });
+  });
+
+  it("shows host totals and both null and undated sides with the changed after name", () => {
+    setChanges([
+      change({
+        diff: [
+          {
+            workoutId: "renamed",
+            before: workout,
+            after: { ...workout, name: "Easy recovery", minutes: 30 },
+          },
+          { workoutId: "added", before: null, after: { ...workout, id: "added", date: null } },
+          { workoutId: "removed", before: { ...workout, id: "removed", date: null }, after: null },
+        ],
+      }),
+    ]);
+    render(<PlanChangeCards />);
+    const differences = screen.getByRole("table", { name: "Affected individual Workouts" });
+    expect(within(differences).getByText(/Easy recovery/)).toBeVisible();
+    expect(within(differences).getAllByText(/Not in Plan/)).toHaveLength(2);
+    expect(within(differences).getAllByText(/Undated/)).toHaveLength(2);
+    const totals = screen.getByRole("table", { name: "Before and after totals" });
+    expect(
+      within(totals)
+        .getAllByRole("rowheader")
+        .map((row) => row.textContent),
+    ).toEqual(["Plan totals", "Week 1"]);
+    expect(totals).toHaveTextContent("1234 min → 1204 min");
+    expect(totals).toHaveTextContent("321 min → 291 min");
+    expect(screen.getByText("Main Goal", { exact: true })).toBeVisible();
+    expect(screen.getByText("Confidence", { exact: true })).toBeVisible();
+    expect(screen.getByText("Confirmed schedule limits", { exact: true })).toBeVisible();
+  });
+
+  it("reads current and historical evidence and differences without mutation actions", async () => {
+    setChanges([
+      change({ changeId: "old", title: "Earlier limit", status: "superseded" }),
+      change(),
+    ]);
+    render(<PlanChangeCards />);
+    await userEvent.click(screen.getByRole("button", { name: "View evidence" }));
+    let source = screen.getByRole("region", { name: "Source details" });
+    expect(
+      within(source).getByRole("rowheader", { name: "Wednesday limit · Your confirmed request" }),
+    ).toBeVisible();
+    expect(source).toHaveTextContent("Your confirmed request");
+    await userEvent.click(within(source).getByRole("button", { name: "Back" }));
+    expect(screen.queryByRole("region", { name: "Source details" })).toBeNull();
+    expect(screen.getByText("Superseded", { exact: true })).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Read historical evidence" }));
+    source = screen.getByRole("region", { name: "Source details" });
+    await userEvent.click(within(source).getByRole("button", { name: "Back" }));
+    await userEvent.click(screen.getByRole("button", { name: "Read this difference" }));
+    const history = screen.getByRole("region", { name: "Source details" });
+    expect(
+      within(history).getByRole("table", { name: "Affected individual Workouts" }),
+    ).toBeVisible();
+    expect(within(history).queryByRole("button", { name: "Apply to Plan" })).toBeNull();
+    expect(within(history).queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("moves focus to the editor, back to Change one thing, and to a new preview heading", async () => {
+    const actions = stubActions();
+    actions.openPlanChangeEditor = vi.fn(() =>
+      patchChange({ editorOpen: true, focusRequest: { target: "editor", revision: 1 } }),
+    );
+    actions.backFromPlanChangeEditor = vi.fn(() =>
+      patchChange({ editorOpen: false, focusRequest: { target: "change", revision: 2 } }),
+    );
+    actions.applyPlanChange = vi.fn(() => {
+      setChanges([change({ status: "cancelled" })]);
+      patchChange({ busy: true, focusRequest: { target: "change", revision: 4 } });
+    });
+    useEnduragentStore.setState({ chatActions: actions });
+    render(<PlanChangeCards />);
+    const entry = screen.getByRole("button", { name: "Change one thing" });
+    await userEvent.click(entry);
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Change" })).toHaveFocus());
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => expect(entry).toHaveFocus());
+    setChanges([change()]);
+    patchChange({ focusRequest: { target: "preview", revision: 3 } });
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Limit Wednesday training" })).toHaveFocus(),
+    );
+    const preview = screen.getByRole("region", { name: "Limit Wednesday training" });
+    expect(
+      within(preview)
+        .getAllByRole("button")
+        .slice(-2)
+        .map((button) => button.textContent),
+    ).toEqual(["Cancel", "Apply to Plan"]);
+    await userEvent.click(within(preview).getByRole("button", { name: "Cancel" }));
+    expect(actions.applyPlanChange).toHaveBeenCalledWith("cancel");
+    expect(entry).toBeDisabled();
+    expect(entry).not.toHaveFocus();
+    patchChange({ busy: false });
+    await waitFor(() => expect(entry).toHaveFocus());
+  });
+
+  it.each([
+    "Review the exact changes before confirming.",
+    "This preview supersedes “Earlier limit”. Training is unchanged until confirmation.",
+    "Change applied locally. Training now matches the confirmed preview.",
+    "Change cancelled. Training is unchanged; the preview remains in history.",
+    "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed.",
+    "This preview is no longer pending. Training is unchanged.",
+    "This Change could not be applied. Training and the pending preview are unchanged.",
+  ])("announces %s", (notice) => {
+    patchChange({ notice });
+    render(<PlanChangeCards />);
+    expect(screen.getByRole("status")).toHaveTextContent(notice);
+  });
+
+  it("renders parameter errors as alerts and disables submission while busy", () => {
+    patchChange({ editorOpen: true, error: "Enter a duration above zero.", busy: true });
+    render(<PlanChangeCards />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Enter a duration above zero.");
+    expect(screen.getByRole("button", { name: "Preview change" })).toBeDisabled();
+  });
+});

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -29,7 +29,7 @@ const change: PlanChangeModel = {
 
 function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
   let surface: PlanChangeSurfaceState = EMPTY_PLAN_CHANGE_SURFACE;
-  const library: ListPlansResult = {
+  let library: ListPlansResult = {
     active: {
       planId: "plan-active",
       version: 7,
@@ -73,7 +73,15 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
     },
     refreshPlanLibrary: refresh,
   });
-  return { controller, call, refresh, surface: () => surface };
+  return {
+    controller,
+    call,
+    refresh,
+    surface: () => surface,
+    updateVersion(version: number) {
+      if (library.active) library = { ...library, active: { ...library.active, version } };
+    },
+  };
 }
 
 describe("Plan Change controller", () => {
@@ -149,7 +157,7 @@ describe("Plan Change controller", () => {
       h.controller.openPlanChangeEditor();
       await h.controller.previewPlanChange(intent);
       expect(h.surface()).toMatchObject({ editorOpen: true, busy: false, error });
-      expect(h.refresh).not.toHaveBeenCalled();
+      expect(h.refresh).toHaveBeenCalledTimes(reason === "stale-version" ? 1 : 0);
     },
   );
 
@@ -196,8 +204,59 @@ describe("Plan Change controller", () => {
     const h = harness({ status: "rejected", reason });
     await h.controller.applyPlanChange("apply");
     expect(h.surface()).toMatchObject({ busy: false, notice });
-    expect(h.refresh).not.toHaveBeenCalled();
+    expect(h.refresh).toHaveBeenCalledTimes(
+      reason === "stale-version" || reason === "not-pending" ? 1 : 0,
+    );
   });
+
+  it.each(["stale-version", "not-pending"])(
+    "refreshes after %s apply so the next preview uses the new version",
+    async (reason) => {
+      const h = harness({ status: "rejected", reason });
+      h.refresh.mockImplementation(async () => h.updateVersion(8));
+      await h.controller.applyPlanChange("apply");
+      expect(h.refresh).toHaveBeenCalledOnce();
+      h.controller.openPlanChangeEditor();
+      await h.controller.previewPlanChange(change.intent);
+      expect(h.call).toHaveBeenNthCalledWith(2, "plan_change.preview", {
+        planId: "plan-active",
+        expectedVersion: 8,
+        intent: change.intent,
+        commandId: expect.any(String),
+      });
+    },
+  );
+
+  it("refreshes a stale preview before another preview", async () => {
+    const h = harness({ status: "rejected", reason: "stale-version" });
+    h.refresh.mockImplementation(async () => h.updateVersion(8));
+    await h.controller.previewPlanChange(change.intent);
+    expect(h.refresh).toHaveBeenCalledOnce();
+    await h.controller.previewPlanChange(change.intent);
+    expect(h.call).toHaveBeenNthCalledWith(2, "plan_change.preview", {
+      planId: "plan-active",
+      expectedVersion: 8,
+      intent: change.intent,
+      commandId: expect.any(String),
+    });
+  });
+
+  it.each(["apply", "preview"] as const)(
+    "preserves stale %s copy if the library refresh fails",
+    async (action) => {
+      const h = harness({ status: "rejected", reason: "stale-version" });
+      h.refresh.mockRejectedValue(new Error("unavailable"));
+      if (action === "apply") await h.controller.applyPlanChange("apply");
+      else await h.controller.previewPlanChange(change.intent);
+      expect(h.refresh).toHaveBeenCalledOnce();
+      expect(h.surface().busy).toBe(false);
+      expect(action === "apply" ? h.surface().notice : h.surface().error).toBe(
+        action === "apply"
+          ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
+          : "This request used an older Plan revision. Request a fresh preview.",
+      );
+    },
+  );
 
   it("keeps the pending preview on transport failure", async () => {
     const h = harness(new Error("offline"));

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -1,0 +1,242 @@
+import type { CoachClient } from "@enduragent/coach-client";
+import type {
+  ListPlansResult,
+  PlanChangeModel,
+  PlanChangeIntent,
+} from "@enduragent/coach-contract";
+import { describe, expect, it, vi } from "vitest";
+import { createChatController } from "../src/chat/controller";
+import { EMPTY_PLAN_CHANGE_SURFACE, type PlanChangeSurfaceState } from "../src/state/chat-slice";
+
+const change: PlanChangeModel = {
+  changeId: "change-preview",
+  planId: "plan-active",
+  baseRevisionNumber: 1,
+  status: "pending",
+  title: "Limit weekday duration",
+  intent: { kind: "weekday-duration", day: 2, minutes: 45 },
+  diff: [],
+  totals: {
+    before: { plan: 120, weeks: [{ number: 1, minutes: 120 }] },
+    after: { plan: 90, weeks: [{ number: 1, minutes: 90 }] },
+  },
+  supersedes: null,
+  supersededBy: null,
+  resultRevisionNumber: null,
+  confidence: "High",
+  premises: [],
+};
+
+function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
+  let surface: PlanChangeSurfaceState = EMPTY_PLAN_CHANGE_SURFACE;
+  const library: ListPlansResult = {
+    active: {
+      planId: "plan-active",
+      version: 7,
+      name: "Build fitness",
+      start: "1998-09-07",
+      end: "1998-10-04",
+      weeks: 4,
+      status: "active",
+      closeReason: null,
+      closedAt: null,
+      activatedAt: "1998-09-07",
+      creationId: null,
+    },
+    creation: null,
+    closed: [],
+    changes,
+  };
+  const call = vi.fn(async (_method: string, _request: unknown): Promise<never> => {
+    if (result instanceof Error) throw result;
+    return result as never;
+  });
+  const client: CoachClient = {
+    handshake: {} as CoachClient["handshake"],
+    call,
+    close: vi.fn(async () => {}),
+  };
+  const refresh = vi.fn(async () => {});
+  const controller = createChatController({
+    clients: {
+      getClient: async () => client,
+      reconnect: async () => client,
+      close: async () => {},
+    },
+    view: { render: vi.fn() },
+    refreshTrainingContext: async () => {},
+    refreshSpend: async () => {},
+    readPlanLibrary: () => library,
+    readPlanChange: () => surface,
+    publishPlanChange: (next) => {
+      surface = next;
+    },
+    refreshPlanLibrary: refresh,
+  });
+  return { controller, call, refresh, surface: () => surface };
+}
+
+describe("Plan Change controller", () => {
+  it("opens and backs out of the editor with explicit focus requests", () => {
+    const h = harness(null);
+    h.controller.openPlanChangeEditor();
+    expect(h.surface()).toMatchObject({
+      open: true,
+      planId: "plan-active",
+      editorOpen: true,
+      focusRequest: { target: "editor", revision: 1 },
+    });
+    h.controller.backFromPlanChangeEditor();
+    expect(h.surface()).toMatchObject({
+      editorOpen: false,
+      focusRequest: { target: "change", revision: 2 },
+    });
+  });
+
+  it("previews with the summary version, refreshes, and focuses the preview", async () => {
+    const h = harness({ status: "previewed", change, version: 8 }, []);
+    h.controller.openPlanChangeEditor();
+    await h.controller.previewPlanChange(change.intent);
+    expect(h.call).toHaveBeenCalledWith("plan_change.preview", {
+      planId: "plan-active",
+      expectedVersion: 7,
+      intent: change.intent,
+      commandId: expect.any(String),
+    });
+    expect(h.refresh).toHaveBeenCalledOnce();
+    expect(h.surface()).toMatchObject({
+      editorOpen: false,
+      busy: false,
+      error: null,
+      notice: "Review the exact changes before confirming.",
+      focusRequest: { target: "preview" },
+    });
+  });
+
+  it("names the superseded preview", async () => {
+    const h = harness({
+      status: "previewed",
+      change: { ...change, changeId: "new-change", supersedes: change.changeId },
+      version: 8,
+    });
+    await h.controller.previewPlanChange(change.intent);
+    expect(h.surface().notice).toBe(
+      "This preview supersedes “Limit weekday duration”. Training is unchanged until confirmation.",
+    );
+  });
+
+  it.each([
+    [
+      "stale-version",
+      change.intent,
+      "This request used an older Plan revision. Request a fresh preview.",
+    ],
+    [
+      "invalid-intent",
+      { kind: "weekday-duration", day: 2, minutes: 45 },
+      "Enter a duration above zero.",
+    ],
+    [
+      "invalid-intent",
+      { kind: "weekly-duration", hours: 6 },
+      "Enter a weekly duration above zero.",
+    ],
+    ["invalid-intent", { kind: "weekday-unavailable", day: 2 }, "Choose the weekday to change."],
+  ] satisfies [string, PlanChangeIntent, string][])(
+    "shows %s preview rejection for %j",
+    async (reason, intent, error) => {
+      const h = harness({ status: "rejected", reason });
+      h.controller.openPlanChangeEditor();
+      await h.controller.previewPlanChange(intent);
+      expect(h.surface()).toMatchObject({ editorOpen: true, busy: false, error });
+      expect(h.refresh).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [
+      "apply",
+      { status: "applied", changeId: change.changeId, revisionNumber: 2, version: 8 },
+      "Change applied locally. Training now matches the confirmed preview.",
+    ],
+    [
+      "cancel",
+      { status: "cancelled", changeId: change.changeId, version: 8 },
+      "Change cancelled. Training is unchanged; the preview remains in history.",
+    ],
+  ] as const)("sends %s and refreshes both Plan projections", async (decision, result, notice) => {
+    const h = harness(result);
+    await h.controller.applyPlanChange(decision);
+    expect(h.call).toHaveBeenCalledWith("plan_change.apply", {
+      planId: "plan-active",
+      changeId: change.changeId,
+      expectedVersion: 7,
+      decision,
+      commandId: expect.any(String),
+    });
+    expect(h.refresh).toHaveBeenCalledOnce();
+    expect(h.surface()).toMatchObject({ busy: false, notice, focusRequest: { target: "change" } });
+  });
+
+  it.each([
+    [
+      "stale-version",
+      "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed.",
+    ],
+    ["not-pending", "This preview is no longer pending. Training is unchanged."],
+    [
+      "command-conflict",
+      "This Change could not be applied. Training and the pending preview are unchanged.",
+    ],
+    [
+      "no-active-plan",
+      "This Change could not be applied. Training and the pending preview are unchanged.",
+    ],
+  ])("shows %s apply rejection", async (reason, notice) => {
+    const h = harness({ status: "rejected", reason });
+    await h.controller.applyPlanChange("apply");
+    expect(h.surface()).toMatchObject({ busy: false, notice });
+    expect(h.refresh).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pending preview on transport failure", async () => {
+    const h = harness(new Error("offline"));
+    await h.controller.applyPlanChange("apply");
+    expect(h.surface()).toMatchObject({
+      busy: false,
+      notice: "This Change could not be applied. Training and the pending preview are unchanged.",
+    });
+    expect(h.refresh).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ kind: "weekday-duration", day: 2, minutes: 0 }, "Enter a duration above zero."],
+    [{ kind: "longest-workout", minutes: Number.NaN }, "Enter a duration above zero."],
+    [{ kind: "weekly-duration", hours: -1 }, "Enter a weekly duration above zero."],
+    [{ kind: "weekday-unavailable", day: 8 }, "Choose the weekday to change."],
+  ] satisfies [PlanChangeIntent, string][])(
+    "validates parameters before the RPC for %j",
+    async (intent, error) => {
+      const h = harness(null);
+      await h.controller.previewPlanChange(intent);
+      expect(h.surface().error).toBe(error);
+      expect(h.call).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not submit a retired preview", async () => {
+    const h = harness(null, [{ ...change, status: "cancelled" }]);
+    await h.controller.applyPlanChange("apply");
+    expect(h.call).not.toHaveBeenCalled();
+    expect(h.surface().notice).toBe("This preview is no longer pending. Training is unchanged.");
+  });
+
+  it("ignores actions and late responses after disposal", async () => {
+    const h = harness(null);
+    h.controller.dispose();
+    await h.controller.previewPlanChange(change.intent);
+    await h.controller.applyPlanChange("cancel");
+    expect(h.call).not.toHaveBeenCalled();
+    expect(h.surface()).toEqual(EMPTY_PLAN_CHANGE_SURFACE);
+  });
+});

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -20,6 +20,10 @@ import { planReadModel } from "./plan-fixtures";
 
 function stubActions(): ChatActions {
   return {
+    openPlanChangeEditor: vi.fn(),
+    backFromPlanChangeEditor: vi.fn(),
+    previewPlanChange: vi.fn(),
+    applyPlanChange: vi.fn(),
     submit: vi.fn(async () => true),
     chooseAttachments: vi.fn(),
     pasteAttachment: vi.fn(),

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -100,6 +100,10 @@ const SELECTED_RIDE_HISTORY = {
 
 function stubActions(): ChatActions {
   return {
+    openPlanChangeEditor: vi.fn(),
+    backFromPlanChangeEditor: vi.fn(),
+    previewPlanChange: vi.fn(),
+    applyPlanChange: vi.fn(),
     submit: vi.fn(),
     chooseAttachments: vi.fn(),
     pasteAttachment: vi.fn(),

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -21,6 +21,10 @@ import { planReadModel } from "./plan-fixtures";
 
 function stubActions(): ChatActions {
   return {
+    openPlanChangeEditor: vi.fn(),
+    backFromPlanChangeEditor: vi.fn(),
+    previewPlanChange: vi.fn(),
+    applyPlanChange: vi.fn(),
     submit: vi.fn(),
     chooseAttachments: vi.fn(),
     pasteAttachment: vi.fn(),

--- a/apps/desktop/tests/e2e/plan-change.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change.spec.ts
@@ -582,62 +582,69 @@ const otherChanges: ChangeCase[] = [
 ];
 
 for (const change of otherChanges) {
-  test(`previews ${change.label} and cancels without changing training`, async ({ playwright }) => {
-    test.setTimeout(120_000);
-    const scenario = await launch(playwright, appearances[0]);
-    try {
-      await enterChanges(scenario);
-      const initial = await scenario.backend.inspectActivation();
-      const pending = await preview(scenario, change);
-      const before = await scenario.backend.inspectActivation();
-      expect(training(before)).toEqual(training(initial));
-      await capture(scenario, `preview-${change.intent.kind}`);
-      await changeCard(scenario, pending.title, "Pending")
-        .getByRole("button", { name: "Cancel", exact: true })
-        .click();
-      await expect(changes(scenario).getByRole("status")).toHaveText(
-        "Change cancelled. Training is unchanged; the preview remains in history.",
-      );
-      await expect(changeCard(scenario, pending.title, "Cancelled")).toBeVisible();
-      await expect(changeCard(scenario, pending.title, "Pending")).toHaveCount(0);
-      await expect(
-        changes(scenario).getByRole("button", { name: "Change one thing", exact: true }),
-      ).toBeFocused();
-      const after = await scenario.backend.inspectActivation();
-      expect(training(after)).toEqual(training(before));
-      expect(after.changes).toHaveLength(1);
-      expect(after.changes[0]).toMatchObject({
-        id: pending.changeId,
-        status: "discarded",
-        version: Number(before.changes[0]?.version) + 1,
-      });
-      expect(after.commands.slice(0, -1)).toEqual(before.commands);
-      expect(after.commands.filter((row) => row.command_name === "plan_change.apply")).toHaveLength(
-        1,
-      );
-      expect(after.commands.at(-1)).toMatchObject({
-        command_name: "plan_change.apply",
-        status: "succeeded",
-      });
-      expect(scenario.backend.changeApplyResponses.at(-1)).toMatchObject({
-        params: { decision: "cancel", changeId: pending.changeId },
-        result: { status: "cancelled" },
-      });
-      const history = changeCard(scenario, pending.title, "Cancelled");
-      await history.getByRole("button", { name: "Read this difference", exact: true }).click();
-      const source = changes(scenario).getByRole("region", { name: "Source details", exact: true });
-      await expect(source.getByText("Cancelled", { exact: true })).toBeVisible();
-      await expect(
-        source
-          .getByRole("table", { name: "Affected individual Workouts", exact: true })
-          .getByRole("row"),
-      ).toHaveCount(4);
-      await source.getByRole("button", { name: "Back", exact: true }).click();
-      await capture(scenario, `cancelled-${change.intent.kind}`);
-    } finally {
-      await close(scenario);
-    }
-  });
+  for (const appearance of appearances) {
+    test(`previews ${change.label} and cancels without changing training at ${appearance.width} in ${appearance.colorScheme}`, async ({
+      playwright,
+    }) => {
+      test.setTimeout(120_000);
+      const scenario = await launch(playwright, appearance);
+      try {
+        await enterChanges(scenario);
+        const initial = await scenario.backend.inspectActivation();
+        const pending = await preview(scenario, change);
+        const before = await scenario.backend.inspectActivation();
+        expect(training(before)).toEqual(training(initial));
+        await capture(scenario, `preview-${change.intent.kind}`);
+        await changeCard(scenario, pending.title, "Pending")
+          .getByRole("button", { name: "Cancel", exact: true })
+          .click();
+        await expect(changes(scenario).getByRole("status")).toHaveText(
+          "Change cancelled. Training is unchanged; the preview remains in history.",
+        );
+        await expect(changeCard(scenario, pending.title, "Cancelled")).toBeVisible();
+        await expect(changeCard(scenario, pending.title, "Pending")).toHaveCount(0);
+        await expect(
+          changes(scenario).getByRole("button", { name: "Change one thing", exact: true }),
+        ).toBeFocused();
+        const after = await scenario.backend.inspectActivation();
+        expect(training(after)).toEqual(training(before));
+        expect(after.changes).toHaveLength(1);
+        expect(after.changes[0]).toMatchObject({
+          id: pending.changeId,
+          status: "discarded",
+          version: Number(before.changes[0]?.version) + 1,
+        });
+        expect(after.commands.slice(0, -1)).toEqual(before.commands);
+        expect(
+          after.commands.filter((row) => row.command_name === "plan_change.apply"),
+        ).toHaveLength(1);
+        expect(after.commands.at(-1)).toMatchObject({
+          command_name: "plan_change.apply",
+          status: "succeeded",
+        });
+        expect(scenario.backend.changeApplyResponses.at(-1)).toMatchObject({
+          params: { decision: "cancel", changeId: pending.changeId },
+          result: { status: "cancelled" },
+        });
+        const history = changeCard(scenario, pending.title, "Cancelled");
+        await history.getByRole("button", { name: "Read this difference", exact: true }).click();
+        const source = changes(scenario).getByRole("region", {
+          name: "Source details",
+          exact: true,
+        });
+        await expect(source.getByText("Cancelled", { exact: true })).toBeVisible();
+        await expect(
+          source
+            .getByRole("table", { name: "Affected individual Workouts", exact: true })
+            .getByRole("row"),
+        ).toHaveCount(4);
+        await source.getByRole("button", { name: "Back", exact: true }).click();
+        await capture(scenario, `cancelled-${change.intent.kind}`);
+      } finally {
+        await close(scenario);
+      }
+    });
+  }
 }
 
 test("supersedes a pending Change with a second request", async ({ playwright }) => {

--- a/apps/desktop/tests/e2e/plan-change.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change.spec.ts
@@ -1,0 +1,764 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import {
+  PlanChangeApplyRpcParamsSchema,
+  PlanChangeWorkoutSchema,
+  PlanCreationDraftSchema,
+  type PlanChangeIntent,
+  type PlanChangeModel,
+  type PlanChangeWorkout,
+  type PlanCreationDraft,
+} from "@enduragent/coach-contract";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  readonly seed: Awaited<ReturnType<PlanCreationBackend["seedActiveTraining"]>>;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Change renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-change-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    const seed = await backend.seedActiveTraining();
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    return { backend, fixture, scratch, seed, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function relaunch(scenario: Scenario, playwright: Playwright): Promise<void> {
+  await scenario.browser.close();
+  await scenario.fixture.relaunch(() => scenario.backend.reopen());
+  await scenario.fixture.setViewport(scenario.width, 820);
+  Object.assign(scenario, await connect(playwright, scenario.fixture, scenario.colorScheme));
+  expect(await scenario.page.evaluate(() => innerWidth)).toBe(scenario.width);
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  const screenshotPath = test.info().outputPath(`${name}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-plan-change", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        activation: await scenario.backend.inspectActivation(),
+        requests: scenario.backend.creationRequests,
+        seed: scenario.seed,
+        library: await scenario.backend.library(),
+        responses: scenario.backend.changeApplyResponses,
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+type Stored = Awaited<ReturnType<PlanCreationBackend["inspectActivation"]>>;
+
+const appearances = [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const;
+const options = [
+  "Weekday duration cap",
+  "Weekday unavailable",
+  "No hard training on a weekday",
+  "Weekly duration cap",
+  "Longest-Workout cap",
+];
+const confidence =
+  "Moderate confidence. Based on your confirmed limits and the available training record.";
+const durationCap = {
+  label: "Weekday duration cap",
+  title: "Limit weekday duration",
+  intent: { kind: "weekday-duration", day: 3, minutes: 30 },
+  weeklyMinutes: 135,
+} satisfies ChangeCase;
+
+interface ChangeCase {
+  readonly label: string;
+  readonly title: string;
+  readonly intent: PlanChangeIntent;
+  readonly weeklyMinutes: number;
+}
+
+function changes(scenario: Scenario) {
+  return scenario.page.getByRole("region", { name: "Plan Changes", exact: true });
+}
+
+function changeCard(scenario: Scenario, title: string, status: string) {
+  return changes(scenario)
+    .getByRole("region", { name: title, exact: true })
+    .filter({ has: scenario.page.getByText(status, { exact: true }) });
+}
+
+async function navigate(scenario: Scenario, destination: "Chat" | "Plan") {
+  await scenario.page
+    .getByRole("navigation", { name: "Main navigation" })
+    .getByRole("button", { name: destination, exact: true })
+    .click();
+}
+
+async function enterChanges(scenario: Scenario) {
+  await navigate(scenario, "Plan");
+  await scenario.page
+    .getByRole("region", { name: "Plan library", exact: true })
+    .getByRole("button", { name: "Change in Chat", exact: true })
+    .click();
+  await expect(changes(scenario)).toBeVisible();
+  await expect(changes(scenario).getByRole("button")).toHaveText(["Change one thing", "Open Plan"]);
+  const stored = await scenario.backend.inspectActivation();
+  expect(stored.planningPlans).toHaveLength(1);
+  expect(stored.planningPlans[0]).toMatchObject({
+    plan_id: scenario.seed.planId,
+    status: "active",
+    version: 1,
+    current_revision_number: 1,
+  });
+  expect(stored.revisions).toHaveLength(1);
+  expect(
+    PlanCreationDraftSchema.parse(JSON.parse(String(stored.revisions[0]?.snapshot_json))),
+  ).toEqual(scenario.seed.draft);
+  const seeded = scenario.seed.draft.weeks.flatMap((week) => week.workouts);
+  expect(seeded).toHaveLength(12);
+  expect(
+    stored.workouts.map((row) =>
+      PlanChangeWorkoutSchema.parse(JSON.parse(String(row.structure_json))),
+    ),
+  ).toEqual(seeded);
+  expect(
+    scenario.seed.draft.weeks.map((week) =>
+      week.workouts.map((workout) => ({
+        name: workout.name,
+        minutes: workout.minutes,
+        pinned: workout.pinned,
+        weekday: weekday(workout),
+      })),
+    ),
+  ).toEqual(
+    Array.from({ length: 4 }, () => [
+      { name: "Controlled effort", minutes: 45, pinned: false, weekday: 6 },
+      { name: "Endurance ride", minutes: 60, pinned: false, weekday: 1 },
+      { name: "Long ride", minutes: 100, pinned: false, weekday: 3 },
+    ]),
+  );
+}
+
+function weekday(workout: PlanChangeWorkout): number | null {
+  return workout.date === null ? null : new Date(`${workout.date}T12:00:00Z`).getUTCDay() || 7;
+}
+
+function expectedChange(draft: PlanCreationDraft, intent: PlanChangeIntent) {
+  const diff: PlanChangeModel["diff"] = [];
+  const weeks = draft.weeks.map((week) => {
+    const beforeMinutes = week.workouts.reduce((sum, workout) => sum + workout.minutes, 0);
+    const workouts = week.workouts.flatMap((before) => {
+      if (before.pinned || before.date === null || before.date < "1998-01-01") return [before];
+      let after: PlanChangeWorkout | null = before;
+      switch (intent.kind) {
+        case "weekday-duration":
+          if (weekday(before) === intent.day && before.minutes > intent.minutes)
+            after = { ...before, minutes: intent.minutes };
+          break;
+        case "weekday-unavailable":
+          if (weekday(before) === intent.day) after = null;
+          break;
+        case "hard-weekday":
+          if (weekday(before) === intent.day && before.kind === "hard")
+            after = { ...before, kind: "easy", name: "Easy ride" };
+          break;
+        case "weekly-duration":
+          if (before.kind === "long" && beforeMinutes > intent.hours * 60)
+            after = { ...before, minutes: before.minutes - (beforeMinutes - intent.hours * 60) };
+          break;
+        case "longest-workout":
+          if (before.minutes > intent.minutes) after = { ...before, minutes: intent.minutes };
+          break;
+      }
+      if (after !== before) diff.push({ workoutId: before.id, before, after });
+      return after === null ? [] : [after];
+    });
+    return { ...week, workouts };
+  });
+  const totals = (value: PlanCreationDraft["weeks"]) => {
+    const weeks = value.map((week) => ({
+      number: week.number,
+      minutes: week.workouts.reduce(
+        (sum, workout) => sum + (workout.date === null ? 0 : workout.minutes),
+        0,
+      ),
+    }));
+    return { plan: weeks.reduce((sum, week) => sum + week.minutes, 0), weeks };
+  };
+  return { diff, weeks, totals: { before: totals(draft.weeks), after: totals(weeks) } };
+}
+
+function workoutText(workout: PlanChangeWorkout | null): string {
+  if (workout === null) return "Not in Plan";
+  const date =
+    workout.date === null
+      ? "Undated"
+      : new Intl.DateTimeFormat("en-GB", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+          timeZone: "UTC",
+        }).format(new Date(`${workout.date}T12:00:00Z`));
+  return `${date} · ${workout.minutes} min`;
+}
+
+async function preview(scenario: Scenario, change: ChangeCase) {
+  await changes(scenario).getByRole("button", { name: "Change one thing", exact: true }).click();
+  const editor = changes(scenario).getByRole("region", {
+    name: "What needs to change?",
+    exact: true,
+  });
+  const kind = editor.getByRole("combobox", { name: "Change", exact: true });
+  await expect(kind).toBeFocused();
+  await expect(kind).toContainText("Weekday duration cap");
+  await expect(editor.getByRole("combobox", { name: "Weekday", exact: true })).toContainText("Wed");
+  await expect(
+    editor.getByRole("spinbutton", { name: "Duration limit in minutes", exact: true }),
+  ).toHaveValue("30");
+  await expect(editor.getByRole("button", { name: /^(Back|Preview change)$/ })).toHaveText([
+    "Back",
+    "Preview change",
+  ]);
+  await kind.click();
+  await expect(scenario.page.getByRole("option")).toHaveText(options);
+  await scenario.page.getByRole("option", { name: change.label, exact: true }).click();
+  const intent = change.intent;
+  if (
+    intent.kind === "weekday-duration" ||
+    intent.kind === "weekday-unavailable" ||
+    intent.kind === "hard-weekday"
+  ) {
+    const day = editor.getByRole("combobox", { name: "Weekday", exact: true });
+    await expect(day).toContainText(intent.kind === "hard-weekday" ? "Mon" : "Wed");
+    await day.click();
+    const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+    await expect(scenario.page.getByRole("option")).toHaveText(days);
+    await scenario.page.getByRole("option", { name: days[intent.day - 1], exact: true }).click();
+  }
+  if (intent.kind === "weekday-duration" || intent.kind === "longest-workout")
+    await expect(
+      editor.getByRole("spinbutton", { name: "Duration limit in minutes", exact: true }),
+    ).toHaveValue(String(intent.minutes));
+  if (intent.kind === "weekly-duration")
+    await expect(
+      editor.getByRole("spinbutton", { name: "Weekly limit in hours", exact: true }),
+    ).toHaveValue("3");
+  await editor.getByRole("button", { name: "Preview change", exact: true }).click();
+  await expect(
+    changeCard(scenario, change.title, "Pending").getByRole("heading", {
+      name: change.title,
+      exact: true,
+    }),
+  ).toBeFocused();
+  expect(scenario.backend.creationRequests.at(-1)).toMatchObject({
+    method: "plan_change.preview",
+    params: { planId: scenario.seed.planId, expectedVersion: 1, intent },
+  });
+  return assertPreview(scenario, change);
+}
+
+async function assertPreview(scenario: Scenario, change: ChangeCase) {
+  const expected = expectedChange(scenario.seed.draft, change.intent);
+  expect(expected.diff).toHaveLength(4);
+  expect(expected.totals.before.plan).toBe(820);
+  expect(expected.totals.after.plan).toBe(change.weeklyMinutes * 4);
+  const pending = changeCard(scenario, change.title, "Pending");
+  await expect(pending.getByText("Pending", { exact: true })).toBeVisible();
+  const table = pending.getByRole("table", { name: "Affected individual Workouts", exact: true });
+  await expect(table.getByRole("row")).toHaveCount(expected.diff.length);
+  await expect(table.getByRole("rowheader")).toHaveText(
+    expected.diff.map((row) => row.before?.name ?? "Workout"),
+  );
+  await expect(table.getByRole("cell")).toHaveText(
+    expected.diff.map(
+      (row) =>
+        `${workoutText(row.before)} → ${workoutText(row.after)}${row.before && row.after && row.before.name !== row.after.name ? ` · ${row.after.name}` : ""}`,
+    ),
+  );
+  const totals = pending.getByRole("table", { name: "Before and after totals", exact: true });
+  await expect(totals.getByRole("rowheader")).toHaveText([
+    "Plan totals",
+    "Week 1",
+    "Week 2",
+    "Week 3",
+    "Week 4",
+  ]);
+  await expect(totals.getByRole("cell")).toHaveText([
+    `${expected.totals.before.plan} min → ${expected.totals.after.plan} min`,
+    ...expected.totals.before.weeks.map(
+      (week, index) => `${week.minutes} min → ${expected.totals.after.weeks[index]?.minutes} min`,
+    ),
+  ]);
+  const facts = pending.getByRole("table", { name: "Facts", exact: true });
+  await expect(facts.getByRole("rowheader")).toHaveText(["Main Goal", "Confidence"]);
+  await expect(facts.getByRole("cell")).toHaveText(["Improve fitness", confidence]);
+  await expect(pending.getByRole("button")).toHaveText([
+    "View evidence",
+    "Cancel",
+    "Apply to Plan",
+  ]);
+  const stored = (await scenario.backend.library()).changes.find(
+    (value) => value.status === "pending",
+  );
+  if (!stored) throw new TypeError("Pending Change is unavailable");
+  expect(stored).toMatchObject({
+    title: change.title,
+    intent: change.intent,
+    diff: expected.diff,
+    totals: expected.totals,
+    baseRevisionNumber: 1,
+  });
+  return stored;
+}
+
+function training(stored: Stored) {
+  return {
+    plans: stored.plans,
+    planningPlans: stored.planningPlans,
+    revisions: stored.revisions,
+    workouts: stored.workouts,
+    creations: stored.creations,
+  };
+}
+
+async function assertApplied(scenario: Scenario, pending: PlanChangeModel, before: Stored) {
+  await expect(changes(scenario).getByRole("status")).toHaveText(
+    "Change applied locally. Training now matches the confirmed preview.",
+  );
+  await expect(changeCard(scenario, pending.title, "Applied")).toBeVisible();
+  await expect(changeCard(scenario, pending.title, "Pending")).toHaveCount(0);
+  const after = await scenario.backend.inspectActivation();
+  expect(after.planningPlans).toHaveLength(1);
+  expect(after.planningPlans[0]).toMatchObject({
+    plan_id: scenario.seed.planId,
+    version: 2,
+    current_revision_number: 2,
+  });
+  expect(after.revisions).toHaveLength(2);
+  expect(after.revisions[0]).toEqual(before.revisions[0]);
+  expect(after.revisions[1]).toMatchObject({
+    plan_id: scenario.seed.planId,
+    revision_number: 2,
+    parent_revision_number: 1,
+    source_kind: "plan-change",
+    source_id: pending.changeId,
+  });
+  const expected = expectedChange(scenario.seed.draft, pending.intent);
+  const revision = PlanCreationDraftSchema.parse(
+    JSON.parse(String(after.revisions[1]?.snapshot_json)),
+  );
+  expect(revision).toEqual({
+    ...scenario.seed.draft,
+    weeks: expected.weeks,
+    outputFingerprint: revision.outputFingerprint,
+  });
+  expect(revision.outputFingerprint).not.toBe(scenario.seed.draft.outputFingerprint);
+  expect(after.workouts.map((row) => row.id)).toEqual(before.workouts.map((row) => row.id));
+  const expectedById = new Map(expected.diff.map((row) => [row.workoutId, row.after]));
+  for (const original of before.workouts) {
+    const workout = PlanChangeWorkoutSchema.parse(JSON.parse(String(original.structure_json)));
+    const updated = after.workouts.find((row) => row.id === original.id);
+    const target = expectedById.get(workout.id);
+    if (target === undefined) {
+      expect(updated).toEqual(original);
+    } else {
+      if (target === null) throw new TypeError("Apply fixture must retain every Workout");
+      expect(updated).toEqual({
+        ...original,
+        duration_s: target.minutes * 60,
+        structure_json: canonicalJson(target),
+        hlc_physical_ms: after.revisions[1]?.hlc_physical_ms,
+      });
+    }
+  }
+  expect(after.changes).toHaveLength(1);
+  expect(after.changes[0]).toMatchObject({ id: pending.changeId, status: "applied" });
+  expect(after.commands.slice(0, -1)).toEqual(before.commands);
+  expect(after.commands.at(-1)).toMatchObject({
+    command_name: "plan_change.apply",
+    status: "succeeded",
+  });
+  return after;
+}
+
+async function assertPlanPage(scenario: Scenario, stored: Stored) {
+  await navigate(scenario, "Plan");
+  await scenario.page.getByRole("button", { name: "Read Plan details", exact: true }).click();
+  await expect(
+    scenario.page.getByRole("heading", { name: "Plan active · week 1 of 4", exact: true }),
+  ).toBeVisible();
+  const firstWednesday = stored.workouts.find((row) => row.date_key === 19980107);
+  if (!firstWednesday) throw new TypeError("First Wednesday is unavailable");
+  await expect(
+    scenario.page.locator(`#workout-row-${firstWednesday.id}`).getByText("30 min", { exact: true }),
+  ).toBeVisible();
+}
+
+for (const appearance of appearances) {
+  test(`persists and applies a Schedule Change at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      await enterChanges(scenario);
+      const initial = await scenario.backend.inspectActivation();
+      const pending = await preview(scenario, durationCap);
+      const before = await scenario.backend.inspectActivation();
+      expect(training(before)).toEqual(training(initial));
+      const card = changeCard(scenario, pending.title, "Pending");
+      await card.getByRole("button", { name: "View evidence", exact: true }).click();
+      const source = changes(scenario).getByRole("region", { name: "Source details", exact: true });
+      await expect(
+        source.getByRole("heading", { name: "Source details", exact: true }),
+      ).toBeFocused();
+      const details = source.getByRole("table", { name: "Source details", exact: true });
+      await expect(details.getByRole("rowheader")).toHaveText([
+        "Confirmed Plan limits · Your confirmed answers",
+      ]);
+      await expect(details.getByRole("cell")).toHaveText(["Wed · 30 min"]);
+      await source.getByRole("button", { name: "Back", exact: true }).click();
+      await expect(card.getByRole("button", { name: "View evidence", exact: true })).toBeFocused();
+      await expect(source).toHaveCount(0);
+      await card.getByRole("heading").scrollIntoViewIfNeeded();
+      await capture(scenario, `preview-${appearance.width}-${appearance.colorScheme}`);
+      await navigate(scenario, "Plan");
+      await navigate(scenario, "Chat");
+      expect(await assertPreview(scenario, durationCap)).toEqual(pending);
+      await relaunch(scenario, playwright);
+      expect(await assertPreview(scenario, durationCap)).toEqual(pending);
+      expect(await scenario.backend.inspectActivation()).toEqual(before);
+      await changeCard(scenario, pending.title, "Pending")
+        .getByRole("button", { name: "Apply to Plan", exact: true })
+        .click();
+      const after = await assertApplied(scenario, pending, before);
+      await capture(scenario, `applied-${appearance.width}-${appearance.colorScheme}`);
+      await assertPlanPage(scenario, after);
+      await capture(scenario, `plan-${appearance.width}-${appearance.colorScheme}`);
+    } finally {
+      await close(scenario);
+    }
+  });
+}
+
+const otherChanges: ChangeCase[] = [
+  {
+    label: "Weekday unavailable",
+    title: "Keep a weekday free",
+    intent: { kind: "weekday-unavailable", day: 3 },
+    weeklyMinutes: 105,
+  },
+  {
+    label: "No hard training on a weekday",
+    title: "No hard training on a weekday",
+    intent: { kind: "hard-weekday", day: 6 },
+    weeklyMinutes: 205,
+  },
+  {
+    label: "Weekly duration cap",
+    title: "Limit weekly duration",
+    intent: { kind: "weekly-duration", hours: 3 },
+    weeklyMinutes: 180,
+  },
+  {
+    label: "Longest-Workout cap",
+    title: "Limit the longest Workout",
+    intent: { kind: "longest-workout", minutes: 60 },
+    weeklyMinutes: 165,
+  },
+];
+
+for (const change of otherChanges) {
+  test(`previews ${change.label} and cancels without changing training`, async ({ playwright }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearances[0]);
+    try {
+      await enterChanges(scenario);
+      const initial = await scenario.backend.inspectActivation();
+      const pending = await preview(scenario, change);
+      const before = await scenario.backend.inspectActivation();
+      expect(training(before)).toEqual(training(initial));
+      await capture(scenario, `preview-${change.intent.kind}`);
+      await changeCard(scenario, pending.title, "Pending")
+        .getByRole("button", { name: "Cancel", exact: true })
+        .click();
+      await expect(changes(scenario).getByRole("status")).toHaveText(
+        "Change cancelled. Training is unchanged; the preview remains in history.",
+      );
+      await expect(changeCard(scenario, pending.title, "Cancelled")).toBeVisible();
+      await expect(changeCard(scenario, pending.title, "Pending")).toHaveCount(0);
+      await expect(
+        changes(scenario).getByRole("button", { name: "Change one thing", exact: true }),
+      ).toBeFocused();
+      const after = await scenario.backend.inspectActivation();
+      expect(training(after)).toEqual(training(before));
+      expect(after.changes).toHaveLength(1);
+      expect(after.changes[0]).toMatchObject({
+        id: pending.changeId,
+        status: "discarded",
+        version: Number(before.changes[0]?.version) + 1,
+      });
+      expect(after.commands.slice(0, -1)).toEqual(before.commands);
+      expect(after.commands.filter((row) => row.command_name === "plan_change.apply")).toHaveLength(
+        1,
+      );
+      expect(after.commands.at(-1)).toMatchObject({
+        command_name: "plan_change.apply",
+        status: "succeeded",
+      });
+      expect(scenario.backend.changeApplyResponses.at(-1)).toMatchObject({
+        params: { decision: "cancel", changeId: pending.changeId },
+        result: { status: "cancelled" },
+      });
+      const history = changeCard(scenario, pending.title, "Cancelled");
+      await history.getByRole("button", { name: "Read this difference", exact: true }).click();
+      const source = changes(scenario).getByRole("region", { name: "Source details", exact: true });
+      await expect(source.getByText("Cancelled", { exact: true })).toBeVisible();
+      await expect(
+        source
+          .getByRole("table", { name: "Affected individual Workouts", exact: true })
+          .getByRole("row"),
+      ).toHaveCount(4);
+      await source.getByRole("button", { name: "Back", exact: true }).click();
+      await capture(scenario, `cancelled-${change.intent.kind}`);
+    } finally {
+      await close(scenario);
+    }
+  });
+}
+
+test("supersedes a pending Change with a second request", async ({ playwright }) => {
+  test.setTimeout(120_000);
+  const scenario = await launch(playwright, appearances[0]);
+  try {
+    await enterChanges(scenario);
+    const first = await preview(scenario, durationCap);
+    const before = await scenario.backend.inspectActivation();
+    const secondCase = otherChanges.find((change) => change.intent.kind === "longest-workout");
+    if (!secondCase) throw new TypeError("Second Change is unavailable");
+    const second = await preview(scenario, secondCase);
+    await expect(changes(scenario).getByRole("status")).toHaveText(
+      `This preview supersedes “${first.title}”. Training is unchanged until confirmation.`,
+    );
+    await expect(changeCard(scenario, first.title, "Superseded")).toBeVisible();
+    await expect(changeCard(scenario, first.title, "Pending")).toHaveCount(0);
+    expect(second.supersedes).toBe(first.changeId);
+    const library = await scenario.backend.library();
+    expect(library.changes.find((change) => change.changeId === first.changeId)).toEqual({
+      ...first,
+      status: "superseded",
+      supersededBy: second.changeId,
+    });
+    const after = await scenario.backend.inspectActivation();
+    expect(training(after)).toEqual(training(before));
+    expect(after.changes.map((row) => ({ id: row.id, status: row.status }))).toEqual([
+      { id: first.changeId, status: "discarded" },
+      { id: second.changeId, status: "preview" },
+    ]);
+    expect(after.commands.slice(0, -1)).toEqual(before.commands);
+    expect(after.commands.at(-1)).toMatchObject({
+      command_name: "plan_change.preview",
+      status: "succeeded",
+    });
+    await capture(scenario, "superseded");
+  } finally {
+    await close(scenario);
+  }
+});
+
+test("rejects a stale preview after an out-of-band Plan revision", async ({ playwright }) => {
+  test.setTimeout(120_000);
+  const scenario = await launch(playwright, appearances[0]);
+  try {
+    await enterChanges(scenario);
+    const pending = await preview(scenario, durationCap);
+    const advanced = await scenario.backend.previewChange({
+      commandId: "advance-plan-preview",
+      planId: scenario.seed.planId,
+      expectedVersion: 1,
+      intent: { kind: "longest-workout", minutes: 60 },
+    });
+    if (advanced.status !== "previewed") throw new TypeError("Out-of-band preview was rejected");
+    expect(
+      await scenario.backend.applyChange({
+        commandId: "advance-plan-apply",
+        planId: scenario.seed.planId,
+        expectedVersion: 1,
+        changeId: advanced.change.changeId,
+        decision: "apply",
+      }),
+    ).toEqual({
+      status: "applied",
+      changeId: advanced.change.changeId,
+      revisionNumber: 2,
+      version: 2,
+    });
+    const before = await scenario.backend.inspectActivation();
+    await changeCard(scenario, pending.title, "Pending")
+      .getByRole("button", { name: "Apply to Plan", exact: true })
+      .click();
+    await expect(changes(scenario).getByRole("status")).toHaveText(
+      "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed.",
+    );
+    expect(scenario.backend.changeApplyResponses).toHaveLength(1);
+    expect(scenario.backend.changeApplyResponses[0]).toMatchObject({
+      params: { changeId: pending.changeId, expectedVersion: 1, decision: "apply" },
+      result: { status: "rejected", reason: "stale-version" },
+    });
+    expect(await scenario.backend.inspectActivation()).toEqual(before);
+    await capture(scenario, "stale");
+  } finally {
+    await close(scenario);
+  }
+});
+
+test("replays the renderer apply command without another write", async ({ playwright }) => {
+  test.setTimeout(120_000);
+  const scenario = await launch(playwright, appearances[0]);
+  try {
+    await enterChanges(scenario);
+    const pending = await preview(scenario, durationCap);
+    const before = await scenario.backend.inspectActivation();
+    await changeCard(scenario, pending.title, "Pending")
+      .getByRole("button", { name: "Apply to Plan", exact: true })
+      .click();
+    const applied = await assertApplied(scenario, pending, before);
+    const request = scenario.backend.creationRequests.find(
+      (entry) => entry.method === "plan_change.apply",
+    );
+    if (!request) throw new TypeError("Renderer apply request is unavailable");
+    const params = PlanChangeApplyRpcParamsSchema.parse(request.params);
+    const response = scenario.backend.changeApplyResponses.find(
+      (entry) => entry.params.commandId === params.commandId,
+    );
+    if (!response) throw new TypeError("Renderer apply response is unavailable");
+    expect(response.params).toEqual(params);
+    expect(response.result).toEqual({
+      status: "applied",
+      changeId: pending.changeId,
+      revisionNumber: 2,
+      version: 2,
+    });
+    expect(await scenario.backend.applyChange(params)).toEqual(response.result);
+    expect(await scenario.backend.inspectActivation()).toEqual(applied);
+    expect(applied.commands.filter((row) => row.command_name === "plan_change.apply")).toHaveLength(
+      1,
+    );
+    await capture(scenario, "replayed");
+  } finally {
+    await close(scenario);
+  }
+});

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -6,6 +6,10 @@ import {
   PlanChangePreviewRpcParamsSchema,
   PlanChangeApplyRpcParamsSchema,
   type PlanChangeOperations,
+  type PlanChangeApplyRpcParams,
+  type PlanChangeApplyResult,
+  type PlanChangePreviewRpcParams,
+  type PlanCreationAnswerInput,
   PlanCreationActivateRpcParamsSchema,
   PlanCreationPreviewRpcParamsSchema,
   type CoachEngine,
@@ -116,6 +120,10 @@ const response = (value: unknown): readonly string[] => [JSON.stringify(value)];
 export class PlanCreationBackend {
   readonly script: DesktopFixtureScript;
   readonly creationRequests: ScriptRequest[] = [];
+  readonly changeApplyResponses: {
+    readonly params: PlanChangeApplyRpcParams;
+    readonly result: PlanChangeApplyResult;
+  }[] = [];
   readonly planListRequests: ScriptRequest[] = [];
   private store: (SqlStore & MigratorStore) | undefined;
   private repository: PlanCreationRepository | undefined;
@@ -142,6 +150,7 @@ export class PlanCreationBackend {
       onRequest: async (value) => {
         const request = value as ScriptRequest;
         if (request.method.startsWith("plan_creation.")) this.creationRequests.push(request);
+        if (request.method.startsWith("plan_change.")) this.creationRequests.push(request);
         if (coexistence && request.method === "listArchivedConversations") {
           return response({
             schemaVersion: 1,
@@ -259,11 +268,10 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
         }
         if (request.method === "plan_change.apply") {
           if (!this.changes) throw new TypeError("Plan Change operations are unavailable");
-          return response(
-            await this.changes["plan_change.apply"](
-              PlanChangeApplyRpcParamsSchema.parse(request.params),
-            ),
-          );
+          const params = PlanChangeApplyRpcParamsSchema.parse(request.params);
+          const result = await this.changes["plan_change.apply"](params);
+          this.changeApplyResponses.push({ params, result });
+          return response(result);
         }
         if (request.method === "plan_creation.activate") {
           return response(
@@ -391,6 +399,63 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
 
   async library() {
     return this.requireHost()["plan.list"]({});
+  }
+
+  async seedActiveTraining() {
+    const host = this.requireHost();
+    const started = await host["plan_creation.start"]({ commandId: "seed-training-start" });
+    if (started.status !== "started") throw new TypeError("Training seed was not started");
+    let card = started.planCreation;
+    const answers: PlanCreationAnswerInput[] = [
+      { kind: "goal", goal: { kind: "fitness" } },
+      { kind: "plan-length", weeks: 4 },
+      { kind: "schedule-mode", mode: "fixed" },
+      {
+        kind: "availability",
+        mode: "fixed",
+        weeklyHoursLimit: 6,
+        longestWorkoutHours: 2,
+        usableWeekdays: [1, 3, 6],
+      },
+      { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
+      { kind: "commitments", commitments: { kind: "none" } },
+      { kind: "baseline", baseline: "regular" },
+      { kind: "success", success: { kind: "authored", text: "Ride four steady hours" } },
+      { kind: "restriction", restriction: { kind: "none" } },
+    ];
+    for (const [index, answer] of answers.entries()) {
+      const answered = await host["plan_creation.answer"]({
+        commandId: `seed-training-answer-${index}`,
+        creationId: card.creationId,
+        expectedVersion: card.version,
+        answer,
+      });
+      if (answered.status !== "answered") throw new TypeError("Training seed answer was rejected");
+      card = answered.planCreation;
+    }
+    const previewed = await host["plan_creation.preview"]({
+      commandId: "seed-training-preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    });
+    if (previewed.status !== "previewed" || previewed.planCreation.draft === null)
+      throw new TypeError("Training seed Draft is unavailable");
+    const activated = await host["plan_creation.activate"]({
+      commandId: "seed-training-activate",
+      creationId: card.creationId,
+      expectedVersion: previewed.planCreation.version,
+    });
+    return { planId: activated.planId, draft: previewed.planCreation.draft };
+  }
+
+  async previewChange(params: PlanChangePreviewRpcParams) {
+    if (!this.changes) throw new TypeError("Plan Change operations are unavailable");
+    return this.changes["plan_change.preview"](params);
+  }
+
+  async applyChange(params: PlanChangeApplyRpcParams) {
+    if (!this.changes) throw new TypeError("Plan Change operations are unavailable");
+    return this.changes["plan_change.apply"](params);
   }
 
   async seedLibrary(presence: {


### PR DESCRIPTION
## Summary

Renderer for Plan Changes in Chat, Schedule intents only, on top of #910.

- Active Plan card in Chat with `Change one thing` and `Open Plan`; a `What needs to change?` editor with the five Schedule options (weekday duration cap, weekday unavailable, no hard training on a weekday, weekly duration cap, longest-Workout cap), their defaults, and an accessible error line.
- Pending preview card with the host diff (`Affected individual Workouts`), before/after totals per week and Plan, facts, `View evidence`, and `Cancel` / `Apply to Plan`. Exact notices for applied, cancelled, superseded, stale, not pending and failure.
- History cards with `Applied`, `Cancelled`, `Superseded` chips, readable evidence and difference.
- A pending preview is restored from `plan.list.changes` on navigation and relaunch; creation stays paused while a Change is pending; stale or not-pending rejections refresh the library so the next request uses the current version; the Plan page reloads after a decision; Change state resets when a different Plan becomes active.
- Desktop E2E `plan-change.spec.ts`: 23 cases at 1180 and 720, light and dark, seeding a real active Plan through the in-process host and asserting exact diff rows, totals, evidence, navigation and relaunch persistence, apply with kept `plan_workout` ids and revision 2, cancel, supersession, stale rejection and command replay. Screenshots compared against the prototype scenarios.

Deferred to later cuts: Undo, Refresh preview, Supporting Events, power/FTP, free-text requests, the "What should I ride today?" action.

## Verification

Astra high read-only verifier, three rounds: round 1 raised five findings (Plan page not reloaded after apply, stale rejection kept the old version, creation could resume while a Change was pending, Change state leaked across Plans, E2E matrix incomplete); round 2 confirmed all five fixed and raised one (component-local Source details survived a Plan switch); round 3 passed with in-memory reproductions.

| Check | Result |
|---|---|
| Root `pnpm check` | green |
| Renderer unit tests (cards, controller, adapter, library, chat surface) | green |
| Desktop E2E plan-change, plan-library, plan-close-history | 41 passed |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
