### PR TITLE
feat(plan): show the saved legacy Plan read-only in the library

### DIFF
--- a/.changeset/plan-library-legacy-entry.md
+++ b/.changeset/plan-library-legacy-entry.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: A Plan saved before Plans moved to Chat now appears in the Plan library as a read-only closed Plan, so its name, goal and target stay visible.

--- a/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
@@ -1,4 +1,5 @@
 import type {
+  LegacyPlanSummary,
   ListPlansResult,
   PlanCreationCardModel,
   PlanSummary,
@@ -130,6 +131,15 @@ function spanLabel(plan: PlanSummary): string {
   return `${dateLabel(plan.start)} to ${dateLabel(plan.end)} · ${plan.weeks} weeks`;
 }
 
+function legacySummary(legacy: LegacyPlanSummary): string {
+  const parts: string[] = [];
+  if (legacy.targetDate !== null) parts.push(`Target ${dateLabel(legacy.targetDate)}`);
+  if (legacy.weeks !== null) parts.push(`${legacy.weeks} ${legacy.weeks === 1 ? "week" : "weeks"}`);
+  if (legacy.goal !== null) parts.push(`Goal: ${legacy.goal}`);
+  parts.push("Unknown reason");
+  return parts.join(" · ");
+}
+
 export function PlanLibrary(props: {
   readonly library: ListPlansResult;
   readonly readDetails: () => void;
@@ -194,7 +204,7 @@ export function PlanLibrary(props: {
     props.readFinalDetails(result.planId, true);
     void actions.refresh();
   };
-  const { creation, active, closed } = props.library;
+  const { creation, active, closed, legacy } = props.library;
   const total =
     creation?.openQuestion?.step.total ??
     creation?.answeredSummaries[0]?.question.step.total ??
@@ -361,6 +371,18 @@ export function PlanLibrary(props: {
           </div>
         </LibraryCard>
       ))}
+      {legacy === null ? null : (
+        <LibraryCard
+          eyebrow="Closed Plan"
+          title={legacy.name}
+          status="Closed"
+          summary={legacySummary(legacy)}
+        >
+          <p className="m-0 text-sm leading-5 text-ink-2">
+            Read only · Saved before Plans moved to Chat
+          </p>
+        </LibraryCard>
+      )}
     </section>
   );
 }

--- a/apps/desktop-renderer/tests/boot-plan-change.test.ts
+++ b/apps/desktop-renderer/tests/boot-plan-change.test.ts
@@ -150,6 +150,7 @@ const creation: PlanCreationCardModel = {
 function library(planId: string, pending = false): ListPlansResult {
   return {
     calendarConnected: false,
+    legacy: null,
     active: {
       planId,
       version: 2,

--- a/apps/desktop-renderer/tests/plan-calendar-dialog.test.tsx
+++ b/apps/desktop-renderer/tests/plan-calendar-dialog.test.tsx
@@ -57,6 +57,7 @@ describe("activation calendar consequence", () => {
           status: "ready",
           value: {
             calendarConnected: true,
+            legacy: null,
             creation: null,
             active: closing ? summary : null,
             closed: closing ? [] : [{ ...summary, status: "closed" }],
@@ -89,6 +90,7 @@ describe("activation calendar consequence", () => {
             status: "ready",
             value: {
               calendarConnected: false,
+              legacy: null,
               creation: null,
               active:
                 kind === "empty"
@@ -129,7 +131,14 @@ describe("activation calendar consequence", () => {
       useEnduragentStore.setState({
         planLibrary: {
           status: "ready",
-          value: { calendarConnected, creation: null, active: null, closed: [], changes: [] },
+          value: {
+            calendarConnected,
+            legacy: null,
+            creation: null,
+            active: null,
+            closed: [],
+            changes: [],
+          },
         },
       });
       render(<PlanCreationActivateDialog />);
@@ -154,7 +163,14 @@ describe("activation calendar consequence", () => {
     useEnduragentStore.setState({
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: true, creation: null, active: null, closed: [], changes: [] },
+        value: {
+          calendarConnected: true,
+          legacy: null,
+          creation: null,
+          active: null,
+          closed: [],
+          changes: [],
+        },
       },
       planLibraryActions: {
         ...useEnduragentStore.getState().planLibraryActions,
@@ -168,7 +184,14 @@ describe("activation calendar consequence", () => {
     useEnduragentStore.setState({
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, creation: null, active: null, closed: [], changes: [] },
+        value: {
+          calendarConnected: false,
+          legacy: null,
+          creation: null,
+          active: null,
+          closed: [],
+          changes: [],
+        },
       },
     });
     finish();
@@ -183,14 +206,28 @@ describe("activation calendar consequence", () => {
       useEnduragentStore.setState({
         planLibrary: {
           status: "unavailable",
-          value: { calendarConnected: true, creation: null, active: null, closed: [], changes: [] },
+          value: {
+            calendarConnected: true,
+            legacy: null,
+            creation: null,
+            active: null,
+            closed: [],
+            changes: [],
+          },
         },
       });
     });
     useEnduragentStore.setState({
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: true, creation: null, active: null, closed: [], changes: [] },
+        value: {
+          calendarConnected: true,
+          legacy: null,
+          creation: null,
+          active: null,
+          closed: [],
+          changes: [],
+        },
       },
       planLibraryActions: {
         ...useEnduragentStore.getState().planLibraryActions,

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -120,7 +120,14 @@ function setChanges(changes: PlanChangeModel[]): void {
     useEnduragentStore.setState({
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, active, creation: null, closed: [], changes },
+        value: {
+          calendarConnected: false,
+          legacy: null,
+          active,
+          creation: null,
+          closed: [],
+          changes,
+        },
       },
     }),
   );
@@ -151,7 +158,14 @@ beforeEach(() => {
     },
     planLibrary: {
       status: "ready",
-      value: { calendarConnected: false, active, creation: null, closed: [], changes: [] },
+      value: {
+        calendarConnected: false,
+        legacy: null,
+        active,
+        creation: null,
+        closed: [],
+        changes: [],
+      },
     },
     planLibraryActions: null,
   });
@@ -181,7 +195,14 @@ describe("Plan Change cards", () => {
       },
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, active, creation, closed: [], changes: [change()] },
+        value: {
+          calendarConnected: false,
+          legacy: null,
+          active,
+          creation,
+          closed: [],
+          changes: [change()],
+        },
       },
     });
     patchChange({ open: false, planId: null });

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -31,6 +31,7 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
   let surface: PlanChangeSurfaceState = EMPTY_PLAN_CHANGE_SURFACE;
   let library: ListPlansResult = {
     calendarConnected: false,
+    legacy: null,
     active: {
       planId: "plan-active",
       version: 7,

--- a/apps/desktop-renderer/tests/plan-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-controller.test.ts
@@ -17,6 +17,7 @@ describe("Plan controller", () => {
     const controller = createPlanController({
       listPlans: async () => ({
         calendarConnected: false,
+        legacy: null,
         creation: null,
         active: null,
         closed: [],
@@ -43,6 +44,7 @@ describe("Plan controller", () => {
     const controller = createPlanController({
       listPlans: async () => ({
         calendarConnected: false,
+        legacy: null,
         creation: null,
         active: null,
         closed: [],
@@ -79,6 +81,7 @@ function deferredLibrary() {
 describe("Plan library refresh", () => {
   const library: ListPlansResult = {
     calendarConnected: false,
+    legacy: null,
     creation: null,
     active: null,
     closed: [],

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -1,4 +1,5 @@
 import type {
+  LegacyPlanSummary,
   ListPlansResult,
   PlanCreationCardModel,
   PlanHistoryResult,
@@ -241,6 +242,97 @@ beforeEach(() => {
 });
 
 describe("Plan library", () => {
+  it("renders no extra card when the legacy summary is absent", () => {
+    render(
+      <PlanLibrary
+        library={{
+          calendarConnected: false,
+          legacy: null,
+          creation: null,
+          active,
+          closed,
+          changes: [],
+        }}
+        readDetails={vi.fn()}
+        readFinalDetails={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByRole("region", { name: "Closed Plan" })).toHaveLength(closed.length);
+    expect(screen.queryByText("Read only · Saved before Plans moved to Chat")).toBeNull();
+  });
+
+  it.each([1, 8])("renders the full legacy summary with %i weeks after closed Plans", (weeks) => {
+    const legacy: LegacyPlanSummary = {
+      name: "Earlier endurance training",
+      goal: "Ride comfortably for four hours",
+      weeks,
+      sourceStatus: "active",
+      createdAt: "1998-07-06",
+      targetDate: "1998-08-30",
+      readOnly: true,
+      source: "current-plan.json",
+    };
+    render(
+      <PlanLibrary
+        library={{ calendarConnected: false, legacy, creation, active, closed, changes: [] }}
+        readDetails={vi.fn()}
+        readFinalDetails={vi.fn()}
+      />,
+    );
+    const cards = screen.getAllByRole("region", { name: "Closed Plan" });
+    expect(cards).toHaveLength(closed.length + 1);
+    const card = cards[cards.length - 1];
+    if (card === undefined) throw new Error("Legacy card is missing");
+    expect(within(card).getByText("Closed Plan", { exact: true })).toBeVisible();
+    expect(within(card).getByRole("heading", { name: legacy.name })).toBeVisible();
+    expect(within(card).getByText("Closed", { exact: true })).toBeVisible();
+    expect(
+      within(card).getByText(
+        `Target 30 Aug 1998 · ${weeks} ${weeks === 1 ? "week" : "weeks"} · Goal: Ride comfortably for four hours · Unknown reason`,
+        { exact: true },
+      ),
+    ).toBeVisible();
+    expect(
+      within(card).getByText("Read only · Saved before Plans moved to Chat", { exact: true }),
+    ).toBeVisible();
+    expect(within(card).queryByRole("button")).toBeNull();
+    expect(within(card).queryByRole("link")).toBeNull();
+    expect(card).not.toHaveTextContent("6 Jul 1998");
+  });
+
+  it("renders only Unknown reason in the summary when only the legacy name is known", () => {
+    render(
+      <PlanLibrary
+        library={{
+          calendarConnected: false,
+          legacy: {
+            name: "Earlier training",
+            goal: null,
+            weeks: null,
+            sourceStatus: null,
+            createdAt: null,
+            targetDate: null,
+            readOnly: true,
+            source: "current-plan.json",
+          },
+          creation: null,
+          active: null,
+          closed: [],
+          changes: [],
+        }}
+        readDetails={vi.fn()}
+        readFinalDetails={vi.fn()}
+      />,
+    );
+    const card = screen.getByRole("region", { name: "Closed Plan" });
+    expect(within(card).getByRole("heading", { name: "Earlier training" })).toBeVisible();
+    expect(within(card).getByText("Unknown reason", { exact: true })).toBeVisible();
+    expect(
+      within(card).getByText("Read only · Saved before Plans moved to Chat", { exact: true }),
+    ).toBeVisible();
+    expect(within(card).queryByRole("button")).toBeNull();
+  });
+
   it.each([
     [
       {
@@ -306,6 +398,7 @@ describe("Plan library", () => {
         <PlanLibrary
           library={{
             calendarConnected: false,
+            legacy: null,
             creation: null,
             active: { ...active, calendar },
             closed,
@@ -338,7 +431,14 @@ describe("Plan library", () => {
       chat: { ...EMPTY_CHAT_SURFACE, notice },
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, creation: null, active, closed, changes: [] },
+        value: {
+          calendarConnected: false,
+          legacy: null,
+          creation: null,
+          active,
+          closed,
+          changes: [],
+        },
       },
     });
     render(<PlanView />);
@@ -352,6 +452,7 @@ describe("Plan library", () => {
     ({ hasCreation, hasActive, hasClosed }) => {
       const library: ListPlansResult = {
         calendarConnected: false,
+        legacy: null,
         creation: hasCreation ? creation : null,
         active: hasActive ? active : null,
         closed: hasClosed ? closed : [],
@@ -426,7 +527,7 @@ describe("Plan library", () => {
     render(
       <PlanLibrary
         readFinalDetails={vi.fn()}
-        library={{ calendarConnected: false, creation, active, closed, changes: [] }}
+        library={{ calendarConnected: false, legacy: null, creation, active, closed, changes: [] }}
         readDetails={readDetails}
       />,
     );
@@ -451,7 +552,14 @@ describe("Plan library", () => {
     const view = render(
       <PlanLibrary
         readFinalDetails={vi.fn()}
-        library={{ calendarConnected: false, creation, active: null, closed: [], changes: [] }}
+        library={{
+          calendarConnected: false,
+          legacy: null,
+          creation,
+          active: null,
+          closed: [],
+          changes: [],
+        }}
         readDetails={vi.fn()}
       />,
     );
@@ -461,6 +569,7 @@ describe("Plan library", () => {
         readFinalDetails={vi.fn()}
         library={{
           calendarConnected: false,
+          legacy: null,
           creation: { ...creation, draft: planCreationDraft() },
           active: null,
           closed: [],
@@ -477,6 +586,7 @@ describe("Plan library", () => {
     const refresh = vi.fn();
     const library: ListPlansResult = {
       calendarConnected: false,
+      legacy: null,
       creation: null,
       active,
       closed,
@@ -510,6 +620,7 @@ describe("Plan library", () => {
       const listPlans = vi.fn(
         async (): Promise<ListPlansResult> => ({
           calendarConnected: false,
+          legacy: null,
           creation,
           active,
           closed,
@@ -603,7 +714,7 @@ describe("Plan library refresh subscription", () => {
       activeView: "plan",
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, creation, active, closed, changes: [] },
+        value: { calendarConnected: false, legacy: null, creation, active, closed, changes: [] },
       },
     });
     const refresh = vi.fn(async () => {
@@ -611,6 +722,7 @@ describe("Plan library refresh subscription", () => {
         status: "ready",
         value: {
           calendarConnected: false,
+          legacy: null,
           creation,
           active: { ...active, calendar: { ...active.calendar, status: "running" } },
           closed,
@@ -646,7 +758,7 @@ describe("Plan library refresh subscription", () => {
       activeView: "plan",
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, creation, active, closed, changes: [] },
+        value: { calendarConnected: false, legacy: null, creation, active, closed, changes: [] },
       },
     });
     const { refresh, unsubscribe } = watchRefresh();
@@ -659,6 +771,7 @@ describe("Plan library refresh subscription", () => {
           status: "ready",
           value: {
             calendarConnected: false,
+            legacy: null,
             creation,
             active: {
               ...active,
@@ -687,6 +800,7 @@ describe("Plan library refresh subscription", () => {
     vi.useFakeTimers();
     const failed: ListPlansResult = {
       calendarConnected: true,
+      legacy: null,
       creation: null,
       closed: [],
       changes: [],
@@ -769,6 +883,7 @@ describe("Plan library refresh subscription", () => {
     vi.useFakeTimers();
     const running: ListPlansResult = {
       calendarConnected: true,
+      legacy: null,
       creation: null,
       closed: [],
       changes: [],
@@ -845,6 +960,7 @@ describe("Plan library refresh subscription", () => {
         status: "ready",
         value: {
           calendarConnected: false,
+          legacy: null,
           creation: null,
           closed: [],
           changes: [],
@@ -878,6 +994,7 @@ describe("Plan library refresh subscription", () => {
       vi.useFakeTimers();
       const library: ListPlansResult = {
         calendarConnected: false,
+        legacy: null,
         creation: null,
         active,
         closed: [],
@@ -945,7 +1062,7 @@ describe("Plan library refresh subscription", () => {
       chat: { ...EMPTY_CHAT_SURFACE, planCreation: null },
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, creation, active, closed, changes: [] },
+        value: { calendarConnected: false, legacy: null, creation, active, closed, changes: [] },
       },
     });
     const { refresh, unsubscribe } = watchRefresh();
@@ -986,7 +1103,7 @@ describe("Plan library refresh subscription", () => {
       chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation, planCreationLoaded: true },
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, creation, active, closed, changes: [] },
+        value: { calendarConnected: false, legacy: null, creation, active, closed, changes: [] },
       },
     });
     const { refresh, unsubscribe } = watchRefresh();
@@ -1005,7 +1122,7 @@ describe("Plan library refresh subscription", () => {
     useEnduragentStore.setState({
       planLibrary: {
         status: "ready",
-        value: { calendarConnected: false, creation, active, closed, changes: [] },
+        value: { calendarConnected: false, legacy: null, creation, active, closed, changes: [] },
       },
     });
     const { refresh, unsubscribe } = watchRefresh();
@@ -1072,13 +1189,20 @@ describe("Plan library refresh subscription", () => {
         },
       });
       expect(refresh).toHaveBeenCalledExactlyOnceWith(false);
-      result.resolve({ calendarConnected: false, creation, active, closed, changes: [] });
+      result.resolve({
+        calendarConnected: false,
+        legacy: null,
+        creation,
+        active,
+        closed,
+        changes: [],
+      });
       await started;
       await Promise.all(refresh.mock.results.map((call) => call.value));
       expect(listPlans).toHaveBeenCalledOnce();
       expect(store.getState().planLibrary).toEqual({
         status: "ready",
-        value: { calendarConnected: false, creation, active, closed, changes: [] },
+        value: { calendarConnected: false, legacy: null, creation, active, closed, changes: [] },
       });
     } finally {
       unsubscribe();
@@ -1125,6 +1249,7 @@ describe("Plan creation title", () => {
           readFinalDetails={vi.fn()}
           library={{
             calendarConnected: false,
+            legacy: null,
             creation: answered,
             active: null,
             closed: [],
@@ -1174,7 +1299,7 @@ it("keeps Plan history below the library while a creation occupies the header", 
     planActions,
     planLibrary: {
       status: "ready",
-      value: { calendarConnected: false, creation, active, closed: [], changes: [] },
+      value: { calendarConnected: false, legacy: null, creation, active, closed: [], changes: [] },
     },
   });
   render(<PlanView />);
@@ -1192,7 +1317,14 @@ describe("Stop Plan", () => {
     const readFinalDetails = vi.fn();
     render(
       <PlanLibrary
-        library={{ calendarConnected: false, creation: null, active, closed, changes: [] }}
+        library={{
+          calendarConnected: false,
+          legacy: null,
+          creation: null,
+          active,
+          closed,
+          changes: [],
+        }}
         readDetails={vi.fn()}
         readFinalDetails={readFinalDetails}
       />,
@@ -1315,6 +1447,7 @@ describe("Stop Plan", () => {
             status: "ready",
             value: {
               calendarConnected: false,
+              legacy: null,
               creation: null,
               active: null,
               closed: [{ ...history.plan, status: "closed" }],
@@ -1326,7 +1459,14 @@ describe("Stop Plan", () => {
       useEnduragentStore.setState({
         planLibrary: {
           status: "ready",
-          value: { calendarConnected: false, creation: null, active, closed, changes: [] },
+          value: {
+            calendarConnected: false,
+            legacy: null,
+            creation: null,
+            active,
+            closed,
+            changes: [],
+          },
         },
       });
       render(<PlanView />);
@@ -1358,10 +1498,13 @@ describe("Stop Plan", () => {
     const initial = new Promise<ListPlansResult>((resolve) => {
       finishRead = resolve;
     });
-    const listPlans = vi
-      .fn()
-      .mockReturnValueOnce(initial)
-      .mockResolvedValue({ calendarConnected: false, creation: null, active: null, closed });
+    const listPlans = vi.fn().mockReturnValueOnce(initial).mockResolvedValue({
+      calendarConnected: false,
+      legacy: null,
+      creation: null,
+      active: null,
+      closed,
+    });
     const controller = createPlanController({
       listPlans,
       read: async () => ({
@@ -1379,7 +1522,14 @@ describe("Stop Plan", () => {
     try {
       const started = controller.start();
       store.getState().setActiveView("plan");
-      finishRead({ calendarConnected: false, creation: null, active, closed, changes: [] });
+      finishRead({
+        calendarConnected: false,
+        legacy: null,
+        creation: null,
+        active,
+        closed,
+        changes: [],
+      });
       await started;
       await vi.waitFor(() => expect(listPlans).toHaveBeenCalledTimes(2));
       expect(store.getState().planLibrary.value?.active).toBeNull();

--- a/apps/desktop/tests/e2e/plan-legacy.spec.ts
+++ b/apps/desktop/tests/e2e/plan-legacy.spec.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, type Browser } from "@playwright/test";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+test("shows the saved legacy Plan as a read-only closed card", async ({ playwright }) => {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-legacy-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true, {
+    legacy: {
+      name: "Earlier endurance training",
+      goal: "Ride comfortably for four hours",
+      weeks: 8,
+      sourceStatus: "active",
+      createdAt: "1998-07-06",
+      targetDate: "1998-08-30",
+      readOnly: true,
+      source: "current-plan.json",
+    },
+  });
+  let fixture: RunningDesktopFixture | undefined;
+  let browser: Browser | undefined;
+  try {
+    backend.setCivilDate("1998-01-03");
+    await backend.open();
+    await backend.seedLibrary({ creation: false, active: true, closed: true });
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token: "d".repeat(43),
+      width: 1180,
+      height: 820,
+      colorScheme: "light",
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(1180, 820);
+    browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+    const page = browser
+      .contexts()[0]
+      ?.pages()
+      .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+    if (page === undefined) throw new TypeError("Plan library renderer is unavailable");
+    await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+      timeout: 30_000,
+    });
+    await page.clock.setFixedTime(new Date("1998-01-03T12:00:00Z"));
+    await page.emulateMedia({ colorScheme: "light", reducedMotion: "reduce" });
+    await page
+      .getByRole("navigation", { name: "Main navigation" })
+      .getByRole("button", { name: "Plan", exact: true })
+      .click();
+    const cards = page.getByRole("region", { name: "Closed Plan", exact: true });
+    await expect(cards).toHaveCount(4);
+    const legacy = cards.last();
+    await expect(legacy.getByText("Closed Plan", { exact: true })).toBeVisible();
+    await expect(
+      legacy.getByRole("heading", { name: "Earlier endurance training", exact: true }),
+    ).toBeVisible();
+    await expect(legacy.getByText("Closed", { exact: true })).toBeVisible();
+    await expect(
+      legacy.getByText(
+        "Target 30 Aug 1998 · 8 weeks · Goal: Ride comfortably for four hours · Unknown reason",
+        { exact: true },
+      ),
+    ).toBeVisible();
+    await expect(
+      legacy.getByText("Read only · Saved before Plans moved to Chat", { exact: true }),
+    ).toBeVisible();
+    await expect(legacy.getByRole("button")).toHaveCount(0);
+    await expect(legacy.getByRole("link")).toHaveCount(0);
+  } finally {
+    await browser?.close().catch(() => {});
+    try {
+      if (fixture !== undefined) {
+        const cleanup = await fixture.close();
+        expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+      }
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+  }
+});

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -13,6 +13,7 @@ import {
   PlanCreationActivateRpcParamsSchema,
   PlanCreationPreviewRpcParamsSchema,
   type CoachEngine,
+  type LegacyPlanSummary,
   type PlanningOperations,
   type PlanCreationCardModel,
 } from "@enduragent/coach-contract";
@@ -153,6 +154,7 @@ export class PlanCreationBackend {
     private readonly options: {
       readonly calendar?: PlanMirrorCalendarPort;
       readonly calendarConnected?: boolean;
+      readonly legacy?: LegacyPlanSummary | null;
     } = {},
   ) {
     const base = coexistence ? createPlanInspectionFixtureScript() : createPlanQaFixtureScript();
@@ -369,6 +371,7 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
       identity,
       crypto: globalThis.crypto,
       eventCandidates: { read: async () => [] },
+      legacyPlan: async () => this.options.legacy ?? null,
       calendarConnected,
       today: () => this.civilDate,
       todayDateKey: () => Number(this.civilDate.replaceAll("-", "")),

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -1059,6 +1059,7 @@ describe("RPC receive and observers", () => {
         },
         "plan.list": {
           calendarConnected: false,
+          legacy: null,
           creation: null,
           active: null,
           closed: [],

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -172,11 +172,26 @@ export const PlanSummarySchema = z
   .strict();
 export type PlanSummary = z.infer<typeof PlanSummarySchema>;
 
+export const LegacyPlanSummarySchema = z
+  .object({
+    name: z.string().min(1),
+    goal: z.string().nullable(),
+    weeks: z.number().int().positive().nullable(),
+    sourceStatus: z.string().nullable(),
+    createdAt: z.iso.date().nullable(),
+    targetDate: z.iso.date().nullable(),
+    readOnly: z.literal(true),
+    source: z.literal("current-plan.json"),
+  })
+  .strict();
+export type LegacyPlanSummary = z.infer<typeof LegacyPlanSummarySchema>;
+
 export const ListPlansParamsSchema = z.object({}).strict();
 export type ListPlansParams = z.infer<typeof ListPlansParamsSchema>;
 export const ListPlansResultSchema = z
   .object({
     calendarConnected: z.boolean(),
+    legacy: LegacyPlanSummarySchema.nullable(),
     creation: PlanCreationCardModelSchema.nullable(),
     active: PlanSummarySchema.extend({ status: z.literal("active") }).nullable(),
     closed: z.array(PlanSummarySchema.extend({ status: z.literal("closed") })),

--- a/packages/coach-contract/tests/plan-change-contract.test.ts
+++ b/packages/coach-contract/tests/plan-change-contract.test.ts
@@ -127,6 +127,7 @@ describe("Plan Change contract", () => {
   it("requires explicit changes in the Plan list", () => {
     const empty = {
       calendarConnected: false,
+      legacy: null,
       creation: null,
       active: null,
       closed: [],
@@ -136,6 +137,7 @@ describe("Plan Change contract", () => {
     expect(
       ListPlansResultSchema.safeParse({
         calendarConnected: false,
+        legacy: null,
         creation: null,
         active: null,
         closed: [],

--- a/packages/coach-contract/tests/planning-read-contract.test.ts
+++ b/packages/coach-contract/tests/planning-read-contract.test.ts
@@ -5,6 +5,7 @@ import {
   ListPlansParamsSchema,
   ListPlansResultSchema,
   PlanSummarySchema,
+  LegacyPlanSummarySchema,
 } from "../src/index.js";
 
 describe("Planning read contract", () => {
@@ -78,6 +79,7 @@ describe("Plan library contract", () => {
   it("accepts the empty library and strict empty params", () => {
     const empty = {
       calendarConnected: false,
+      legacy: null,
       creation: null,
       active: null,
       closed: [],
@@ -89,8 +91,42 @@ describe("Plan library contract", () => {
     expect(ListPlansResultSchema.safeParse({ ...empty, extra: true }).success).toBe(false);
   });
 
+  it("accepts a read-only legacy summary and rejects invented or invalid fields", () => {
+    const legacy = {
+      name: "8-Week Plan",
+      goal: "Gran Fondo",
+      weeks: 8,
+      sourceStatus: "draft",
+      createdAt: "1998-07-04",
+      targetDate: "1998-08-30",
+      readOnly: true,
+      source: "current-plan.json",
+    };
+    const library = {
+      calendarConnected: false,
+      legacy,
+      creation: null,
+      active: null,
+      closed: [],
+      changes: [],
+    };
+    expect(LegacyPlanSummarySchema.parse(legacy)).toEqual(legacy);
+    expect(ListPlansResultSchema.parse(library)).toEqual(library);
+    for (const invalid of [{ version: 1 }, { readOnly: false }, { weeks: 0 }]) {
+      expect(
+        ListPlansResultSchema.safeParse({
+          ...library,
+          legacy: { ...legacy, ...invalid },
+        }).success,
+      ).toBe(false);
+    }
+    const { legacy: omitted, ...withoutLegacy } = library;
+    expect(omitted).toEqual(legacy);
+    expect(ListPlansResultSchema.safeParse(withoutLegacy).success).toBe(false);
+  });
+
   it("requires an explicit boolean calendar connection independently of library contents", () => {
-    const library = { creation: null, active: null, closed: [], changes: [] };
+    const library = { legacy: null, creation: null, active: null, closed: [], changes: [] };
     expect(ListPlansResultSchema.safeParse(library).success).toBe(false);
     expect(ListPlansResultSchema.safeParse({ ...library, calendarConnected: "true" }).success).toBe(
       false,
@@ -117,6 +153,7 @@ describe("Plan library contract", () => {
       };
       const library = {
         calendarConnected: false,
+        legacy: null,
         creation: null,
         active,
         closed: [closed],

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1327,6 +1327,7 @@ describe("coach request and event projection", () => {
       }),
       "plan.list": async () => ({
         calendarConnected: false,
+        legacy: null,
         creation: null,
         active: null,
         closed: [],

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -90,6 +90,7 @@ import {
   createLegacyPlanRepository,
   createLegacyPlanRowWriter,
   importLegacyCurrentPlan,
+  readLegacyCurrentPlanSummary,
 } from "@enduragent/kernel-node/planning";
 import {
   createLegacyWriterFence,
@@ -890,6 +891,11 @@ export async function createLocalCoachComposition(
     eventCandidates: { read: async () => [] },
     baselineEvidence: { read: async () => undefined },
     calendarConnected: () => approvedConfig().intervals.apiKey.length > 0,
+    legacyPlan: () =>
+      readLegacyCurrentPlanSummary({
+        home: input.home,
+        logger: { warn: () => logger.warn("legacy_plan_summary_skipped") },
+      }),
     today: () => todayInTZ(planningTimezone, new Date(now())),
     todayDateKey: planningDateKey,
     now,

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -14,6 +14,7 @@ import {
   ListPlansResultSchema,
   type ListPlansParams,
   type ListPlansResult,
+  type LegacyPlanSummary,
   PlanCreationActivateRpcParamsSchema,
   PlanCreationActivateRpcResultSchema,
   PlanCreationAnswerRpcParamsSchema,
@@ -102,6 +103,7 @@ export function createPlanCreationOperations(input: {
   eventCandidates: GoalEventCandidateSource;
   baselineEvidence?: BaselineEvidenceSource;
   calendarConnected?: () => boolean;
+  legacyPlan?: () => Promise<LegacyPlanSummary | null>;
   today?: () => string;
   todayDateKey?: () => number;
   now?: () => number;
@@ -115,6 +117,7 @@ export function createPlanCreationOperations(input: {
   const todayDateKey = input.todayDateKey ?? (() => dateKeyFromText(today()));
   const now = input.now ?? Date.now;
   const calendarConnected = input.calendarConnected ?? (() => false);
+  const legacyPlan = input.legacyPlan ?? (async () => null);
   const stamp = async (commandId: string, digest: string) => {
     const clock = input.identity.hlcStamp();
     return {
@@ -230,6 +233,7 @@ export function createPlanCreationOperations(input: {
   return {
     async "plan.list"(request) {
       ListPlansParamsSchema.parse(request);
+      const legacy = await legacyPlan();
       return input.store.transaction(async () => {
         const transactionStore = {
           exec: (sql: string) => input.store.exec(sql),
@@ -271,6 +275,7 @@ export function createPlanCreationOperations(input: {
         const active = summaries.find((plan) => plan.status === "active") ?? null;
         return ListPlansResultSchema.parse({
           calendarConnected: calendarConnected(),
+          legacy,
           creation:
             creation === undefined ? null : projectPlanCreationCard(creation, { today: today() }),
           active,

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -215,6 +215,7 @@ const operations: CoachOperations &
   }),
   "plan.list": async () => ({
     calendarConnected: false,
+    legacy: null,
     creation: null,
     active: null,
     closed: [],
@@ -867,6 +868,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
           calls.push("plan.list");
           return {
             calendarConnected: false,
+            legacy: null,
             creation: null,
             active: null,
             closed: [],
@@ -2469,6 +2471,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     };
     const listPlans = vi.fn(async () => ({
       calendarConnected: false,
+      legacy: null,
       creation: startedCard,
       active: null,
       closed: [],
@@ -2583,6 +2586,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         params: {},
         result: {
           calendarConnected: false,
+          legacy: null,
           creation: startedCard,
           active: null,
           closed: [],

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1,3 +1,4 @@
+import type { LegacyPlanSummary } from "@enduragent/coach-contract";
 import { createHash } from "node:crypto";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import { describe, expect, it, vi, onTestFinished } from "vitest";
@@ -856,7 +857,7 @@ describe("Plan Creation operations", () => {
   });
 });
 
-async function previewHarness() {
+async function previewHarness(legacyPlan?: () => Promise<LegacyPlanSummary | null>) {
   let currentToday = today;
   let connected = false;
   const store = openSqliteStorage(":memory:");
@@ -875,6 +876,7 @@ async function previewHarness() {
     crypto: globalThis.crypto,
     eventCandidates: { read: async () => [candidateSource] },
     calendarConnected: () => connected,
+    legacyPlan,
     today: () => currentToday,
     todayDateKey: () => Number(currentToday.replaceAll("-", "")),
     now: () => Date.parse(`${currentToday}T12:00:00Z`),
@@ -1107,6 +1109,35 @@ describe("Plan Creation activation", () => {
     };
   };
 
+  it("reads the injected legacy summary before opening the list transaction", async () => {
+    const legacy = {
+      name: "8-Week Plan",
+      goal: "Gran Fondo",
+      weeks: 8,
+      sourceStatus: "draft",
+      createdAt: "1998-07-04",
+      targetDate: "1998-08-30",
+      readOnly: true,
+      source: "current-plan.json",
+    } satisfies LegacyPlanSummary;
+    let resolveLegacy: (value: LegacyPlanSummary | null) => void = () => {};
+    const pending = new Promise<LegacyPlanSummary | null>((resolve) => {
+      resolveLegacy = resolve;
+    });
+    const legacyPlan = vi.fn(() => pending);
+    const test = await previewHarness(legacyPlan);
+    const transaction = vi.spyOn(test.store, "transaction");
+    const reading = test.host["plan.list"]({});
+    expect(legacyPlan).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
+    resolveLegacy(legacy);
+    expect((await reading).legacy).toEqual(legacy);
+    expect(transaction).toHaveBeenCalledTimes(1);
+    legacyPlan.mockResolvedValueOnce(null);
+    expect((await test.host["plan.list"]({})).legacy).toBeNull();
+    expect(legacyPlan).toHaveBeenCalledTimes(2);
+  });
+
   it("reads the current calendar connection with an empty library", async () => {
     const test = await previewHarness();
     const card = test.card();
@@ -1117,6 +1148,7 @@ describe("Plan Creation activation", () => {
     });
     await expect(test.host["plan.list"]({})).resolves.toMatchObject({
       calendarConnected: false,
+      legacy: null,
       creation: null,
       active: null,
       closed: [],
@@ -1124,6 +1156,7 @@ describe("Plan Creation activation", () => {
     test.setConnected(true);
     await expect(test.host["plan.list"]({})).resolves.toMatchObject({
       calendarConnected: true,
+      legacy: null,
       creation: null,
       active: null,
       closed: [],
@@ -1414,6 +1447,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     expect(transaction).toHaveBeenCalledTimes(1);
     expect(after).toEqual({
       calendarConnected: false,
+      legacy: null,
       creation: null,
       changes: [],
       active: {

--- a/packages/kernel-node/src/planning/index.ts
+++ b/packages/kernel-node/src/planning/index.ts
@@ -1,1 +1,2 @@
 export * from "./legacy-plan-store.js";
+export * from "./legacy-plan-summary.js";

--- a/packages/kernel-node/src/planning/legacy-plan-summary.ts
+++ b/packages/kernel-node/src/planning/legacy-plan-summary.ts
@@ -1,0 +1,81 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import type { AthleteHome } from "../home/resolve-athlete-home.js";
+import type { LegacyPlanImportLogger } from "./legacy-plan-store.js";
+
+const LegacyPlanSourceSchema = z.object({
+  name: z.string().refine((value) => value.trim().length > 0),
+  primaryGoal: z.unknown().optional(),
+  totalWeeks: z.unknown().optional(),
+  status: z.unknown().optional(),
+  createdAt: z.unknown().optional(),
+  targetDate: z.unknown().optional(),
+});
+
+function optionalDate(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return null;
+  const date = new Date(timestamp).toISOString().split("T")[0];
+  const parsed = z.iso.date().safeParse(date);
+  return parsed.success ? parsed.data : null;
+}
+
+function summarize(source: z.infer<typeof LegacyPlanSourceSchema>) {
+  return {
+    name: source.name,
+    goal:
+      typeof source.primaryGoal === "string" && source.primaryGoal.trim().length > 0
+        ? source.primaryGoal
+        : null,
+    weeks:
+      typeof source.totalWeeks === "number" &&
+      Number.isSafeInteger(source.totalWeeks) &&
+      source.totalWeeks > 0
+        ? source.totalWeeks
+        : null,
+    sourceStatus: typeof source.status === "string" ? source.status : null,
+    createdAt: optionalDate(source.createdAt),
+    targetDate: optionalDate(source.targetDate),
+    readOnly: true as const,
+    source: "current-plan.json" as const,
+  };
+}
+
+type LegacyPlanSummary = ReturnType<typeof summarize>;
+
+function warn(logger: LegacyPlanImportLogger, message: string): void {
+  try {
+    logger.warn(message);
+  } catch {}
+}
+
+export async function readLegacyCurrentPlanSummary(input: {
+  readonly home: AthleteHome;
+  readonly logger: LegacyPlanImportLogger;
+}): Promise<LegacyPlanSummary | null> {
+  let bytes: string;
+  try {
+    bytes = await readFile(join(input.home.root, "plans", "current-plan.json"), "utf8");
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return null;
+    }
+    warn(input.logger, "Legacy Plan summary skipped because the source could not be read.");
+    return null;
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(bytes);
+  } catch {
+    warn(input.logger, "Legacy Plan summary skipped because the source is malformed.");
+    return null;
+  }
+  const parsed = LegacyPlanSourceSchema.safeParse(value);
+  if (!parsed.success) {
+    warn(input.logger, "Legacy Plan summary skipped because the source is malformed.");
+    return null;
+  }
+  return summarize(parsed.data);
+}

--- a/packages/kernel-node/tests/legacy-plan-summary.test.ts
+++ b/packages/kernel-node/tests/legacy-plan-summary.test.ts
@@ -1,0 +1,149 @@
+import { LegacyPlanSummarySchema, type LegacyPlanSummary } from "../../coach-contract/src/index.js";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { readLegacyCurrentPlanSummary } from "../src/planning/index.js";
+import { legacyCurrentPlanJson } from "./helpers/legacy-v11-store.js";
+
+describe("legacy current Plan summary", () => {
+  let root: string;
+  const logger = { warn: vi.fn() };
+  const home = () => ({
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  });
+  const read = () => readLegacyCurrentPlanSummary({ home: home(), logger });
+  const write = (value: unknown) =>
+    writeFile(join(root, "plans", "current-plan.json"), JSON.stringify(value));
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "legacy-plan-summary-"));
+    await mkdir(join(root, "plans"));
+    logger.warn.mockClear();
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns null without warning when the file is missing", async () => {
+    expect(await read()).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns null and warns once for malformed JSON", async () => {
+    await writeFile(join(root, "plans", "current-plan.json"), "{broken");
+    expect(await read()).toBeNull();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when the logger itself throws", async () => {
+    await writeFile(join(root, "plans", "current-plan.json"), "{broken");
+    const throwing = {
+      warn: () => {
+        throw new Error("logger unavailable");
+      },
+    };
+    await expect(
+      readLegacyCurrentPlanSummary({ home: home(), logger: throwing }),
+    ).resolves.toBeNull();
+  });
+
+  it.each([{}, { name: "" }, { name: "   " }, { name: 12 }, null, [], "Plan", 12])(
+    "returns null and warns once for an invalid source %j",
+    async (value) => {
+      await write(value);
+      expect(await read()).toBeNull();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("reads the exact summary without changing the source or needing an imported row", async () => {
+    await write(legacyCurrentPlanJson("with-workouts"));
+    const path = join(root, "plans", "current-plan.json");
+    const bytes = await readFile(path);
+    const before = await stat(path);
+    const summary = await read();
+    expectTypeOf(summary).toEqualTypeOf<LegacyPlanSummary | null>();
+    expect(LegacyPlanSummarySchema.parse(summary)).toEqual(summary);
+    expect(summary).toEqual({
+      name: "8-Week Plan",
+      goal: "Gran Fondo",
+      weeks: 8,
+      sourceStatus: "draft",
+      createdAt: "1998-07-04",
+      targetDate: "1998-08-30",
+      readOnly: true,
+      source: "current-plan.json",
+    });
+    expect(await readFile(path)).toEqual(bytes);
+    expect((await stat(path)).mtimeMs).toBe(before.mtimeMs);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps valid partial fields while nulling wrong types independently", async () => {
+    await write({
+      name: "Partial Plan",
+      primaryGoal: "Build fitness",
+      totalWeeks: "8",
+      createdAt: 12,
+      status: 3,
+      targetDate: "1998-08-30T12:00:00Z",
+    });
+    expect(await read()).toEqual({
+      name: "Partial Plan",
+      goal: "Build fitness",
+      weeks: null,
+      sourceStatus: null,
+      createdAt: null,
+      targetDate: "1998-08-30",
+      readOnly: true,
+      source: "current-plan.json",
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "nulls invalid weeks %s",
+    async (totalWeeks) => {
+      await write({ name: "Plan", totalWeeks });
+      expect(await read()).toMatchObject({ weeks: null });
+      expect(logger.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves raw strings and nulls absent or invalid optional values", async () => {
+    await write({
+      name: " Plan ",
+      primaryGoal: " ",
+      status: "unknown legacy status",
+      createdAt: "not a date",
+      targetDate: "+010000-01-01T00:00:00Z",
+    });
+    expect(await read()).toEqual({
+      name: " Plan ",
+      goal: null,
+      weeks: null,
+      sourceStatus: "unknown legacy status",
+      createdAt: null,
+      targetDate: null,
+      readOnly: true,
+      source: "current-plan.json",
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("normalizes parseable dates to UTC calendar dates", async () => {
+    await write({ name: "Plan", createdAt: "1998-07-04T23:00:00-02:00", targetDate: "1998-08-30" });
+    expect(await read()).toMatchObject({ createdAt: "1998-07-05", targetDate: "1998-08-30" });
+  });
+
+  it("returns null and warns once when the source cannot be read", async () => {
+    await mkdir(join(root, "plans", "current-plan.json"));
+    expect(await read()).toBeNull();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kernel-node/tests/legacy-v11-upgrade.test.ts
+++ b/packages/kernel-node/tests/legacy-v11-upgrade.test.ts
@@ -15,7 +15,7 @@ import { createLocalCoachComposition } from "../../coach/src/composition.js";
 import { createPlanCreationOperations } from "../../coach/src/plan-creation-operations.js";
 import { createAuthoredIdentity, type AthleteHome } from "../src/home/index.js";
 import { inertWriterProtocolListener } from "../src/lock/index.js";
-import { LEGACY_PLAN_IMPORT_MARKER } from "../src/planning/index.js";
+import { LEGACY_PLAN_IMPORT_MARKER, readLegacyCurrentPlanSummary } from "../src/planning/index.js";
 import {
   dumpLegacyV11Tables,
   legacyCurrentPlanJson,
@@ -209,7 +209,7 @@ describe("legacy v11 store upgrade and startup import", () => {
   });
 
   it.each(["draft", "active", "with-workouts"] as const)(
-    "imports %s once, preserves its source and workout ids, and excludes it from plan.list",
+    "imports %s once, preserves its source and workout ids, and lists it as read-only legacy history",
     async (variant) => {
       await runMigrations(store, MIGRATIONS);
       const source = legacyCurrentPlanJson(variant);
@@ -288,6 +288,7 @@ describe("legacy v11 store upgrade and startup import", () => {
       await expectMarker();
 
       const operations = createPlanCreationOperations({
+        legacyPlan: () => readLegacyCurrentPlanSummary({ home, logger: { warn: vi.fn() } }),
         store,
         repository: createPlanCreationRepository(store),
         identity: createAuthoredIdentity(home.configDir, { now: () => Date.UTC(1998, 6, 7, 12) }),
@@ -296,7 +297,18 @@ describe("legacy v11 store upgrade and startup import", () => {
         today: () => "1998-07-07",
         now: () => Date.UTC(1998, 6, 7, 12),
       });
-      await expect(operations["plan.list"]({})).resolves.toMatchObject({
+      const library = await operations["plan.list"]({});
+      expect(library.legacy).toEqual({
+        name: source.name,
+        goal: source.primaryGoal,
+        weeks: 8,
+        sourceStatus: source.status,
+        createdAt: "1998-07-04",
+        targetDate: "1998-08-30",
+        readOnly: true,
+        source: "current-plan.json",
+      });
+      expect(library).toMatchObject({
         active: null,
         closed: [],
         creation: null,


### PR DESCRIPTION
## Summary

A Plan saved by the pre-Chat flow (`plans/current-plan.json`) now appears in the Plan library as a read-only closed card. This is the second END-of-migration cut: it inverts the "not in library" pin from #921 and prepares for retiring the file-marker importer, since the entry is read from the file itself rather than the imported store row.

- kernel-node: tolerant `readLegacyCurrentPlanSummary({ home, logger })`. Missing file → null silently; unreadable, malformed, non-object or nameless source → null plus one warning; a throwing logger never propagates. Individual fields degrade to null.
- coach-contract: strict `LegacyPlanSummarySchema` (name, goal, weeks, sourceStatus, createdAt, targetDate, readOnly true, source "current-plan.json"); `ListPlansResult.legacy` nullable.
- coach: `plan.list` reads the summary outside the store transaction via an injected `legacyPlan` reader, default null; composition wires the real reader.
- renderer: `PlanLibrary` renders the card after closed Plans with the same card component, eyebrow "Closed Plan", status "Closed", summary `Target … · N weeks · Goal: … · Unknown reason`, a "Read only · Saved before Plans moved to Chat" line, no actions. Follows the prototype's unknown-legacy-ending closed card.
- tests: reader suite (19 cases), contract accept/reject, operations default and injected, all result literals updated, the v11 pin test now asserts the exact legacy summary per variant, renderer library cases, and a new E2E spec.

## Verification

- astra high read-only verifier: round 1 one blocking finding (unguarded logger warn could reject the reader), fixed inline with a guarded helper and a test; round 2 `pass: true`, blocking 0.
- Root `pnpm check` green; workspace suite 2031 passed with the two known daemon-handoff 5 s load timeouts; renderer-dom 697 passed with one onboarding 5 s load timeout that passes in isolation (55/55); full build green; E2E plan-legacy + plan-close-history + plan-calendar 16/16 in light and dark.
- Screenshot of the library with the legacy card matches the closed-card pattern.

| Limit | Value |
|---|---|
| Legacy entries per library | 1 |
| Fields shown | 6 plus two literal markers |
| Actions on the card | 0 |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
