### PR TITLE
feat(coach): mirror Chat-owned Plans to the calendar

### DIFF
--- a/.changeset/plan-calendar-drain.md
+++ b/.changeset/plan-calendar-drain.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Mirror Chat-owned Plans to intervals.icu: activation, changes, and stops enqueue calendar work that runs in the background, and the Plan library reports its calendar state.
+
+User-facing: Workouts from a Plan you start or change in Chat now appear on your intervals.icu calendar for the coming week, and stopping a Plan removes the ones from tomorrow onward.

--- a/apps/desktop-renderer/tests/boot-plan-change.test.ts
+++ b/apps/desktop-renderer/tests/boot-plan-change.test.ts
@@ -160,6 +160,7 @@ function library(planId: string, pending = false): ListPlansResult {
       closeReason: null,
       closedAt: null,
       activatedAt: "1998-09-07",
+      calendar: { status: "pending", window: null, currentThrough: null, error: null },
       creationId: null,
     },
     closed: [],

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -74,6 +74,7 @@ const active: NonNullable<ListPlansResult["active"]> = {
   closeReason: null,
   closedAt: null,
   activatedAt: "1998-09-07",
+  calendar: { status: "pending", window: null, currentThrough: null, error: null },
   creationId: null,
 };
 const workout: PlanChangeWorkout = {

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -41,6 +41,7 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
       closeReason: null,
       closedAt: null,
       activatedAt: "1998-09-07",
+      calendar: { status: "pending", window: null, currentThrough: null, error: null },
       creationId: null,
     },
     creation: null,

--- a/apps/desktop-renderer/tests/plan-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-controller.test.ts
@@ -115,6 +115,7 @@ describe("Plan library refresh", () => {
           closeReason: "completed",
           closedAt: "1998-10-04",
           activatedAt: "1998-09-07",
+          calendar: { status: "pending", window: null, currentThrough: null, error: null },
           creationId: null,
         },
       ],

--- a/apps/desktop-renderer/tests/plan-final-details.test.tsx
+++ b/apps/desktop-renderer/tests/plan-final-details.test.tsx
@@ -36,6 +36,7 @@ function history(): NonNullable<PlanHistoryResult> {
       closeReason: "stopped",
       closedAt: "1998-09-14",
       activatedAt: "1998-09-07",
+      calendar: { status: "pending", window: null, currentThrough: null, error: null },
       creationId: "creation-closed",
     },
     closeActor: "fictional-device",

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -187,6 +187,7 @@ const active: NonNullable<ListPlansResult["active"]> = {
   closeReason: null,
   closedAt: null,
   activatedAt: "1998-09-07",
+  calendar: { status: "pending", window: null, currentThrough: null, error: null },
   creationId: null,
 };
 const closed: ListPlansResult["closed"] = [

--- a/apps/desktop/tests/helpers/plan-calendar-fake.ts
+++ b/apps/desktop/tests/helpers/plan-calendar-fake.ts
@@ -1,0 +1,95 @@
+import type {
+  PlanMirrorCalendarPort,
+  PlanMirrorCreateInput,
+  PlanMirrorEvent,
+  PlanMirrorUpdateInput,
+} from "@enduragent/engine";
+
+const eventContent = (structureJson: string) => {
+  const content: unknown = JSON.parse(structureJson);
+  if (content === null || typeof content !== "object" || Array.isArray(content))
+    throw new TypeError("Calendar Workout structure must be an object");
+  return {
+    description:
+      "description" in content && typeof content.description === "string"
+        ? content.description
+        : null,
+    workoutDoc:
+      "workoutDoc" in content &&
+      content.workoutDoc !== null &&
+      typeof content.workoutDoc === "object" &&
+      !Array.isArray(content.workoutDoc)
+        ? Object.fromEntries(Object.entries(content.workoutDoc))
+        : null,
+  };
+};
+
+class MemoryPlanCalendar implements PlanMirrorCalendarPort {
+  readonly events: PlanMirrorEvent[] = [];
+  readonly creates: PlanMirrorCreateInput[] = [];
+  readonly updates: PlanMirrorUpdateInput[] = [];
+  readonly deletes: number[] = [];
+  readonly lists: Array<{ readonly startDateKey: number; readonly endDateKey: number }> = [];
+  failNextList = false;
+  failNextCreate = false;
+  delayMs = 0;
+  nextEventId = 100;
+
+  async listEvents(input: { startDateKey: number; endDateKey: number }) {
+    this.lists.push(input);
+    await this.delay();
+    if (this.failNextList) {
+      this.failNextList = false;
+      throw new Error("unavailable");
+    }
+    return this.events.filter(
+      (event) => event.dateKey >= input.startDateKey && event.dateKey <= input.endDateKey,
+    );
+  }
+
+  async createEvent(input: PlanMirrorCreateInput) {
+    this.creates.push(input);
+    await this.delay();
+    if (this.failNextCreate) {
+      this.failNextCreate = false;
+      throw new Error("unavailable");
+    }
+    this.events.push({
+      id: this.nextEventId++,
+      dateKey: input.dateKey,
+      externalId: input.externalId,
+      name: input.name,
+      durationS: input.durationS,
+      ...eventContent(input.structureJson),
+    });
+  }
+
+  async updateEvent(input: PlanMirrorUpdateInput) {
+    this.updates.push(input);
+    await this.delay();
+    const index = this.events.findIndex((event) => event.id === input.eventId);
+    const event = this.events[index];
+    if (event === undefined) throw new Error("missing");
+    this.events[index] = {
+      ...event,
+      dateKey: input.dateKey,
+      name: input.name,
+      durationS: input.durationS,
+      ...eventContent(input.structureJson),
+    };
+  }
+
+  async deleteEvent(input: { eventId: number }) {
+    this.deletes.push(input.eventId);
+    await this.delay();
+    const index = this.events.findIndex((event) => event.id === input.eventId);
+    if (index < 0) throw new Error("missing");
+    this.events.splice(index, 1);
+  }
+
+  private async delay(): Promise<void> {
+    if (this.delayMs > 0) await new Promise<void>((resolve) => setTimeout(resolve, this.delayMs));
+  }
+}
+
+export const createMemoryPlanCalendar = () => new MemoryPlanCalendar();

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -20,6 +20,11 @@ import {
   createPlanCreationRepository,
   type PlanCreationRepository,
 } from "@enduragent/kernel/planning";
+import type { PlanMirrorCalendarPort } from "@enduragent/engine";
+import {
+  createPlanCalendarDrain,
+  type PlanCalendarDrain,
+} from "../../../../packages/coach/src/plan-calendar-drain.js";
 import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { inertWriterProtocolListener } from "@enduragent/kernel-node/lock";
@@ -130,6 +135,7 @@ export class PlanCreationBackend {
   private host: PlanCreationHost | undefined;
   private changes: PlanChangeOperations | undefined;
   private planning: PlanningOperations | undefined;
+  private calendarDrain: PlanCalendarDrain | undefined;
   planStateReadFails = false;
   planListReadFails = false;
   private sequence = 0;
@@ -144,6 +150,10 @@ export class PlanCreationBackend {
     private readonly databasePath: string,
     coexistence = false,
     readStoredPlans = false,
+    private readonly options: {
+      readonly calendar?: PlanMirrorCalendarPort;
+      readonly calendarConnected?: boolean;
+    } = {},
   ) {
     const base = coexistence ? createPlanInspectionFixtureScript() : createPlanQaFixtureScript();
     this.script = {
@@ -178,7 +188,11 @@ export class PlanCreationBackend {
           const config = JSON.parse(frames[0] ?? "null");
           return response({
             ...config,
-            intervals: { ...config.intervals, credential_configured: false },
+            intervals: {
+              ...config.intervals,
+              credential_configured:
+                this.options.calendarConnected ?? Boolean(this.options.calendar),
+            },
           });
         }
         if (
@@ -343,19 +357,69 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
       store: this.store,
       identity,
       crypto: globalThis.crypto,
-      todayDateKey: () => 19980101,
+      todayDateKey: () =>
+        this.options.calendar === undefined
+          ? 19980101
+          : Number(this.civilDate.replaceAll("-", "")),
       now: () => this.instant,
     });
+    const calendarConnected = () =>
+      this.options.calendarConnected ?? Boolean(this.options.calendar);
     this.host = createPlanCreationOperations({
       store: this.store,
       repository: this.repository,
       identity,
       crypto: globalThis.crypto,
       eventCandidates: { read: async () => [] },
+      calendarConnected,
       today: () => this.civilDate,
       todayDateKey: () => Number(this.civilDate.replaceAll("-", "")),
       now: () => Date.parse(`${this.civilDate}T00:00:00.000Z`),
     });
+    if (this.options.calendar !== undefined) {
+      const drain = createPlanCalendarDrain({
+        store: this.store,
+        calendar: this.options.calendar,
+        calendarConnected,
+        identity,
+        todayDateKey: () => Number(this.civilDate.replaceAll("-", "")),
+        now: () => this.instant,
+        logger: { warn: () => {} },
+      });
+      this.calendarDrain = drain;
+      const host = this.host;
+      this.host = {
+        ...host,
+        "plan_creation.activate": async (input) => {
+          const result = await host["plan_creation.activate"](input);
+          void drain.kick();
+          return result;
+        },
+        "plan.close": async (input) => {
+          const result = await host["plan.close"](input);
+          void drain.kick();
+          return result;
+        },
+        "plan.list": async (input) => {
+          const result = await host["plan.list"](input);
+          void drain.kick();
+          return result;
+        },
+      };
+      const changes = this.changes;
+      this.changes = {
+        ...changes,
+        "plan_change.apply": async (input) => {
+          const result = await changes["plan_change.apply"](input);
+          void drain.kick();
+          return result;
+        },
+      };
+    }
+  }
+
+  async calendarIdle(): Promise<void> {
+    await this.calendarDrain?.idle();
   }
 
   setCivilDate(date: string): void {
@@ -379,6 +443,8 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
   }
 
   async close(): Promise<void> {
+    await this.calendarIdle();
+    this.calendarDrain = undefined;
     await this.store?.close();
     this.store = undefined;
     this.repository = undefined;

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -94,6 +94,66 @@ export type GetPlanningReadModelRpcParams = z.infer<typeof GetPlanningReadModelR
 export const GetPlanningReadModelRpcResultSchema = PlanningReadModelSchema;
 export type GetPlanningReadModelRpcResult = z.infer<typeof GetPlanningReadModelRpcResultSchema>;
 
+const PlanCalendarWindowSchema = z
+  .object({ start: z.iso.date(), end: z.iso.date() })
+  .strict()
+  .nullable();
+
+const PlanCalendarBaseSchema = z
+  .object({
+    window: PlanCalendarWindowSchema,
+    currentThrough: z.iso.date().nullable(),
+    error: z.string().nullable(),
+  })
+  .strict();
+
+export const PlanCalendarStatusSchema = z
+  .discriminatedUnion("status", [
+    PlanCalendarBaseSchema.extend({ status: z.literal("not-connected"), error: z.null() }),
+    PlanCalendarBaseSchema.extend({ status: z.literal("pending"), error: z.null() }),
+    PlanCalendarBaseSchema.extend({ status: z.literal("running") }),
+    PlanCalendarBaseSchema.extend({ status: z.literal("verified"), currentThrough: z.iso.date() }),
+    PlanCalendarBaseSchema.extend({ status: z.literal("failed"), error: z.string() }),
+  ])
+  .superRefine((value, context) => {
+    if (value.status !== "failed" && value.error !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["error"],
+        message: "Only a failed calendar can have an error",
+      });
+    }
+    if (value.window !== null && value.window.start > value.window.end) {
+      context.addIssue({
+        code: "custom",
+        path: ["window", "end"],
+        message: "Window end must be on or after its start",
+      });
+    }
+    if (value.status === "verified") {
+      if (value.window === null) {
+        context.addIssue({
+          code: "custom",
+          path: ["window"],
+          message: "Verified calendar requires a window",
+        });
+      } else if (value.currentThrough !== value.window.end) {
+        context.addIssue({
+          code: "custom",
+          path: ["currentThrough"],
+          message: "Verified calendar must be current through the window end",
+        });
+      }
+    } else if (value.currentThrough !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["currentThrough"],
+        message: "Only a verified calendar can have a current-through date",
+      });
+    }
+  });
+export type PlanCalendarStatus = z.infer<typeof PlanCalendarStatusSchema>;
+
 export const PlanSummarySchema = z
   .object({
     planId: z.string().min(1),
@@ -107,6 +167,7 @@ export const PlanSummarySchema = z
     closedAt: z.iso.date().nullable(),
     activatedAt: z.iso.date().nullable(),
     creationId: z.string().min(1).nullable(),
+    calendar: PlanCalendarStatusSchema,
   })
   .strict();
 export type PlanSummary = z.infer<typeof PlanSummarySchema>;

