### PR TITLE
feat(coach): fence legacy Plan writers around Chat-owned Plans

### DIFF
--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -91,6 +91,7 @@ import {
   importLegacyCurrentPlan,
 } from "@enduragent/kernel-node/planning";
 import {
+  createLegacyWriterFence,
   createPlanDraftBuildRepository,
   createPlanIntakeRepository,
 } from "@enduragent/kernel/planning";
@@ -899,14 +900,17 @@ export async function createLocalCoachComposition(
     now,
   });
   const planningRepository = createLegacyPlanRepository(input.context.store);
-  await importLegacyCurrentPlan({
-    home: input.home,
-    store: input.context.store,
-    identity: planningIdentity,
-    importDateKey: planningDateKey(),
-    importTimestampMs: now(),
-    logger: { warn: () => logger.warn("legacy_plan_import_skipped") },
-  });
+  const legacyWriterFence = createLegacyWriterFence(input.context.store);
+  if (!(await legacyWriterFence.fenced())) {
+    await importLegacyCurrentPlan({
+      home: input.home,
+      store: input.context.store,
+      identity: planningIdentity,
+      importDateKey: planningDateKey(),
+      importTimestampMs: now(),
+      logger: { warn: () => logger.warn("legacy_plan_import_skipped") },
+    });
+  }
   const persistPlan = await createLegacyPlanRowWriter({
     repository: planningRepository,
     identity: planningIdentity,
@@ -1309,6 +1313,10 @@ export async function createLocalCoachComposition(
       const memory = new Memory(input.home.root, timezone, {
         platform: dependencies.platform,
         persistPlan,
+        planWriteGate: async () =>
+          (await legacyWriterFence.fenced())
+            ? "This Plan is managed in Chat. Change or stop it from Chat or the Plan library."
+            : null,
       });
       const conversationStore = createConversationStore(
         input.home.root,

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -1913,7 +1913,9 @@ export function createPlanningOperations(
     if (fence.activePlanId !== null) {
       const activePlan = await plans.read(fence.activePlanId);
       if (activePlan === undefined) throw new TypeError("An active Plan requires a Plan record.");
-      return readActive(activePlan, 0, overrides);
+      if (activePlan.status === "active" && overrides.endedScenario === undefined) {
+        return readActive(activePlan, 0, overrides);
+      }
     }
     const conversation = await conversations.readLatestOpenConversation();
     if (conversation === undefined) {
@@ -1933,11 +1935,15 @@ export function createPlanningOperations(
     const [turns, draft, queue, decision, ftp] = await Promise.all([
       conversations.readTurns(conversation.id),
       conversations.readLatestDraftRevision(conversation.id),
-      input.engine.getChatQueue?.({ chatId }).catch(() => EMPTY_QUEUE) ?? EMPTY_QUEUE,
-      input.engine
-        .getCoachDecision({ chatId })
-        .then((result) => result.decision)
-        .catch(() => null),
+      overrides.readOnly
+        ? EMPTY_QUEUE
+        : (input.engine.getChatQueue?.({ chatId }).catch(() => EMPTY_QUEUE) ?? EMPTY_QUEUE),
+      overrides.readOnly
+        ? null
+        : input.engine
+            .getCoachDecision({ chatId })
+            .then((result) => result.decision)
+            .catch(() => null),
       dependencies.ftp?.read(),
     ]);
     const projectedPlanId = draft?.planId ?? conversation.planId;

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -1916,6 +1916,7 @@ export function createPlanningOperations(
       if (activePlan.status === "active" && overrides.endedScenario === undefined) {
         return readActive(activePlan, 0, overrides);
       }
+      return readEnded(activePlan, 0, overrides);
     }
     const conversation = await conversations.readLatestOpenConversation();
     if (conversation === undefined) {

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -114,6 +114,7 @@ import {
 } from "./planning-lifecycle.js";
 import {
   addCivilDays,
+  createLegacyWriterFence,
   createPlanConversationRepository,
   createPlanReconciliationRepository,
   createPlanRepository,
@@ -1217,6 +1218,7 @@ function courseProjection(input: {
 }
 
 interface ReadOverrides {
+  readonly readOnly?: boolean;
   readonly sourceConversationId?: string | null;
   readonly ftpScenario?: FtpScenario;
   readonly ftpError?: PlanError | null;
@@ -1269,6 +1271,30 @@ export function createPlanningOperations(
   },
   dependencies: CreatePlanningOperationsDependencies = {},
 ): PlanningOperations {
+  const writerFence = createLegacyWriterFence(input.context.store);
+  const fencedTransitions = new Set<ExecutePlanTransitionRpcParams["transitionId"]>([
+    "PL-T01",
+    "PL-T02",
+    "PL-T03",
+    "PL-T04",
+    "PL-T05",
+    "PL-T06",
+    "PL-T07",
+    "PL-T08",
+    "PL-T09",
+    "PL-T10",
+    "PL-T11",
+    "PL-T17",
+    "PL-T18",
+    "PL-T19",
+    "PL-T20",
+    "PL-T21",
+    "PL-T22",
+    "PL-T24",
+    "PL-T25",
+    "PL-T26",
+    "PL-T40",
+  ]);
   const conversations =
     dependencies.conversations ?? createPlanConversationRepository(input.context.store);
   const intakes = dependencies.intakes ?? createPlanIntakeRepository(input.context.store);
@@ -1356,6 +1382,20 @@ export function createPlanningOperations(
           : patch.currentTrainingSummary,
     };
   };
+  const projectIntake = (
+    current: PlanIntakeRecord,
+    turns: readonly PlanConversationTurnRecord[],
+  ): PlanIntakeRecord => {
+    let next = current;
+    for (const turn of turns.filter((turn) => turn.sequence > current.sourceTurnSequence)) {
+      try {
+        const lineage = snapshot(turn.lineageJson) as { readonly planIntakePatch?: unknown };
+        const parsed = PlanIntakePatchSchema.safeParse(lineage.planIntakePatch);
+        if (parsed.success) next = applyIntakePatch(next, parsed.data);
+      } catch {}
+    }
+    return next;
+  };
   const synchronizeIntake = async (
     conversationId: string,
     knownTurns?: readonly PlanConversationTurnRecord[],
@@ -1364,14 +1404,7 @@ export function createPlanningOperations(
     const turns = knownTurns ?? (await conversations.readTurns(conversationId));
     const pending = turns.filter((turn) => turn.sequence > current.sourceTurnSequence);
     if (pending.length === 0) return current;
-    let next = current;
-    for (const turn of pending) {
-      try {
-        const lineage = snapshot(turn.lineageJson) as { readonly planIntakePatch?: unknown };
-        const parsed = PlanIntakePatchSchema.safeParse(lineage.planIntakePatch);
-        if (parsed.success) next = applyIntakePatch(next, parsed.data);
-      } catch {}
-    }
+    const next = projectIntake(current, pending);
     const stamp = input.identity.hlcStamp();
     return intakes.save(
       {
@@ -1484,18 +1517,26 @@ export function createPlanningOperations(
       week.kind === "inside" ? week.weekIndex : week.side === "before" ? 1 : plan.totalWeeks;
     const weekStartDateKey = addCivilDays(plan.startDateKey, (weekIndex - 1) * 7);
     const matchSync = await workoutMatches.readSyncStatus();
-    const refreshed = await refreshPlanWorkoutMatches({
-      planId: plan.id,
-      workouts,
-      startDateKey: weekStartDateKey,
-      endDateKey: addCivilDays(weekStartDateKey, 6),
-      repository: workoutMatches,
-      identity: {
-        newId: () => input.identity.newUlid(),
-        deviceId: () => input.identity.deviceId(),
-        stamp: () => input.identity.hlcStamp(),
-      },
-    });
+    const refreshed = overrides.readOnly
+      ? {
+          activities: await workoutMatches.listActivities(
+            weekStartDateKey,
+            addCivilDays(weekStartDateKey, 6),
+          ),
+          matches: await workoutMatches.readForPlan(plan.id),
+        }
+      : await refreshPlanWorkoutMatches({
+          planId: plan.id,
+          workouts,
+          startDateKey: weekStartDateKey,
+          endDateKey: addCivilDays(weekStartDateKey, 6),
+          repository: workoutMatches,
+          identity: {
+            newId: () => input.identity.newUlid(),
+            deviceId: () => input.identity.deviceId(),
+            stamp: () => input.identity.hlcStamp(),
+          },
+        });
     const matchRows = projectWorkoutMatches({
       workouts: workouts.filter(
         (workout) =>
@@ -1540,7 +1581,7 @@ export function createPlanningOperations(
       }
     }
     let drifts = await workoutDrifts.readOpenForPlan(plan.id);
-    if (dependencies.workoutDriftCalendar !== undefined) {
+    if (!overrides.readOnly && dependencies.workoutDriftCalendar !== undefined) {
       try {
         const windowEndDateKey = addCivilDays(todayDateKey, 6);
         const events = await dependencies.workoutDriftCalendar.listEvents({
@@ -1668,7 +1709,7 @@ export function createPlanningOperations(
               });
             }
             if (error.code !== "stale-base") {
-              await refuseProposal(proposal);
+              if (!overrides.readOnly) await refuseProposal(proposal);
               return null;
             }
             try {
@@ -1680,7 +1721,7 @@ export function createPlanningOperations(
                 error: PROPOSAL_STALE,
               });
             } catch {
-              await refuseProposal(proposal);
+              if (!overrides.readOnly) await refuseProposal(proposal);
               return null;
             }
           }
@@ -1868,6 +1909,12 @@ export function createPlanningOperations(
   };
 
   const read = async (overrides: ReadOverrides = {}): Promise<PlanReadModel> => {
+    const fence = await writerFence.read();
+    if (fence.activePlanId !== null) {
+      const activePlan = await plans.read(fence.activePlanId);
+      if (activePlan === undefined) throw new TypeError("An active Plan requires a Plan record.");
+      return readActive(activePlan, 0, overrides);
+    }
     const conversation = await conversations.readLatestOpenConversation();
     if (conversation === undefined) {
       const latestPlan = await plans.readLatest();
@@ -1910,7 +1957,28 @@ export function createPlanningOperations(
         : startDateProjection({ plan: draftPlan, todayDateKey }));
     const dateScenario =
       overrides.dateScenario ?? (projectedStartDate?.status === "invalid" ? "PL-S046" : undefined);
-    const intake = await synchronizeIntake(conversation.id, turns);
+    const intake = overrides.readOnly
+      ? projectIntake(
+          (await intakes.read(conversation.id)) ?? {
+            conversationId: conversation.id,
+            eventName: null,
+            eventPriority: null,
+            eventDateKey: null,
+            athleteGoal: null,
+            availabilitySessionsPerWeek: null,
+            availabilityWeekdays: [],
+            experience: null,
+            currentTrainingSummary: null,
+            sourceTurnSequence: 0,
+            createdAtMs: conversation.createdAtMs,
+            updatedAtMs: conversation.updatedAtMs,
+            deviceId: conversation.deviceId,
+            hlcPhysicalMs: conversation.hlcPhysicalMs,
+            hlcCounter: conversation.hlcCounter,
+          },
+          turns,
+        )
+      : await synchronizeIntake(conversation.id, turns);
     const readiness = await draftReadiness({ conversation, turns, draft }, intake);
     const ready = conversation.courseChoiceStatus !== "undecided" && readiness.ready;
     const projectedCourse = overrides.course ?? storedCourseProjection(conversation, draft);
@@ -2394,6 +2462,18 @@ export function createPlanningOperations(
     executePlanTransition(request, onEvent) {
       const command = ExecutePlanTransitionRpcParamsSchema.parse(request);
       return enqueue(async () => {
+        const fenced = await writerFence.fenced();
+        if (fenced && fencedTransitions.has(command.transitionId)) {
+          return reject(
+            {
+              code: "conflict",
+              message:
+                "This Plan is managed in Chat. Change or stop it from Chat or the Plan library.",
+              retryable: false,
+            },
+            { readOnly: true },
+          );
+        }
         if (command.transitionId === "PL-T01") {
           const latestPlan = await plans.readLatest();
           const replacementPlanId = latestPlan?.status === "active" ? latestPlan.id : null;

--- a/packages/coach/tests/writer-fence.test.ts
+++ b/packages/coach/tests/writer-fence.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import type {
+  CoachEngine,
+  ExecutePlanTransitionRpcParams,
+  PlanCreationAnswerInput,
+} from "@enduragent/coach-contract";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import {
+  createLegacyWriterFence,
+  createPlanConversationRepository,
+  createPlanCreationRepository,
+  createPlanRepository,
+  createPlanWorkoutMatchRepository,
+} from "@enduragent/kernel/planning";
+import { dumpStore, runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { inertWriterProtocolListener } from "@enduragent/kernel-node/lock";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanCreationOperations } from "../src/plan-creation-operations.js";
+import { createPlanningOperations } from "../src/planning-operations.js";
+import type { CoachStoreWriterContext } from "../src/runtime.js";
+
+const MESSAGE = "This Plan is managed in Chat. Change or stop it from Chat or the Plan library.";
+const CONVERSATION_ID = "00000000000000000000000001";
+
+async function fixture(
+  status: "empty" | "in-progress" | "review" | "active" | "closed" | "discarded",
+) {
+  const store = openSqliteStorage(":memory:");
+  onTestFinished(() => store.close());
+  await runMigrations(store, MIGRATIONS);
+  let sequence = 100;
+  const identity = {
+    deviceId: async () => "writer-fence-test-device",
+    newUlid: () => String(++sequence).padStart(26, "0"),
+    hlcStamp: () => ({ physicalMs: 904_694_400_000, counter: sequence }),
+  };
+  const dependencies = {
+    store,
+    identity,
+    crypto: globalThis.crypto,
+    todayDateKey: () => 19980902,
+    now: () => 904_694_400_000,
+  };
+  const creation = createPlanCreationOperations({
+    ...dependencies,
+    repository: createPlanCreationRepository(store),
+    eventCandidates: { read: async () => [] },
+    today: () => "1998-09-02",
+  });
+  const seed = async () => {
+    if (status === "empty") return { creationId: null, planId: null };
+    const start = await creation["plan_creation.start"]({ commandId: "start" });
+    if (start.status !== "started") throw new Error("Expected creation");
+    let card = start.planCreation;
+    if (status === "in-progress") return { creationId: card.creationId, planId: null };
+    if (status === "discarded") {
+      await creation["plan_creation.discard"]({
+        commandId: "discard",
+        creationId: card.creationId,
+        expectedVersion: card.version,
+      });
+      return { creationId: card.creationId, planId: null };
+    }
+    const answers: PlanCreationAnswerInput[] = [
+      { kind: "goal", goal: { kind: "fitness" } },
+      { kind: "plan-length", weeks: 4 },
+      { kind: "schedule-mode", mode: "fixed" },
+      {
+        kind: "availability",
+        mode: "fixed",
+        weeklyHoursLimit: 8,
+        longestWorkoutHours: 3,
+        usableWeekdays: [6, 2, 4],
+      },
+      { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
+      { kind: "commitments", commitments: { kind: "none" } },
+      { kind: "baseline", baseline: "regular" },
+      { kind: "success", success: { kind: "fitness-choice", choice: "climb-stronger" } },
+      { kind: "restriction", restriction: { kind: "none" } },
+    ];
+    for (const answer of answers) {
+      const result = await creation["plan_creation.answer"]({
+        commandId: `answer-${++sequence}`,
+        creationId: card.creationId,
+        expectedVersion: card.version,
+        answer,
+      });
+      if (result.status !== "answered") throw new Error("Expected answer");
+      card = result.planCreation;
+    }
+    const draftResult = await creation["plan_creation.preview"]({
+      commandId: "draft",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    });
+    if (draftResult.status !== "previewed" || draftResult.planCreation.draft === null)
+      throw new Error("Expected Draft");
+    if (status === "review") return { creationId: card.creationId, planId: null };
+    const activated = await creation["plan_creation.activate"]({
+      commandId: "activate",
+      creationId: card.creationId,
+      expectedVersion: draftResult.planCreation.version,
+    });
+    expect(activated.planId).toBeTruthy();
+    const listed = await creation["plan.list"]({});
+    if (listed.active === null) throw new Error("Expected active Plan summary");
+    const planId = listed.active.planId;
+    if (status === "closed") {
+      await creation["plan.close"]({ commandId: "close", planId, expectedVersion: 1 });
+    }
+    return { creationId: card.creationId, planId };
+  };
+  const ids = await seed();
+  const context: CoachStoreWriterContext = {
+    home: {
+      root: "/synthetic/athlete",
+      storeDir: "/synthetic/athlete/store",
+      archiveDir: "/synthetic/athlete/archive",
+      configDir: "/synthetic/athlete/config",
+    },
+    store,
+    listener: inertWriterProtocolListener,
+  };
+  const unsupported = async (): Promise<never> => {
+    throw new Error("Unexpected engine call");
+  };
+  const engine: CoachEngine = {
+    chat: vi.fn(unsupported),
+    answerCoachDecision: unsupported,
+    skipCoachDecision: unsupported,
+    resumeCoachDecision: unsupported,
+    resetSession: unsupported,
+    hasSession: unsupported,
+    getAthleteState: unsupported,
+    getChatQueue: async () => ({ schemaVersion: 1, revision: 0, items: [] }),
+    getCoachDecision: async () => ({ decision: null }),
+  };
+  const operations = createPlanningOperations(
+    { context, engine, identity },
+    { todayDateKey: () => 19980902 },
+  );
+  const openConversation = async () => {
+    const conversations = createPlanConversationRepository(store);
+    await conversations.saveConversation({
+      id: CONVERSATION_ID,
+      planId: null,
+      replacesPlanId: null,
+      courseChoiceStatus: "omitted",
+      raceCourseJson: null,
+      status: "open",
+      endedAtMs: null,
+      createdAtMs: 100,
+      updatedAtMs: 100,
+      deviceId: "fence-test-device",
+      hlcPhysicalMs: 100,
+      hlcCounter: 0,
+    });
+    await conversations.appendTurn({
+      id: "00000000000000000000000002",
+      conversationId: CONVERSATION_ID,
+      sequence: 1,
+      athleteText: "Improve my climbing.",
+      coachText: "We can build toward that.",
+      lineageJson: canonicalJson({ planIntakePatch: { goal: "Improve my climbing" } }),
+      completedAtMs: 101,
+      deviceId: "fence-test-device",
+      hlcPhysicalMs: 101,
+      hlcCounter: 0,
+    });
+  };
+  return { store, operations, openConversation, creation, context, engine, identity, ...ids };
+}
+
+function commands(planId: string): ExecutePlanTransitionRpcParams[] {
+  return [
+    { transitionId: "PL-T01", commandId: "start-legacy", sourceConversationId: null },
+    {
+      transitionId: "PL-T11",
+      commandId: "activate-legacy",
+      draftId: CONVERSATION_ID,
+      expectedRevision: 1,
+    },
+    {
+      transitionId: "PL-T17",
+      commandId: "proposal-legacy",
+      planId,
+      proposalId: CONVERSATION_ID,
+      selectedProposalReturn: { sourceScenarioId: "PL-S010", returnFocusId: "workout-row" },
+    },
+    { transitionId: "PL-T21", commandId: "undo-legacy", planId, ledgerId: CONVERSATION_ID },
+    { transitionId: "PL-T24", commandId: "stop-legacy", planId, mode: "cleanup" },
+    {
+      transitionId: "PL-T26",
+      commandId: "replace-legacy",
+      activePlanId: planId,
+      draftId: CONVERSATION_ID,
+      expectedRevision: 1,
+      confirm: true,
+    },
+  ];
+}
+
+describe("legacy writer fence", () => {
+  it.each(["in-progress", "review", "active"] as const)(
+    "reads %s ownership without writes",
+    async (status) => {
+      const test = await fixture(status);
+      const fence = createLegacyWriterFence(test.store);
+      const before = await dumpStore(test.store);
+      expect(await fence.read()).toEqual({
+        activePlanId: status === "active" ? test.planId : null,
+        creationId: status === "active" ? null : test.creationId,
+      });
+      expect(await fence.fenced()).toBe(true);
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+
+  it.each(["in-progress", "review", "active"] as const)(
+    "rejects authoring families with %s ownership and preserves the entire store",
+    async (status) => {
+      const test = await fixture(status);
+      await test.openConversation();
+      let operations = test.operations;
+      if (test.planId !== null) {
+        const [workout] = await createPlanRepository(test.store).readWorkouts(test.planId);
+        if (workout === undefined) throw new Error("Expected Workout");
+        operations = createPlanningOperations(
+          { context: test.context, engine: test.engine, identity: test.identity },
+          {
+            todayDateKey: () => 19980902,
+            workoutMatches: {
+              ...createPlanWorkoutMatchRepository(test.store),
+              listActivities: async () => [
+                {
+                  activityId: "b".repeat(64),
+                  providerActivityId: "synthetic-unmatched-activity",
+                  dateKey: workout.dateKey,
+                  sport: workout.sport,
+                  durationS: workout.durationS,
+                  pairedEventId: null,
+                },
+              ],
+            },
+          },
+        );
+      }
+      const before = await dumpStore(test.store);
+      for (const command of commands(test.planId ?? CONVERSATION_ID)) {
+        const result = await operations.executePlanTransition?.(command);
+        expect(result).toMatchObject({
+          status: "rejected",
+          error: { code: "conflict", message: MESSAGE },
+          state: { projection: status === "active" ? "active" : "coach" },
+        });
+        expect(await dumpStore(test.store)).toBe(before);
+      }
+    },
+  );
+
+  it.each(["empty", "closed", "discarded"] as const)(
+    "permits legacy authoring with %s ownership",
+    async (status) => {
+      const test = await fixture(status);
+      const fence = createLegacyWriterFence(test.store);
+      const before = await dumpStore(test.store);
+      expect(await fence.read()).toEqual({ activePlanId: null, creationId: null });
+      expect(await fence.fenced()).toBe(false);
+      expect(await dumpStore(test.store)).toBe(before);
+      await expect(
+        test.operations.executePlanTransition?.({
+          transitionId: "PL-T01",
+          commandId: "legacy-start",
+          sourceConversationId: null,
+        }),
+      ).resolves.toMatchObject({ status: "completed" });
+    },
+  );
+
+  it("prefers the active Chat Plan over an open legacy conversation without intake writes", async () => {
+    const test = await fixture("active");
+    await test.openConversation();
+    const before = await dumpStore(test.store);
+    await expect(test.operations.getPlanState?.({})).resolves.toMatchObject({
+      status: "ready",
+      state: {
+        projection: "active",
+        planId: test.planId,
+        data: { plan: { id: test.planId, name: "Improve fitness" }, workouts: expect.any(Array) },
+      },
+    });
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it("checks ownership when a queued command enters the serialized lane", async () => {
+    const test = await fixture("empty");
+    let signalEntered: () => void = () => {};
+    const entered = new Promise<void>((resolve) => {
+      signalEntered = resolve;
+    });
+    let release: () => void = () => {};
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+    const operations = createPlanningOperations(
+      { context: test.context, engine: test.engine, identity: test.identity },
+      {
+        todayDateKey: () => 19980902,
+        isReady: async () => {
+          calls += 1;
+          if (calls === 1) {
+            signalEntered();
+            await released;
+          }
+          return false;
+        },
+      },
+    );
+    const first = operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "first",
+      sourceConversationId: null,
+    });
+    await entered;
+    const queued = operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "queued",
+      sourceConversationId: null,
+    });
+    await test.creation["plan_creation.start"]({ commandId: "chat-start" });
+    release();
+    await expect(first).resolves.toMatchObject({ status: "completed" });
+    await expect(queued).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "conflict", message: MESSAGE },
+    });
+  });
+
+  it("retains Workout match confirmation while a Chat Plan is active", async () => {
+    const test = await fixture("active");
+    if (test.planId === null) throw new Error("Expected active Plan");
+    const [workout] = await createPlanRepository(test.store).readWorkouts(test.planId);
+    if (workout === undefined) throw new Error("Expected Workout");
+    const matches = createPlanWorkoutMatchRepository(test.store);
+    const activityId = "a".repeat(64);
+    const matchId = "00000000000000000000000003";
+    await matches.observe({
+      id: matchId,
+      planId: test.planId,
+      planWorkoutId: workout.id,
+      activityId,
+      providerActivityId: "synthetic-activity",
+      providerEventId: null,
+      source: "heuristic",
+      decision: "suggested",
+      activityDateKey: workout.dateKey,
+      activitySport: workout.sport,
+      activityDurationS: workout.durationS,
+      observedAtMs: 100,
+      decidedAtMs: null,
+      deviceId: "fence-test-device",
+      hlcPhysicalMs: 100,
+      hlcCounter: 0,
+    });
+    await expect(
+      test.operations.executePlanTransition?.({
+        transitionId: "PL-T14",
+        commandId: "confirm-match",
+        planId: test.planId,
+        workoutId: workout.id,
+        activityId,
+        decision: "confirm",
+      }),
+    ).resolves.toMatchObject({ status: "completed" });
+    expect(await matches.readForWorkout(workout.id)).toMatchObject([
+      { id: matchId, decision: "confirmed" },
+    ]);
+  });
+});

--- a/packages/coach/tests/writer-fence.test.ts
+++ b/packages/coach/tests/writer-fence.test.ts
@@ -202,6 +202,91 @@ function commands(planId: string): ExecutePlanTransitionRpcParams[] {
 }
 
 describe("legacy writer fence", () => {
+  it.each(["in-progress", "review"] as const)(
+    "rejects with %s creation without engine reads or store writes",
+    async (status) => {
+      const test = await fixture(status);
+      await test.openConversation();
+      const getChatQueue = vi.spyOn(test.engine, "getChatQueue");
+      const getCoachDecision = vi.spyOn(test.engine, "getCoachDecision");
+      const before = await dumpStore(test.store);
+
+      await expect(
+        test.operations.executePlanTransition?.({
+          transitionId: "PL-T01",
+          commandId: "fenced-legacy-start",
+          sourceConversationId: null,
+        }),
+      ).resolves.toMatchObject({
+        status: "rejected",
+        error: { code: "conflict", message: MESSAGE },
+        state: { projection: "coach" },
+      });
+
+      expect(getChatQueue).not.toHaveBeenCalled();
+      expect(getCoachDecision).not.toHaveBeenCalled();
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+
+  it("retains natural completion while target ownership remains active", async () => {
+    const test = await fixture("active");
+    if (test.planId === null) throw new Error("Expected active Plan");
+    const planId = test.planId;
+    const plans = createPlanRepository(test.store);
+    const plan = await plans.read(planId);
+    if (plan === undefined) throw new Error("Expected Plan record");
+    await plans.replace(
+      {
+        ...plan,
+        name: "Gran Fondo Plan",
+        primaryGoal: "Finish",
+        startDateKey: 19980713,
+        targetDateKey: 19981004,
+        kind: "full_plan",
+        totalWeeks: 12,
+        weekStartDay: 1,
+      },
+      [],
+    );
+    let todayDateKey = 19981004;
+    const operations = createPlanningOperations(
+      { context: test.context, engine: test.engine, identity: test.identity },
+      { plans, todayDateKey: () => todayDateKey },
+    );
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T29",
+        commandId: "natural-too-early",
+        planId,
+        asOf: "1998-10-04",
+      }),
+    ).resolves.toMatchObject({ status: "rejected" });
+    await expect(plans.read(planId)).resolves.toMatchObject({ status: "active" });
+
+    todayDateKey = 19981005;
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T29",
+        commandId: "natural-completion",
+        planId,
+        asOf: "1998-10-05",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: { lifecycle: "ended", projection: "ended", scenarioId: "PL-S094" },
+    });
+    await expect(plans.read(planId)).resolves.toMatchObject({ status: "ended" });
+    await expect(createLegacyWriterFence(test.store).read()).resolves.toMatchObject({
+      activePlanId: planId,
+    });
+    await expect(operations.getPlanState?.({})).resolves.toMatchObject({
+      status: "ready",
+      state: { lifecycle: "ended", projection: "ended" },
+    });
+  });
+
   it.each(["in-progress", "review", "active"] as const)(
     "reads %s ownership without writes",
     async (status) => {

--- a/packages/coach/tests/writer-fence.test.ts
+++ b/packages/coach/tests/writer-fence.test.ts
@@ -229,8 +229,9 @@ describe("legacy writer fence", () => {
     },
   );
 
-  it("retains natural completion while target ownership remains active", async () => {
+  it("retains natural completion over an open legacy conversation while target ownership remains active", async () => {
     const test = await fixture("active");
+    await test.openConversation();
     if (test.planId === null) throw new Error("Expected active Plan");
     const planId = test.planId;
     const plans = createPlanRepository(test.store);
@@ -281,10 +282,12 @@ describe("legacy writer fence", () => {
     await expect(createLegacyWriterFence(test.store).read()).resolves.toMatchObject({
       activePlanId: planId,
     });
+    const before = await dumpStore(test.store);
     await expect(operations.getPlanState?.({})).resolves.toMatchObject({
       status: "ready",
-      state: { lifecycle: "ended", projection: "ended" },
+      state: { lifecycle: "ended", projection: "ended", planId },
     });
+    expect(await dumpStore(test.store)).toBe(before);
   });
 
   it.each(["in-progress", "review", "active"] as const)(

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -98,6 +98,7 @@ type RenameOutcome = "renamed" | "noop" | "merged";
 export interface MemoryOptions {
   readonly platform?: NodeJS.Platform;
   readonly persistPlan?: (plan: unknown) => Promise<void>;
+  readonly planWriteGate?: () => Promise<string | null>;
 }
 
 /**
@@ -131,6 +132,7 @@ export class Memory implements MemoryStore {
   private provenance: ProvenanceMetadata;
   private readonly platform: NodeJS.Platform;
   private readonly persistPlan: ((plan: unknown) => Promise<void>) | undefined;
+  private readonly planWriteGate: (() => Promise<string | null>) | undefined;
   private readonly writeProvenance = new AsyncLocalStorage<SourceProvenance>();
 
   constructor(dataDir: string, tz: string = "UTC", options: MemoryOptions = {}) {
@@ -139,6 +141,7 @@ export class Memory implements MemoryStore {
     this.tz = tz;
     this.platform = options.platform ?? process.platform;
     this.persistPlan = options.persistPlan;
+    this.planWriteGate = options.planWriteGate;
     mkdirSync(this.memoryDir, { recursive: true, mode: 0o700 });
     mkdirSync(this.plansDir, { recursive: true, mode: 0o700 });
     this.provenance = new ProvenanceMetadata(this.memoryDir, { platform: this.platform });
@@ -460,19 +463,26 @@ export class Memory implements MemoryStore {
     source: MemoryWriteSource = "unattributed",
     provenance?: SourceProvenance,
   ): void | Promise<void> {
-    const path = join(this.plansDir, "current-plan.json");
-    const newBody = JSON.stringify(plan, null, 2);
-    this.provenance.write("plan", newBody, this.resolvedWriteProvenance(provenance));
-    appendJournalEntry(this.memoryDir, {
-      ts: new Date().toISOString(),
-      op: "save-plan",
-      section: null,
-      oldBody: existsSync(path) ? readFileSync(path, "utf-8") : null,
-      newBody,
-      source,
+    const write = () => {
+      const path = join(this.plansDir, "current-plan.json");
+      const newBody = JSON.stringify(plan, null, 2);
+      this.provenance.write("plan", newBody, this.resolvedWriteProvenance(provenance));
+      appendJournalEntry(this.memoryDir, {
+        ts: new Date().toISOString(),
+        op: "save-plan",
+        section: null,
+        oldBody: existsSync(path) ? readFileSync(path, "utf-8") : null,
+        newBody,
+        source,
+      });
+      atomicWriteFileSync(path, newBody, { platform: this.platform });
+      return this.persistPlan?.(plan);
+    };
+    if (!this.planWriteGate) return write();
+    return this.planWriteGate().then((message) => {
+      if (message !== null) throw new Error(message);
+      return write();
     });
-    atomicWriteFileSync(path, newBody, { platform: this.platform });
-    return this.persistPlan?.(plan);
   }
 
   loadPlan(): unknown | null {

--- a/packages/core/tests/memory-plan-write-gate.test.ts
+++ b/packages/core/tests/memory-plan-write-gate.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Memory } from "../src/memory/store.js";
+
+describe("Memory plan write gate", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "memory-plan-write-gate-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("waits for the gate and rejects without writing any files or persisting the plan", async () => {
+    let resolveDecision: (message: string | null) => void = () => {};
+    const decision = new Promise<string | null>((resolve) => {
+      resolveDecision = resolve;
+    });
+    const persistPlan = vi.fn(async () => {});
+    const memory = new Memory(dataDir, "UTC", {
+      planWriteGate: () => decision,
+      persistPlan,
+    });
+    const pending = memory.savePlan({ name: "Base" });
+
+    expect(readdirSync(join(dataDir, "memory"))).toEqual([]);
+    expect(readdirSync(join(dataDir, "plans"))).toEqual([]);
+    expect(persistPlan).not.toHaveBeenCalled();
+
+    const message =
+      "This Plan is managed in Chat. Change or stop it from Chat or the Plan library.";
+    resolveDecision(message);
+    await expect(pending).rejects.toThrow(new Error(message));
+
+    expect(readdirSync(join(dataDir, "memory"))).toEqual([]);
+    expect(readdirSync(join(dataDir, "plans"))).toEqual([]);
+    expect(persistPlan).not.toHaveBeenCalled();
+    expect(memory.loadPlan()).toBeNull();
+  });
+
+  it("writes and persists the plan when the gate allows it", async () => {
+    const persistPlan = vi.fn(async () => {});
+    const memory = new Memory(dataDir, "UTC", {
+      planWriteGate: async () => null,
+      persistPlan,
+    });
+    const plan = { name: "Base" };
+
+    await memory.savePlan(plan);
+
+    expect(memory.loadPlan()).toEqual(plan);
+    expect(persistPlan).toHaveBeenCalledExactlyOnceWith(plan);
+  });
+
+  it("preserves synchronous file writes when no gate is configured", () => {
+    const memory = new Memory(dataDir);
+    const plan = { name: "Base" };
+
+    expect(memory.savePlan(plan)).toBeUndefined();
+    expect(memory.loadPlan()).toEqual(plan);
+  });
+});

--- a/packages/kernel-node/tests/legacy-plan-store.test.ts
+++ b/packages/kernel-node/tests/legacy-plan-store.test.ts
@@ -3,10 +3,17 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { PlanningDateError, createPlanRepository } from "@enduragent/kernel/planning";
-import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { engineConfigFromConfig, type Config } from "@enduragent/core";
+import {
+  PlanningDateError,
+  createPlanCreationRepository,
+  createPlanRepository,
+} from "@enduragent/kernel/planning";
+import { dumpStore, runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createLocalCoachComposition } from "../../coach/src/composition.js";
 import { createAuthoredIdentity, type AthleteHome } from "../src/home/index.js";
+import { inertWriterProtocolListener } from "../src/lock/index.js";
 import {
   LEGACY_PLAN_IMPORT_MARKER,
   createLegacyPlanRowWriter,
@@ -54,6 +61,105 @@ describe("legacy current Plan import and dual-write adapter", () => {
   afterEach(async () => {
     await store.close();
     rmSync(root, { recursive: true, force: true });
+  });
+
+  async function startCompositionUntilReferenceBootstrap() {
+    const config: Config = {
+      dataSource: "store",
+      llm: { provider: "anthropic", model: "synthetic", apiKey: "" },
+      intervals: { apiKey: "", athleteId: "synthetic" },
+      telegram: { botToken: "" },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+        resetArchiveRetentionDays: 0,
+        timezone: "UTC",
+      },
+      contextWindowTokens: 1000,
+      dataDir: home.root,
+    };
+    const bootstrapReached = new Error("Reference bootstrap reached");
+    const bootstrap = vi.fn(async () => {
+      throw bootstrapReached;
+    });
+    await expect(createLocalCoachComposition({
+      env: { ENDURAGENT_HOME: home.root },
+      home,
+      context: { home, store, listener: inertWriterProtocolListener },
+      config,
+      engineConfig: engineConfigFromConfig(config),
+    }, {
+      bootstrap,
+      now: () => Date.UTC(1998, 6, 7, 12),
+    })).rejects.toBe(bootstrapReached);
+    expect(bootstrap).toHaveBeenCalledOnce();
+  }
+
+  it.each(["active-plan", "unfinished-creation"])(
+    "skips the startup legacy import with an %s and leaves its marker untouched",
+    async (owner) => {
+      if (owner === "unfinished-creation") {
+        await createPlanCreationRepository(store).start({
+          creationId: "00000000000000000000000001",
+          seed: { schemaVersion: 1, eventCandidates: [] },
+          command: {
+            commandId: "start-creation",
+            requestDigest: "a".repeat(64),
+            nowMs: 900,
+            deviceId: "synthetic-device",
+            hlcPhysicalMs: 900,
+            hlcCounter: 0,
+          },
+        });
+      } else {
+        await createPlanRepository(store).replace({
+          id: "00000000000000000000000002",
+          originId: null,
+          name: "Chat Plan",
+          primaryGoal: "Ride consistently",
+          startDateKey: 19980706,
+          targetDateKey: 19980830,
+          status: "active",
+          kind: "short_race_preparation",
+          totalWeeks: 8,
+          weekStartDay: 1,
+          structureJson: "{}",
+          createdAtMs: 900,
+          updatedAtMs: 900,
+          deviceId: "synthetic-device",
+          hlcPhysicalMs: 900,
+          hlcCounter: 0,
+        }, []);
+        await store.run(`INSERT INTO planning_plan (
+          plan_id,status,version,current_revision_number,activated_at_ms,updated_at_ms,
+          device_id,hlc_physical_ms,hlc_counter
+        ) VALUES (?, 'active', 1, 1, 900, 900, 'synthetic-device', 900, 0)`, [
+          "00000000000000000000000002",
+        ]);
+      }
+      const sourcePath = join(root, "plans", "current-plan.json");
+      const sourceBytes = JSON.stringify(legacyPlan());
+      await writeFile(sourcePath, sourceBytes);
+      const before = await dumpStore(store);
+
+      await startCompositionUntilReferenceBootstrap();
+
+      expect(await dumpStore(store)).toEqual(before);
+      expect(await readFile(sourcePath, "utf8")).toBe(sourceBytes);
+      await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER)))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it("imports the legacy Plan at startup when no Chat Plan or unfinished creation exists", async () => {
+    await writeFile(join(root, "plans", "current-plan.json"), JSON.stringify(legacyPlan()));
+
+    await startCompositionUntilReferenceBootstrap();
+
+    expect(await createPlanRepository(store).count()).toBe(1);
+    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER), "utf8"))
+      .resolves.toBe("completed\n");
   });
 
   it("imports the real Draft shape once without modifying its source", async () => {

--- a/packages/kernel/src/planning/index.ts
+++ b/packages/kernel/src/planning/index.ts
@@ -19,3 +19,4 @@ export * from "./draft-build-repository.js";
 export * from "./creation-repository.js";
 export * from "./lifecycle-repository.js";
 export * from "./change-repository.js";
+export * from "./writer-fence.js";

--- a/packages/kernel/src/planning/writer-fence.ts
+++ b/packages/kernel/src/planning/writer-fence.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import type { SqlReadStore } from "../store/ports.js";
+
+const FenceSchema = z.object({
+  activePlanId: z.string().nullable(),
+  creationId: z.string().nullable(),
+});
+
+export function createLegacyWriterFence(store: Pick<SqlReadStore, "get">) {
+  const read = async (): Promise<{ activePlanId: string | null; creationId: string | null }> =>
+    FenceSchema.parse(
+      (await store.get(`SELECT
+        (SELECT plan_id FROM planning_plan WHERE status='active') AS activePlanId,
+        (SELECT id FROM plan_creation WHERE status IN ('in-progress','review')) AS creationId`)) ?? {
+        activePlanId: null,
+        creationId: null,
+      },
+    );
+  return {
+    read,
+    async fenced(): Promise<boolean> {
+      const state = await read();
+      return state.activePlanId !== null || state.creationId !== null;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Runtime fence for legacy Plan writers while a Chat-owned Plan exists. Without it, the legacy transition dispatcher, the `plan_save` tool and the startup current-plan import could still create a competing Plan or alter Chat-owned training beside `plan_creation.*`, `plan.close` and `plan_change.*`.

- Fence condition: an active Chat-owned Plan (`planning_plan.status='active'`) or an unfinished Plan creation. The kernel reader is a single read-only query and tolerates stub stores.
- Legacy authoring transitions (conversation start, course, FTP, answers, form and revise, start date, rebuild, discard, activation, proposals and Auto-apply, revise, approve, reject, immediate Undo, settings, legacy close, replacement, date-conflict resolution) are rejected at command entry inside the serialized lane with a `conflict` error and the message `This Plan is managed in Chat. Change or stop it from Chat or the Plan library.` Rejections write nothing: the projection they return uses an empty queue and no Coach decision, and skips the intake sync.
- Retained routes (mirror, reconciliation, match confirmation, drift resolution, cleanup and mirror retry, race outcome, weekly review, readiness, navigation) are untouched.
- Reads prefer the Chat-owned Plan over an open legacy conversation, including after natural completion ends the physical Plan.
- `Memory.savePlan` takes an optional write gate and rejects before any provenance, journal or JSON write; the startup import is skipped and its marker left untouched while fenced.

Infra-only: no user-visible change, no RPC, no migration, no changeset.

## Verification

Astra high read-only verifier, three rounds: round 1 raised two findings (rejection projection still reached the chat queue; the active-Plan shortcut ignored an ended physical Plan), round 2 raised one (open legacy conversation regained precedence after natural completion), round 3 passed with Node probes for every fenced family, retained routes, both hydration states and byte-identical store dumps.

| Check | Result |
|---|---|
| Root `pnpm check` | green |
| Fence, planning-operations, composition, creation, Change suites | 219 passed |
| Legacy import and memory gate tests | green |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
