### PR TITLE
feat(desktop): simplify the tray menu

### DIFF
--- a/.changeset/great-turkeys-smoke.md
+++ b/.changeset/great-turkeys-smoke.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+Replace the macOS tray popup with a native action menu and add a Settings shortcut.
+
+User-facing: Click the menu bar icon to open Enduragent, go to Settings, choose whether it starts at login, or quit.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -1,5 +1,6 @@
 interface EnduragentAuth {
   readonly platform: DesktopPlatformProjection;
+  onOpenSettings(listener: () => void): () => void;
   getDaemonConnection(failedGeneration?: number): Promise<{
     readonly url: `ws://127.0.0.1:${number}/rpc`;
     readonly rendererCapability: string;

--- a/apps/desktop-renderer/src/main.tsx
+++ b/apps/desktop-renderer/src/main.tsx
@@ -8,6 +8,11 @@ import { bootTheme, useEnduragentStore } from "./state/store";
 
 bootTheme();
 
+const disposeOpenSettings = window.enduragentAuth.onOpenSettings(() => {
+  useEnduragentStore.getState().setActiveView("settings");
+});
+window.addEventListener("beforeunload", disposeOpenSettings, { once: true });
+
 const container = document.querySelector("#root");
 if (!(container instanceof HTMLElement)) {
   throw new TypeError("Desktop shell host is invalid: #root");

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -323,6 +323,7 @@ async function security() {
             "onChatgptLoginProgress",
             "onDroppedChatAttachments",
             "onDroppedImportFiles",
+            "onOpenSettings",
             "onPlanProgress",
             "onUpdateState",
             "pasteChatAttachment",

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -51,6 +51,7 @@ export const DESKTOP_TELEGRAM_ACKNOWLEDGE_GAP_WARNING_CHANNEL =
 export const DESKTOP_TRAY_TELEGRAM_STATUS_CHANNEL = "desktop:tray:telegram-status" as const;
 export const DESKTOP_LIFECYCLE_CHANNEL = "desktop:daemon-lifecycle" as const;
 export const DESKTOP_OPEN_EXTERNAL_CHANNEL = "desktop:open-external" as const;
+export const DESKTOP_OPEN_SETTINGS_CHANNEL = "enduragent:open-settings" as const;
 export const DESKTOP_APPEARANCE_CHANNEL = "desktop:set-appearance" as const;
 export const DESKTOP_WINDOW_LIGHT_BACKGROUND = "#f4f6f5" as const;
 export const DESKTOP_WINDOW_DARK_BACKGROUND = "#0f1520" as const;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1400,19 +1400,9 @@ async function runDesktop(): Promise<void> {
           ? "../../resources/tray.ico"
           : "../../resources/trayTemplate.png",
       ),
-      trayPopoverUrl: rendererSource.trayPopoverUrl,
-      trayPreloadPath: resolve(mainDirectory, "../preload/tray.cjs"),
       platform: process.platform,
       loginItemExecutablePath: process.execPath,
       persistLoginPreference: (enabled) => backgroundAtLoginPreference.set(enabled),
-      telegramStatus: async () => {
-        const snapshot = await telegramCoordinator.status();
-        const warning = await telegramPower!.warning();
-        return {
-          channelState: snapshot.channel.state,
-          gapWarning: warning.state === "possible-message-loss",
-        };
-      },
       reportFailure(operation) {
         process.stderr.write(`desktop-residency-failure ${operation}\n`);
       },

--- a/apps/desktop/src/main/residency.ts
+++ b/apps/desktop/src/main/residency.ts
@@ -6,6 +6,7 @@ import {
   type BrowserWindow,
   type MenuItemConstructorOptions,
 } from "electron";
+import { DESKTOP_OPEN_SETTINGS_CHANNEL } from "./constants.js";
 import {
   isLoginItemResidencyEnabled,
   loginItemResidencyMatchesRequest,
@@ -14,7 +15,6 @@ import {
   type BackgroundAtLoginPreferenceWriteResult,
   type LoginItemResidencyState,
 } from "./login-item.js";
-import { createTrayPopover, type TrayPopover } from "./tray-popover.js";
 
 export const TRAY_TOOLTIP = "Enduragent" as const;
 export const TRAY_POPOVER_WIDTH = 420 as const;
@@ -30,8 +30,6 @@ export interface MainWindowResidencyPort {
 export type DesktopResidencyEvent =
   | { readonly type: "tray-created" }
   | { readonly type: "tray-destroyed" }
-  | { readonly type: "popover-shown" }
-  | { readonly type: "popover-hidden" }
   | { readonly type: "main-window-shown" }
   | { readonly type: "login-item-read"; readonly state: LoginItemResidencyState }
   | { readonly type: "login-item-set"; readonly state: LoginItemResidencyState };
@@ -40,11 +38,8 @@ export interface DesktopResidencyInput {
   readonly app: App;
   readonly mainWindow: MainWindowResidencyPort;
   readonly trayIconPath: string;
-  readonly trayPopoverUrl: string;
-  readonly trayPreloadPath: string;
   readonly platform?: NodeJS.Platform;
   readonly loginItemExecutablePath?: string;
-  readonly telegramStatus: () => Promise<TrayTelegramStatus>;
   readonly persistLoginPreference: (
     enabled: boolean,
   ) => Promise<BackgroundAtLoginPreferenceWriteResult>;
@@ -52,23 +47,6 @@ export interface DesktopResidencyInput {
     operation: "read-login-item" | "set-login-item" | "show-window" | "tray-start",
   ) => void;
   readonly observe?: (event: DesktopResidencyEvent) => void;
-}
-
-export type TrayTelegramChannelState =
-  | "disabled"
-  | "waiting-for-credential"
-  | "starting"
-  | "suspended"
-  | "online"
-  | "offline-retrying"
-  | "conflict"
-  | "invalid-token"
-  | "transfer-required"
-  | "failed";
-
-export interface TrayTelegramStatus {
-  readonly channelState: TrayTelegramChannelState;
-  readonly gapWarning: boolean;
 }
 
 export interface DesktopResidency {
@@ -82,7 +60,6 @@ export interface DesktopResidency {
 export function createDesktopResidency(input: DesktopResidencyInput): DesktopResidency {
   const platform = input.platform ?? process.platform;
   let tray: Tray | undefined;
-  let popover: TrayPopover | undefined;
   let startPromise: Promise<void> | undefined;
   let quitRequested = false;
   let closed = false;
@@ -90,7 +67,6 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
   let loginItemMutation: Promise<void> = Promise.resolve();
   const managedWindows = new WeakSet<BrowserWindow>();
 
-  const hidePopover = (): void => popover?.hide();
   const manageMainWindow = (window: BrowserWindow): void => {
     if (platform !== "win32" || managedWindows.has(window)) return;
     managedWindows.add(window);
@@ -100,45 +76,17 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       window.hide();
     });
   };
-  const showMainWindow = async (): Promise<void> => {
+  const showMainWindow = async (view: "current" | "settings" = "current"): Promise<void> => {
     if (closed) return;
-    hidePopover();
     try {
       const window = await input.mainWindow.show();
+      if (closed) return;
       manageMainWindow(window);
-      if (!closed) input.observe?.({ type: "main-window-shown" });
+      if (view === "settings") window.webContents.send(DESKTOP_OPEN_SETTINGS_CHANNEL);
+      input.observe?.({ type: "main-window-shown" });
     } catch {
       if (!closed) input.reportFailure("show-window");
     }
-  };
-  const ensurePopover = (): TrayPopover => {
-    if (popover !== undefined) return popover;
-    if (tray === undefined) throw new TypeError();
-    popover = createTrayPopover({
-      url: input.trayPopoverUrl,
-      preload: input.trayPreloadPath,
-      getTrayBounds: () => tray?.getBounds() ?? { x: 0, y: 0, width: 0, height: 0 },
-    });
-    popover.window.on("show", () => {
-      if (closed) return;
-      input.observe?.({ type: "popover-shown" });
-      const target = popover;
-      if (target === undefined) return;
-      void input.telegramStatus().then(
-        (status) => {
-          if (!closed && popover === target) target.publishTelegramStatus(status);
-        },
-        () => {
-          if (!closed && popover === target) {
-            target.publishTelegramStatus({ channelState: "failed", gapWarning: false });
-          }
-        },
-      );
-    });
-    popover.window.on("hide", () => {
-      if (!closed) input.observe?.({ type: "popover-hidden" });
-    });
-    return popover;
   };
   const readLoginState = (): LoginItemResidencyState | undefined => {
     try {
@@ -228,6 +176,10 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       },
       { type: "separator" },
       {
+        label: "Settings…",
+        click: () => void showMainWindow("settings"),
+      },
+      {
         label: "Start in background at login",
         type: "checkbox",
         checked: state === undefined ? false : isLoginItemResidencyEnabled(state, platform),
@@ -256,7 +208,7 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
           tray.setToolTip(TRAY_TOOLTIP);
           tray.on("click", () => {
             if (platform === "win32") void showMainWindow();
-            else ensurePopover().toggle();
+            else showContextMenu();
           });
           tray.on("right-click", showContextMenu);
           input.observe?.({ type: "tray-created" });
@@ -277,8 +229,6 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       if (closePromise !== undefined) return closePromise;
       closed = true;
       closePromise = loginItemMutation;
-      popover?.close();
-      popover = undefined;
       if (tray !== undefined) {
         tray.removeAllListeners();
         tray.destroy();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -30,6 +30,7 @@ import {
   DESKTOP_LIFECYCLE_CHANNEL,
   DESKTOP_PLANNING_READ_CHANNEL,
   DESKTOP_OPEN_EXTERNAL_CHANNEL,
+  DESKTOP_OPEN_SETTINGS_CHANNEL,
   DESKTOP_PLAN_PROGRESS_CHANNEL,
   DESKTOP_PLAN_COURSE_FILE_CHANNEL,
   DESKTOP_PLAN_STATE_CHANNEL,
@@ -1346,6 +1347,7 @@ async function invokeTelegramSenders(): Promise<unknown> {
 let dropDisposer: (() => void) | undefined;
 let chatAttachmentDropDisposer: (() => void) | undefined;
 let chatAttachmentDropSequence = 0;
+const openSettingsListeners = new Set<() => void>();
 const updateListeners = new Set<(state: PreloadUpdateState) => void>();
 const chatGptLoginProgressListeners = new Set<(progress: PreloadChatGptLoginProgress) => void>();
 const planProgressListeners = new Set<(progress: PlanProgressEvent) => void>();
@@ -1411,6 +1413,10 @@ ipcRenderer.on(DESKTOP_CHATGPT_LOGIN_PROGRESS_CHANNEL, (_event, value: unknown) 
   }
 });
 
+ipcRenderer.on(DESKTOP_OPEN_SETTINGS_CHANNEL, () => {
+  for (const listener of openSettingsListeners) listener();
+});
+
 ipcRenderer.on(DESKTOP_PLAN_PROGRESS_CHANNEL, (_event, value: unknown) => {
   const parsed = PlanProgressEventSchema.safeParse(value);
   if (!parsed.success) return;
@@ -1433,6 +1439,16 @@ contextBridge.exposeInMainWorld(
   "enduragentAuth",
   Object.freeze({
     platform: desktopPlatformProjection(),
+    onOpenSettings: (listener: unknown) => {
+      if (typeof listener !== "function") throw new TypeError();
+      const notify = (): void => {
+        listener();
+      };
+      openSettingsListeners.add(notify);
+      return (): void => {
+        openSettingsListeners.delete(notify);
+      };
+    },
     getDaemonConnection: (failedGeneration?: number) => {
       if (
         failedGeneration !== undefined &&

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1852,6 +1852,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "onChatgptLoginProgress",
         "onDroppedChatAttachments",
         "onDroppedImportFiles",
+        "onOpenSettings",
         "onPlanProgress",
         "onUpdateState",
         "pasteChatAttachment",

--- a/apps/desktop/tests/fixtures/residency/main.ts
+++ b/apps/desktop/tests/fixtures/residency/main.ts
@@ -133,10 +133,7 @@ async function run(): Promise<void> {
     app,
     mainWindow: windowPort(),
     trayIconPath,
-    trayPopoverUrl: "data:text/html,<main>Enduragent</main>",
-    trayPreloadPath: join(app.getAppPath(), "tray-preload.cjs"),
     persistLoginPreference: async (enabled) => ({ status: "stored", enabled }),
-    telegramStatus: async () => ({ channelState: "disabled", gapWarning: false }),
     reportFailure(operation) {
       output({ event: "failure", operation });
     },

--- a/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
@@ -161,7 +161,7 @@
       "expected": "Explicit Quit is deduplicated, closes resident tray resources, drains accepted desktop work before normal exit, blocks repeated pre-drain exits, and never restarts the intentionally stopped daemon.",
       "automation": "deterministic",
       "tests": [
-        "apps/desktop/tests/residency.test.ts > deduplicates quit and destroys popover before tray exactly once",
+        "apps/desktop/tests/residency.test.ts > deduplicates quit and destroys the tray exactly once",
         "apps/desktop/tests/quit-coordinator.test.ts > blocks repeated pre-drain quits and permits only the updater-generated post-drain quit",
         "apps/desktop/tests/quit-coordinator.test.ts > permits a normal final exit only after a successful drain",
         "apps/desktop/tests/supervisor.test.ts > does not restart when shutdown requested the child exit"

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -70,6 +70,7 @@ vi.mock("electron", () => ({
 
 interface AuthBridge {
   readonly platform: unknown;
+  onOpenSettings(listener: unknown): () => void;
   getDaemonConnection(failedGeneration?: number): Promise<unknown>;
   initialSetupStatusSettled(input: unknown): Promise<unknown>;
   getTranscriptPage(input: unknown): Promise<unknown>;
@@ -396,6 +397,7 @@ describe("desktop preload ChatGPT auth", () => {
         "onDroppedChatAttachments",
         "onDroppedImportFiles",
         "onPlanProgress",
+        "onOpenSettings",
         "onUpdateState",
         "pasteChatAttachment",
         "pasteIntervalsApiKeyFromClipboard",
@@ -2080,5 +2082,22 @@ describe("desktop preload ChatGPT auth", () => {
         : bridge.chatgptLogin(chatGptLoginInput);
       await expect(operation).rejects.toBeInstanceOf(TypeError);
     }
+  });
+});
+
+describe("Settings navigation", () => {
+  it("delivers the fixed Settings command and removes disposed listeners", () => {
+    const event = mocks.on.mock.calls.find(([channel]) => channel === "enduragent:open-settings");
+    if (event === undefined) throw new Error("Settings event missing");
+    const listener = vi.fn();
+    const dispose = bridge.onOpenSettings(listener);
+    event[1]({});
+    expect(listener).toHaveBeenCalledExactlyOnceWith();
+    dispose();
+    dispose();
+    event[1]({});
+    expect(listener).toHaveBeenCalledOnce();
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(() => bridge.onOpenSettings("settings")).toThrow(TypeError);
   });
 });

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -40,14 +40,6 @@ const mocks = vi.hoisted(() => {
       FakeTray.instances.push(this);
     }
   }
-  const popoverWindow = new Emitter();
-  const popover = {
-    window: popoverWindow,
-    publishTelegramStatus: vi.fn(),
-    toggle: vi.fn(),
-    hide: vi.fn(),
-    close: vi.fn(() => order.push("popover-destroy")),
-  };
   const app = Object.assign(new Emitter(), {
     requestSingleInstanceLock: vi.fn(() => true),
     exit: vi.fn(),
@@ -67,9 +59,6 @@ const mocks = vi.hoisted(() => {
     order,
     image,
     FakeTray,
-    popover,
-    popoverWindow,
-    createTrayPopover: vi.fn(() => popover),
     buildFromTemplate: vi.fn((template) => ({ template })),
     app,
     BrowserWindow: vi.fn(),
@@ -91,10 +80,6 @@ vi.mock("electron", () => ({
   safeStorage: {},
   session: { defaultSession: { protocol: { unhandle: vi.fn() } } },
   utilityProcess: { fork: vi.fn() },
-}));
-
-vi.mock("../src/main/tray-popover.js", () => ({
-  createTrayPopover: mocks.createTrayPopover,
 }));
 
 vi.mock("../src/main/security.js", () => ({
@@ -166,15 +151,12 @@ function setup(
   const reportFailure = vi.fn();
   const browserWindow = Object.assign(new mocks.Emitter(), {
     hide: vi.fn(),
+    webContents: { send: vi.fn() },
   });
   const mainWindow = {
     current: vi.fn(() => null),
     show: vi.fn(async () => browserWindow),
   };
-  const telegramStatus = vi.fn(async () => ({
-    channelState: "online" as const,
-    gapWarning: false,
-  }));
   const persistLoginPreference = vi.fn<
     (enabled: boolean) => Promise<BackgroundAtLoginPreferenceWriteResult>
   >(async (enabled) => ({ status: "stored", enabled }));
@@ -183,11 +165,8 @@ function setup(
     app: mocks.app as never,
     mainWindow: mainWindow as never,
     trayIconPath: "/synthetic/trayTemplate.png",
-    trayPopoverUrl: "enduragent://app/tray.html",
-    trayPreloadPath: "/synthetic/tray.cjs",
     platform: options.platform ?? "darwin",
     loginItemExecutablePath: options.loginItemExecutablePath,
-    telegramStatus,
     persistLoginPreference,
     reportFailure,
     observe: (event) => events.push(event),
@@ -198,7 +177,6 @@ function setup(
     reportFailure,
     mainWindow,
     browserWindow,
-    telegramStatus,
     persistLoginPreference,
   };
 }
@@ -209,11 +187,6 @@ beforeEach(() => {
   mocks.image.isEmpty.mockReturnValue(false);
   mocks.image.isEmpty.mockClear();
   mocks.image.setTemplateImage.mockClear();
-  mocks.popover.toggle.mockClear();
-  mocks.popover.hide.mockClear();
-  mocks.popover.close.mockClear();
-  mocks.popover.publishTelegramStatus.mockClear();
-  mocks.createTrayPopover.mockClear();
   mocks.buildFromTemplate.mockClear();
   mocks.app.quit.mockClear();
   mocks.app.getLoginItemSettings.mockReset();
@@ -227,7 +200,7 @@ afterEach(async () => {
 });
 
 describe("desktop residency", () => {
-  it("deduplicates start, template-marks before one tray, and toggles one lazy popover", async () => {
+  it("deduplicates start, template-marks before one tray, and opens the native menu on either click", async () => {
     const { residency, events } = setup();
     const first = residency.start();
     const second = residency.start();
@@ -241,10 +214,11 @@ describe("desktop residency", () => {
     expect(tray.listenerCount("click")).toBe(1);
     expect(tray.listenerCount("right-click")).toBe(1);
     tray.emit("click");
-    tray.emit("click");
-    expect(mocks.createTrayPopover).toHaveBeenCalledOnce();
-    expect(mocks.popover.toggle).toHaveBeenCalledTimes(2);
-    expect(mocks.app.getLoginItemSettings).not.toHaveBeenCalled();
+    tray.emit("right-click");
+    expect(mocks.buildFromTemplate).toHaveBeenCalledTimes(2);
+    expect(tray.popUpContextMenu).toHaveBeenCalledTimes(2);
+    expect(mocks.app.getLoginItemSettings).toHaveBeenCalledTimes(2);
+    expect(mocks.BrowserWindow).not.toHaveBeenCalled();
     expect(events).toContainEqual({ type: "tray-created" });
   });
 
@@ -258,7 +232,7 @@ describe("desktop residency", () => {
 
     await vi.waitFor(() => expect(mainWindow.show).toHaveBeenCalledTimes(2));
     expect(mocks.image.setTemplateImage).not.toHaveBeenCalled();
-    expect(mocks.createTrayPopover).not.toHaveBeenCalled();
+    expect(mocks.buildFromTemplate).not.toHaveBeenCalled();
     expect(tray.listenerCount("right-click")).toBe(1);
   });
 
@@ -292,22 +266,10 @@ describe("desktop residency", () => {
     mocks.FakeTray.instances[0]!.emit("right-click");
 
     const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
-    expect(menu[2]).toMatchObject({ type: "checkbox", checked: false, enabled: true });
+    expect(menu[3]).toMatchObject({ type: "checkbox", checked: false, enabled: true });
     expect(mocks.app.getLoginItemSettings).toHaveBeenCalledWith({
       path: executablePath,
       args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
-    });
-  });
-
-  it("refreshes a redacted Telegram projection whenever the popover is shown", async () => {
-    const { residency, telegramStatus } = setup();
-    await residency.start();
-    mocks.FakeTray.instances[0]!.emit("click");
-    mocks.popoverWindow.emit("show");
-    await vi.waitFor(() => expect(telegramStatus).toHaveBeenCalledOnce());
-    expect(mocks.popover.publishTelegramStatus).toHaveBeenCalledWith({
-      channelState: "online",
-      gapWarning: false,
     });
   });
 
@@ -326,18 +288,66 @@ describe("desktop residency", () => {
     expect(first.map((item) => item.label ?? item.type)).toEqual([
       "Open Enduragent",
       "separator",
+      "Settings…",
       "Start in background at login",
       "separator",
       "Quit Enduragent",
     ]);
-    expect(first[2]).toMatchObject({ type: "checkbox", checked: true, enabled: true });
+    expect(first[3]).toMatchObject({ type: "checkbox", checked: true, enabled: true });
     (first[0]!.click as () => void)();
     await vi.waitFor(() => expect(mainWindow.show).toHaveBeenCalledOnce());
-    (first[2]!.click as (item: { checked: boolean }) => void)({ checked: false });
+    (first[3]!.click as (item: { checked: boolean }) => void)({ checked: false });
     await vi.waitFor(() =>
       expect(mocks.app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false }),
     );
     expect(events).toContainEqual({ type: "main-window-shown" });
+  });
+
+  it("opens Settings only after the main window is ready", async () => {
+    const { residency, mainWindow, browserWindow } = setup();
+    const opening = deferred<typeof browserWindow>();
+    mainWindow.show.mockReturnValueOnce(opening.promise);
+    await residency.start();
+    mocks.FakeTray.instances[0]!.emit("click");
+    const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
+
+    (menu[2]!.click as () => void)();
+
+    expect(mainWindow.show).toHaveBeenCalledOnce();
+    expect(browserWindow.webContents.send).not.toHaveBeenCalled();
+    opening.resolve(browserWindow);
+    await vi.waitFor(() =>
+      expect(browserWindow.webContents.send).toHaveBeenCalledWith("enduragent:open-settings"),
+    );
+  });
+
+  it("does not send Settings after residency closes while the main window is opening", async () => {
+    const { residency, mainWindow, browserWindow } = setup();
+    const opening = deferred<typeof browserWindow>();
+    mainWindow.show.mockReturnValueOnce(opening.promise);
+    await residency.start();
+    mocks.FakeTray.instances[0]!.emit("click");
+    const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
+    (menu[2]!.click as () => void)();
+
+    await residency.close();
+    opening.resolve(browserWindow);
+    await opening.promise;
+
+    expect(browserWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it("reports Settings window failures without sending the navigation request", async () => {
+    const { residency, mainWindow, browserWindow, reportFailure } = setup();
+    mainWindow.show.mockRejectedValueOnce(new Error("private path"));
+    await residency.start();
+    mocks.FakeTray.instances[0]!.emit("click");
+    const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
+
+    (menu[2]!.click as () => void)();
+
+    await vi.waitFor(() => expect(reportFailure).toHaveBeenCalledWith("show-window"));
+    expect(browserWindow.webContents.send).not.toHaveBeenCalled();
   });
 
   it("keeps Open and Quit usable when reads fail and emits fixed failure tags only", async () => {
@@ -351,13 +361,13 @@ describe("desktop residency", () => {
     mocks.FakeTray.instances[0]!.emit("right-click");
     const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
     expect(menu[0]!.click).toBeTypeOf("function");
-    expect(menu[2]).toMatchObject({ checked: false, enabled: false });
-    expect(menu[4]!.click).toBeTypeOf("function");
+    expect(menu[3]).toMatchObject({ checked: false, enabled: false });
+    expect(menu[5]!.click).toBeTypeOf("function");
     expect(reportFailure).toHaveBeenCalledWith("read-login-item");
     expect(JSON.stringify(reportFailure.mock.calls)).not.toContain(secret.message);
     (menu[0]!.click as () => void)();
     await vi.waitFor(() => expect(mainWindow.show).toHaveBeenCalledOnce());
-    (menu[4]!.click as () => void)();
+    (menu[5]!.click as () => void)();
     expect(mocks.app.quit).toHaveBeenCalledOnce();
   });
 
@@ -372,7 +382,7 @@ describe("desktop residency", () => {
     });
     mocks.FakeTray.instances[0]!.emit("right-click");
     const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
-    (menu[2]!.click as (item: { checked: boolean }) => void)({ checked: true });
+    (menu[3]!.click as (item: { checked: boolean }) => void)({ checked: true });
     await vi.waitFor(() => expect(reportFailure).toHaveBeenCalledWith("set-login-item"));
     expect(persistLoginPreference.mock.calls).toEqual([[true], [false]]);
     expect(mocks.app.getLoginItemSettings).toHaveBeenCalled();
@@ -389,7 +399,7 @@ describe("desktop residency", () => {
       mocks.FakeTray.instances[0]!.emit("right-click");
       const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
 
-      (menu[2]!.click as (item: { checked: boolean }) => void)({ checked: true });
+      (menu[3]!.click as (item: { checked: boolean }) => void)({ checked: true });
 
       await vi.waitFor(() => expect(persistLoginPreference).toHaveBeenCalledWith(true));
       expect(mocks.app.setLoginItemSettings).not.toHaveBeenCalled();
@@ -397,7 +407,7 @@ describe("desktop residency", () => {
     },
   );
 
-  it("deduplicates quit and destroys popover before tray exactly once", async () => {
+  it("deduplicates quit and destroys the tray exactly once", async () => {
     const { residency } = setup();
     await residency.start();
     mocks.FakeTray.instances[0]!.emit("click");
@@ -407,9 +417,8 @@ describe("desktop residency", () => {
     const firstClose = residency.close();
     expect(residency.close()).toBe(firstClose);
     await firstClose;
-    expect(mocks.popover.close).toHaveBeenCalledOnce();
     expect(mocks.FakeTray.instances[0]!.destroy).toHaveBeenCalledOnce();
-    expect(mocks.order.slice(-2)).toEqual(["popover-destroy", "tray-destroy"]);
+    expect(mocks.order.at(-1)).toBe("tray-destroy");
     expect(mocks.app.setLoginItemSettings).not.toHaveBeenCalled();
   });
 
@@ -430,7 +439,7 @@ describe("desktop residency", () => {
     tray.emit("right-click");
     const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
 
-    (menu[2]!.click as (item: { checked: boolean }) => void)({ checked: true });
+    (menu[3]!.click as (item: { checked: boolean }) => void)({ checked: true });
     await vi.waitFor(() => expect(persistLoginPreference).toHaveBeenCalledWith(true));
 
     const close = residency.close();
@@ -441,11 +450,11 @@ describe("desktop residency", () => {
     await Promise.resolve();
 
     expect(settled).toBe(false);
-    expect(mocks.popover.close).toHaveBeenCalledOnce();
     expect(tray.destroy).toHaveBeenCalledOnce();
     (menu[0]!.click as () => void)();
-    (menu[2]!.click as (item: { checked: boolean }) => void)({ checked: false });
-    (menu[4]!.click as () => void)();
+    (menu[2]!.click as () => void)();
+    (menu[3]!.click as (item: { checked: boolean }) => void)({ checked: false });
+    (menu[5]!.click as () => void)();
     expect(mainWindow.show).not.toHaveBeenCalled();
     expect(persistLoginPreference).toHaveBeenCalledTimes(1);
     expect(mocks.app.quit).not.toHaveBeenCalled();
@@ -473,7 +482,7 @@ describe("desktop residency", () => {
     mocks.FakeTray.instances[0]!.emit("right-click");
     const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
 
-    (menu[2]!.click as (item: { checked: boolean }) => void)({ checked: true });
+    (menu[3]!.click as (item: { checked: boolean }) => void)({ checked: true });
     await vi.waitFor(() => expect(persistLoginPreference).toHaveBeenNthCalledWith(2, false));
 
     const close = residency.close();
@@ -516,7 +525,7 @@ describe("desktop residency", () => {
     mocks.FakeTray.instances[0]!.emit("right-click");
     const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
 
-    (menu[2]!.click as (item: { checked: boolean }) => void)({ checked: true });
+    (menu[3]!.click as (item: { checked: boolean }) => void)({ checked: true });
     await vi.waitFor(() => expect(reportFailure).toHaveBeenCalledWith("set-login-item"));
     await residency.close();
 
@@ -581,7 +590,7 @@ describe("desktop residency", () => {
       mocks.FakeTray.instances[0]!.emit("right-click");
       const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
 
-      (menu[2]!.click as (item: { checked: boolean }) => void)({ checked: true });
+      (menu[3]!.click as (item: { checked: boolean }) => void)({ checked: true });
       await vi.waitFor(() => expect(reportFailure).toHaveBeenCalledWith("set-login-item"));
       await residency.close();
 

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -486,6 +486,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "onChatgptLoginProgress",
       "onDroppedChatAttachments",
       "onDroppedImportFiles",
+      "onOpenSettings",
       "onPlanProgress",
       "onUpdateState",
       "pasteChatAttachment",


### PR DESCRIPTION
Replace the macOS tray status popup with the approved native menu: Open Enduragent, Settings…, Start in background at login, and Quit Enduragent, with the agreed separators. Both macOS tray clicks open that menu. Settings restores or creates the main window and selects the existing Settings view. Windows left-click restoration and login preference persistence keep their existing behavior.

The operator approved this menu in the task. The runtime no longer creates the custom popup or fetches Telegram status for it. Packaging assets are unchanged.

Validation:
- 112 focused tests passed for residency, the preload bridge, and existing popover compatibility.
- All 35 verification catalogue checks and the exact 13-test macOS integration batch passed after updating the bridge allowlists and renamed lifecycle test citation.
- Desktop and renderer TypeScript checks passed, including renderer tests and previews.
- Desktop dependencies and app build passed.
- Focused lint, formatting, fixture privacy, and changeset checks passed.
- Required isolated OpenAI Codex review passed with no actionable findings. Completed correction cycles: 1. The correction updates only test expectations and the catalogue citation; repeat review passed. All eight CI checks pass on commit 8882c371.
- The isolated running application launched; closing and restoring its main window and opening the existing Settings destination were exercised.

Native tray UI QA remains pending. The available UI automation cannot expose or click macOS menu-bar extras. Before merge, verify both tray clicks, menu dismissal, Open, Settings with the main window open and closed, checkbox state, and Quit in the running application.