--- a/packages/coach-contract/tests/planning-read-contract.test.ts
+++ b/packages/coach-contract/tests/planning-read-contract.test.ts
@@ -70,6 +70,7 @@ describe("Plan library contract", () => {
     closeReason: null,
     closedAt: null,
     activatedAt: "1998-12-20",
+    calendar: { status: "pending", window: null, currentThrough: null, error: null },
     version: 1,
     creationId: "creation-active",
   };
@@ -92,6 +93,7 @@ describe("Plan library contract", () => {
         closeReason,
         closedAt: "1999-01-18",
         activatedAt: null,
+        calendar: { status: "pending", window: null, currentThrough: null, error: null },
         creationId: null,
       };
       const library = { creation: null, active, closed: [closed], changes: [] };
@@ -100,6 +102,94 @@ describe("Plan library contract", () => {
       expect(ListPlansResultSchema.safeParse({ ...library, closed: [active] }).success).toBe(false);
     },
   );
+
+  it("accepts the calendar shape and enforces status requirements", () => {
+    const calendar = {
+      status: "verified",
+      window: { start: "1998-12-21", end: "1998-12-27" },
+      currentThrough: "1998-12-27",
+      error: null,
+    };
+    expect(PlanSummarySchema.parse({ ...active, calendar }).calendar).toEqual(calendar);
+    for (const invalid of [
+      { ...calendar, currentThrough: null },
+      { status: "verified", window: calendar.window, error: null },
+      { ...calendar, status: "unknown" },
+      { ...calendar, status: "failed", error: null },
+      { ...calendar, status: "pending", error: "failure" },
+      { ...calendar, status: "not-connected", error: "failure" },
+      { ...calendar, extra: true },
+      { ...calendar, window: { ...calendar.window, extra: true } },
+      { ...calendar, window: { start: "1998-02-30", end: "1998-12-27" } },
+    ])
+      expect(PlanSummarySchema.safeParse({ ...active, calendar: invalid }).success).toBe(false);
+    const { calendar: omitted, ...withoutCalendar } = active;
+    expect(omitted).toBeDefined();
+    expect(PlanSummarySchema.safeParse(withoutCalendar).success).toBe(false);
+  });
+
+  it.each([
+    [
+      "verified with an error",
+      {
+        status: "verified",
+        window: { start: "1998-12-21", end: "1998-12-27" },
+        currentThrough: "1998-12-27",
+        error: "Calendar sync failed. Retry available.",
+      },
+    ],
+    [
+      "running with an error",
+      {
+        status: "running",
+        window: { start: "1998-12-21", end: "1998-12-27" },
+        currentThrough: null,
+        error: "Calendar sync failed. Retry available.",
+      },
+    ],
+    [
+      "verified without a window",
+      { status: "verified", window: null, currentThrough: "1998-12-27", error: null },
+    ],
+    [
+      "current through beyond the window",
+      {
+        status: "verified",
+        window: { start: "1998-12-21", end: "1998-12-27" },
+        currentThrough: "1998-12-28",
+        error: null,
+      },
+    ],
+    [
+      "current through before the window end",
+      {
+        status: "verified",
+        window: { start: "1998-12-21", end: "1998-12-27" },
+        currentThrough: "1998-12-26",
+        error: null,
+      },
+    ],
+    [
+      "reversed window",
+      {
+        status: "pending",
+        window: { start: "1998-12-27", end: "1998-12-21" },
+        currentThrough: null,
+        error: null,
+      },
+    ],
+    ...["pending", "running", "failed", "not-connected"].map((status): [string, unknown] => [
+      `${status} with a current-through date`,
+      {
+        status,
+        window: { start: "1998-12-21", end: "1998-12-27" },
+        currentThrough: "1998-12-27",
+        error: status === "failed" ? "Calendar sync failed. Retry available." : null,
+      },
+    ]),
+  ])("rejects %s", (_name: string, calendar: unknown) => {
+    expect(PlanSummarySchema.safeParse({ ...active, calendar }).success).toBe(false);
+  });
 
   it.each([
     { start: 19981221 },
@@ -111,7 +201,6 @@ describe("Plan library contract", () => {
     { closeReason: "unknown" },
     { creationId: "" },
     { version: 0 },
-    { calendarStatus: "healthy" },
   ])("rejects invalid summary fields %j", (fields) => {
     expect(PlanSummarySchema.safeParse({ ...active, ...fields }).success).toBe(false);
   });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -1,3 +1,4 @@
+import { createPlanCalendarDrain } from "./plan-calendar-drain.js";
 import { randomBytes, randomUUID } from "node:crypto";
 import {
   chmodSync,
@@ -888,6 +889,7 @@ export async function createLocalCoachComposition(
     crypto: globalThis.crypto,
     eventCandidates: { read: async () => [] },
     baselineEvidence: { read: async () => undefined },
+    calendarConnected: () => approvedConfig().intervals.apiKey.length > 0,
     today: () => todayInTZ(planningTimezone, new Date(now())),
     todayDateKey: planningDateKey,
     now,
@@ -1735,6 +1737,9 @@ export async function createLocalCoachComposition(
       if (initialRefreshPromise !== undefined) return initialRefreshPromise;
       initialPlanCompletion ??= planLifecycle
         .completeExpired({ todayDateKey: planningDateKey(), nowMs: now() })
+        .then(() => {
+          if (!closing) void drain.kick();
+        })
         .catch((error: unknown) => {
           initialPlanCompletion = undefined;
           throw error;
@@ -1787,7 +1792,9 @@ export async function createLocalCoachComposition(
             );
           }),
         )
-        .then(() => undefined)
+        .then(() => {
+          if (!closing) void drain.kick();
+        })
         .finally(() => {
           if (ownerSucceeded && unapprovedConfig.intervals.apiKey.length > 0) {
             ensureSchedulerStarted();
@@ -2023,6 +2030,28 @@ export async function createLocalCoachComposition(
         ? null
         : makeChatClient({ apiKey: intervals.apiKey, athleteId: intervals.athleteId });
     });
+    const drain = createPlanCalendarDrain({
+      store: input.context.store,
+      calendar: planCalendar,
+      calendarConnected: () => approvedConfig().intervals.apiKey.length > 0,
+      identity: planningIdentity,
+      todayDateKey: planningDateKey,
+      now,
+      logger,
+    });
+    const runWindow = runtime.runWindow.bind(runtime);
+    runtime.runWindow = async () => {
+      const result = await runWindow();
+      if (!closing) void drain.kick();
+      return result;
+    };
+    const kickAfter =
+      <Params, Result>(operation: (params: Params) => Promise<Result>) =>
+      async (params: Params): Promise<Result> => {
+        const result = await operation(params);
+        if (!closing) void drain.kick();
+        return result;
+      };
     const readiness = {
       async read({
         plan,
@@ -2283,15 +2312,20 @@ export async function createLocalCoachComposition(
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
       ...planningRequestOperations,
-      "plan.list": planCreationOperations["plan.list"],
-      "plan.close": planCreationOperations["plan.close"],
+      "plan.list": async (params) => {
+        const result = await planCreationOperations["plan.list"](params);
+        if (!closing) void drain.kick();
+        return result;
+      },
+      "plan.close": kickAfter(planCreationOperations["plan.close"]),
       ...planChangeOperations,
+      "plan_change.apply": kickAfter(planChangeOperations["plan_change.apply"]),
       "plan.history": planCreationOperations["plan.history"],
       "plan_creation.start": planCreationOperations["plan_creation.start"],
       "plan_creation.answer": planCreationOperations["plan_creation.answer"],
       "plan_creation.preview": planCreationOperations["plan_creation.preview"],
       "plan_creation.discard": planCreationOperations["plan_creation.discard"],
-      "plan_creation.activate": planCreationOperations["plan_creation.activate"],
+      "plan_creation.activate": kickAfter(planCreationOperations["plan_creation.activate"]),
       ...planningOperations,
     } satisfies CoachOperations &
       PlanningReadOperations &
@@ -2323,6 +2357,7 @@ export async function createLocalCoachComposition(
           };
           await attempt(() => dependencies.closeHostAdapters?.());
           await attempt(() => reference!.scheduler.stop());
+          await attempt(() => drain.idle());
           await attempt(() => runtime!.close());
           await initialRefreshPromise?.catch(() => {});
           if (failure !== undefined) throw failure.error;

--- a/packages/coach/src/plan-calendar-drain.ts
+++ b/packages/coach/src/plan-calendar-drain.ts
@@ -1,0 +1,157 @@
+import {
+  cleanupPlanMirror,
+  reconcileActivePlanWindow,
+  verifyPlanMirror,
+  type PlanMirrorCalendarPort,
+} from "@enduragent/engine";
+import { addCivilDays, createPlanReconciliationRepository } from "@enduragent/kernel/planning";
+import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
+import { createLegacyPlanRepository } from "@enduragent/kernel-node/planning";
+
+export interface PlanCalendarDrain {
+  kick(): Promise<void>;
+  idle(): Promise<void>;
+}
+
+function hasTransactions(store: SqlStore): store is SqlStore & Pick<MigratorStore, "transaction"> {
+  return "transaction" in store && typeof store.transaction === "function";
+}
+
+export function createPlanCalendarDrain(deps: {
+  store: SqlStore;
+  calendar: PlanMirrorCalendarPort;
+  calendarConnected: () => boolean;
+  identity: { newUlid(): string };
+  todayDateKey: () => number;
+  now: () => number;
+  logger: { warn(event: string, fields?: Record<string, unknown>): void };
+}): PlanCalendarDrain {
+  let active: Promise<void> | undefined;
+  let rerun = false;
+
+  const run = async (): Promise<void> => {
+    const { store } = deps;
+    if (!hasTransactions(store))
+      throw new TypeError("Calendar reconciliation requires transactions.");
+    const repository = createPlanReconciliationRepository(store);
+    const plans = createLegacyPlanRepository(store);
+    const engine = {
+      repository,
+      calendar: deps.calendar,
+      identity: { newId: () => deps.identity.newUlid() },
+      now: deps.now,
+    };
+    const today = deps.todayDateKey();
+    const activePlan = await store.get("SELECT plan_id FROM planning_plan WHERE status='active'");
+    if (typeof activePlan?.plan_id === "string") {
+      const existing = await store.get(
+        "SELECT id FROM plan_reconciliation_job WHERE plan_id=? AND kind='mirror' AND window_start_date_key=?",
+        [activePlan.plan_id, today],
+      );
+      if (existing === undefined) {
+        await repository.createOrGetJob({
+          id: deps.identity.newUlid(),
+          planId: activePlan.plan_id,
+          kind: "mirror",
+          windowStartDateKey: today,
+          windowEndDateKey: addCivilDays(today, 6),
+          createdAtMs: deps.now(),
+        });
+      }
+    }
+    const jobs = await repository.listRunnable({
+      nowMs: deps.now(),
+      leaseMs: 300_000,
+      maxFailures: 5,
+    });
+    for (const job of jobs) {
+      try {
+        if (job.kind === "cleanup") {
+          await cleanupPlanMirror(
+            {
+              planId: job.planId,
+              todayDateKey: today,
+              startDateKey: job.windowStartDateKey,
+              endDateKey: job.windowEndDateKey,
+            },
+            engine,
+          );
+          continue;
+        }
+        const target = await store.get(
+          "SELECT status, version FROM planning_plan WHERE plan_id=?",
+          [job.planId],
+        );
+        if (target?.status !== "active" || job.windowStartDateKey > today) continue;
+        if (job.windowStartDateKey < today) {
+          if ((await repository.readItems(job.id)).length > 0) {
+            await verifyPlanMirror(job, engine);
+          } else {
+            await repository.beginAttempt(job.id, deps.now());
+            await repository.verifyJob(job.id, deps.now());
+          }
+          continue;
+        }
+        const plan = await plans.read(job.planId);
+        if (plan === undefined || plan.status !== "active") continue;
+        const tomorrow = addCivilDays(today, 1);
+        const cleanup = await store.get(
+          "SELECT id FROM plan_reconciliation_job WHERE kind='cleanup' AND plan_id<>? AND window_start_date_key=? LIMIT 1",
+          [job.planId, tomorrow],
+        );
+        await reconcileActivePlanWindow(
+          {
+            plan,
+            workouts: await plans.readWorkouts(job.planId),
+            todayDateKey: today,
+            firstEligibleDateKey: cleanup === undefined ? today : tomorrow,
+          },
+          engine,
+        );
+        const current = await store.get("SELECT version FROM planning_plan WHERE plan_id=?", [
+          job.planId,
+        ]);
+        if (current?.version !== target.version) {
+          await repository.reopenJob(job.id, deps.now());
+          rerun = true;
+        }
+      } catch (error) {
+        deps.logger.warn("plan_calendar_drain_failed", { jobId: job.id, kind: job.kind, error });
+        const current = await repository.readJob(job.id);
+        if (current?.status === "running" || current?.status === "retrying") {
+          await repository.failJob(job.id, "calendar-verification-failed", deps.now());
+        }
+      }
+    }
+  };
+
+  return {
+    kick() {
+      if (!deps.calendarConnected()) return Promise.resolve();
+      if (active !== undefined) {
+        rerun = true;
+        return Promise.resolve();
+      }
+      rerun = false;
+      active = Promise.resolve().then(async () => {
+        try {
+          for (;;) {
+            try {
+              await run();
+            } catch (error) {
+              deps.logger.warn("plan_calendar_drain_failed", { error });
+            }
+            if (!rerun || !deps.calendarConnected()) break;
+            rerun = false;
+          }
+        } finally {
+          active = undefined;
+        }
+      });
+      return active;
+    },
+    async idle() {
+      while (active !== undefined) await active;
+    },
+  };
+}

--- a/packages/coach/src/plan-change-operations.ts
+++ b/packages/coach/src/plan-change-operations.ts
@@ -112,6 +112,8 @@ export function createPlanChangeOperations(input: {
         expectedVersion: parsed.expectedVersion,
         decision: parsed.decision,
         nowMs: input.now(),
+        todayDateKey: input.todayDateKey(),
+        mirrorJobId: input.identity.newUlid(),
         materialize(snapshotJson, currentWorkouts, diffIds) {
           const draft = PlanCreationDraftSchema.parse(JSON.parse(snapshotJson));
           const currentByDraftId = new Map(

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -5,6 +5,7 @@ import {
   PlanCloseResultSchema,
   PlanHistoryParamsSchema,
   PlanHistoryResultSchema,
+  type PlanCalendarStatus,
   type PlanCloseRpcParams,
   type PlanCloseResult,
   type PlanHistoryParams,
@@ -33,6 +34,7 @@ import {
   addCivilDays,
   createPlanChangeRepository,
   createPlanLifecycleRepository,
+  createPlanReconciliationRepository,
   createPlanRepository,
   dateKeyFromText,
   inclusiveCivilDays,
@@ -42,6 +44,7 @@ import {
   type PlanCreationRepository,
   type PlanCreationSnapshot,
   type PlanSummaryRecord,
+  type PlanReconciliationJobRecord,
 } from "@enduragent/kernel/planning";
 import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
@@ -98,6 +101,7 @@ export function createPlanCreationOperations(input: {
   crypto: Crypto;
   eventCandidates: GoalEventCandidateSource;
   baselineEvidence?: BaselineEvidenceSource;
+  calendarConnected?: () => boolean;
   today?: () => string;
   todayDateKey?: () => number;
   now?: () => number;
@@ -110,6 +114,7 @@ export function createPlanCreationOperations(input: {
   const today = input.today ?? (() => new Date().toISOString().slice(0, 10));
   const todayDateKey = input.todayDateKey ?? (() => dateKeyFromText(today()));
   const now = input.now ?? Date.now;
+  const calendarConnected = input.calendarConnected ?? (() => false);
   const stamp = async (commandId: string, digest: string) => {
     const clock = input.identity.hlcStamp();
     return {
@@ -176,6 +181,39 @@ export function createPlanCreationOperations(input: {
   };
   const timestampDate = (value: number | null): string | null =>
     value === null ? null : new Date(value).toISOString().slice(0, 10);
+  const summarizeCalendar = (job: PlanReconciliationJobRecord | undefined): PlanCalendarStatus => {
+    const window =
+      job === undefined
+        ? null
+        : {
+            start: dateText(job.windowStartDateKey),
+            end: dateText(job.windowEndDateKey),
+          };
+    if (job?.status === "verified") {
+      return {
+        status: "verified",
+        window,
+        currentThrough: dateText(job.windowEndDateKey),
+        error: null,
+      };
+    }
+    if (!calendarConnected()) {
+      return { status: "not-connected", window, currentThrough: null, error: null };
+    }
+    if (job === undefined || job.status === "pending") {
+      return { status: "pending", window, currentThrough: null, error: null };
+    }
+    if (job.status === "failed") {
+      const error = job.kind === "mirror" ? "Calendar sync failed." : "Calendar cleanup failed.";
+      return {
+        status: "failed",
+        window,
+        currentThrough: null,
+        error: job.failureCount >= 5 ? error : `${error} Retry available.`,
+      };
+    }
+    return { status: "running", window, currentThrough: null, error: null };
+  };
   const summarizePlan = (plan: PlanSummaryRecord) => ({
     planId: plan.planId,
     version: plan.version,
@@ -218,7 +256,18 @@ export function createPlanCreationOperations(input: {
         });
         const creation = await input.repository.readUnfinished();
         const records = await plans.listPlans();
-        const summaries = records.map(summarizePlan);
+        const reconciliation = createPlanReconciliationRepository(transactionStore);
+        const summaries = await Promise.all(
+          records.map(async (plan) => ({
+            ...summarizePlan(plan),
+            calendar: summarizeCalendar(
+              await reconciliation.readLatestJobByWindow(
+                plan.planId,
+                plan.status === "active" ? "mirror" : "cleanup",
+              ),
+            ),
+          })),
+        );
         const active = summaries.find((plan) => plan.status === "active") ?? null;
         return ListPlansResultSchema.parse({
           creation:
@@ -250,15 +299,34 @@ export function createPlanCreationOperations(input: {
     },
     async "plan.history"(request) {
       const parsed = PlanHistoryParamsSchema.parse(request);
-      const detail = await lifecycle.readClosedDetail(parsed.planId);
-      return PlanHistoryResultSchema.parse(
-        detail === null
-          ? null
-          : {
-              ...detail,
-              plan: summarizePlan(detail.plan),
-            },
-      );
+      return input.store.transaction(async () => {
+        const transactionStore = {
+          exec: (sql: string) => input.store.exec(sql),
+          get: input.store.get.bind(input.store),
+          all: input.store.all.bind(input.store),
+          run: input.store.run.bind(input.store),
+          close: () => input.store.close(),
+          transaction: async <T>(run: () => Promise<T>): Promise<T> => run(),
+        };
+        const detail = await createPlanLifecycleRepository(transactionStore, {
+          newId: () => input.identity.newUlid(),
+        }).readClosedDetail(parsed.planId);
+        return PlanHistoryResultSchema.parse(
+          detail === null
+            ? null
+            : {
+                ...detail,
+                plan: {
+                  ...summarizePlan(detail.plan),
+                  calendar: summarizeCalendar(
+                    await createPlanReconciliationRepository(
+                      transactionStore,
+                    ).readLatestJobByWindow(detail.plan.planId, "cleanup"),
+                  ),
+                },
+              },
+        );
+      });
     },
     async "plan_creation.start"(request) {
       const parsed = PlanCreationStartRpcParamsSchema.parse(request);
@@ -456,6 +524,9 @@ export function createPlanCreationOperations(input: {
         creationId: parsed.creationId,
         expectedVersion: parsed.expectedVersion,
         activatedAt: today(),
+        todayDateKey: todayDateKey(),
+        mirrorJobId: input.identity.newUlid(),
+        cleanupJobId: input.identity.newUlid(),
         revisionId: input.identity.newUlid(),
         materialize(snapshot) {
           if (snapshot.currentDraft === null || resolvePlanCreationDraftAnswers(snapshot) === null)

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1,3 +1,4 @@
+import * as calendarDrain from "../src/plan-calendar-drain.js";
 import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { existsSync, unlinkSync } from "node:fs";
@@ -528,6 +529,67 @@ afterEach(async () => {
 });
 
 describe("local coach composition", () => {
+  it("kicks after startup and successful refreshes and waits for calendar idle before closing", async () => {
+    const home = await freshHome();
+    let release: () => void = () => {};
+    const completion = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const kick = vi.fn(() => completion);
+    const idle = vi.fn(() => completion);
+    vi.spyOn(calendarDrain, "createPlanCalendarDrain").mockReturnValue({ kick, idle });
+    const storeRuntime = runtime();
+    const close = vi.spyOn(storeRuntime, "close");
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => storeRuntime,
+      createBackend: () => backend(),
+      createResolver: missingResolver,
+    });
+
+    await lifecycle.startInitialRefresh();
+    expect(kick).toHaveBeenCalledTimes(1);
+    await storeRuntime.runWindow();
+    expect(kick).toHaveBeenCalledTimes(2);
+    expect(kick.mock.calls).toEqual([[], []]);
+    const list = lifecycle.operations["plan.list"];
+    if (list === undefined) throw new Error("Expected plan.list");
+    await list({});
+    expect(kick).toHaveBeenLastCalledWith();
+    expect(kick).toHaveBeenCalledTimes(3);
+    await storeRuntime.runWindow();
+    expect(kick).toHaveBeenLastCalledWith();
+    expect(kick).toHaveBeenCalledTimes(4);
+    const closing = lifecycle.close();
+    await vi.waitFor(() => expect(idle).toHaveBeenCalledOnce());
+    expect(close).not.toHaveBeenCalled();
+    release();
+    await closing;
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("builds and completes startup without a calendar connection or stored rows", async () => {
+    const home = await freshHome();
+    const context = fakeContext(home);
+    const get = vi.spyOn(context.store, "get");
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createResolver: missingResolver,
+      },
+      context,
+      { apiKey: "", athleteId: "0" },
+    );
+
+    await expect(lifecycle.startInitialRefresh()).resolves.toBeUndefined();
+    expect(get).toHaveBeenCalled();
+    expect(get.mock.results.every((result) => result.type === "return")).toBe(true);
+    await expect(lifecycle.close()).resolves.toBeUndefined();
+  });
+
   it("uses trusted channel identity to require Telegram confirmation without changing Desktop execution", async () => {
     const home = await freshHome();
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);

--- a/packages/coach/tests/plan-calendar-drain.test.ts
+++ b/packages/coach/tests/plan-calendar-drain.test.ts
@@ -1,0 +1,819 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { PlanCreationDraftSchema, type PlanCreationAnswerInput } from "@enduragent/coach-contract";
+import { planMirrorExternalId } from "@enduragent/engine";
+import {
+  addCivilDays,
+  createPlanCreationRepository,
+  createPlanChangeRepository,
+  createPlanReconciliationRepository,
+  createPlanRepository,
+} from "@enduragent/kernel/planning";
+import { runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createMemoryPlanCalendar } from "../../../apps/desktop/tests/helpers/plan-calendar-fake.js";
+import { createPlanCalendarDrain } from "../src/plan-calendar-drain.js";
+import { createPlanChangeOperations } from "../src/plan-change-operations.js";
+import { createPlanCreationOperations } from "../src/plan-creation-operations.js";
+
+async function harness() {
+  const store = openSqliteStorage(":memory:");
+  await runMigrations(store, MIGRATIONS);
+  let sequence = 100;
+  let today = 19980902;
+  let connected = true;
+  const calendar = createMemoryPlanCalendar();
+  const logger = { warn: vi.fn() };
+  const identity = {
+    deviceId: async () => "calendar-drain-test-device",
+    newUlid: () => String(++sequence).padStart(26, "0"),
+    hlcStamp: () => ({ physicalMs: 904_694_400_000, counter: sequence }),
+  };
+  const dependencies = {
+    store,
+    identity,
+    crypto: globalThis.crypto,
+    todayDateKey: () => today,
+    now: () => 904_694_400_000,
+    calendarConnected: () => connected,
+  };
+  const creation = createPlanCreationOperations({
+    ...dependencies,
+    repository: createPlanCreationRepository(store),
+    eventCandidates: { read: async () => [] },
+    today: () => String(today).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3"),
+  });
+  const changes = createPlanChangeOperations(dependencies);
+  const drain = createPlanCalendarDrain({ ...dependencies, calendar, logger });
+  onTestFinished(async () => {
+    await drain.idle();
+    await store.close();
+  });
+  const reconciliation = createPlanReconciliationRepository(store);
+  const plans = createPlanRepository(store);
+  const activate = async () => {
+    const start = await creation["plan_creation.start"]({ commandId: `start-${++sequence}` });
+    if (start.status !== "started") throw new Error("Expected creation");
+    let card = start.planCreation;
+    const answers: PlanCreationAnswerInput[] = [
+      { kind: "goal", goal: { kind: "fitness" } },
+      { kind: "plan-length", weeks: 4 },
+      { kind: "schedule-mode", mode: "fixed" },
+      {
+        kind: "availability",
+        mode: "fixed",
+        weeklyHoursLimit: 8,
+        longestWorkoutHours: 3,
+        usableWeekdays: [1, 2, 3, 4, 5, 6, 7],
+      },
+      { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
+      { kind: "commitments", commitments: { kind: "none" } },
+      { kind: "baseline", baseline: "regular" },
+      { kind: "success", success: { kind: "fitness-choice", choice: "climb-stronger" } },
+      { kind: "restriction", restriction: { kind: "none" } },
+    ];
+    for (const answer of answers) {
+      const result = await creation["plan_creation.answer"]({
+        commandId: `answer-${++sequence}`,
+        creationId: card.creationId,
+        expectedVersion: card.version,
+        answer,
+      });
+      if (result.status !== "answered") throw new Error("Expected answer");
+      card = result.planCreation;
+    }
+    const preview = await creation["plan_creation.preview"]({
+      commandId: `preview-${++sequence}`,
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    });
+    if (preview.status !== "previewed" || preview.planCreation.draft === null)
+      throw new Error("Expected Draft");
+    const result = await creation["plan_creation.activate"]({
+      commandId: `activate-${++sequence}`,
+      creationId: card.creationId,
+      expectedVersion: preview.planCreation.version,
+    });
+    return { ...result, draft: preview.planCreation.draft };
+  };
+  const previewWorkoutChange = async (
+    planId: string,
+    workoutId: string,
+    patch: { date?: string; name?: string },
+  ) => {
+    const plan = (await plans.listPlans()).find((row) => row.planId === planId);
+    if (plan === undefined) throw new Error("Expected Plan");
+    const workout = (await plans.readWorkouts(planId)).find((row) => row.id === workoutId);
+    if (workout === undefined) throw new Error("Expected Workout");
+    const structure: unknown = JSON.parse(workout.structureJson);
+    if (
+      structure === null ||
+      typeof structure !== "object" ||
+      !("id" in structure) ||
+      typeof structure.id !== "string"
+    )
+      throw new Error("Expected Draft Workout id");
+    const draftWorkoutId = structure.id;
+    const repository = createPlanChangeRepository(store, {
+      newId: () => identity.newUlid(),
+      sha256: (text) => createHash("sha256").update(text).digest("hex"),
+    });
+    const preview = await repository.preview({
+      command: {
+        commandId: `workout-preview-${++sequence}`,
+        requestDigest: "a".repeat(64),
+        nowMs: 904_694_400_000,
+        deviceId: "calendar-drain-test-device",
+        hlcPhysicalMs: 904_694_400_000,
+        hlcCounter: sequence,
+      },
+      planId,
+      expectedVersion: plan.version,
+      nowMs: 904_694_400_000,
+      changeId: identity.newUlid(),
+      build(snapshotJson) {
+        const snapshot = PlanCreationDraftSchema.parse(JSON.parse(snapshotJson));
+        const before = snapshot.weeks
+          .flatMap((week) => week.workouts)
+          .find((row) => row.id === draftWorkoutId);
+        if (before === undefined) throw new Error("Expected Workout");
+        const after = { ...before, ...patch };
+        const weeks = snapshot.weeks.map((week) => ({
+          number: week.number,
+          minutes: week.workouts.reduce((sum, row) => sum + row.minutes, 0),
+        }));
+        const totals = { plan: weeks.reduce((sum, week) => sum + week.minutes, 0), weeks };
+        for (const week of snapshot.weeks) {
+          week.workouts = week.workouts.map((row) => (row.id === draftWorkoutId ? after : row));
+        }
+        const intent: Record<string, string | null> =
+          patch.date === undefined
+            ? { kind: "rename", name: after.name }
+            : { kind: "move", date: after.date };
+        return {
+          afterSnapshotJson: JSON.stringify(snapshot),
+          envelope: {
+            title: "Update Workout",
+            intent,
+            diff: [{ workoutId: draftWorkoutId, before, after }],
+            totals: { before: totals, after: totals },
+            supersedes: null,
+            premises: [],
+            confidence: "Confirmed update",
+          },
+        };
+      },
+    });
+    if (preview.status !== "previewed") throw new Error("Expected Change");
+    return async () => {
+      expect(
+        await changes["plan_change.apply"]({
+          commandId: `workout-apply-${++sequence}`,
+          planId,
+          changeId: preview.change.changeId,
+          expectedVersion: plan.version,
+          decision: "apply",
+        }),
+      ).toMatchObject({ status: "applied" });
+    };
+  };
+  return {
+    store,
+    creation,
+    changes,
+    drain,
+    calendar,
+    logger,
+    identity,
+    reconciliation,
+    plans,
+    activate,
+    previewWorkoutChange,
+    today: () => today,
+    advanceDay: () => {
+      today = addCivilDays(today, 1);
+    },
+    disconnect: () => {
+      connected = false;
+    },
+  };
+}
+
+describe("Plan calendar drain", () => {
+  it("mirrors and verifies the seven-day window after activation", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    const pending = await test.reconciliation.readLatestJob(planId, "mirror");
+    expect(pending).toMatchObject({
+      status: "pending",
+      windowStartDateKey: 19980902,
+      windowEndDateKey: 19980908,
+    });
+    expect(test.calendar.events).toEqual([]);
+    await test.drain.kick();
+    const selected = (await test.plans.readWorkouts(planId)).filter(
+      (workout) =>
+        workout.dateKey >= test.today() && workout.dateKey <= addCivilDays(test.today(), 6),
+    );
+    expect(selected.length).toBeGreaterThan(0);
+    expect(test.calendar.events.map((event) => event.externalId).sort()).toEqual(
+      selected.map((workout) => planMirrorExternalId(planId, workout.id)).sort(),
+    );
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      id: pending?.id,
+      status: "verified",
+      attemptCount: 1,
+    });
+    expect(
+      test.calendar.lists.every(
+        (window) => window.startDateKey >= 19980902 && window.endDateKey <= 19980908,
+      ),
+    ).toBe(true);
+    expect(test.logger.warn).not.toHaveBeenCalled();
+    await expect(test.drain.idle()).resolves.toBeUndefined();
+  });
+
+  it("replaces an incumbent from tomorrow while retaining its event today", async () => {
+    const test = await harness();
+    const incumbent = await test.activate();
+    await test.drain.kick();
+    const oldToday = test.calendar.events.filter((event) => event.dateKey === test.today());
+    expect(oldToday.length).toBeGreaterThan(0);
+    const replacement = await test.activate();
+    expect(replacement.closedPlanId).toBe(incumbent.planId);
+    expect(await test.reconciliation.readLatestJob(incumbent.planId, "cleanup")).toMatchObject({
+      status: "pending",
+      windowStartDateKey: addCivilDays(test.today(), 1),
+      windowEndDateKey: Number(incumbent.draft.end.replaceAll("-", "")),
+    });
+    const newWorkouts = await test.plans.readWorkouts(replacement.planId);
+    expect(newWorkouts.some((workout) => workout.dateKey === test.today())).toBe(true);
+    await test.drain.kick();
+    expect(test.calendar.events.filter((event) => event.dateKey === test.today())).toEqual(
+      oldToday,
+    );
+    const expected = newWorkouts.filter(
+      (workout) =>
+        workout.dateKey > test.today() && workout.dateKey <= addCivilDays(test.today(), 6),
+    );
+    expect(
+      test.calendar.events
+        .filter((event) => event.dateKey > test.today())
+        .map((event) => event.externalId)
+        .sort(),
+    ).toEqual(
+      expected.map((workout) => planMirrorExternalId(replacement.planId, workout.id)).sort(),
+    );
+    expect(await test.reconciliation.readLatestJob(replacement.planId, "mirror")).toMatchObject({
+      status: "verified",
+    });
+    expect(await test.reconciliation.readLatestJob(incumbent.planId, "cleanup")).toMatchObject({
+      status: "verified",
+    });
+  });
+
+  it("keeps today with the incumbent after verified cleanup and a same-day Change", async () => {
+    const test = await harness();
+    const incumbent = await test.activate();
+    await test.drain.kick();
+    const oldToday = structuredClone(
+      test.calendar.events.filter((event) => event.dateKey === test.today()),
+    );
+    expect(oldToday.length).toBeGreaterThan(0);
+    const replacement = await test.activate();
+    await test.drain.kick();
+    expect(await test.reconciliation.readLatestJob(incumbent.planId, "cleanup")).toMatchObject({
+      status: "verified",
+    });
+    const preview = await test.changes["plan_change.preview"]({
+      commandId: "change-after-cleanup",
+      planId: replacement.planId,
+      expectedVersion: 1,
+      intent: { kind: "longest-workout", minutes: 30 },
+    });
+    if (preview.status !== "previewed") throw new Error("Expected Change");
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "apply-after-cleanup",
+        planId: replacement.planId,
+        changeId: preview.change.changeId,
+        expectedVersion: 1,
+        decision: "apply",
+      }),
+    ).toMatchObject({ status: "applied" });
+    await test.drain.kick();
+    expect(test.calendar.events.filter((event) => event.dateKey === test.today())).toEqual(
+      oldToday,
+    );
+    const expected = (await test.plans.readWorkouts(replacement.planId)).filter(
+      (workout) =>
+        workout.dateKey > test.today() && workout.dateKey <= addCivilDays(test.today(), 6),
+    );
+    expect(
+      test.calendar.events
+        .filter((event) => event.dateKey > test.today())
+        .map((event) => event.externalId)
+        .sort(),
+    ).toEqual(
+      expected.map((workout) => planMirrorExternalId(replacement.planId, workout.id)).sort(),
+    );
+    expect(await test.reconciliation.readLatestJob(replacement.planId, "mirror")).toMatchObject({
+      status: "verified",
+      attemptCount: 2,
+    });
+    expect(test.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps exhausted jobs outside the retry budget on every kick", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    for (let attempt = 0; attempt < 5; attempt++) {
+      test.calendar.failNextList = true;
+      await test.drain.kick();
+    }
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      status: "failed",
+      failureCount: 5,
+      attemptCount: 5,
+    });
+    const listCount = test.calendar.lists.length;
+    await test.drain.kick();
+    expect(test.calendar.lists).toHaveLength(listCount);
+    await test.drain.kick();
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      status: "failed",
+      failureCount: 5,
+      attemptCount: 5,
+    });
+    expect(test.calendar.lists).toHaveLength(listCount);
+    expect(test.calendar.events).toEqual([]);
+  });
+
+  it("deletes a moved Workout's old event and verifies the rest after a Change outside the horizon", async () => {
+    const test = await harness();
+    const { planId, draft } = await test.activate();
+    await test.drain.kick();
+    const original = await test.reconciliation.readLatestJob(planId, "mirror");
+    const workout = (await test.plans.readWorkouts(planId)).find(
+      (row) => row.dateKey === test.today(),
+    );
+    if (workout === undefined || original === undefined)
+      throw new Error("Expected mirrored Workout");
+    const oldEvent = test.calendar.events.find(
+      (event) => event.externalId === planMirrorExternalId(planId, workout.id),
+    );
+    if (oldEvent === undefined) throw new Error("Expected old event");
+    const before = draft.weeks
+      .flatMap((week) => week.workouts)
+      .find((row) => row.date === "1998-09-02");
+    if (before === undefined) throw new Error("Expected Draft Workout");
+    const after = { ...before, date: "1998-09-09" };
+    const repository = createPlanChangeRepository(test.store, {
+      newId: () => test.identity.newUlid(),
+      sha256: (text) => createHash("sha256").update(text).digest("hex"),
+    });
+    const weeks = draft.weeks.map((week) => ({
+      number: week.number,
+      minutes: week.workouts.reduce((sum, row) => sum + row.minutes, 0),
+    }));
+    const totals = { plan: weeks.reduce((sum, week) => sum + week.minutes, 0), weeks };
+    const preview = await repository.preview({
+      command: {
+        commandId: "move-preview",
+        requestDigest: "a".repeat(64),
+        nowMs: 904_694_400_000,
+        deviceId: "calendar-drain-test-device",
+        hlcPhysicalMs: 904_694_400_000,
+        hlcCounter: 1,
+      },
+      planId,
+      expectedVersion: 1,
+      nowMs: 904_694_400_000,
+      changeId: test.identity.newUlid(),
+      build(snapshotJson) {
+        const snapshot = PlanCreationDraftSchema.parse(JSON.parse(snapshotJson));
+        for (const week of snapshot.weeks) {
+          week.workouts = week.workouts.map((row) => (row.id === before.id ? after : row));
+        }
+        return {
+          afterSnapshotJson: JSON.stringify(snapshot),
+          envelope: {
+            title: "Move Workout",
+            intent: { kind: "move", date: after.date },
+            diff: [{ workoutId: before.id, before, after }],
+            totals: { before: totals, after: totals },
+            supersedes: null,
+            premises: [],
+            confidence: "Confirmed move",
+          },
+        };
+      },
+    });
+    if (preview.status !== "previewed") throw new Error("Expected Change");
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "move-apply",
+        planId,
+        changeId: preview.change.changeId,
+        expectedVersion: 1,
+        decision: "apply",
+      }),
+    ).toMatchObject({ status: "applied" });
+    expect(
+      (await test.plans.readWorkouts(planId)).find((row) => row.id === workout.id)?.dateKey,
+    ).toBe(19980909);
+    expect(
+      (await test.reconciliation.readItems(original.id)).some(
+        (item) => item.operation === "create" && item.planWorkoutId === workout.id,
+      ),
+    ).toBe(false);
+    await test.drain.kick();
+    expect(test.calendar.deletes).toEqual([oldEvent.id]);
+    const remaining = (await test.plans.readWorkouts(planId)).filter(
+      (row) => row.dateKey >= test.today() && row.dateKey <= addCivilDays(test.today(), 6),
+    );
+    expect(test.calendar.events.map((event) => event.externalId).sort()).toEqual(
+      remaining.map((row) => planMirrorExternalId(planId, row.id)).sort(),
+    );
+    expect(await test.reconciliation.readJob(original.id)).toMatchObject({
+      status: "verified",
+      attemptCount: 2,
+    });
+    expect(test.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the restored event after a Workout moves outside and back inside the window", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    await test.drain.kick();
+    const workout = (await test.plans.readWorkouts(planId)).find(
+      (row) => row.dateKey === test.today(),
+    );
+    const job = await test.reconciliation.readLatestJob(planId, "mirror");
+    if (workout === undefined || job === undefined) throw new Error("Expected mirrored Workout");
+    const event = test.calendar.events.find(
+      (row) => row.externalId === planMirrorExternalId(planId, workout.id),
+    );
+    if (event === undefined) throw new Error("Expected event");
+    await (
+      await test.previewWorkoutChange(planId, workout.id, { date: "1998-09-09" })
+    )();
+    vi.spyOn(test.calendar, "deleteEvent").mockRejectedValueOnce(new Error("unavailable"));
+    await test.drain.kick();
+    expect(await test.reconciliation.readJob(job.id)).toMatchObject({
+      status: "failed",
+      failureCount: 1,
+    });
+    expect(
+      (await test.reconciliation.readItems(job.id)).some((item) => item.operation === "delete"),
+    ).toBe(true);
+    await (
+      await test.previewWorkoutChange(planId, workout.id, { date: "1998-09-02" })
+    )();
+    expect(
+      (await test.reconciliation.readItems(job.id)).some((item) => item.operation === "delete"),
+    ).toBe(false);
+    await test.drain.kick();
+    expect(test.calendar.events).toContainEqual(event);
+    expect(test.calendar.deleteEvent).toHaveBeenCalledTimes(1);
+    expect(await test.reconciliation.readJob(job.id)).toMatchObject({
+      status: "verified",
+      attemptCount: 3,
+    });
+    expect(test.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("retires a retained create moved to excluded today and removes its old event", async () => {
+    const test = await harness();
+    await test.activate();
+    await test.drain.kick();
+    const { planId } = await test.activate();
+    await test.drain.kick();
+    const workout = (await test.plans.readWorkouts(planId)).find(
+      (row) => row.dateKey > test.today() && row.dateKey <= addCivilDays(test.today(), 6),
+    );
+    const job = await test.reconciliation.readLatestJob(planId, "mirror");
+    if (workout === undefined || job === undefined) throw new Error("Expected mirrored Workout");
+    const externalId = planMirrorExternalId(planId, workout.id);
+    expect(test.calendar.events.some((row) => row.externalId === externalId)).toBe(true);
+    await (
+      await test.previewWorkoutChange(planId, workout.id, { date: "1998-09-02" })
+    )();
+    await test.drain.kick();
+    expect(await test.reconciliation.readJob(job.id)).toMatchObject({
+      status: "verified",
+      failureCount: 0,
+    });
+    expect(test.calendar.events.some((row) => row.externalId === externalId)).toBe(false);
+    expect(
+      (await test.reconciliation.readItems(job.id)).filter(
+        (item) => item.externalId === externalId && item.operation === "create",
+      ),
+    ).toEqual([]);
+    expect(test.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it.each(["before-attempt", "during-list"])(
+    "reruns a mirror when a Change commits after its Workout snapshot: %s",
+    async (timing) => {
+      const test = await harness();
+      const { planId } = await test.activate();
+      const workout = (await test.plans.readWorkouts(planId)).find(
+        (row) => row.dateKey === test.today(),
+      );
+      if (workout === undefined) throw new Error("Expected Workout");
+      const apply = await test.previewWorkoutChange(planId, workout.id, {
+        name: "Changed Workout",
+      });
+      if (timing === "before-attempt") {
+        const all = test.store.all.bind(test.store);
+        let applied = false;
+        vi.spyOn(test.store, "all").mockImplementation(async (sql, params) => {
+          const rows = await all(sql, params);
+          if (
+            !applied &&
+            sql === "SELECT * FROM plan_workout WHERE plan_id = ? ORDER BY date_key, id"
+          ) {
+            applied = true;
+            await apply();
+          }
+          return rows;
+        });
+      } else {
+        const listEvents = test.calendar.listEvents.bind(test.calendar);
+        vi.spyOn(test.calendar, "listEvents").mockImplementationOnce(async (input) => {
+          await apply();
+          await test.drain.kick();
+          return listEvents(input);
+        });
+      }
+      await test.drain.kick();
+      await test.drain.idle();
+      expect(
+        test.calendar.events.find(
+          (event) => event.externalId === planMirrorExternalId(planId, workout.id),
+        ),
+      ).toMatchObject({ name: "Changed Workout" });
+      expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+        status: "verified",
+        attemptCount: 2,
+      });
+    },
+  );
+
+  it("persists a list failure for the run and verifies on a later kick", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    test.calendar.failNextList = true;
+    await test.drain.kick();
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      status: "failed",
+      lastErrorCode: "calendar-list-failed",
+      attemptCount: 1,
+      failureCount: 1,
+    });
+    expect(test.calendar.events).toEqual([]);
+    await test.drain.kick();
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      status: "verified",
+      attemptCount: 2,
+      failureCount: 1,
+    });
+    expect(test.calendar.events.length).toBeGreaterThan(0);
+  });
+
+  it("reopens the same window after a Change and updates retained external ids without duplicates", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    await test.drain.kick();
+    const original = await test.reconciliation.readLatestJob(planId, "mirror");
+    const before = structuredClone(test.calendar.events);
+    const preview = await test.changes["plan_change.preview"]({
+      commandId: "change-preview",
+      planId,
+      expectedVersion: 1,
+      intent: { kind: "longest-workout", minutes: 30 },
+    });
+    if (preview.status !== "previewed") throw new Error(`Expected Change: ${preview.reason}`);
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "change-apply",
+        planId,
+        changeId: preview.change.changeId,
+        expectedVersion: 1,
+        decision: "apply",
+      }),
+    ).toMatchObject({ status: "applied" });
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      id: original?.id,
+      status: "pending",
+    });
+    await test.drain.kick();
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      id: original?.id,
+      status: "verified",
+      attemptCount: 2,
+    });
+    expect(test.calendar.updates.length).toBeGreaterThan(0);
+    expect(test.calendar.events.map((event) => [event.id, event.externalId])).toEqual(
+      before.map((event) => [event.id, event.externalId]),
+    );
+    expect(
+      test.calendar.events.some((event, index) => event.durationS !== before[index]?.durationS),
+    ).toBe(true);
+    expect(new Set(test.calendar.events.map((event) => event.externalId)).size).toBe(
+      test.calendar.events.length,
+    );
+    expect(test.calendar.creates).toHaveLength(before.length);
+  });
+
+  it.each([false, true])(
+    "only verifies yesterday's items and creates today's rollover window with a missing event: %s",
+    async (missingEvent) => {
+      const test = await harness();
+      const { planId } = await test.activate();
+      await test.drain.kick();
+      const previous = await test.reconciliation.readLatestJob(planId, "mirror");
+      if (previous === undefined) throw new Error("Expected mirror job");
+      await test.reconciliation.beginAttempt(previous.id, 904_694_400_000);
+      await test.reconciliation.failJob(
+        previous.id,
+        "calendar-verification-failed",
+        904_694_400_000,
+      );
+      const yesterday = test.calendar.events.find((event) => event.dateKey === test.today());
+      if (yesterday === undefined) throw new Error("Expected today's event");
+      if (missingEvent) test.calendar.events.splice(test.calendar.events.indexOf(yesterday), 1);
+      test.calendar.lists.length = 0;
+      test.calendar.creates.length = 0;
+      test.advanceDay();
+      await test.drain.kick();
+      expect(test.calendar.lists[0]).toEqual({ startDateKey: 19980902, endDateKey: 19980908 });
+      expect(await test.reconciliation.readJob(previous.id)).toMatchObject({
+        status: missingEvent ? "failed" : "verified",
+        attemptCount: 3,
+        lastErrorCode: missingEvent ? "calendar-verification-failed" : null,
+      });
+      expect(test.calendar.events.some((event) => event.externalId === yesterday.externalId)).toBe(
+        !missingEvent,
+      );
+      expect(test.calendar.creates.every((event) => event.dateKey >= test.today())).toBe(true);
+      expect(test.calendar.updates).toEqual([]);
+      expect(await test.reconciliation.readLatestJobByWindow(planId, "mirror")).toMatchObject({
+        status: "verified",
+        windowStartDateKey: 19980903,
+        windowEndDateKey: 19980909,
+      });
+    },
+  );
+
+  it("retires an empty older window without sending it to the calendar", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    const previous = await test.reconciliation.readLatestJob(planId, "mirror");
+    if (previous === undefined) throw new Error("Expected mirror job");
+    test.advanceDay();
+    await test.drain.kick();
+    expect(await test.reconciliation.readJob(previous.id)).toMatchObject({
+      status: "verified",
+      attemptCount: 1,
+    });
+    expect(test.calendar.lists.every((window) => window.startDateKey >= test.today())).toBe(true);
+    expect(await test.reconciliation.readLatestJobByWindow(planId, "mirror")).toMatchObject({
+      status: "verified",
+      windowStartDateKey: test.today(),
+    });
+  });
+
+  it("does nothing when the calendar is disconnected", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    test.disconnect();
+    test.advanceDay();
+    await test.drain.kick();
+    await test.drain.idle();
+    expect(await test.reconciliation.readLatestJobByWindow(planId, "mirror")).toMatchObject({
+      status: "pending",
+      attemptCount: 0,
+      windowStartDateKey: 19980902,
+    });
+    expect(test.calendar.lists).toEqual([]);
+    expect(test.calendar.events).toEqual([]);
+  });
+
+  it("serializes concurrent kicks into one run and one rerun and waits for both when idle", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    test.calendar.failNextList = true;
+    test.calendar.delayMs = 10;
+    const reads = vi.spyOn(test.store, "all");
+    let complete = false;
+    const running = test.drain.kick().then(() => {
+      complete = true;
+    });
+    await Promise.all([test.drain.kick(), test.drain.kick()]);
+    expect(complete).toBe(false);
+    let idle = false;
+    const settled = test.drain.idle().then(() => {
+      idle = true;
+    });
+    await Promise.resolve();
+    expect(idle).toBe(false);
+    await settled;
+    await running;
+    expect(idle).toBe(true);
+    expect(await test.reconciliation.readLatestJob(planId, "mirror")).toMatchObject({
+      status: "verified",
+      attemptCount: 2,
+      resumedCount: 0,
+    });
+    expect(
+      reads.mock.calls.filter(([sql]) => sql.includes("status IN ('pending','retrying')")),
+    ).toHaveLength(2);
+  });
+
+  it("cleans a closed Plan from tomorrow and leaves today", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    await test.drain.kick();
+    const todayEvents = test.calendar.events.filter((event) => event.dateKey === test.today());
+    expect(todayEvents.length).toBeGreaterThan(0);
+    expect(
+      await test.creation["plan.close"]({ commandId: "close", planId, expectedVersion: 1 }),
+    ).toMatchObject({ status: "closed" });
+    await test.drain.kick();
+    expect(test.calendar.events).toEqual(todayEvents);
+    expect(await test.reconciliation.readLatestJob(planId, "cleanup")).toMatchObject({
+      status: "verified",
+      windowStartDateKey: addCivilDays(test.today(), 1),
+    });
+  });
+
+  it("skips a Plan closed after runnable jobs were listed", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    const current = await test.reconciliation.readLatestJob(planId, "mirror");
+    if (current === undefined) throw new Error("Expected mirror job");
+    const all = test.store.all.bind(test.store);
+    let closed = false;
+    vi.spyOn(test.store, "all").mockImplementation(async (sql, params) => {
+      const rows = await all(sql, params);
+      if (
+        !closed &&
+        sql.includes("FROM plan_reconciliation_job") &&
+        sql.includes("ORDER BY window_start_date_key ASC")
+      ) {
+        closed = true;
+        expect(rows.some((row) => row.id === current.id)).toBe(true);
+        await test.creation["plan.close"]({
+          commandId: "close-after-list",
+          planId,
+          expectedVersion: 1,
+        });
+      }
+      return rows;
+    });
+    await test.drain.kick();
+    expect(closed).toBe(true);
+    expect(await test.reconciliation.readJob(current.id)).toMatchObject({
+      status: "pending",
+      attemptCount: 0,
+    });
+    expect(test.calendar.events).toEqual([]);
+    expect(test.calendar.lists).toEqual([]);
+    expect(test.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("skips inactive Plans' mirror jobs and future windows", async () => {
+    const test = await harness();
+    const { planId } = await test.activate();
+    const current = await test.reconciliation.readLatestJob(planId, "mirror");
+    const future = await test.reconciliation.createOrGetJob({
+      id: test.identity.newUlid(),
+      planId,
+      kind: "mirror",
+      windowStartDateKey: addCivilDays(test.today(), 1),
+      windowEndDateKey: addCivilDays(test.today(), 7),
+      createdAtMs: 904_694_400_000,
+    });
+    await test.drain.kick();
+    expect(await test.reconciliation.readJob(future.id)).toMatchObject({
+      status: "pending",
+      attemptCount: 0,
+    });
+    if (current === undefined) throw new Error("Expected mirror job");
+    await test.reconciliation.beginAttempt(current.id, 904_694_400_000);
+    await test.reconciliation.failJob(current.id, "calendar-list-failed", 904_694_400_000);
+    await test.creation["plan.close"]({ commandId: "close", planId, expectedVersion: 1 });
+    await test.drain.kick();
+    expect(await test.reconciliation.readJob(current.id)).toMatchObject({
+      status: "failed",
+      attemptCount: 2,
+    });
+    expect(await test.reconciliation.readJob(future.id)).toMatchObject({
+      status: "pending",
+      attemptCount: 0,
+    });
+  });
+});

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@enduragent/coach-contract";
 import {
   createPlanCreationRepository,
+  createPlanReconciliationRepository,
   createPlanRepository,
   PlanCreationStoreError,
   type PlanCreationAnswerRecord,
@@ -24,6 +25,7 @@ import {
 import { runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanChangeOperations } from "../src/plan-change-operations.js";
 import { createPlanningReadService } from "../src/planning-read-service.js";
 import { readPlanCreationAnswers } from "../src/plan-creation-answers.js";
 
@@ -856,6 +858,7 @@ describe("Plan Creation operations", () => {
 
 async function previewHarness() {
   let currentToday = today;
+  let connected = false;
   const store = openSqliteStorage(":memory:");
   onTestFinished(() => store.close());
   await runMigrations(store, MIGRATIONS);
@@ -871,6 +874,7 @@ async function previewHarness() {
     },
     crypto: globalThis.crypto,
     eventCandidates: { read: async () => [candidateSource] },
+    calendarConnected: () => connected,
     today: () => currentToday,
     todayDateKey: () => Number(currentToday.replaceAll("-", "")),
     now: () => Date.parse(`${currentToday}T12:00:00Z`),
@@ -911,6 +915,9 @@ async function previewHarness() {
     ready,
     answer,
     card: () => card,
+    setConnected: (value: boolean) => {
+      connected = value;
+    },
     setToday: (value: string) => {
       currentToday = value;
     },
@@ -1100,27 +1107,245 @@ describe("Plan Creation activation", () => {
     };
   };
 
+  it("projects pending, running, failed and verified mirror work across connection changes", async () => {
+    const test = await review();
+    const activated = await test.host["plan_creation.activate"](test.request);
+    const repository = createPlanReconciliationRepository(test.store);
+    const job = await repository.readLatestJobByWindow(activated.planId, "mirror");
+    if (job === undefined) throw new Error("Expected mirror job");
+    const calendar = {
+      status: "not-connected",
+      window: { start: today, end: "1998-09-08" },
+      currentThrough: null,
+      error: null,
+    };
+    const read = async () => (await test.host["plan.list"]({})).active?.calendar;
+    expect(await read()).toEqual(calendar);
+    test.setConnected(true);
+    expect(await read()).toEqual({ ...calendar, status: "pending" });
+    await repository.beginAttempt(job.id, job.updatedAtMs + 1);
+    expect(await read()).toEqual({ ...calendar, status: "running" });
+    await repository.failJob(job.id, "calendar-list-failed", job.updatedAtMs + 2);
+    expect(await read()).toEqual({
+      ...calendar,
+      status: "failed",
+      error: "Calendar sync failed. Retry available.",
+    });
+    test.setConnected(false);
+    expect(await read()).toEqual(calendar);
+    test.setConnected(true);
+    await repository.beginAttempt(job.id, job.updatedAtMs + 3);
+    expect(await read()).toEqual({ ...calendar, status: "running" });
+    await repository.verifyJob(job.id, job.updatedAtMs + 4);
+    expect(await read()).toEqual({ ...calendar, status: "verified", currentThrough: "1998-09-08" });
+    test.setConnected(false);
+    expect(await read()).toEqual({ ...calendar, status: "verified", currentThrough: "1998-09-08" });
+    await test.store.run("DELETE FROM plan_reconciliation_job WHERE id = ?", [job.id]);
+    expect(await read()).toEqual({ ...calendar, window: null });
+    test.setConnected(true);
+    expect(await read()).toEqual({ ...calendar, status: "pending", window: null });
+  });
+
+  it("projects the cleanup job for a closed Plan and preserves history cleanup", async () => {
+    const test = await review();
+    test.setConnected(true);
+    const activated = await test.host["plan_creation.activate"](test.request);
+    await test.host["plan.close"]({
+      commandId: "close-calendar",
+      planId: activated.planId,
+      expectedVersion: 1,
+    });
+    const repository = createPlanReconciliationRepository(test.store);
+    const job = await repository.readLatestJobByWindow(activated.planId, "cleanup");
+    if (job === undefined) throw new Error("Expected cleanup job");
+    const calendar = {
+      status: "pending",
+      window: { start: "1998-09-03", end: test.draft.end },
+      currentThrough: null,
+      error: null,
+    };
+    expect((await test.host["plan.list"]({})).closed[0]?.calendar).toEqual(calendar);
+    await repository.beginAttempt(job.id, job.updatedAtMs + 1);
+    await repository.failJob(job.id, "calendar-list-failed", job.updatedAtMs + 2);
+    const failed = {
+      ...calendar,
+      status: "failed",
+      error: "Calendar cleanup failed. Retry available.",
+    };
+    expect((await test.host["plan.list"]({})).closed[0]?.calendar).toEqual(failed);
+    expect(await test.host["plan.history"]({ planId: activated.planId })).toMatchObject({
+      plan: { calendar: failed },
+      cleanup: "failed",
+    });
+  });
+
+  it.each(["mirror", "cleanup"] as const)(
+    "offers retry only below the failure budget for %s work in the library",
+    async (kind) => {
+      const test = await review();
+      test.setConnected(true);
+      const activated = await test.host["plan_creation.activate"](test.request);
+      if (kind === "cleanup") {
+        await test.host["plan.close"]({
+          commandId: "close-calendar",
+          planId: activated.planId,
+          expectedVersion: 1,
+        });
+      }
+      const repository = createPlanReconciliationRepository(test.store);
+      const job = await repository.readLatestJobByWindow(activated.planId, kind);
+      if (job === undefined) throw new Error("Expected calendar job");
+      const error = kind === "mirror" ? "Calendar sync failed." : "Calendar cleanup failed.";
+      for (let failureCount = 1; failureCount <= 6; failureCount += 1) {
+        await repository.beginAttempt(job.id, job.updatedAtMs + failureCount * 2 - 1);
+        await repository.failJob(
+          job.id,
+          "calendar-list-failed",
+          job.updatedAtMs + failureCount * 2,
+        );
+        const library = await test.host["plan.list"]({});
+        const calendar = kind === "mirror" ? library.active?.calendar : library.closed[0]?.calendar;
+        expect(calendar).toMatchObject({
+          status: "failed",
+          error: failureCount >= 5 ? error : `${error} Retry available.`,
+        });
+      }
+    },
+  );
+
+  it("reads history cleanup and calendar from one snapshot during verification", async () => {
+    const test = await review();
+    test.setConnected(true);
+    const activated = await test.host["plan_creation.activate"](test.request);
+    await test.host["plan.close"]({
+      commandId: "close-calendar-snapshot",
+      planId: activated.planId,
+      expectedVersion: 1,
+    });
+    const repository = createPlanReconciliationRepository(test.store);
+    const job = await repository.readLatestJobByWindow(activated.planId, "cleanup");
+    if (job === undefined) throw new Error("Expected cleanup job");
+    await repository.beginAttempt(job.id, job.updatedAtMs + 1);
+    await repository.failJob(job.id, "calendar-list-failed", job.updatedAtMs + 2);
+    const transaction = vi.spyOn(test.store, "transaction");
+    const get = test.store.get.bind(test.store);
+    let signalEntered = () => {};
+    let releaseRead = () => {};
+    const entered = new Promise<void>((resolve) => {
+      signalEntered = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const reader = vi.spyOn(test.store, "get").mockImplementation(async (sql, params) => {
+      const row = await get(sql, params);
+      if (sql.includes("AS cleanup_status")) {
+        signalEntered();
+        await released;
+      }
+      return row;
+    });
+    const history = test.host["plan.history"]({ planId: activated.planId });
+    await entered;
+    expect(transaction).toHaveBeenCalledTimes(1);
+    let verified = false;
+    const verification = test.store.transaction(async () => {
+      await test.store.run(
+        "UPDATE plan_reconciliation_job SET status='verified',last_error_code=NULL,completed_at_ms=?,updated_at_ms=? WHERE id=?",
+        [job.updatedAtMs + 3, job.updatedAtMs + 3, job.id],
+      );
+      verified = true;
+    });
+    expect(transaction).toHaveBeenCalledTimes(2);
+    expect(verified).toBe(false);
+    releaseRead();
+    await expect(history).resolves.toMatchObject({
+      cleanup: "failed",
+      plan: { calendar: { status: "failed", currentThrough: null } },
+    });
+    await verification;
+    reader.mockRestore();
+    transaction.mockClear();
+    await expect(test.host["plan.history"]({ planId: activated.planId })).resolves.toMatchObject({
+      cleanup: "complete",
+      plan: { calendar: { status: "verified", currentThrough: test.draft.end } },
+    });
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows pending again after a second Change in the verified window", async () => {
+    const test = await review();
+    test.setConnected(true);
+    const activated = await test.host["plan_creation.activate"](test.request);
+    let sequence = 1000;
+    const changes = createPlanChangeOperations({
+      store: test.store,
+      identity: {
+        deviceId: async () => "calendar-change-test-device",
+        newUlid: () => id(String(++sequence)),
+        hlcStamp: () => ({ physicalMs: 904_694_400_000, counter: sequence }),
+      },
+      crypto: globalThis.crypto,
+      todayDateKey: () => 19980902,
+      now: () => 904_694_400_000,
+    });
+    const repository = createPlanReconciliationRepository(test.store);
+    for (const [index, minutes] of [60, 30].entries()) {
+      const plan = (await test.host["plan.list"]({})).active;
+      if (plan === null) throw new Error("Expected active Plan");
+      const preview = await changes["plan_change.preview"]({
+        commandId: `preview-calendar-${index}`,
+        planId: activated.planId,
+        expectedVersion: plan.version,
+        intent: { kind: "longest-workout", minutes },
+      });
+      if (preview.status !== "previewed") throw new Error(`Expected preview: ${preview.reason}`);
+      const result = await changes["plan_change.apply"]({
+        commandId: `apply-calendar-${index}`,
+        planId: activated.planId,
+        changeId: preview.change.changeId,
+        expectedVersion: plan.version,
+        decision: "apply",
+      });
+      expect(result.status).toBe("applied");
+      expect((await test.host["plan.list"]({})).active?.calendar).toEqual({
+        status: "pending",
+        window: { start: today, end: "1998-09-08" },
+        currentThrough: null,
+        error: null,
+      });
+      const job = await repository.readLatestJobByWindow(activated.planId, "mirror");
+      if (job === undefined) throw new Error("Expected mirror job");
+      await repository.beginAttempt(job.id, job.updatedAtMs);
+      await repository.verifyJob(job.id, job.updatedAtMs);
+      expect((await test.host["plan.list"]({})).active?.calendar.status).toBe("verified");
+    }
+  });
+
   it("reads one snapshot while replacing the active Plan", async () => {
     const test = await review();
     const incumbentId = id("800");
-    await createPlanRepository(test.store).replace({
-      id: incumbentId,
-      originId: null,
-      name: "Earlier Plan",
-      primaryGoal: "Build fitness",
-      startDateKey: 19971222,
-      targetDateKey: 19980118,
-      status: "active",
-      kind: "short_race_preparation",
-      totalWeeks: 4,
-      weekStartDay: 1,
-      structureJson: "{}",
-      createdAtMs: 882_748_800_000,
-      updatedAtMs: 882_748_800_000,
-      deviceId: "test-device",
-      hlcPhysicalMs: 882_748_800_000,
-      hlcCounter: 0,
-    }, []);
+    await createPlanRepository(test.store).replace(
+      {
+        id: incumbentId,
+        originId: null,
+        name: "Earlier Plan",
+        primaryGoal: "Build fitness",
+        startDateKey: 19971222,
+        targetDateKey: 19980118,
+        status: "active",
+        kind: "short_race_preparation",
+        totalWeeks: 4,
+        weekStartDay: 1,
+        structureJson: "{}",
+        createdAtMs: 882_748_800_000,
+        updatedAtMs: 882_748_800_000,
+        deviceId: "test-device",
+        hlcPhysicalMs: 882_748_800_000,
+        hlcCounter: 0,
+      },
+      [],
+    );
     await test.store.run(
       `INSERT INTO planning_plan
 (plan_id,status,version,current_revision_number,activated_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter)
@@ -1176,20 +1401,34 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
         closedAt: null,
         activatedAt: "1998-01-01",
         creationId: test.request.creationId,
+        calendar: {
+          status: "not-connected",
+          window: { start: "1998-01-01", end: "1998-01-07" },
+          currentThrough: null,
+          error: null,
+        },
       },
-      closed: [{
-        planId: incumbentId,
-        version: 2,
-        name: "Earlier Plan",
-        start: "1997-12-22",
-        end: "1998-01-18",
-        weeks: 4,
-        status: "closed",
-        closeReason: "stopped",
-        closedAt: "1998-01-01",
-        activatedAt: "1997-12-22",
-        creationId: null,
-      }],
+      closed: [
+        {
+          planId: incumbentId,
+          version: 2,
+          name: "Earlier Plan",
+          start: "1997-12-22",
+          end: "1998-01-18",
+          weeks: 4,
+          status: "closed",
+          closeReason: "stopped",
+          closedAt: "1998-01-01",
+          activatedAt: "1997-12-22",
+          creationId: null,
+          calendar: {
+            status: "not-connected",
+            window: { start: "1998-01-02", end: "1998-01-18" },
+            currentThrough: null,
+            error: null,
+          },
+        },
+      ],
     });
   });
 
@@ -1228,7 +1467,10 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     const result = await test.host["plan.close"](request);
     expect(result).toMatchObject({ status: "closed", planId: activated.planId });
     await expect(test.host["plan.close"](request)).resolves.toEqual(result);
-    await expect(test.host["plan.close"]({ ...request, expectedVersion: 2 })).resolves.toEqual({ status: "rejected", reason: "command-conflict" });
+    await expect(test.host["plan.close"]({ ...request, expectedVersion: 2 })).resolves.toEqual({
+      status: "rejected",
+      reason: "command-conflict",
+    });
     const detail = await test.host["plan.history"]({ planId: activated.planId });
     expect(detail).toMatchObject({
       plan: { planId: activated.planId, status: "closed", closeReason: "stopped" },

--- a/packages/engine/src/planning/reconciler.ts
+++ b/packages/engine/src/planning/reconciler.ts
@@ -277,9 +277,12 @@ async function verifyMirrorItems(
   deps: PlanReconcilerDeps,
   job: PlanReconciliationJobRecord,
   grouped: ReadonlyMap<string, readonly PlanMirrorEvent[]>,
+  firstEligibleDateKey = Number.NEGATIVE_INFINITY,
 ): Promise<void> {
   for (const item of await deps.repository.readItems(job.id)) {
-    const matches = grouped.get(item.externalId) ?? [];
+    const matches = (grouped.get(item.externalId) ?? []).filter(
+      (event) => item.operation !== "delete" || event.dateKey >= firstEligibleDateKey,
+    );
     if (item.operation === "delete" && matches.length === 0) {
       await deps.repository.verifyItem(item.id, null, deps.now());
     } else if (
@@ -299,11 +302,16 @@ export async function reconcileActivePlanWindow(
     readonly plan: PlanRecord;
     readonly workouts: readonly PlanWorkoutRecord[];
     readonly todayDateKey: number;
+    readonly firstEligibleDateKey?: number;
   },
   deps: PlanReconcilerDeps,
 ): Promise<PlanReconciliationProjection> {
   if (input.plan.status !== "active") throw new PlanReconciliationError("plan-not-active");
   const windowEndDateKey = addCivilDays(input.todayDateKey, PLAN_MIRROR_DAYS - 1);
+  const firstEligibleDateKey = Math.max(
+    input.todayDateKey,
+    input.firstEligibleDateKey ?? input.todayDateKey,
+  );
   const now = deps.now();
   const job = await deps.repository.createOrGetJob({
     id: deps.identity.newId(),
@@ -317,7 +325,7 @@ export async function reconcileActivePlanWindow(
     if (workout.planId !== input.plan.id) throw new PlanReconciliationError("invalid-workout");
     return (
       workout.origin === "coach" &&
-      workout.dateKey >= input.todayDateKey &&
+      workout.dateKey >= firstEligibleDateKey &&
       workout.dateKey <= windowEndDateKey
     );
   });
@@ -354,24 +362,20 @@ export async function reconcileActivePlanWindow(
   const prefix = planMirrorExternalIdPrefix(input.plan.id);
   for (const [externalId, events] of before) {
     if (!externalId.startsWith(prefix) || selectedExternalIds.has(externalId)) continue;
+    const eligible = events.filter((event) => event.dateKey >= firstEligibleDateKey);
+    if (eligible.length === 0) continue;
     const workoutId = externalId.slice(prefix.length);
     if (!ULID.test(workoutId)) continue;
     const workout = workoutById.get(workoutId);
-    if (
-      workout !== undefined &&
-      (workout.origin !== "coach" ||
-        (workout.dateKey >= input.todayDateKey && workout.dateKey <= windowEndDateKey))
-    ) {
-      continue;
-    }
+    if (workout !== undefined && workout.origin !== "coach") continue;
     await deps.repository.prepareItem({
       id: deps.identity.newId(),
       jobId: job.id,
       planWorkoutId: null,
       operation: "delete",
-      dateKey: events[0]!.dateKey,
+      dateKey: eligible[0]!.dateKey,
       externalId,
-      expectedJson: JSON.stringify(events.map((event) => ({ eventId: event.id }))),
+      expectedJson: JSON.stringify(eligible.map((event) => ({ eventId: event.id }))),
       createdAtMs: deps.now(),
     });
   }
@@ -379,13 +383,18 @@ export async function reconcileActivePlanWindow(
   for (const item of await deps.repository.readItems(job.id)) {
     const matches = before.get(item.externalId) ?? [];
     if (item.operation === "delete") {
-      if (matches.length === 0) {
+      if (selectedExternalIds.has(item.externalId)) {
+        await deps.repository.deleteItem(item.id);
+        continue;
+      }
+      const eligible = matches.filter((event) => event.dateKey >= firstEligibleDateKey);
+      if (eligible.length === 0) {
         await deps.repository.verifyItem(item.id, null, deps.now());
         continue;
       }
       await deps.repository.startItem(item.id, deps.now());
       let failed = false;
-      for (const event of matches) {
+      for (const event of eligible) {
         try {
           await deps.calendar.deleteEvent({ eventId: event.id });
         } catch {
@@ -395,13 +404,16 @@ export async function reconcileActivePlanWindow(
       if (failed) await deps.repository.failItem(item.id, "calendar-delete-failed", deps.now());
       continue;
     }
+    const workout =
+      item.planWorkoutId === null ? undefined : selectedWorkoutById.get(item.planWorkoutId);
+    if (workout === undefined) {
+      await deps.repository.deleteItem(item.id);
+      continue;
+    }
     if (matches.length > 1) {
       await deps.repository.failItem(item.id, "calendar-verification-failed", deps.now());
       continue;
     }
-    const workout =
-      item.planWorkoutId === null ? undefined : selectedWorkoutById.get(item.planWorkoutId);
-    if (workout === undefined) throw new PlanReconciliationError("invalid-workout");
     if (matches.length === 1) {
       if (canVerifyMirrorEvent(item, matches[0]!)) {
         await deps.repository.verifyItem(item.id, matches[0]!.id, deps.now());
@@ -468,7 +480,7 @@ export async function reconcileActivePlanWindow(
     }
     return failListedJob(deps, running);
   }
-  await verifyMirrorItems(deps, job, after);
+  await verifyMirrorItems(deps, job, after, firstEligibleDateKey);
   return finishJob(deps, running);
 }
 

--- a/packages/engine/tests/plan-reconciler.test.ts
+++ b/packages/engine/tests/plan-reconciler.test.ts
@@ -104,6 +104,18 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
       .at(-1);
   }
 
+  async reopenJob(id: string, updatedAtMs: number): Promise<PlanReconciliationJobRecord> {
+    const job: PlanReconciliationJobRecord = {
+      ...this.jobs.get(id)!,
+      status: "pending",
+      lastErrorCode: null,
+      completedAtMs: null,
+      updatedAtMs,
+    };
+    this.jobs.set(id, job);
+    return job;
+  }
+
   async beginAttempt(id: string, updatedAtMs: number): Promise<PlanReconciliationJobRecord> {
     const current = this.jobs.get(id)!;
     const job: PlanReconciliationJobRecord = {
@@ -123,6 +135,57 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
     };
     this.jobs.set(id, job);
     return job;
+  }
+
+  async listRunnable(input: {
+    nowMs: number;
+    leaseMs: number;
+    maxFailures: number;
+  }): Promise<readonly PlanReconciliationJobRecord[]> {
+    return [...this.jobs.values()]
+      .filter(
+        (job) =>
+          job.status === "pending" ||
+          job.status === "retrying" ||
+          (job.status === "failed" && job.failureCount < input.maxFailures) ||
+          (job.status === "running" && job.updatedAtMs + input.leaseMs <= input.nowMs),
+      )
+      .sort(
+        (left, right) =>
+          left.windowStartDateKey - right.windowStartDateKey ||
+          left.createdAtMs - right.createdAtMs ||
+          left.id.localeCompare(right.id),
+      );
+  }
+
+  async claim(
+    id: string,
+    nowMs: number,
+    leaseMs: number,
+  ): Promise<PlanReconciliationJobRecord | undefined> {
+    const job = this.jobs.get(id);
+    if (
+      job === undefined ||
+      job.status === "verified" ||
+      (job.status === "running" && job.updatedAtMs + leaseMs > nowMs)
+    ) {
+      return undefined;
+    }
+    return this.beginAttempt(id, nowMs);
+  }
+
+  async readLatestJobByWindow(
+    planId: string,
+    kind: PlanReconciliationKind,
+  ): Promise<PlanReconciliationJobRecord | undefined> {
+    return [...this.jobs.values()]
+      .filter((job) => job.planId === planId && job.kind === kind)
+      .sort(
+        (left, right) =>
+          right.windowStartDateKey - left.windowStartDateKey ||
+          right.windowEndDateKey - left.windowEndDateKey ||
+          right.id.localeCompare(left.id),
+      )[0];
   }
 
   async failJob(
@@ -240,6 +303,10 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
     };
     this.items.set(id, item);
     return item;
+  }
+
+  async deleteItem(id: string): Promise<void> {
+    this.items.delete(id);
   }
 
   async verifyItem(
@@ -429,6 +496,293 @@ describe("Plan reconciler", () => {
       value.deps,
     );
     expect(value.calendar.creates).toHaveLength(1);
+  });
+
+  it("preserves today's events when eligibility starts tomorrow without shifting the window", async () => {
+    const value = harness();
+    const activePlan = { ...plan(), startDateKey: 19980824, targetDateKey: 19981115 };
+    const today = workout("01K00000000000000000000101", 19980831);
+    const tomorrow = workout("01K00000000000000000000102", 19980901);
+    const daySix = workout("01K00000000000000000000103", 19980906);
+    const outside = workout("01K00000000000000000000104", 19980907);
+    const otherPlanToday = {
+      id: 42,
+      dateKey: today.dateKey,
+      externalId: planMirrorExternalId(OTHER_PLAN_ID, "01K00000000000000000000105"),
+    };
+    const staleToday = {
+      id: 43,
+      dateKey: today.dateKey,
+      externalId: planMirrorExternalId(PLAN_ID, "01K00000000000000000000106"),
+    };
+    const staleTomorrow = {
+      id: 44,
+      dateKey: tomorrow.dateKey,
+      externalId: planMirrorExternalId(PLAN_ID, "01K00000000000000000000107"),
+    };
+    value.calendar.events.push(otherPlanToday, staleToday, staleTomorrow);
+    const input = {
+      plan: activePlan,
+      workouts: [today, tomorrow, daySix, outside],
+      todayDateKey: today.dateKey,
+    };
+    const first = await reconcileActivePlanWindow(
+      { ...input, firstEligibleDateKey: tomorrow.dateKey },
+      value.deps,
+    );
+    expect(first.state).toBe("reconcile-verified");
+    expect([...value.repository.jobs.values()]).toMatchObject([
+      { windowStartDateKey: today.dateKey, windowEndDateKey: daySix.dateKey },
+    ]);
+    expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([
+      tomorrow.id,
+      daySix.id,
+    ]);
+    expect(value.calendar.deletes).toEqual([staleTomorrow.id]);
+    expect(value.calendar.events).toEqual(expect.arrayContaining([otherPlanToday, staleToday]));
+    expect([...value.repository.items.values()].map((item) => item.dateKey)).toEqual([
+      tomorrow.dateKey,
+      daySix.dateKey,
+      tomorrow.dateKey,
+    ]);
+    const second = await reconcileActivePlanWindow(input, value.deps);
+    expect(second.state).toBe("reconcile-verified");
+    expect(value.repository.jobs.size).toBe(1);
+    expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([
+      tomorrow.id,
+      daySix.id,
+      today.id,
+    ]);
+    expect(value.calendar.events).toContainEqual(otherPlanToday);
+  });
+
+  it.each([true, false])(
+    "verifies today's retained delete without touching its pre-eligibility event: %s",
+    async (eventExists) => {
+      const value = harness();
+      const tomorrow = workout("01K00000000000000000000102", 19980901);
+      const event = {
+        id: 43,
+        dateKey: 19980831,
+        externalId: planMirrorExternalId(PLAN_ID, "01K00000000000000000000106"),
+      };
+      const job = await value.repository.createOrGetJob({
+        id: "01K00000000000000000000201",
+        planId: PLAN_ID,
+        kind: "mirror",
+        windowStartDateKey: event.dateKey,
+        windowEndDateKey: 19980906,
+        createdAtMs: 1,
+      });
+      const retained = await value.repository.prepareItem({
+        id: "01K00000000000000000000202",
+        jobId: job.id,
+        planWorkoutId: null,
+        operation: "delete",
+        dateKey: event.dateKey,
+        externalId: event.externalId,
+        expectedJson: JSON.stringify([{ eventId: event.id }]),
+        createdAtMs: 1,
+      });
+      if (eventExists) value.calendar.events.push(event);
+
+      const result = await reconcileActivePlanWindow(
+        {
+          plan: { ...plan(), startDateKey: 19980824, targetDateKey: 19981115 },
+          workouts: [tomorrow],
+          todayDateKey: event.dateKey,
+          firstEligibleDateKey: tomorrow.dateKey,
+        },
+        value.deps,
+      );
+
+      expect(result).toMatchObject({ state: "reconcile-verified", pending: 0 });
+      expect(value.repository.items.get(retained.id)).toMatchObject({ status: "verified" });
+      expect(await value.repository.readJob(job.id)).toMatchObject({ status: "verified" });
+      expect(value.calendar.deletes).toEqual([]);
+      if (eventExists) expect(value.calendar.events).toContainEqual(event);
+      expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([tomorrow.id]);
+    },
+  );
+
+  it("removes an obsolete retained delete when its Workout is selected again", async () => {
+    const value = harness();
+    const restored = workout("01K00000000000000000000102", 19980903);
+    const externalId = planMirrorExternalId(PLAN_ID, restored.id);
+    const event = { id: 46, dateKey: restored.dateKey, externalId };
+    const job = await value.repository.createOrGetJob({
+      id: "01K00000000000000000000201",
+      planId: PLAN_ID,
+      kind: "mirror",
+      windowStartDateKey: 19980831,
+      windowEndDateKey: 19980906,
+      createdAtMs: 1,
+    });
+    const obsolete = await value.repository.prepareItem({
+      id: "01K00000000000000000000202",
+      jobId: job.id,
+      planWorkoutId: null,
+      operation: "delete",
+      dateKey: event.dateKey,
+      externalId,
+      expectedJson: JSON.stringify([{ eventId: event.id }]),
+      createdAtMs: 1,
+    });
+    value.calendar.events.push(event);
+
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: { ...plan(), startDateKey: 19980824, targetDateKey: 19981115 },
+        workouts: [restored],
+        todayDateKey: 19980831,
+      },
+      value.deps,
+    );
+
+    expect(result).toMatchObject({ state: "reconcile-verified", pending: 0 });
+    expect(value.repository.items.has(obsolete.id)).toBe(false);
+    expect(value.calendar.deletes).toEqual([]);
+    expect(value.calendar.events.filter((row) => row.externalId === externalId)).toHaveLength(1);
+  });
+
+  it("deletes an unwanted future duplicate while keeping today's owned event under tomorrow eligibility", async () => {
+    const value = harness();
+    const tomorrow = workout("01K00000000000000000000102", 19980901);
+    const externalId = planMirrorExternalId(PLAN_ID, "01K00000000000000000000106");
+    const todayEvent = { id: 47, dateKey: 19980831, externalId };
+    const futureEvent = { id: 48, dateKey: 19980902, externalId };
+    value.calendar.events.push(todayEvent, futureEvent);
+
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: { ...plan(), startDateKey: 19980824, targetDateKey: 19981115 },
+        workouts: [tomorrow],
+        todayDateKey: 19980831,
+        firstEligibleDateKey: tomorrow.dateKey,
+      },
+      value.deps,
+    );
+
+    expect(result).toMatchObject({ state: "reconcile-verified", pending: 0 });
+    expect(value.calendar.deletes).toEqual([futureEvent.id]);
+    expect(value.calendar.events).toContainEqual(todayEvent);
+    expect(value.calendar.events).not.toContainEqual(futureEvent);
+    expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([tomorrow.id]);
+  });
+
+  it("retires a retained create whose Workout moved to an excluded today and deletes its event", async () => {
+    const value = harness();
+    const moved = workout("01K00000000000000000000102", 19980831);
+    const tomorrow = workout("01K00000000000000000000103", 19980901);
+    const event = {
+      id: 45,
+      dateKey: 19980902,
+      externalId: planMirrorExternalId(PLAN_ID, moved.id),
+    };
+    const job = await value.repository.createOrGetJob({
+      id: "01K00000000000000000000201",
+      planId: PLAN_ID,
+      kind: "mirror",
+      windowStartDateKey: 19980831,
+      windowEndDateKey: 19980906,
+      createdAtMs: 1,
+    });
+    const retained = await value.repository.prepareItem({
+      id: "01K00000000000000000000202",
+      jobId: job.id,
+      planWorkoutId: moved.id,
+      operation: "create",
+      dateKey: event.dateKey,
+      externalId: event.externalId,
+      expectedJson: JSON.stringify({ dateKey: event.dateKey }),
+      createdAtMs: 1,
+    });
+    value.calendar.events.push(event);
+
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: { ...plan(), startDateKey: 19980824, targetDateKey: 19981115 },
+        workouts: [moved, tomorrow],
+        todayDateKey: 19980831,
+        firstEligibleDateKey: tomorrow.dateKey,
+      },
+      value.deps,
+    );
+
+    expect(result).toMatchObject({ state: "reconcile-verified" });
+    expect(value.repository.items.has(retained.id)).toBe(false);
+    expect(value.calendar.deletes).toEqual([event.id]);
+    expect(value.calendar.events.some((row) => row.externalId === event.externalId)).toBe(false);
+    expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([tomorrow.id]);
+  });
+
+  it.each([false, true])(
+    "deletes only eligible matches of a retained delete and keeps its pre-eligibility event: %s",
+    async (hasEligibleMatch) => {
+      const value = harness();
+      const tomorrow = workout("01K00000000000000000000102", 19980901);
+      const event = {
+        id: 43,
+        dateKey: 19980831,
+        externalId: planMirrorExternalId(PLAN_ID, "01K00000000000000000000106"),
+      };
+      const eligibleEvent = { ...event, id: 44, dateKey: tomorrow.dateKey };
+      const job = await value.repository.createOrGetJob({
+        id: "01K00000000000000000000201",
+        planId: PLAN_ID,
+        kind: "mirror",
+        windowStartDateKey: event.dateKey,
+        windowEndDateKey: 19980906,
+        createdAtMs: 1,
+      });
+      const retained = await value.repository.prepareItem({
+        id: "01K00000000000000000000202",
+        jobId: job.id,
+        planWorkoutId: null,
+        operation: "delete",
+        dateKey: tomorrow.dateKey,
+        externalId: event.externalId,
+        expectedJson: JSON.stringify([{ eventId: event.id }]),
+        createdAtMs: 1,
+      });
+      value.calendar.events.push(event);
+      if (hasEligibleMatch) value.calendar.events.push(eligibleEvent);
+
+      const result = await reconcileActivePlanWindow(
+        {
+          plan: { ...plan(), startDateKey: 19980824, targetDateKey: 19981115 },
+          workouts: [tomorrow],
+          todayDateKey: event.dateKey,
+          firstEligibleDateKey: tomorrow.dateKey,
+        },
+        value.deps,
+      );
+
+      expect(result).toMatchObject({ state: "reconcile-verified", pending: 0 });
+      expect(value.repository.items.get(retained.id)).toMatchObject({ status: "verified" });
+      expect(await value.repository.readJob(job.id)).toMatchObject({ status: "verified" });
+      expect(value.calendar.deletes).toEqual(hasEligibleMatch ? [eligibleEvent.id] : []);
+      expect(value.calendar.events).toContainEqual(event);
+      expect(value.calendar.events).not.toContainEqual(eligibleEvent);
+      expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([tomorrow.id]);
+    },
+  );
+
+  it("keeps today as the selection start when first eligibility is earlier", async () => {
+    const value = harness();
+    const today = workout("01K00000000000000000000101", 19980901);
+    const yesterday = workout("01K00000000000000000000102", 19980831);
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: { ...plan(), startDateKey: 19980824, targetDateKey: 19981115 },
+        workouts: [yesterday, today],
+        todayDateKey: today.dateKey,
+        firstEligibleDateKey: yesterday.dateKey,
+      },
+      value.deps,
+    );
+    expect(result.state).toBe("reconcile-verified");
+    expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([today.id]);
   });
 
   it("lists again immediately before create and skips an event that appeared after the batch precheck", async () => {

--- a/packages/kernel-node/tests/plan-change-repository.test.ts
+++ b/packages/kernel-node/tests/plan-change-repository.test.ts
@@ -5,6 +5,7 @@ import {
   createPlanChangeRepository,
   createPlanCreationRepository,
   createPlanLifecycleRepository,
+  createPlanReconciliationRepository,
   type PlanCreationCommandStamp,
 } from "@enduragent/kernel/planning";
 import {
@@ -121,6 +122,9 @@ describe("Plan Change repository", () => {
       creationId: id("1"),
       expectedVersion: 2,
       activatedAt: "1998-01-01",
+      todayDateKey: 19980101,
+      mirrorJobId: id("4"),
+      cleanupJobId: id("5"),
       revisionId: id("3"),
       materialize: () => ({
         plan: {
@@ -172,6 +176,8 @@ describe("Plan Change repository", () => {
     expectedVersion: 1,
     decision,
     nowMs: nowMs + 30,
+    todayDateKey: 19980102,
+    mirrorJobId: id("6"),
     materialize: (
       snapshotJson: string,
       current: Parameters<Parameters<typeof repository.apply>[0]["materialize"]>[1],
@@ -370,6 +376,204 @@ describe("Plan Change repository", () => {
     expect(JSON.parse(builder.mock.calls[0]?.[0] ?? "null")).toEqual(after);
   });
 
+  it("enqueues a pending mirror job for a fresh seven-day window on apply", async () => {
+    await activate();
+    await repository.preview(previewInput());
+    const jobs = await store.all("SELECT * FROM plan_reconciliation_job ORDER BY id");
+    await expect(repository.apply(applyInput())).resolves.toMatchObject({ status: "applied" });
+    expect(
+      await store.all("SELECT * FROM plan_reconciliation_job WHERE id<>? ORDER BY id", [id("6")]),
+    ).toEqual(jobs);
+    expect(await store.get("SELECT * FROM plan_reconciliation_job WHERE id=?", [id("6")])).toEqual({
+      id: id("6"),
+      plan_id: planId,
+      kind: "mirror",
+      status: "pending",
+      window_start_date_key: 19980102,
+      window_end_date_key: 19980108,
+      attempt_count: 0,
+      failure_count: 0,
+      resumed_count: 0,
+      last_resumed_attempt: null,
+      last_error_code: null,
+      created_at_ms: nowMs + 30,
+      updated_at_ms: nowMs + 30,
+      completed_at_ms: null,
+    });
+  });
+
+  it("reopens a verified same-window mirror while preserving counters and retained items", async () => {
+    await activate();
+    const reconciliation = createPlanReconciliationRepository(store);
+    await reconciliation.prepareItem({
+      id: id("7"),
+      jobId: id("4"),
+      planWorkoutId: id("31"),
+      operation: "create",
+      dateKey: 19980101,
+      externalId: `cycling-coach:plan:${planId}:${id("31")}`,
+      expectedJson: JSON.stringify(keptWorkout),
+      createdAtMs: nowMs + 4,
+    });
+    await reconciliation.beginAttempt(id("4"), nowMs + 5);
+    await reconciliation.failJob(id("4"), "calendar-list-failed", nowMs + 6);
+    await reconciliation.beginAttempt(id("4"), nowMs + 7);
+    await reconciliation.beginAttempt(id("4"), nowMs + 8);
+    await reconciliation.startItem(id("7"), nowMs + 9);
+    await reconciliation.verifyItem(id("7"), 42, nowMs + 10);
+    const verified = await reconciliation.verifyJob(id("4"), nowMs + 11);
+    const items = await reconciliation.readItems(id("4"));
+    await repository.preview(previewInput(12));
+    await expect(
+      repository.apply({ ...applyInput(), changeId: id("92"), todayDateKey: 19980101 }),
+    ).resolves.toMatchObject({ status: "applied" });
+    expect(await reconciliation.readJob(id("4"))).toEqual({
+      ...verified,
+      status: "pending",
+      lastErrorCode: null,
+      completedAtMs: null,
+      updatedAtMs: nowMs + 30,
+    });
+    expect(await reconciliation.readItems(id("4"))).toEqual(items);
+    expect(await store.all("SELECT id FROM plan_reconciliation_job")).toEqual([{ id: id("4") }]);
+  });
+
+  it("clears delete items when a Workout moves outside and back inside the reopened window", async () => {
+    await activate();
+    await store.run("UPDATE plan SET total_weeks=2,target_date_key=19980114 WHERE id=?", [planId]);
+    const reconciliation = createPlanReconciliationRepository(store);
+    const movedWorkout = { ...removedWorkout, date: "1998-01-09" };
+    const movedSnapshot = {
+      ...draft,
+      weeks: [{ number: 1, minutes: 180, workouts: [keptWorkout, movedWorkout, poolWorkout] }],
+    };
+    const retainedCreate = await reconciliation.prepareItem({
+      id: id("7"),
+      jobId: id("4"),
+      planWorkoutId: id("31"),
+      operation: "create",
+      dateKey: 19980101,
+      externalId: `cycling-coach:plan:${planId}:${id("31")}`,
+      expectedJson: JSON.stringify(keptWorkout),
+      createdAtMs: nowMs + 4,
+    });
+    const movedCreate = await reconciliation.prepareItem({
+      ...retainedCreate,
+      id: id("8"),
+      planWorkoutId: id("32"),
+      dateKey: 19980102,
+      externalId: `cycling-coach:plan:${planId}:${id("32")}`,
+      expectedJson: JSON.stringify(removedWorkout),
+    });
+    const retainedDelete = await reconciliation.prepareItem({
+      ...retainedCreate,
+      id: id("9"),
+      planWorkoutId: null,
+      operation: "delete",
+      externalId: "synthetic-old-event",
+    });
+    await reconciliation.createOrGetJob({
+      id: id("10"),
+      planId,
+      kind: "mirror",
+      windowStartDateKey: 19971231,
+      windowEndDateKey: 19980106,
+      createdAtMs: nowMs + 4,
+    });
+    const otherWindowCreate = await reconciliation.prepareItem({
+      ...movedCreate,
+      id: id("12"),
+      jobId: id("10"),
+    });
+    await reconciliation.beginAttempt(id("4"), nowMs + 5);
+    await reconciliation.verifyItem(retainedCreate.id, 41, nowMs + 6);
+    await reconciliation.verifyItem(movedCreate.id, 42, nowMs + 6);
+    await reconciliation.verifyItem(retainedDelete.id, null, nowMs + 6);
+    await reconciliation.verifyJob(id("4"), nowMs + 7);
+    const retainedItems = (await reconciliation.readItems(id("4"))).filter(
+      (item) => item.id === retainedCreate.id,
+    );
+    await repository.preview({
+      ...previewInput(),
+      build: () => ({
+        afterSnapshotJson: JSON.stringify(movedSnapshot),
+        envelope: {
+          ...envelope,
+          diff: [{ workoutId: "removed", before: removedWorkout, after: movedWorkout }],
+          totals: { before: envelope.totals.before, after: envelope.totals.before },
+        },
+      }),
+    });
+    await expect(
+      repository.apply({
+        ...applyInput(),
+        todayDateKey: 19980101,
+        materialize: (_snapshotJson, current) => {
+          const moved = current.find((workout) => workout.id === id("32"));
+          if (moved === undefined) throw new Error("Expected moved Workout");
+          return {
+            insert: [],
+            delete: [],
+            update: [{ ...moved, dateKey: 19980109, structureJson: JSON.stringify(movedWorkout) }],
+          };
+        },
+      }),
+    ).resolves.toMatchObject({ status: "applied" });
+    expect(await reconciliation.readItems(id("4"))).toEqual(retainedItems);
+    expect(await reconciliation.readItems(id("10"))).toEqual([otherWindowCreate]);
+    expect(await reconciliation.readJob(id("4"))).toMatchObject({ status: "pending" });
+    expect(await store.get("SELECT date_key FROM plan_workout WHERE id=?", [id("32")])).toEqual({
+      date_key: 19980109,
+    });
+    await reconciliation.prepareItem({
+      ...movedCreate,
+      id: id("13"),
+      operation: "delete",
+      planWorkoutId: null,
+      createdAtMs: nowMs + 31,
+    });
+    await repository.preview({
+      ...previewInput(40),
+      expectedVersion: 2,
+      build: () => ({
+        afterSnapshotJson: JSON.stringify(draft),
+        envelope: {
+          ...envelope,
+          diff: [{ workoutId: "removed", before: movedWorkout, after: removedWorkout }],
+          totals: { before: envelope.totals.before, after: envelope.totals.before },
+        },
+      }),
+    });
+    await expect(
+      repository.apply({
+        ...applyInput(),
+        command: stamp("restore", 50),
+        changeId: id("120"),
+        expectedVersion: 2,
+        nowMs: nowMs + 50,
+        todayDateKey: 19980101,
+        materialize: (_snapshotJson, current) => {
+          const moved = current.find((workout) => workout.id === id("32"));
+          if (moved === undefined) throw new Error("Expected moved Workout");
+          return {
+            insert: [],
+            delete: [],
+            update: [
+              { ...moved, dateKey: 19980102, structureJson: JSON.stringify(removedWorkout) },
+            ],
+          };
+        },
+      }),
+    ).resolves.toMatchObject({ status: "applied" });
+    expect(await reconciliation.readItems(id("4"))).toEqual(retainedItems);
+    expect(retainedItems).toHaveLength(1);
+    expect(retainedItems[0]?.operation).toBe("create");
+    expect(await reconciliation.readItems(id("10"))).toEqual([otherWindowCreate]);
+    expect(await store.get("SELECT date_key FROM plan_workout WHERE id=?", [id("32")])).toEqual({
+      date_key: 19980102,
+    });
+  });
+
   it("preserves an unchanged Workout's full row after an athlete edit", async () => {
     await activate();
     await repository.preview(previewInput());
@@ -484,11 +688,20 @@ describe("Plan Change repository", () => {
       const input = applyInput(decision);
       const result = await repository.apply(input);
       const before = await dumpStore(store);
+      const jobs = await store.all("SELECT * FROM plan_reconciliation_job ORDER BY id");
       const materialize = vi.fn(input.materialize);
-      expect(JSON.stringify(await repository.apply({ ...input, materialize }))).toBe(
-        JSON.stringify(result),
-      );
+      expect(
+        JSON.stringify(
+          await repository.apply({
+            ...input,
+            mirrorJobId: id("8"),
+            todayDateKey: 19980103,
+            materialize,
+          }),
+        ),
+      ).toBe(JSON.stringify(result));
       expect(materialize).not.toHaveBeenCalled();
+      expect(await store.all("SELECT * FROM plan_reconciliation_job ORDER BY id")).toEqual(jobs);
       await expect(
         repository.apply({
           ...input,
@@ -506,6 +719,7 @@ describe("Plan Change repository", () => {
     const workouts = await store.all("SELECT * FROM plan_workout");
     const revisions = await store.all("SELECT * FROM plan_revision");
     const plan = await store.all("SELECT * FROM planning_plan");
+    const jobs = await store.all("SELECT * FROM plan_reconciliation_job ORDER BY id");
     const materialize = vi.fn(applyInput().materialize);
     await expect(repository.apply({ ...applyInput("cancel"), materialize })).resolves.toEqual({
       status: "cancelled",
@@ -516,6 +730,7 @@ describe("Plan Change repository", () => {
     expect(await store.all("SELECT * FROM plan_workout")).toEqual(workouts);
     expect(await store.all("SELECT * FROM plan_revision")).toEqual(revisions);
     expect(await store.all("SELECT * FROM planning_plan")).toEqual(plan);
+    expect(await store.all("SELECT * FROM plan_reconciliation_job ORDER BY id")).toEqual(jobs);
     expect(await store.get("SELECT diff_json FROM plan_change")).toEqual(original);
     await expect(repository.listChanges(planId)).resolves.toMatchObject([
       { status: "cancelled", resultRevisionNumber: null, supersededBy: null },

--- a/packages/kernel-node/tests/plan-creation-activation.test.ts
+++ b/packages/kernel-node/tests/plan-creation-activation.test.ts
@@ -39,6 +39,9 @@ const activationInput = (key = "1") => {
     creationId: id(key),
     expectedVersion: 2,
     activatedAt: "1998-01-01",
+    todayDateKey: 19980101,
+    mirrorJobId: id(`5${key}`),
+    cleanupJobId: id(`6${key}`),
     revisionId: id(`2${key}`),
     materialize: () => ({
       plan: {
@@ -140,6 +143,24 @@ describe("Plan Creation activation repository", () => {
     expect(await store.all("SELECT id,status FROM plan")).toEqual([
       { id: id("11"), status: "active" },
     ]);
+    expect(await store.all("SELECT * FROM plan_reconciliation_job")).toEqual([
+      {
+        id: input.mirrorJobId,
+        plan_id: id("11"),
+        kind: "mirror",
+        status: "pending",
+        window_start_date_key: 19980101,
+        window_end_date_key: 19980107,
+        attempt_count: 0,
+        failure_count: 0,
+        resumed_count: 0,
+        last_resumed_attempt: null,
+        last_error_code: null,
+        created_at_ms: input.command.nowMs,
+        updated_at_ms: input.command.nowMs,
+        completed_at_ms: null,
+      },
+    ]);
     expect(await store.all("SELECT date_key,origin,structure_json FROM plan_workout")).toEqual([
       { date_key: 19980101, origin: "coach", structure_json: JSON.stringify(datedWorkout) },
     ]);
@@ -187,10 +208,42 @@ describe("Plan Creation activation repository", () => {
       { id: first.planId, status: "ended" },
       { id: second.planId, status: "active" },
     ]);
+    expect(
+      await store.all(
+        "SELECT id,plan_id,kind,status,window_start_date_key,window_end_date_key FROM plan_reconciliation_job ORDER BY id",
+      ),
+    ).toEqual([
+      {
+        id: id("51"),
+        plan_id: first.planId,
+        kind: "mirror",
+        status: "pending",
+        window_start_date_key: 19980101,
+        window_end_date_key: 19980107,
+      },
+      {
+        id: id("52"),
+        plan_id: second.planId,
+        kind: "mirror",
+        status: "pending",
+        window_start_date_key: 19980101,
+        window_end_date_key: 19980107,
+      },
+      {
+        id: id("62"),
+        plan_id: first.planId,
+        kind: "cleanup",
+        status: "pending",
+        window_start_date_key: 19980102,
+        window_end_date_key: 19980114,
+      },
+    ]);
     const before = await dumpStore(store);
     await expect(
       createPlanCreationRepository(store).activate({
         ...activationInput(),
+        mirrorJobId: id("91"),
+        cleanupJobId: id("92"),
         materialize: () => {
           throw new Error("Replay must not materialize again");
         },
@@ -204,6 +257,26 @@ describe("Plan Creation activation repository", () => {
       }),
     ).rejects.toMatchObject({ code: "command-conflict" });
     expect(await dumpStore(store)).toBe(before);
+  });
+
+  it("uses civil-day windows and keeps cleanup nonempty after the incumbent's final day", async () => {
+    await review();
+    await repository.activate(activationInput());
+    await review("2");
+    await repository.activate({
+      ...activationInput("2"),
+      activatedAt: "1998-01-31",
+      todayDateKey: 19980131,
+    });
+    expect(
+      await store.all(
+        "SELECT kind,window_start_date_key,window_end_date_key FROM plan_reconciliation_job WHERE id IN (?,?) ORDER BY id",
+        [id("52"), id("62")],
+      ),
+    ).toEqual([
+      { kind: "mirror", window_start_date_key: 19980131, window_end_date_key: 19980206 },
+      { kind: "cleanup", window_start_date_key: 19980201, window_end_date_key: 19980201 },
+    ]);
   });
 
   it.each(["missing", "stale", "version", "empty", "fingerprint"])(
@@ -277,6 +350,15 @@ describe("Plan Creation activation repository", () => {
           expect(await store.get("SELECT status FROM plan_creation WHERE id=?", [id("2")])).toEqual(
             { status: "activated" },
           );
+          expect(
+            await store.all(
+              "SELECT id,plan_id,kind,status FROM plan_reconciliation_job WHERE id IN (?,?) ORDER BY id",
+              [id("52"), id("62")],
+            ),
+          ).toEqual([
+            { id: id("52"), plan_id: id("12"), kind: "mirror", status: "pending" },
+            { id: id("62"), plan_id: id("11"), kind: "cleanup", status: "pending" },
+          ]);
           closureObserved = true;
           throw new Error("Synthetic activation ledger failure");
         }

--- a/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
+++ b/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
@@ -42,6 +42,9 @@ const activationInput = (key = "1") => {
     creationId: id(key),
     expectedVersion: 2,
     activatedAt: "1998-01-01",
+    todayDateKey: 19980101,
+    mirrorJobId: id(`5${key}`),
+    cleanupJobId: id(`6${key}`),
     revisionId: id(`2${key}`),
     materialize: () => ({
       plan: {
@@ -176,7 +179,7 @@ describe("Plan lifecycle repository", () => {
     expect(await store.get("SELECT status FROM plan")).toEqual({ status: "ended" });
     expect(
       await store.get(`SELECT kind,status,window_start_date_key,window_end_date_key
-      FROM plan_reconciliation_job`),
+      FROM plan_reconciliation_job WHERE kind='cleanup'`),
     ).toEqual({
       kind: "cleanup",
       status: "pending",
@@ -250,7 +253,7 @@ describe("Plan lifecycle repository", () => {
     await lifecycle.close({ ...closeInput(), todayDateKey: 19980201 });
     expect(
       await store.get(
-        "SELECT window_start_date_key,window_end_date_key FROM plan_reconciliation_job",
+        "SELECT window_start_date_key,window_end_date_key FROM plan_reconciliation_job WHERE kind='cleanup'",
       ),
     ).toEqual({ window_start_date_key: 19980202, window_end_date_key: 19980202 });
   });
@@ -351,7 +354,7 @@ describe("Plan lifecycle repository", () => {
       expect(await store.get("SELECT status FROM plan")).toEqual({ status: "ended" });
       expect(
         await store.get(
-          "SELECT kind,status,window_start_date_key,window_end_date_key FROM plan_reconciliation_job",
+          "SELECT kind,status,window_start_date_key,window_end_date_key FROM plan_reconciliation_job WHERE kind='cleanup'",
         ),
       ).toEqual({
         kind: "cleanup",
@@ -421,7 +424,10 @@ describe("Plan lifecycle repository", () => {
       [id("90"), id("11"), nowMs, nowMs],
     );
     await expect(lifecycle.close(closeInput())).resolves.toMatchObject({ cleanupJobId: id("90") });
-    expect(await store.all("SELECT id FROM plan_reconciliation_job")).toEqual([{ id: id("90") }]);
+    expect(await store.all("SELECT id FROM plan_reconciliation_job ORDER BY id")).toEqual([
+      { id: id("51") },
+      { id: id("90") },
+    ]);
   });
 
   it("reads immutable closed details including undated Workouts and cleanup state", async () => {

--- a/packages/kernel-node/tests/plan-reconciliation-repository.test.ts
+++ b/packages/kernel-node/tests/plan-reconciliation-repository.test.ts
@@ -22,14 +22,37 @@ async function seedPlan(store: SqlStore): Promise<void> {
       id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,total_weeks,
       week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
     ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-    [PLAN_ID, null, "Synthetic Plan", "Synthetic goal", 20260824, 20261115, "active",
-      "short_race_preparation", 12, 1, "{}", 1, 1, "device", 1, 0],
+    [
+      PLAN_ID,
+      null,
+      "Synthetic Plan",
+      "Synthetic goal",
+      19980824,
+      19981115,
+      "active",
+      "short_race_preparation",
+      12,
+      1,
+      "{}",
+      1,
+      1,
+      "device",
+      1,
+      0,
+    ],
+  );
+  await store.run(
+    `INSERT INTO planning_plan (
+      plan_id,status,version,current_revision_number,activated_at_ms,updated_at_ms,
+      device_id,hlc_physical_ms,hlc_counter
+    ) VALUES (?,'active',1,1,1,1,'device',1,0)`,
+    [PLAN_ID],
   );
   await store.run(
     `INSERT INTO plan_workout (
       id,plan_id,date_key,sport,name,duration_s,structure_json,origin,device_id,hlc_physical_ms,hlc_counter
     ) VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
-    [WORKOUT_ID, PLAN_ID, 20260825, "cycling", "Endurance", 3600, "{}", "coach", "device", 1, 0],
+    [WORKOUT_ID, PLAN_ID, 19980825, "cycling", "Endurance", 3600, "{}", "coach", "device", 1, 0],
   );
 }
 
@@ -38,8 +61,8 @@ function job() {
     id: JOB_ID,
     planId: PLAN_ID,
     kind: "mirror" as const,
-    windowStartDateKey: 20260825,
-    windowEndDateKey: 20260831,
+    windowStartDateKey: 19980825,
+    windowEndDateKey: 19980831,
     createdAtMs: 10,
   };
 }
@@ -50,7 +73,7 @@ function item(expectedJson = "{}") {
     jobId: JOB_ID,
     planWorkoutId: WORKOUT_ID,
     operation: "create" as const,
-    dateKey: 20260825,
+    dateKey: 19980825,
     externalId: `cycling-coach:plan:${PLAN_ID}:${WORKOUT_ID}`,
     expectedJson,
     createdAtMs: 10,
@@ -90,6 +113,190 @@ describe("Plan reconciliation repository", () => {
     expect(await repository.readItems(JOB_ID)).toEqual([savedItem]);
   });
 
+  it("lists runnable jobs across Plans by window, creation time, and identity", async () => {
+    const repository = await fresh();
+    if (store === undefined) throw new Error("missing store");
+    const otherPlanId = "01K00000000000000000000009";
+    await store.run(
+      `INSERT INTO plan (
+        id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,total_weeks,
+        week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+      ) SELECT ?,origin_id,name,primary_goal,start_date_key,target_date_key,'ended',kind,total_weeks,
+        week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+        FROM plan WHERE id=?`,
+      [otherPlanId, PLAN_ID],
+    );
+    const pendingId = "01K00000000000000000000010";
+    const retryingId = "01K00000000000000000000011";
+    const failedId = "01K00000000000000000000012";
+    const staleId = "01K00000000000000000000013";
+    const freshId = "01K00000000000000000000014";
+    const exhaustedId = "01K00000000000000000000015";
+    const verifiedId = "01K00000000000000000000016";
+    for (const record of [
+      { id: staleId, planId: PLAN_ID, windowStartDateKey: 19980827, createdAtMs: 10 },
+      { id: failedId, planId: PLAN_ID, windowStartDateKey: 19980826, createdAtMs: 11 },
+      { id: retryingId, planId: otherPlanId, windowStartDateKey: 19980826, createdAtMs: 11 },
+      { id: pendingId, planId: PLAN_ID, windowStartDateKey: 19980826, createdAtMs: 10 },
+      { id: freshId, planId: PLAN_ID, windowStartDateKey: 19980825, createdAtMs: 10 },
+      { id: exhaustedId, planId: PLAN_ID, windowStartDateKey: 19980824, createdAtMs: 10 },
+      { id: verifiedId, planId: otherPlanId, windowStartDateKey: 19980824, createdAtMs: 10 },
+    ]) {
+      await repository.createOrGetJob({
+        ...job(),
+        ...record,
+        kind: record.planId === otherPlanId ? "cleanup" : "mirror",
+        windowEndDateKey: record.createdAtMs === 11 ? 19980901 : 19980831,
+      });
+    }
+    for (const id of [retryingId, failedId, exhaustedId]) {
+      await repository.beginAttempt(id, 20);
+      await repository.failJob(id, "calendar-list-failed", 21);
+    }
+    await repository.beginAttempt(retryingId, 99);
+    await repository.beginAttempt(exhaustedId, 22);
+    await repository.failJob(exhaustedId, "calendar-list-failed", 23);
+    await repository.beginAttempt(staleId, 50);
+    await repository.beginAttempt(freshId, 51);
+    await repository.beginAttempt(verifiedId, 20);
+    await repository.verifyJob(verifiedId, 21);
+    const runnable = await repository.listRunnable({ nowMs: 100, leaseMs: 50, maxFailures: 2 });
+    expect(runnable.map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: pendingId, status: "pending" },
+      { id: retryingId, status: "retrying" },
+      { id: failedId, status: "failed" },
+      { id: staleId, status: "running" },
+    ]);
+  });
+
+  it("lists cleanup but excludes closed Chat and legacy Plan mirrors", async () => {
+    const repository = await fresh();
+    if (store === undefined) throw new Error("missing store");
+    const legacyPlanId = "01K00000000000000000000009";
+    await store.run(
+      `INSERT INTO plan (
+        id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,total_weeks,
+        week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+      ) SELECT ?,origin_id,name,primary_goal,start_date_key,target_date_key,'ended',kind,total_weeks,
+        week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+        FROM plan WHERE id=?`,
+      [legacyPlanId, PLAN_ID],
+    );
+    await store.run(
+      `UPDATE planning_plan SET status='closed',version=version+1,closed_at_ms=2,updated_at_ms=2,
+        close_reason='stopped',close_actor='device' WHERE plan_id=?`,
+      [PLAN_ID],
+    );
+    const closedMirror = await repository.createOrGetJob(job());
+    const legacyMirror = await repository.createOrGetJob({
+      ...job(),
+      id: "01K00000000000000000000010",
+      planId: legacyPlanId,
+    });
+    const cleanup = await repository.createOrGetJob({
+      ...job(),
+      id: "01K00000000000000000000011",
+      kind: "cleanup",
+    });
+    expect(closedMirror.status).toBe("pending");
+    expect(legacyMirror.status).toBe("pending");
+    expect(await repository.listRunnable({ nowMs: 100, leaseMs: 50, maxFailures: 5 })).toEqual([
+      cleanup,
+    ]);
+  });
+
+  it("claims a pending job and preserves a fresh lease until its exact expiry", async () => {
+    const repository = await fresh();
+    await repository.createOrGetJob(job());
+    const running = await repository.claim(JOB_ID, 20, 50);
+    expect(running).toMatchObject({
+      status: "running",
+      attemptCount: 1,
+      resumedCount: 0,
+      lastResumedAttempt: null,
+      updatedAtMs: 20,
+    });
+    expect(await repository.claim(JOB_ID, 69, 50)).toBeUndefined();
+    expect(await repository.readJob(JOB_ID)).toEqual(running);
+    expect(await repository.claim(JOB_ID, 70, 50)).toMatchObject({
+      status: "running",
+      attemptCount: 2,
+      resumedCount: 1,
+      lastResumedAttempt: 2,
+      updatedAtMs: 70,
+    });
+    const verified = await repository.verifyJob(JOB_ID, 71);
+    expect(await repository.claim(JOB_ID, 200, 50)).toBeUndefined();
+    expect(await repository.readJob(JOB_ID)).toEqual(verified);
+  });
+
+  it("claims failed jobs as retries and resumes an interrupted retry", async () => {
+    const repository = await fresh();
+    await repository.createOrGetJob(job());
+    await repository.beginAttempt(JOB_ID, 20);
+    await repository.failJob(JOB_ID, "calendar-list-failed", 21);
+    expect(await repository.claim(JOB_ID, 22, 50)).toMatchObject({
+      status: "retrying",
+      attemptCount: 2,
+      failureCount: 1,
+      resumedCount: 0,
+      lastResumedAttempt: null,
+      lastErrorCode: null,
+      completedAtMs: null,
+      updatedAtMs: 22,
+    });
+    expect(await repository.claim(JOB_ID, 23, 50)).toBeUndefined();
+    expect(await repository.claim(JOB_ID, 71, 50)).toBeUndefined();
+    expect(await repository.claim(JOB_ID, 72, 50)).toMatchObject({
+      status: "retrying",
+      attemptCount: 3,
+      failureCount: 1,
+      resumedCount: 1,
+      lastResumedAttempt: 3,
+      updatedAtMs: 72,
+    });
+  });
+
+  it("serializes concurrent claims so only one obtains a pending job", async () => {
+    const repository = await fresh();
+    await repository.createOrGetJob(job());
+    const claims = await Promise.all([
+      repository.claim(JOB_ID, 20, 50),
+      repository.claim(JOB_ID, 20, 50),
+    ]);
+    expect(claims.filter((claim) => claim !== undefined)).toHaveLength(1);
+    expect(await repository.readJob(JOB_ID)).toMatchObject({ attemptCount: 1, resumedCount: 0 });
+  });
+
+  it("reads the newest window even when an older window was updated later", async () => {
+    const repository = await fresh();
+    expect(await repository.readLatestJobByWindow(PLAN_ID, "mirror")).toBeUndefined();
+    const older = await repository.createOrGetJob(job());
+    const newer = await repository.createOrGetJob({
+      ...job(),
+      id: "01K00000000000000000000005",
+      windowStartDateKey: 19980826,
+      windowEndDateKey: 19980901,
+    });
+    const longest = await repository.createOrGetJob({
+      ...job(),
+      id: "01K00000000000000000000006",
+      windowStartDateKey: 19980826,
+      windowEndDateKey: 19980902,
+    });
+    await repository.createOrGetJob({
+      ...job(),
+      id: "01K00000000000000000000007",
+      kind: "cleanup",
+      windowStartDateKey: 19980827,
+      windowEndDateKey: 19980903,
+    });
+    await repository.beginAttempt(newer.id, 20);
+    await repository.beginAttempt(older.id, 30);
+    expect(await repository.readLatestJobByWindow(PLAN_ID, "mirror")).toEqual(longest);
+    expect(await repository.readLatestJob(PLAN_ID, "mirror")).toMatchObject({ id: older.id });
+  });
+
   it("tracks first failure retry repeated failure and final verification", async () => {
     const repository = await fresh();
     await repository.createOrGetJob(job());
@@ -119,6 +326,51 @@ describe("Plan reconciliation repository", () => {
       attemptCount: 3,
       completedAtMs: 23,
     });
+  });
+
+  it.each(["pending", "running", "retrying", "failed", "verified"] as const)(
+    "reopens a %s job while preserving its counters and items",
+    async (status) => {
+      const repository = await fresh();
+      await repository.createOrGetJob(job());
+      if (status !== "pending") {
+        await repository.beginAttempt(JOB_ID, 11);
+        await repository.failJob(JOB_ID, "calendar-list-failed", 12);
+        if (status !== "failed") {
+          await repository.beginAttempt(JOB_ID, 13);
+          await repository.beginAttempt(JOB_ID, 14);
+          if (status === "running") {
+            await repository.reopenJob(JOB_ID, 15);
+            await repository.beginAttempt(JOB_ID, 16);
+          }
+          if (status === "verified") await repository.verifyJob(JOB_ID, 17);
+        }
+      }
+      const before = await repository.readJob(JOB_ID);
+      expect(before?.status).toBe(status);
+      const savedItem = await repository.prepareItem(item());
+      expect(await repository.reopenJob(JOB_ID, 20)).toEqual({
+        ...before,
+        status: "pending",
+        lastErrorCode: null,
+        completedAtMs: null,
+        updatedAtMs: 20,
+      });
+      expect(await repository.readItems(JOB_ID)).toEqual([savedItem]);
+    },
+  );
+
+  it("rejects invalid reopen input and missing jobs", async () => {
+    const repository = await fresh();
+    await expect(repository.reopenJob("invalid", 20)).rejects.toEqual(
+      new PlanReconciliationValidationError("invalid-job"),
+    );
+    await expect(repository.reopenJob(JOB_ID, -1)).rejects.toEqual(
+      new PlanReconciliationValidationError("invalid-job"),
+    );
+    await expect(repository.reopenJob(JOB_ID, 20)).rejects.toEqual(
+      new PlanReconciliationValidationError("missing-job"),
+    );
   });
 
   it("refuses to verify a job while any item is incomplete", async () => {
@@ -220,14 +472,34 @@ describe("Plan reconciliation repository", () => {
     expect(await repository.readItems(JOB_ID)).toMatchObject([{ status: "running" }]);
   });
 
+  it("deletes a single item and leaves the job and its other items intact", async () => {
+    const repository = await fresh();
+    await repository.createOrGetJob(job());
+    await repository.prepareItem(item());
+    const second = await repository.prepareItem({
+      ...item(),
+      id: "01K00000000000000000000005",
+      externalId: "cycling-coach:plan:second",
+    });
+    await repository.deleteItem(ITEM_ID);
+    expect(await repository.readItems(JOB_ID)).toMatchObject([{ id: second.id }]);
+    expect(await repository.readJob(JOB_ID)).toMatchObject({ status: "pending" });
+    await expect(repository.deleteItem("nope")).rejects.toEqual(
+      new PlanReconciliationValidationError("invalid-item"),
+    );
+  });
+
   it("rejects invalid jobs and items before storage", async () => {
     const repository = await fresh();
-    await expect(repository.createOrGetJob({ ...job(), windowEndDateKey: 20260824 }))
-      .rejects.toEqual(new PlanReconciliationValidationError("invalid-job"));
-    await expect(repository.createOrGetJob({ ...job(), windowStartDateKey: 20260230 }))
-      .rejects.toEqual(new PlanReconciliationValidationError("invalid-job"));
+    await expect(
+      repository.createOrGetJob({ ...job(), windowEndDateKey: 19980824 }),
+    ).rejects.toEqual(new PlanReconciliationValidationError("invalid-job"));
+    await expect(
+      repository.createOrGetJob({ ...job(), windowStartDateKey: 19980230 }),
+    ).rejects.toEqual(new PlanReconciliationValidationError("invalid-job"));
     await repository.createOrGetJob(job());
-    await expect(repository.prepareItem({ ...item(), externalId: "" }))
-      .rejects.toEqual(new PlanReconciliationValidationError("invalid-item"));
+    await expect(repository.prepareItem({ ...item(), externalId: "" })).rejects.toEqual(
+      new PlanReconciliationValidationError("invalid-item"),
+    );
   });
 });

--- a/packages/kernel/src/planning/change-repository.ts
+++ b/packages/kernel/src/planning/change-repository.ts
@@ -3,7 +3,7 @@ import { canonicalJson } from "../archive/canonical.js";
 import { createPlanningCommandLedger, fail, PlanCreationStoreError } from "./command-ledger.js";
 import type { PlanCreationCommandStamp, PlanningCommandName } from "./command-ledger.js";
 import type { PlanCreationStore } from "./creation-repository.js";
-import { dateKeyFromText } from "./date-keys.js";
+import { addCivilDays, dateKeyFromText } from "./date-keys.js";
 import { createPlanRepository, validatePlanWorkoutRecord } from "./repository.js";
 import type { PlanWorkoutRecord } from "./repository.js";
 
@@ -96,6 +96,8 @@ export interface ApplyPlanChangeInput {
   readonly expectedVersion: number;
   readonly decision: "apply" | "cancel";
   readonly nowMs: number;
+  readonly todayDateKey: number;
+  readonly mirrorJobId: string;
   readonly materialize: (
     afterSnapshotJson: string,
     currentWorkouts: readonly PlanWorkoutRecord[],
@@ -468,6 +470,45 @@ export function createPlanChangeRepository(
               input.command.hlcCounter,
               input.planId,
             ],
+          );
+          const windowEnd = addCivilDays(input.todayDateKey, 6);
+          await store.run(
+            `INSERT INTO plan_reconciliation_job (
+            id,plan_id,kind,status,window_start_date_key,window_end_date_key,
+            attempt_count,failure_count,resumed_count,last_resumed_attempt,last_error_code,
+            created_at_ms,updated_at_ms,completed_at_ms
+            ) VALUES (?,?,'mirror','pending',?,?,0,0,0,NULL,NULL,?,?,NULL)
+            ON CONFLICT(plan_id,kind,window_start_date_key,window_end_date_key) DO NOTHING`,
+            [
+              input.mirrorJobId,
+              input.planId,
+              input.todayDateKey,
+              windowEnd,
+              input.nowMs,
+              input.nowMs,
+            ],
+          );
+          const job = z.object({ id: UlidSchema }).parse(
+            await store.get(
+              `SELECT id FROM plan_reconciliation_job
+              WHERE plan_id=? AND kind='mirror' AND window_start_date_key=? AND window_end_date_key=?`,
+              [input.planId, input.todayDateKey, windowEnd],
+            ),
+          );
+          await store.run(
+            `DELETE FROM plan_reconciliation_item
+            WHERE job_id=? AND (operation='delete' OR (operation='create' AND (
+              plan_workout_id IS NULL OR NOT EXISTS (
+                SELECT 1 FROM plan_workout WHERE id=plan_workout_id
+                  AND origin='coach' AND date_key BETWEEN ? AND ?
+              )
+            )))`,
+            [job.id, input.todayDateKey, windowEnd],
+          );
+          await store.run(
+            `UPDATE plan_reconciliation_job SET status='pending',last_error_code=NULL,
+            completed_at_ms=NULL,updated_at_ms=? WHERE id=?`,
+            [input.nowMs, job.id],
           );
           result = {
             status: "applied",

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -16,6 +16,7 @@ export {
   type PlanCreationCommandStamp,
 } from "./command-ledger.js";
 import { canonicalJson } from "../archive/canonical.js";
+import { addCivilDays } from "./date-keys.js";
 import type { MigratorStore } from "../store/migrator.js";
 import type { Row, SqlStore } from "../store/ports.js";
 import { z } from "zod";
@@ -133,6 +134,9 @@ export type PlanCreationActivationResult = z.infer<typeof PlanCreationActivation
 
 export interface ActivatePlanCreationInput extends DiscardPlanCreationInput {
   readonly activatedAt: string;
+  readonly todayDateKey: number;
+  readonly mirrorJobId: string;
+  readonly cleanupJobId: string;
   readonly revisionId: string;
   readonly materialize: (snapshot: PlanCreationSnapshot) => {
     readonly plan: PlanRecord;
@@ -421,7 +425,17 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
         return { outcome: "recorded", snapshot };
       });
     },
-    async activate({ command, creationId, expectedVersion, activatedAt, revisionId, materialize }) {
+    async activate({
+      command,
+      creationId,
+      expectedVersion,
+      activatedAt,
+      todayDateKey,
+      mirrorJobId,
+      cleanupJobId,
+      revisionId,
+      materialize,
+    }) {
       return store.transaction(async () => {
         const prior = await hasReplay("plan_creation.activate", command);
         if (prior !== undefined) {
@@ -525,6 +539,46 @@ VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
               workout.hlcPhysicalMs,
               workout.hlcCounter,
             ],
+          );
+        }
+        await store.run(
+          `INSERT INTO plan_reconciliation_job (
+id,plan_id,kind,status,window_start_date_key,window_end_date_key,
+attempt_count,failure_count,resumed_count,last_resumed_attempt,last_error_code,
+created_at_ms,updated_at_ms,completed_at_ms
+) VALUES (?,?,'mirror','pending',?,?,0,0,0,NULL,NULL,?,?,NULL)
+ON CONFLICT(plan_id,kind,window_start_date_key,window_end_date_key) DO NOTHING`,
+          [
+            mirrorJobId,
+            plan.id,
+            todayDateKey,
+            addCivilDays(todayDateKey, 6),
+            command.nowMs,
+            command.nowMs,
+          ],
+        );
+        if (closedPlanId !== null) {
+          const closedPlan = await store.get(
+            "SELECT start_date_key,total_weeks FROM plan WHERE id=?",
+            [closedPlanId],
+          );
+          if (closedPlan === undefined) return fail();
+          const windowStart = addCivilDays(todayDateKey, 1);
+          const windowEnd = Math.max(
+            windowStart,
+            addCivilDays(
+              integer(closedPlan, "start_date_key"),
+              integer(closedPlan, "total_weeks") * 7 - 1,
+            ),
+          );
+          await store.run(
+            `INSERT INTO plan_reconciliation_job (
+id,plan_id,kind,status,window_start_date_key,window_end_date_key,
+attempt_count,failure_count,resumed_count,last_resumed_attempt,last_error_code,
+created_at_ms,updated_at_ms,completed_at_ms
+) VALUES (?,?,'cleanup','pending',?,?,0,0,0,NULL,NULL,?,?,NULL)
+ON CONFLICT(plan_id,kind,window_start_date_key,window_end_date_key) DO NOTHING`,
+            [cleanupJobId, closedPlanId, windowStart, windowEnd, command.nowMs, command.nowMs],
           );
         }
         await store.run(

--- a/packages/kernel/src/planning/reconciliation-repository.ts
+++ b/packages/kernel/src/planning/reconciliation-repository.ts
@@ -4,7 +4,12 @@ import { addCivilDays } from "./date-keys.js";
 
 export type PlanReconciliationKind = "mirror" | "cleanup";
 export type PlanReconciliationStatus = "pending" | "running" | "retrying" | "failed" | "verified";
-export type PlanReconciliationItemStatus = "pending" | "running" | "created" | "failed" | "verified";
+export type PlanReconciliationItemStatus =
+  | "pending"
+  | "running"
+  | "created"
+  | "failed"
+  | "verified";
 export type PlanReconciliationOperation = "create" | "delete";
 export type PlanReconciliationErrorCode =
   | "calendar-list-failed"
@@ -73,7 +78,22 @@ export interface PlanReconciliationRepository {
     planId: string,
     kind: PlanReconciliationKind,
   ): Promise<PlanReconciliationJobRecord | undefined>;
+  listRunnable(input: {
+    nowMs: number;
+    leaseMs: number;
+    maxFailures: number;
+  }): Promise<readonly PlanReconciliationJobRecord[]>;
+  claim(
+    id: string,
+    nowMs: number,
+    leaseMs: number,
+  ): Promise<PlanReconciliationJobRecord | undefined>;
+  readLatestJobByWindow(
+    planId: string,
+    kind: PlanReconciliationKind,
+  ): Promise<PlanReconciliationJobRecord | undefined>;
   beginAttempt(id: string, updatedAtMs: number): Promise<PlanReconciliationJobRecord>;
+  reopenJob(id: string, updatedAtMs: number): Promise<PlanReconciliationJobRecord>;
   failJob(
     id: string,
     errorCode: PlanReconciliationErrorCode,
@@ -94,6 +114,7 @@ export interface PlanReconciliationRepository {
     providerEventId: number | null,
     updatedAtMs: number,
   ): Promise<PlanReconciliationItemRecord>;
+  deleteItem(id: string): Promise<void>;
 }
 
 export class PlanReconciliationValidationError extends Error {
@@ -131,7 +152,11 @@ const ITEM_ERROR_CODE = new Set<unknown>([
 ]);
 
 function validDateKey(value: unknown): value is number {
-  if (!Number.isSafeInteger(value) || (value as number) < 10_101 || (value as number) > 99_991_231) {
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < 10_101 ||
+    (value as number) > 99_991_231
+  ) {
     return false;
   }
   try {
@@ -158,13 +183,13 @@ function validJson(value: unknown): value is string {
 
 function validateNewJob(record: NewPlanReconciliationJob): void {
   if (
-    !ULID.test(record.id)
-    || !ULID.test(record.planId)
-    || !JOB_KIND.has(record.kind)
-    || !validDateKey(record.windowStartDateKey)
-    || !validDateKey(record.windowEndDateKey)
-    || record.windowEndDateKey < record.windowStartDateKey
-    || !validTimestamp(record.createdAtMs)
+    !ULID.test(record.id) ||
+    !ULID.test(record.planId) ||
+    !JOB_KIND.has(record.kind) ||
+    !validDateKey(record.windowStartDateKey) ||
+    !validDateKey(record.windowEndDateKey) ||
+    record.windowEndDateKey < record.windowStartDateKey ||
+    !validTimestamp(record.createdAtMs)
   ) {
     throw new PlanReconciliationValidationError("invalid-job");
   }
@@ -172,17 +197,17 @@ function validateNewJob(record: NewPlanReconciliationJob): void {
 
 function validateNewItem(record: NewPlanReconciliationItem): void {
   if (
-    !ULID.test(record.id)
-    || !ULID.test(record.jobId)
-    || (record.planWorkoutId !== null && !ULID.test(record.planWorkoutId))
-    || !OPERATION.has(record.operation)
-    || (record.operation === "create" && record.planWorkoutId === null)
-    || !validDateKey(record.dateKey)
-    || typeof record.externalId !== "string"
-    || record.externalId.length < 1
-    || record.externalId.length > 256
-    || !validJson(record.expectedJson)
-    || !validTimestamp(record.createdAtMs)
+    !ULID.test(record.id) ||
+    !ULID.test(record.jobId) ||
+    (record.planWorkoutId !== null && !ULID.test(record.planWorkoutId)) ||
+    !OPERATION.has(record.operation) ||
+    (record.operation === "create" && record.planWorkoutId === null) ||
+    !validDateKey(record.dateKey) ||
+    typeof record.externalId !== "string" ||
+    record.externalId.length < 1 ||
+    record.externalId.length > 256 ||
+    !validJson(record.expectedJson) ||
+    !validTimestamp(record.createdAtMs)
   ) {
     throw new PlanReconciliationValidationError("invalid-item");
   }
@@ -206,29 +231,30 @@ function jobFromRow(row: Row): PlanReconciliationJobRecord {
     completedAtMs: row.completed_at_ms as number | null,
   };
   if (
-    !ULID.test(value.id)
-    || !ULID.test(value.planId)
-    || !JOB_KIND.has(value.kind)
-    || !STATUS.has(value.status)
-    || !validDateKey(value.windowStartDateKey)
-    || !validDateKey(value.windowEndDateKey)
-    || value.windowEndDateKey < value.windowStartDateKey
-    || !Number.isSafeInteger(value.attemptCount)
-    || value.attemptCount < 0
-    || !Number.isSafeInteger(value.resumedCount)
-    || value.resumedCount < 0
-    || !Number.isSafeInteger(value.failureCount)
-    || value.failureCount < 0
-    || value.resumedCount > value.attemptCount
-    || (value.lastResumedAttempt !== null
-      && (!Number.isSafeInteger(value.lastResumedAttempt)
-        || value.lastResumedAttempt <= 0
-        || value.lastResumedAttempt > value.attemptCount))
-    || (value.lastErrorCode !== null && !ERROR_CODE.has(value.lastErrorCode))
-    || !validTimestamp(value.createdAtMs)
-    || !validTimestamp(value.updatedAtMs)
-    || value.updatedAtMs < value.createdAtMs
-    || (value.completedAtMs !== null && (!validTimestamp(value.completedAtMs) || value.completedAtMs < value.createdAtMs))
+    !ULID.test(value.id) ||
+    !ULID.test(value.planId) ||
+    !JOB_KIND.has(value.kind) ||
+    !STATUS.has(value.status) ||
+    !validDateKey(value.windowStartDateKey) ||
+    !validDateKey(value.windowEndDateKey) ||
+    value.windowEndDateKey < value.windowStartDateKey ||
+    !Number.isSafeInteger(value.attemptCount) ||
+    value.attemptCount < 0 ||
+    !Number.isSafeInteger(value.resumedCount) ||
+    value.resumedCount < 0 ||
+    !Number.isSafeInteger(value.failureCount) ||
+    value.failureCount < 0 ||
+    value.resumedCount > value.attemptCount ||
+    (value.lastResumedAttempt !== null &&
+      (!Number.isSafeInteger(value.lastResumedAttempt) ||
+        value.lastResumedAttempt <= 0 ||
+        value.lastResumedAttempt > value.attemptCount)) ||
+    (value.lastErrorCode !== null && !ERROR_CODE.has(value.lastErrorCode)) ||
+    !validTimestamp(value.createdAtMs) ||
+    !validTimestamp(value.updatedAtMs) ||
+    value.updatedAtMs < value.createdAtMs ||
+    (value.completedAtMs !== null &&
+      (!validTimestamp(value.completedAtMs) || value.completedAtMs < value.createdAtMs))
   ) {
     throw new PlanReconciliationValidationError("invalid-job");
   }
@@ -253,30 +279,34 @@ function itemFromRow(row: Row): PlanReconciliationItemRecord {
     completedAtMs: row.completed_at_ms as number | null,
   };
   if (
-    !ULID.test(value.id)
-    || !ULID.test(value.jobId)
-    || (value.planWorkoutId !== null && !ULID.test(value.planWorkoutId))
-    || !OPERATION.has(value.operation)
-    || !ITEM_STATUS.has(value.status)
-    || (value.operation === "create" && value.planWorkoutId === null)
-    || (value.operation === "delete" && value.planWorkoutId !== null)
-    || (value.status === "created" && value.operation !== "create")
-    || !validDateKey(value.dateKey)
-    || typeof value.externalId !== "string"
-    || value.externalId.length < 1
-    || value.externalId.length > 256
-    || (value.providerEventId !== null && (!Number.isSafeInteger(value.providerEventId) || value.providerEventId <= 0))
-    || (value.operation === "create" && value.status === "verified" && value.providerEventId === null)
-    || (value.operation === "delete" && value.providerEventId !== null)
-    || (value.status !== "verified" && value.providerEventId !== null)
-    || !validJson(value.expectedJson)
-    || !Number.isSafeInteger(value.attemptCount)
-    || value.attemptCount < 0
-    || (value.lastErrorCode !== null && !ITEM_ERROR_CODE.has(value.lastErrorCode))
-    || !validTimestamp(value.createdAtMs)
-    || !validTimestamp(value.updatedAtMs)
-    || value.updatedAtMs < value.createdAtMs
-    || (value.completedAtMs !== null && (!validTimestamp(value.completedAtMs) || value.completedAtMs < value.createdAtMs))
+    !ULID.test(value.id) ||
+    !ULID.test(value.jobId) ||
+    (value.planWorkoutId !== null && !ULID.test(value.planWorkoutId)) ||
+    !OPERATION.has(value.operation) ||
+    !ITEM_STATUS.has(value.status) ||
+    (value.operation === "create" && value.planWorkoutId === null) ||
+    (value.operation === "delete" && value.planWorkoutId !== null) ||
+    (value.status === "created" && value.operation !== "create") ||
+    !validDateKey(value.dateKey) ||
+    typeof value.externalId !== "string" ||
+    value.externalId.length < 1 ||
+    value.externalId.length > 256 ||
+    (value.providerEventId !== null &&
+      (!Number.isSafeInteger(value.providerEventId) || value.providerEventId <= 0)) ||
+    (value.operation === "create" &&
+      value.status === "verified" &&
+      value.providerEventId === null) ||
+    (value.operation === "delete" && value.providerEventId !== null) ||
+    (value.status !== "verified" && value.providerEventId !== null) ||
+    !validJson(value.expectedJson) ||
+    !Number.isSafeInteger(value.attemptCount) ||
+    value.attemptCount < 0 ||
+    (value.lastErrorCode !== null && !ITEM_ERROR_CODE.has(value.lastErrorCode)) ||
+    !validTimestamp(value.createdAtMs) ||
+    !validTimestamp(value.updatedAtMs) ||
+    value.updatedAtMs < value.createdAtMs ||
+    (value.completedAtMs !== null &&
+      (!validTimestamp(value.completedAtMs) || value.completedAtMs < value.createdAtMs))
   ) {
     throw new PlanReconciliationValidationError("invalid-item");
   }
@@ -293,15 +323,47 @@ export function createPlanReconciliationRepository(
   store: ReconciliationStore,
 ): PlanReconciliationRepository {
   async function requireJob(id: string): Promise<PlanReconciliationJobRecord> {
-    const row = await store.get(`SELECT ${JOB_COLUMNS} FROM plan_reconciliation_job WHERE id=?`, [id]);
+    const row = await store.get(`SELECT ${JOB_COLUMNS} FROM plan_reconciliation_job WHERE id=?`, [
+      id,
+    ]);
     if (row === undefined) throw new PlanReconciliationValidationError("missing-job");
     return jobFromRow(row);
   }
 
   async function requireItem(id: string): Promise<PlanReconciliationItemRecord> {
-    const row = await store.get(`SELECT ${ITEM_COLUMNS} FROM plan_reconciliation_item WHERE id=?`, [id]);
+    const row = await store.get(`SELECT ${ITEM_COLUMNS} FROM plan_reconciliation_item WHERE id=?`, [
+      id,
+    ]);
     if (row === undefined) throw new PlanReconciliationValidationError("missing-item");
     return itemFromRow(row);
+  }
+
+  async function persistAttempt(
+    current: PlanReconciliationJobRecord,
+    updatedAtMs: number,
+  ): Promise<void> {
+    if (updatedAtMs < current.updatedAtMs) {
+      throw new PlanReconciliationValidationError("invalid-job");
+    }
+    const nextAttempt = current.attemptCount + 1;
+    const resumed = current.status === "running" || current.status === "retrying";
+    const nextStatus =
+      current.status === "failed" || current.status === "retrying" ? "retrying" : "running";
+    await store.run(
+      `UPDATE plan_reconciliation_job SET
+         status=?,attempt_count=?,resumed_count=resumed_count+?,
+         last_resumed_attempt=?,last_error_code=NULL,
+         updated_at_ms=?,completed_at_ms=NULL
+       WHERE id=?`,
+      [
+        nextStatus,
+        nextAttempt,
+        resumed ? 1 : 0,
+        resumed ? nextAttempt : null,
+        updatedAtMs,
+        current.id,
+      ],
+    );
   }
 
   const repository: PlanReconciliationRepository = {
@@ -314,8 +376,15 @@ export function createPlanReconciliationRepository(
           created_at_ms,updated_at_ms,completed_at_ms
         ) VALUES (?,?,?,'pending',?,?,0,0,0,NULL,NULL,?,?,NULL)
         ON CONFLICT(plan_id,kind,window_start_date_key,window_end_date_key) DO NOTHING`,
-        [record.id, record.planId, record.kind, record.windowStartDateKey,
-          record.windowEndDateKey, record.createdAtMs, record.createdAtMs],
+        [
+          record.id,
+          record.planId,
+          record.kind,
+          record.windowStartDateKey,
+          record.windowEndDateKey,
+          record.createdAtMs,
+          record.createdAtMs,
+        ],
       );
       const row = await store.get(
         `SELECT ${JOB_COLUMNS} FROM plan_reconciliation_job
@@ -327,7 +396,9 @@ export function createPlanReconciliationRepository(
     },
     async readJob(id) {
       if (!ULID.test(id)) throw new PlanReconciliationValidationError("invalid-job");
-      const row = await store.get(`SELECT ${JOB_COLUMNS} FROM plan_reconciliation_job WHERE id=?`, [id]);
+      const row = await store.get(`SELECT ${JOB_COLUMNS} FROM plan_reconciliation_job WHERE id=?`, [
+        id,
+      ]);
       return row === undefined ? undefined : jobFromRow(row);
     },
     async readLatestJob(planId, kind) {
@@ -341,29 +412,70 @@ export function createPlanReconciliationRepository(
       );
       return row === undefined ? undefined : jobFromRow(row);
     },
+    async listRunnable({ nowMs, leaseMs, maxFailures }) {
+      if (!validTimestamp(nowMs) || !validTimestamp(leaseMs) || !validTimestamp(maxFailures)) {
+        throw new PlanReconciliationValidationError("invalid-job");
+      }
+      const rows = await store.all(
+        `SELECT ${JOB_COLUMNS} FROM plan_reconciliation_job
+         WHERE (kind='cleanup' OR (kind='mirror' AND plan_id IN (
+           SELECT plan_id FROM planning_plan WHERE status='active'
+         ))) AND (status IN ('pending','retrying')
+           OR (status='failed' AND failure_count<?)
+           OR (status='running' AND updated_at_ms+?<=?))
+         ORDER BY window_start_date_key ASC,created_at_ms ASC,id ASC`,
+        [maxFailures, leaseMs, nowMs],
+      );
+      return Object.freeze(rows.map(jobFromRow));
+    },
+    async claim(id, nowMs, leaseMs) {
+      if (!ULID.test(id) || !validTimestamp(nowMs) || !validTimestamp(leaseMs)) {
+        throw new PlanReconciliationValidationError("invalid-job");
+      }
+      return store.transaction(async () => {
+        const current = await requireJob(id);
+        if (
+          current.status === "verified" ||
+          ((current.status === "running" || current.status === "retrying") &&
+            current.updatedAtMs + leaseMs > nowMs)
+        ) {
+          return undefined;
+        }
+        await persistAttempt(current, nowMs);
+        return requireJob(id);
+      });
+    },
+    async readLatestJobByWindow(planId, kind) {
+      if (!ULID.test(planId) || !JOB_KIND.has(kind)) {
+        throw new PlanReconciliationValidationError("invalid-job");
+      }
+      const row = await store.get(
+        `SELECT ${JOB_COLUMNS} FROM plan_reconciliation_job
+         WHERE plan_id=? AND kind=?
+         ORDER BY window_start_date_key DESC,window_end_date_key DESC,id DESC LIMIT 1`,
+        [planId, kind],
+      );
+      return row === undefined ? undefined : jobFromRow(row);
+    },
     async beginAttempt(id, updatedAtMs) {
       if (!ULID.test(id) || !validTimestamp(updatedAtMs)) {
         throw new PlanReconciliationValidationError("invalid-job");
       }
       await store.transaction(async () => {
         const current = await requireJob(id);
-        if (updatedAtMs < current.updatedAtMs) {
-          throw new PlanReconciliationValidationError("invalid-job");
-        }
-        const nextAttempt = current.attemptCount + 1;
-        const resumed = current.status === "running" || current.status === "retrying";
-        const nextStatus = current.status === "failed" || current.status === "retrying"
-          ? "retrying"
-          : "running";
-        await store.run(
-          `UPDATE plan_reconciliation_job SET
-             status=?,attempt_count=?,resumed_count=resumed_count+?,
-             last_resumed_attempt=?,last_error_code=NULL,
-             updated_at_ms=?,completed_at_ms=NULL
-           WHERE id=?`,
-          [nextStatus, nextAttempt, resumed ? 1 : 0, resumed ? nextAttempt : null, updatedAtMs, id],
-        );
+        await persistAttempt(current, updatedAtMs);
       });
+      return requireJob(id);
+    },
+    async reopenJob(id, updatedAtMs) {
+      if (!ULID.test(id) || !validTimestamp(updatedAtMs)) {
+        throw new PlanReconciliationValidationError("invalid-job");
+      }
+      await store.run(
+        `UPDATE plan_reconciliation_job SET status='pending',last_error_code=NULL,
+         completed_at_ms=NULL,updated_at_ms=? WHERE id=?`,
+        [updatedAtMs, id],
+      );
       return requireJob(id);
     },
     async failJob(id, errorCode, updatedAtMs) {
@@ -372,8 +484,8 @@ export function createPlanReconciliationRepository(
       }
       const current = await requireJob(id);
       if (
-        (current.status !== "running" && current.status !== "retrying")
-        || updatedAtMs < current.updatedAtMs
+        (current.status !== "running" && current.status !== "retrying") ||
+        updatedAtMs < current.updatedAtMs
       ) {
         throw new PlanReconciliationValidationError("invalid-job");
       }
@@ -391,8 +503,8 @@ export function createPlanReconciliationRepository(
       }
       const current = await requireJob(id);
       if (
-        (current.status !== "running" && current.status !== "retrying")
-        || updatedAtMs < current.updatedAtMs
+        (current.status !== "running" && current.status !== "retrying") ||
+        updatedAtMs < current.updatedAtMs
       ) {
         throw new PlanReconciliationValidationError("invalid-job");
       }
@@ -423,8 +535,17 @@ export function createPlanReconciliationRepository(
             provider_event_id,expected_json,attempt_count,last_error_code,
             created_at_ms,updated_at_ms,completed_at_ms
           ) VALUES (?,?,?,?,'pending',?,?,NULL,?,0,NULL,?,?,NULL)`,
-          [record.id, record.jobId, record.planWorkoutId, record.operation, record.dateKey,
-            record.externalId, record.expectedJson, record.createdAtMs, record.createdAtMs],
+          [
+            record.id,
+            record.jobId,
+            record.planWorkoutId,
+            record.operation,
+            record.dateKey,
+            record.externalId,
+            record.expectedJson,
+            record.createdAtMs,
+            record.createdAtMs,
+          ],
         );
       } else {
         const current = itemFromRow(existing);
@@ -432,16 +553,22 @@ export function createPlanReconciliationRepository(
           throw new PlanReconciliationValidationError("invalid-item");
         }
         if (
-          current.planWorkoutId !== record.planWorkoutId
-          || current.dateKey !== record.dateKey
-          || current.expectedJson !== record.expectedJson
+          current.planWorkoutId !== record.planWorkoutId ||
+          current.dateKey !== record.dateKey ||
+          current.expectedJson !== record.expectedJson
         ) {
           await store.run(
             `UPDATE plan_reconciliation_item SET
                plan_workout_id=?,date_key=?,expected_json=?,status='pending',
                provider_event_id=NULL,last_error_code=NULL,updated_at_ms=?,completed_at_ms=NULL
              WHERE id=?`,
-            [record.planWorkoutId, record.dateKey, record.expectedJson, record.createdAtMs, current.id],
+            [
+              record.planWorkoutId,
+              record.dateKey,
+              record.expectedJson,
+              record.createdAtMs,
+              current.id,
+            ],
           );
         }
       }
@@ -467,7 +594,8 @@ export function createPlanReconciliationRepository(
         throw new PlanReconciliationValidationError("invalid-item");
       }
       const current = await requireItem(id);
-      if (updatedAtMs < current.updatedAtMs) throw new PlanReconciliationValidationError("invalid-item");
+      if (updatedAtMs < current.updatedAtMs)
+        throw new PlanReconciliationValidationError("invalid-item");
       await store.run(
         `UPDATE plan_reconciliation_item SET
            status='running',attempt_count=attempt_count+1,last_error_code=NULL,
@@ -482,9 +610,9 @@ export function createPlanReconciliationRepository(
       }
       const current = await requireItem(id);
       if (
-        current.operation !== "create"
-        || current.status !== "running"
-        || updatedAtMs < current.updatedAtMs
+        current.operation !== "create" ||
+        current.status !== "running" ||
+        updatedAtMs < current.updatedAtMs
       ) {
         throw new PlanReconciliationValidationError("invalid-item");
       }
@@ -497,15 +625,12 @@ export function createPlanReconciliationRepository(
       return requireItem(id);
     },
     async failItem(id, errorCode, updatedAtMs) {
-      if (
-        !ULID.test(id)
-        || !ITEM_ERROR_CODE.has(errorCode)
-        || !validTimestamp(updatedAtMs)
-      ) {
+      if (!ULID.test(id) || !ITEM_ERROR_CODE.has(errorCode) || !validTimestamp(updatedAtMs)) {
         throw new PlanReconciliationValidationError("invalid-item");
       }
       const current = await requireItem(id);
-      if (updatedAtMs < current.updatedAtMs) throw new PlanReconciliationValidationError("invalid-item");
+      if (updatedAtMs < current.updatedAtMs)
+        throw new PlanReconciliationValidationError("invalid-item");
       await store.run(
         `UPDATE plan_reconciliation_item SET
            status='failed',provider_event_id=NULL,last_error_code=?,
@@ -514,19 +639,24 @@ export function createPlanReconciliationRepository(
       );
       return requireItem(id);
     },
+    async deleteItem(id) {
+      if (!ULID.test(id)) throw new PlanReconciliationValidationError("invalid-item");
+      await store.run("DELETE FROM plan_reconciliation_item WHERE id=?", [id]);
+    },
     async verifyItem(id, providerEventId, updatedAtMs) {
       if (
-        !ULID.test(id)
-        || (providerEventId !== null && (!Number.isSafeInteger(providerEventId) || providerEventId <= 0))
-        || !validTimestamp(updatedAtMs)
+        !ULID.test(id) ||
+        (providerEventId !== null &&
+          (!Number.isSafeInteger(providerEventId) || providerEventId <= 0)) ||
+        !validTimestamp(updatedAtMs)
       ) {
         throw new PlanReconciliationValidationError("invalid-item");
       }
       const current = await requireItem(id);
       if (
-        (current.operation === "create" && providerEventId === null)
-        || (current.operation === "delete" && providerEventId !== null)
-        || updatedAtMs < current.updatedAtMs
+        (current.operation === "create" && providerEventId === null) ||
+        (current.operation === "delete" && providerEventId !== null) ||
+        updatedAtMs < current.updatedAtMs
       ) {
         throw new PlanReconciliationValidationError("invalid-item");
       }


### PR DESCRIPTION
## Summary

Backend half of the calendar mirror for Chat-owned Plans (PR L of the Plan-in-Chat epic). Until now no target Planning operation enqueued or ran any calendar work.

- `plan_creation.activate` inserts the new Plan's pending seven-day mirror job and, when replacing an incumbent, that incumbent's cleanup job (tomorrow through its final day) in the activation transaction, before the command ledger row.
- `plan_change.apply` (confirmed only) inserts or reopens the same-window mirror job; retained items whose Workout left the window and all derived delete items are pruned so the executor rebuilds intent. Cancel, rejected and replayed paths write nothing.
- New `plan-calendar-drain.ts`: one sequential pass per kick over every runnable job across Plans, oldest window first; in-process mutex plus the store single-writer lock for serialization; five-failure budget; day rollover creates today's window; older windows are verified only; thrown executor errors count as failures; a Plan version change during a pass reopens the job and reruns.
- Composition kicks the drain after activate, close, apply and list, on startup completion and after each scheduled refresh, and waits for idle before closing the store. No Intervals key means no work.
- Engine executor: optional first-eligible mirror date keeps job identity and horizon while a replaced Plan keeps today's Workout; pre-eligibility events are filtered per event; a retained create item whose Workout is no longer selected is retired and its event removed; an obsolete delete item for a re-selected Workout is dropped.
- Kernel repository: `listRunnable`, `claim`, `readLatestJobByWindow`, `reopenJob`, `deleteItem`; `beginAttempt` unchanged.
- `plan.list` and `plan.history` gain a strict per-Plan `calendar` status (`not-connected | pending | running | verified | failed`, window, current-through, error copy). Failed jobs past the budget drop "Retry available".
- Desktop test fixture accepts a fake calendar and drain for the renderer PR that follows.

No new public RPC. No migration. The legacy-writer fence is untouched.

## Verification

Five astra verifier rounds; the final read-only verdict is `pass: true`. Local gate in the worktree: root `pnpm check` exit 0; workspace suite 2023 passed with three load-timeout failures (`package-exports`, both `daemon-handoff` integration files) that fail identically on a clean epic-head checkout under the current machine load; renderer-dom suite passed; macOS Plan E2E (`plan-creation-slice5`, `plan-close-history`, `plan-change`) 41 passed.

| Limit | Value |
|---|---|
| Mirror horizon | today through today+6 |
| Cleanup window | tomorrow through final Plan day |
| Failure budget per job | 5 |
| Stale lease | 300 000 ms |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
