### PR TITLE
feat(planning): make Chat ownership durable and retire the legacy Plan importer

### DIFF
--- a/.changeset/planning-authority-fence.md
+++ b/.changeset/planning-authority-fence.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Once you start a Plan in Chat, the app remembers that Chat owns your Plans, even after restarts, backups, or restores. The app no longer copies an older saved Plan into its records at startup, and the old Plan page no longer shows a separate calendar update box.

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -3535,39 +3535,6 @@ function ActiveProjection(): ReactElement {
   if (model.scenarioId === "PL-S026" || model.scenarioId === "PL-S027") {
     return <HistoryResultProjection scenarioId={model.scenarioId} entry={selectedHistoryEntry} />;
   }
-  const reconciling =
-    (transition.status === "submitting" || transition.status === "running") &&
-    transition.transitionId === "PL-T12";
-  const failed = model.reconciliation.status === "failed";
-  const verified = model.reconciliation.status === "verified";
-  const retrying = reconciling && failed;
-  const running = reconciling || model.reconciliation.status === "running";
-  const completed = model.reconciliation.created;
-  const total = model.reconciliation.total;
-  const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
-  const showReconciliation = [
-    "PL-S010",
-    "PL-S037",
-    "PL-S038",
-    "PL-S039",
-    "PL-S040",
-    "PL-S041",
-    "PL-S042",
-    "PL-S043",
-  ].includes(model.scenarioId);
-  const calendarTitle = verified
-    ? `Intervals · current through ${formatCivilDate(model.reconciliation.currentThrough!)}`
-    : retrying
-      ? "Retrying Intervals update"
-      : running
-        ? model.scenarioId === "PL-S042"
-          ? "Resuming Intervals update"
-          : "Updating Intervals"
-        : failed
-          ? model.scenarioId === "PL-S041"
-            ? "Intervals still needs attention"
-            : "Intervals update needs attention"
-          : "Update Intervals for the next seven days";
   const selectedWorkout =
     data.selectedWorkoutId === undefined || data.selectedWorkoutId === null
       ? null
@@ -3670,78 +3637,6 @@ function ActiveProjection(): ReactElement {
       </section>
 
       <PredictionsSummary readiness={data.readiness} />
-
-      {showReconciliation ? (
-        <section
-          className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1"
-          aria-live="polite"
-        >
-          <div className="flex items-start gap-row">
-            {failed && !retrying ? (
-              <TriangleAlert className="mt-0.5 size-5 shrink-0 text-warn" aria-hidden="true" />
-            ) : verified ? (
-              <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-ok" aria-hidden="true" />
-            ) : running ? (
-              <LoaderCircle
-                className="mt-0.5 size-5 shrink-0 animate-spin text-primary"
-                aria-hidden="true"
-              />
-            ) : (
-              <CalendarDays className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
-            )}
-            <div className={`${SUPPORT_PAIR} min-w-0 flex-1`}>
-              <h2 className="m-0 text-base font-semibold">{calendarTitle}</h2>
-              <p className="m-0 text-ink-2">
-                {total > 0
-                  ? `Created ${completed} · Pending ${model.reconciliation.pending} · Failed ${model.reconciliation.failed} · Total ${total}`
-                  : "Only today plus the next six civil dates will be written."}
-              </p>
-            </div>
-            {verified ? (
-              <span className="rounded-full border border-ok px-3 py-1 text-sm text-ok">
-                Verified
-              </span>
-            ) : null}
-          </div>
-          {total > 0 ? (
-            <div
-              className="h-2 overflow-hidden rounded-full bg-sunk"
-              role="progressbar"
-              aria-label="Intervals calendar update"
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-valuenow={percent}
-            >
-              <div className="h-full rounded-full bg-primary" style={{ width: `${percent}%` }} />
-            </div>
-          ) : null}
-          {!running && !verified ? (
-            <div className="flex flex-wrap justify-end gap-inset">
-              {failed ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={actions === null}
-                  onClick={() => actions?.verifyReconciliation()}
-                >
-                  Verify again
-                </Button>
-              ) : null}
-              <Button
-                type="button"
-                disabled={actions === null}
-                onClick={() => actions?.reconcilePlan()}
-              >
-                {failed
-                  ? "Retry"
-                  : model.scenarioId === "PL-S037"
-                    ? "View calendar progress"
-                    : "Update Intervals"}
-              </Button>
-            </div>
-          ) : null}
-        </section>
-      ) : null}
 
       <section className="overflow-hidden rounded-card bg-surface shadow-elev-1">
         <div className="flex items-start justify-between gap-row px-5 py-row">

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -1012,72 +1012,82 @@ describe("Plan surface", () => {
     expect(planActions.retry).toHaveBeenCalledOnce();
   });
 
-  it("keeps reconciliation failures inline on the active Plan with retry and verify actions", async () => {
-    const user = userEvent.setup();
-    const planActions = actions();
-    const state = planReadModel({
-      lifecycle: "active",
-      scenarioId: "PL-S039",
-      projection: "active",
-      planId: "00000000000000000000000003",
-      attentionCount: 1,
-      reconciliation: {
-        status: "failed",
-        created: 1,
-        pending: 0,
-        failed: 1,
-        total: 2,
-        currentThrough: null,
-        error: {
-          code: "provider-failed",
-          message: "Some workouts could not be updated in Intervals.",
-          retryable: true,
+  it.each(["pending", "failed", "running", "verified"] as const)(
+    "hides the legacy calendar panel when reconciliation is %s",
+    (status) => {
+      const planActions = actions();
+      const state = planReadModel({
+        lifecycle: "active",
+        scenarioId: status === "failed" ? "PL-S039" : "PL-S010",
+        projection: "active",
+        planId: "00000000000000000000000003",
+        attentionCount: 1,
+        reconciliation: {
+          status: status === "pending" ? "not-started" : status,
+          created: 1,
+          pending: status === "pending" ? 1 : 0,
+          failed: status === "failed" ? 1 : 0,
+          total: 2,
+          currentThrough: status === "verified" ? "2026-08-18" : null,
+          error:
+            status === "failed"
+              ? {
+                  code: "provider-failed",
+                  message: "Some workouts could not be updated in Intervals.",
+                  retryable: true,
+                }
+              : null,
         },
-      },
-      data: {
+        data: {
+          plan: {
+            id: "00000000000000000000000003",
+            name: "Gran Fondo Almaty",
+            primaryGoal: "Finish in the front half",
+            startDate: "2026-07-13",
+            targetDate: "2026-10-04",
+            kind: "full-plan",
+            totalWeeks: 12,
+            weekStartDay: 1,
+            workoutCount: 20,
+            plannedDurationS: 72_000,
+          },
+          today: "2026-08-18",
+          weekIndex: 6,
+          todayWorkout: {
+            id: "00000000000000000000000004",
+            date: "2026-08-18",
+            sport: "cycling",
+            name: "Recovery spin",
+            durationS: 2_700,
+          },
+          workouts: [],
+        },
+      });
+      useEnduragentStore.setState({
         plan: {
-          id: "00000000000000000000000003",
-          name: "Gran Fondo Almaty",
-          primaryGoal: "Finish in the front half",
-          startDate: "2026-07-13",
-          targetDate: "2026-10-04",
-          kind: "full-plan",
-          totalWeeks: 12,
-          weekStartDay: 1,
-          workoutCount: 20,
-          plannedDurationS: 72_000,
+          ...EMPTY_PLAN_SURFACE,
+          hydration: { status: "ready", state },
+          lastReady: state,
         },
-        today: "2026-08-18",
-        weekIndex: 6,
-        todayWorkout: {
-          id: "00000000000000000000000004",
-          date: "2026-08-18",
-          sport: "cycling",
-          name: "Recovery spin",
-          durationS: 2_700,
-        },
-        workouts: [],
-      },
-    });
-    useEnduragentStore.setState({
-      plan: {
-        ...EMPTY_PLAN_SURFACE,
-        hydration: { status: "ready", state },
-        lastReady: state,
-      },
-      planActions,
-    });
+        planActions,
+      });
 
-    render(<PlanView />);
+      render(<PlanView />);
 
-    expect(screen.getByRole("heading", { name: "Plan active · week 6 of 12" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Today · Recovery spin" })).toBeInTheDocument();
-    expect(screen.getByText("Created 1 · Pending 0 · Failed 1 · Total 2")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Retry" }));
-    await user.click(screen.getByRole("button", { name: "Verify again" }));
-    expect(planActions.reconcilePlan).toHaveBeenCalledOnce();
-    expect(planActions.verifyReconciliation).toHaveBeenCalledOnce();
-  });
+      expect(
+        screen.getByRole("heading", { name: "Plan active · week 6 of 12" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Today · Recovery spin" })).toBeInTheDocument();
+      expect(screen.queryByLabelText("Intervals calendar update")).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Update Intervals" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Verify again" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /Intervals/u })).not.toBeInTheDocument();
+      expect(screen.queryByText(/Created 1 · Pending/u)).not.toBeInTheDocument();
+      expect(planActions.reconcilePlan).not.toHaveBeenCalled();
+      expect(planActions.verifyReconciliation).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps the normal active Plan concise and shows the prototype summary facts", () => {
     const state = planReadModel({

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -89,7 +89,6 @@ import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-no
 import {
   createLegacyPlanRepository,
   createLegacyPlanRowWriter,
-  importLegacyCurrentPlan,
   readLegacyCurrentPlanSummary,
 } from "@enduragent/kernel-node/planning";
 import {
@@ -909,16 +908,6 @@ export async function createLocalCoachComposition(
   });
   const planningRepository = createLegacyPlanRepository(input.context.store);
   const legacyWriterFence = createLegacyWriterFence(input.context.store);
-  if (!(await legacyWriterFence.fenced())) {
-    await importLegacyCurrentPlan({
-      home: input.home,
-      store: input.context.store,
-      identity: planningIdentity,
-      importDateKey: planningDateKey(),
-      importTimestampMs: now(),
-      logger: { warn: () => logger.warn("legacy_plan_import_skipped") },
-    });
-  }
   const persistPlan = await createLegacyPlanRowWriter({
     repository: planningRepository,
     identity: planningIdentity,

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -592,7 +592,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 32 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -578,7 +578,7 @@ describe("coach sync composition", () => {
             return store.get("PRAGMA user_version");
           },
         );
-        expect(value).toEqual({ user_version: 31 });
+        expect(value).toEqual({ user_version: 32 });
         expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
         expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
         expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -586,7 +586,7 @@ describe("coach sync composition", () => {
         const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
         try {
           await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-            user_version: 31,
+            user_version: 32,
           });
         } finally {
           await reopened.close();

--- a/packages/coach/tests/writer-fence.test.ts
+++ b/packages/coach/tests/writer-fence.test.ts
@@ -202,7 +202,7 @@ function commands(planId: string): ExecutePlanTransitionRpcParams[] {
 }
 
 describe("legacy writer fence", () => {
-  it.each(["in-progress", "review"] as const)(
+  it.each(["in-progress", "review", "discarded"] as const)(
     "rejects with %s creation without engine reads or store writes",
     async (status) => {
       const test = await fixture(status);
@@ -290,7 +290,7 @@ describe("legacy writer fence", () => {
     expect(await dumpStore(test.store)).toBe(before);
   });
 
-  it.each(["in-progress", "review", "active"] as const)(
+  it.each(["in-progress", "review", "active", "closed", "discarded"] as const)(
     "reads %s ownership without writes",
     async (status) => {
       const test = await fixture(status);
@@ -298,14 +298,15 @@ describe("legacy writer fence", () => {
       const before = await dumpStore(test.store);
       expect(await fence.read()).toEqual({
         activePlanId: status === "active" ? test.planId : null,
-        creationId: status === "active" ? null : test.creationId,
+        creationId: status === "in-progress" || status === "review" ? test.creationId : null,
+        chatAuthoritySinceMs: 904_694_400_000,
       });
       expect(await fence.fenced()).toBe(true);
       expect(await dumpStore(test.store)).toBe(before);
     },
   );
 
-  it.each(["in-progress", "review", "active"] as const)(
+  it.each(["in-progress", "review", "active", "closed", "discarded"] as const)(
     "rejects authoring families with %s ownership and preserves the entire store",
     async (status) => {
       const test = await fixture(status);
@@ -347,22 +348,36 @@ describe("legacy writer fence", () => {
     },
   );
 
-  it.each(["empty", "closed", "discarded"] as const)(
-    "permits legacy authoring with %s ownership",
-    async (status) => {
-      const test = await fixture(status);
-      const fence = createLegacyWriterFence(test.store);
-      const before = await dumpStore(test.store);
-      expect(await fence.read()).toEqual({ activePlanId: null, creationId: null });
-      expect(await fence.fenced()).toBe(false);
-      expect(await dumpStore(test.store)).toBe(before);
-      await expect(
-        test.operations.executePlanTransition?.({
-          transitionId: "PL-T01",
-          commandId: "legacy-start",
-          sourceConversationId: null,
-        }),
-      ).resolves.toMatchObject({ status: "completed" });
+  it("permits legacy authoring when no Chat creation has ever started", async () => {
+    const test = await fixture("empty");
+    const fence = createLegacyWriterFence(test.store);
+    const before = await dumpStore(test.store);
+    expect(await fence.read()).toEqual({
+      activePlanId: null,
+      creationId: null,
+      chatAuthoritySinceMs: null,
+    });
+    expect(await fence.fenced()).toBe(false);
+    expect(await dumpStore(test.store)).toBe(before);
+    await expect(
+      test.operations.executePlanTransition?.({
+        transitionId: "PL-T01",
+        commandId: "legacy-start",
+        sourceConversationId: null,
+      }),
+    ).resolves.toMatchObject({ status: "completed" });
+  });
+
+  it.each(commands(CONVERSATION_ID))(
+    "does not fence $transitionId when no Chat creation has ever started",
+    async (command) => {
+      const test = await fixture("empty");
+      const result = await test.operations.executePlanTransition?.(command);
+      expect(result).toBeDefined();
+      expect(result).not.toMatchObject({
+        status: "rejected",
+        error: { code: "conflict", message: MESSAGE },
+      });
     },
   );
 

--- a/packages/kernel-node/src/planning/legacy-plan-store.ts
+++ b/packages/kernel-node/src/planning/legacy-plan-store.ts
@@ -1,5 +1,3 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import {
   createPlanRepository,
   legacyPlanRows,
@@ -7,44 +5,13 @@ import {
   type PlanningIdentity,
 } from "@enduragent/kernel/planning";
 import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
-import type { AthleteHome } from "../home/resolve-athlete-home.js";
 import type { AuthoredIdentity } from "../store/authored-identity.js";
-
-export const LEGACY_PLAN_IMPORT_MARKER = "planning-current-plan-import-v1" as const;
 
 export interface LegacyPlanImportLogger {
   warn(message: string): void;
 }
 
-export type LegacyPlanImportResult =
-  | { readonly status: "imported"; readonly planId: string }
-  | { readonly status: "already-completed" | "no-source" | "malformed" };
-
 type PlanningStore = SqlStore & Pick<MigratorStore, "transaction">;
-
-function errorCode(error: unknown): string | undefined {
-  return typeof error === "object" && error !== null
-    ? (error as { readonly code?: string }).code
-    : undefined;
-}
-
-async function exists(path: string): Promise<boolean> {
-  try {
-    await readFile(path);
-    return true;
-  } catch (error) {
-    if (errorCode(error) === "ENOENT") return false;
-    throw error;
-  }
-}
-
-async function markCompleted(path: string): Promise<void> {
-  try {
-    await writeFile(path, "completed\n", { flag: "wx", mode: 0o600 });
-  } catch (error) {
-    if (errorCode(error) !== "EEXIST") throw error;
-  }
-}
 
 async function planningIdentity(identity: AuthoredIdentity): Promise<PlanningIdentity> {
   const deviceId = await identity.deviceId();
@@ -53,60 +20,6 @@ async function planningIdentity(identity: AuthoredIdentity): Promise<PlanningIde
     newId: () => identity.newUlid(),
     stamp: () => identity.hlcStamp(),
   });
-}
-
-export async function importLegacyCurrentPlan(input: {
-  readonly home: AthleteHome;
-  readonly store: PlanningStore;
-  readonly identity: AuthoredIdentity;
-  readonly importDateKey: number;
-  readonly importTimestampMs: number;
-  readonly logger: LegacyPlanImportLogger;
-}): Promise<LegacyPlanImportResult> {
-  const markerPath = join(input.home.configDir, LEGACY_PLAN_IMPORT_MARKER);
-  if (await exists(markerPath)) return { status: "already-completed" };
-  const sourcePath = join(input.home.root, "plans", "current-plan.json");
-  let sourceBytes: Buffer;
-  try {
-    sourceBytes = await readFile(sourcePath);
-  } catch (error) {
-    if (errorCode(error) !== "ENOENT") throw error;
-    await mkdir(input.home.configDir, { recursive: true, mode: 0o700 });
-    await markCompleted(markerPath);
-    return { status: "no-source" };
-  }
-  let value: unknown;
-  try {
-    value = JSON.parse(sourceBytes.toString("utf8"));
-  } catch {
-    input.logger.warn("Legacy Plan import skipped because the source is malformed.");
-    return { status: "malformed" };
-  }
-  const repository = createPlanRepository(input.store);
-  let rows;
-  try {
-    const originId = typeof value === "object"
-      && value !== null
-      && !Array.isArray(value)
-      && typeof (value as { readonly id?: unknown }).id === "string"
-      ? (value as { readonly id: string }).id
-      : undefined;
-    const existing = originId === undefined ? undefined : await repository.readByOriginId(originId);
-    rows = legacyPlanRows({
-      value,
-      identity: await planningIdentity(input.identity),
-      fallbackDateKey: input.importDateKey,
-      fallbackTimestampMs: input.importTimestampMs,
-      ...(existing === undefined ? {} : { existingPlanId: existing.id }),
-    });
-    await repository.replace(rows.plan, rows.workouts);
-  } catch {
-    input.logger.warn("Legacy Plan import skipped because the source is malformed.");
-    return { status: "malformed" };
-  }
-  await mkdir(input.home.configDir, { recursive: true, mode: 0o700 });
-  await markCompleted(markerPath);
-  return { status: "imported", planId: rows.plan.id };
 }
 
 export async function createLegacyPlanRowWriter(input: {
@@ -119,17 +32,19 @@ export async function createLegacyPlanRowWriter(input: {
   let currentPlanId: string | undefined;
   return async (value: unknown): Promise<void> => {
     const todayDateKey = input.fallbackDateKey();
-    const originId = typeof value === "object"
-      && value !== null
-      && !Array.isArray(value)
-      && typeof (value as { readonly id?: unknown }).id === "string"
-      ? (value as { readonly id: string }).id
-      : undefined;
-    const existing = originId === undefined
-      ? currentPlanId === undefined
-        ? await input.repository.readLatest()
-        : await input.repository.read(currentPlanId)
-      : await input.repository.readByOriginId(originId);
+    const originId =
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value) &&
+      typeof (value as { readonly id?: unknown }).id === "string"
+        ? (value as { readonly id: string }).id
+        : undefined;
+    const existing =
+      originId === undefined
+        ? currentPlanId === undefined
+          ? await input.repository.readLatest()
+          : await input.repository.read(currentPlanId)
+        : await input.repository.readByOriginId(originId);
     const rows = legacyPlanRows({
       value,
       identity,

--- a/packages/kernel-node/src/store-export/sqlite-import.ts
+++ b/packages/kernel-node/src/store-export/sqlite-import.ts
@@ -99,6 +99,37 @@ function normalizeRows(
   return rows.map((row) => ({ ...row, operation: "update" }));
 }
 
+async function restorePlanningAuthority(
+  store: SqliteImportStore,
+  rows: readonly AuthoredRow[],
+): Promise<RestoreTableResult> {
+  const table = "planning_authority";
+  if (rows.length === 0) return { table, inserted: 0, skipped: 0 };
+  if (rows.length !== 1 || integer(rows[0]!, "singleton") !== 1) {
+    throw new TypeError("Export row is invalid");
+  }
+  const row = rows[0]!;
+  if (row.chat_authority_since_ms === null) return { table, inserted: 0, skipped: 1 };
+  const instant = integer(row, "chat_authority_since_ms");
+  const current = await store.get(
+    "SELECT chat_authority_since_ms FROM planning_authority WHERE singleton = 1",
+  );
+  if (current === undefined) throw new TypeError("Planning authority is missing");
+  if (current.chat_authority_since_ms !== null) return { table, inserted: 0, skipped: 1 };
+  await store.run(
+    `UPDATE planning_authority
+SET chat_authority_since_ms = ?, device_id = ?, hlc_physical_ms = ?, hlc_counter = ?
+WHERE singleton = 1 AND chat_authority_since_ms IS NULL`,
+    [
+      instant,
+      toSqlValue(row.device_id),
+      toSqlValue(row.hlc_physical_ms),
+      toSqlValue(row.hlc_counter),
+    ],
+  );
+  return { table, inserted: 1, skipped: 0 };
+}
+
 async function restoreRows(
   store: SqliteImportStore,
   table: string,
@@ -123,11 +154,20 @@ export function createSqliteImportSink(store: SqliteImportStore): ImportSink {
   return {
     restoreAuthoredTable(table, rows, { sourceUserVersion }) {
       return store.transaction(async () => {
+        if (table === "planning_authority") return restorePlanningAuthority(store, rows);
         const normalized = normalizeRows(table, rows, sourceUserVersion);
         if (table === "plan_replacement" && sourceUserVersion >= 21 && sourceUserVersion < 29) {
           for (const row of normalized) await requireCompatibleCleanupJob(store, row);
         }
-        return restoreRows(store, table, normalized);
+        const result = await restoreRows(store, table, normalized);
+        if (table === "plan_creation") {
+          await store.run(
+            `UPDATE planning_authority
+SET chat_authority_since_ms = (SELECT MIN(created_at_ms) FROM plan_creation)
+WHERE singleton = 1 AND chat_authority_since_ms IS NULL AND EXISTS (SELECT 1 FROM plan_creation)`,
+          );
+        }
+        return result;
       });
     },
   };

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -598,7 +598,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/legacy-plan-store.test.ts
+++ b/packages/kernel-node/tests/legacy-plan-store.test.ts
@@ -1,24 +1,13 @@
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { engineConfigFromConfig, type Config } from "@enduragent/core";
-import {
-  PlanningDateError,
-  createPlanCreationRepository,
-  createPlanRepository,
-} from "@enduragent/kernel/planning";
-import { dumpStore, runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PlanningDateError, createPlanRepository } from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
-import { createLocalCoachComposition } from "../../coach/src/composition.js";
 import { createAuthoredIdentity, type AthleteHome } from "../src/home/index.js";
-import { inertWriterProtocolListener } from "../src/lock/index.js";
-import {
-  LEGACY_PLAN_IMPORT_MARKER,
-  createLegacyPlanRowWriter,
-  importLegacyCurrentPlan,
-} from "../src/planning/index.js";
+import { createLegacyPlanRowWriter } from "../src/planning/index.js";
 import { openSqliteStorage } from "../src/sqlite/index.js";
 
 function legacyPlan(): Record<string, unknown> {
@@ -35,13 +24,13 @@ function legacyPlan(): Record<string, unknown> {
   };
 }
 
-describe("legacy current Plan import and dual-write adapter", () => {
+describe("legacy current Plan dual-write adapter", () => {
   let root: string;
   let home: AthleteHome;
   let store: SqlStore & MigratorStore;
 
   beforeEach(async () => {
-    root = mkdtempSync(join(tmpdir(), "plan-import-"));
+    root = mkdtempSync(join(tmpdir(), "plan-writer-"));
     home = {
       root,
       storeDir: join(root, "store"),
@@ -63,202 +52,6 @@ describe("legacy current Plan import and dual-write adapter", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  async function startCompositionUntilReferenceBootstrap() {
-    const config: Config = {
-      dataSource: "store",
-      llm: { provider: "anthropic", model: "synthetic", apiKey: "" },
-      intervals: { apiKey: "", athleteId: "synthetic" },
-      telegram: { botToken: "" },
-      session: {
-        historyTokenBudgetRatio: 0.3,
-        idleMinutes: 0,
-        dailyResetHour: 4,
-        resetArchiveRetentionDays: 0,
-        timezone: "UTC",
-      },
-      contextWindowTokens: 1000,
-      dataDir: home.root,
-    };
-    const bootstrapReached = new Error("Reference bootstrap reached");
-    const bootstrap = vi.fn(async () => {
-      throw bootstrapReached;
-    });
-    await expect(createLocalCoachComposition({
-      env: { ENDURAGENT_HOME: home.root },
-      home,
-      context: { home, store, listener: inertWriterProtocolListener },
-      config,
-      engineConfig: engineConfigFromConfig(config),
-    }, {
-      bootstrap,
-      now: () => Date.UTC(1998, 6, 7, 12),
-    })).rejects.toBe(bootstrapReached);
-    expect(bootstrap).toHaveBeenCalledOnce();
-  }
-
-  it.each(["active-plan", "unfinished-creation"])(
-    "skips the startup legacy import with an %s and leaves its marker untouched",
-    async (owner) => {
-      if (owner === "unfinished-creation") {
-        await createPlanCreationRepository(store).start({
-          creationId: "00000000000000000000000001",
-          seed: { schemaVersion: 1, eventCandidates: [] },
-          command: {
-            commandId: "start-creation",
-            requestDigest: "a".repeat(64),
-            nowMs: 900,
-            deviceId: "synthetic-device",
-            hlcPhysicalMs: 900,
-            hlcCounter: 0,
-          },
-        });
-      } else {
-        await createPlanRepository(store).replace({
-          id: "00000000000000000000000002",
-          originId: null,
-          name: "Chat Plan",
-          primaryGoal: "Ride consistently",
-          startDateKey: 19980706,
-          targetDateKey: 19980830,
-          status: "active",
-          kind: "short_race_preparation",
-          totalWeeks: 8,
-          weekStartDay: 1,
-          structureJson: "{}",
-          createdAtMs: 900,
-          updatedAtMs: 900,
-          deviceId: "synthetic-device",
-          hlcPhysicalMs: 900,
-          hlcCounter: 0,
-        }, []);
-        await store.run(`INSERT INTO planning_plan (
-          plan_id,status,version,current_revision_number,activated_at_ms,updated_at_ms,
-          device_id,hlc_physical_ms,hlc_counter
-        ) VALUES (?, 'active', 1, 1, 900, 900, 'synthetic-device', 900, 0)`, [
-          "00000000000000000000000002",
-        ]);
-      }
-      const sourcePath = join(root, "plans", "current-plan.json");
-      const sourceBytes = JSON.stringify(legacyPlan());
-      await writeFile(sourcePath, sourceBytes);
-      const before = await dumpStore(store);
-
-      await startCompositionUntilReferenceBootstrap();
-
-      expect(await dumpStore(store)).toEqual(before);
-      expect(await readFile(sourcePath, "utf8")).toBe(sourceBytes);
-      await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER)))
-        .rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
-
-  it("imports the legacy Plan at startup when no Chat Plan or unfinished creation exists", async () => {
-    await writeFile(join(root, "plans", "current-plan.json"), JSON.stringify(legacyPlan()));
-
-    await startCompositionUntilReferenceBootstrap();
-
-    expect(await createPlanRepository(store).count()).toBe(1);
-    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER), "utf8"))
-      .resolves.toBe("completed\n");
-  });
-
-  it("imports the real Draft shape once without modifying its source", async () => {
-    const sourcePath = join(root, "plans", "current-plan.json");
-    const sourceBytes = Buffer.from(JSON.stringify(legacyPlan(), null, 2));
-    await writeFile(sourcePath, sourceBytes);
-    const before = await stat(sourcePath);
-    const logger = { warn: vi.fn() };
-    const identity = createAuthoredIdentity(home.configDir, {
-      now: () => 900,
-      randomBytes: () => new Uint8Array(10).fill(1),
-    });
-
-    const first = await importLegacyCurrentPlan({
-      home,
-      store,
-      identity,
-      importDateKey: 19980707,
-      importTimestampMs: 900,
-      logger,
-    });
-    const second = await importLegacyCurrentPlan({
-      home,
-      store,
-      identity,
-      importDateKey: 19980707,
-      importTimestampMs: 900,
-      logger,
-    });
-
-    expect(first).toEqual({
-      status: "imported",
-      planId: expect.stringMatching(/^[0-9A-HJKMNP-TV-Z]{26}$/),
-    });
-    expect(second).toEqual({ status: "already-completed" });
-    const repository = createPlanRepository(store);
-    expect(await repository.count()).toBe(1);
-    expect(await repository.readByOriginId("32cc7944-facd-4b56-b1a1-7dfe43e4bfe7"))
-      .toMatchObject({
-        startDateKey: 19980706,
-        status: "draft",
-        kind: "short_race_preparation",
-        totalWeeks: 8,
-      });
-    expect(await readFile(sourcePath)).toEqual(sourceBytes);
-    expect((await stat(sourcePath)).mtimeMs).toBe(before.mtimeMs);
-    expect(logger.warn).not.toHaveBeenCalled();
-    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER), "utf8"))
-      .resolves.toBe("completed\n");
-  });
-
-  it("logs and skips malformed input without a partial Plan or completion marker", async () => {
-    const sourcePath = join(root, "plans", "current-plan.json");
-    await writeFile(sourcePath, '{"name":');
-    const logger = { warn: vi.fn() };
-    const identity = createAuthoredIdentity(home.configDir, {
-      now: () => 900,
-      randomBytes: () => new Uint8Array(10).fill(2),
-    });
-
-    await expect(importLegacyCurrentPlan({
-      home,
-      store,
-      identity,
-      importDateKey: 19980707,
-      importTimestampMs: 900,
-      logger,
-    })).resolves.toEqual({ status: "malformed" });
-    expect(await createPlanRepository(store).count()).toBe(0);
-    expect(logger.warn).toHaveBeenCalledOnce();
-    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER)))
-      .rejects.toMatchObject({ code: "ENOENT" });
-  });
-
-  it("falls back to the import date when createdAt is absent or unparseable", async () => {
-    const sourcePath = join(root, "plans", "current-plan.json");
-    await writeFile(sourcePath, JSON.stringify({
-      ...legacyPlan(),
-      id: "0a8c6007-d36e-4d44-82d7-5df9fa2db200",
-      createdAt: "not-an-instant",
-      targetDate: undefined,
-    }));
-    const identity = createAuthoredIdentity(home.configDir, {
-      now: () => 900,
-      randomBytes: () => new Uint8Array(10).fill(3),
-    });
-    await importLegacyCurrentPlan({
-      home,
-      store,
-      identity,
-      importDateKey: 19980707,
-      importTimestampMs: 900,
-      logger: { warn: vi.fn() },
-    });
-    expect(await createPlanRepository(store).readByOriginId(
-      "0a8c6007-d36e-4d44-82d7-5df9fa2db200",
-    )).toMatchObject({ startDateKey: 19980707, createdAtMs: 900 });
-  });
-
   it("upserts the same row through repeated compatibility writes", async () => {
     const identity = createAuthoredIdentity(home.configDir, {
       now: () => 900,
@@ -274,8 +67,9 @@ describe("legacy current Plan import and dual-write adapter", () => {
     await writeRows(legacyPlan());
     await writeRows({ ...legacyPlan(), name: "Updated Plan" });
     expect(await repository.count()).toBe(1);
-    expect(await repository.readByOriginId("32cc7944-facd-4b56-b1a1-7dfe43e4bfe7"))
-      .toMatchObject({ name: "Updated Plan" });
+    expect(await repository.readByOriginId("32cc7944-facd-4b56-b1a1-7dfe43e4bfe7")).toMatchObject({
+      name: "Updated Plan",
+    });
   });
 
   it.each([
@@ -291,25 +85,30 @@ describe("legacy current Plan import and dual-write adapter", () => {
       "1998-08-30T00:00:00.000Z",
       new PlanningDateError("start-after-target"),
     ],
-  ])("rejects a new compatibility Plan starting %s", async (_label, startDate, targetDate, error) => {
-    const identity = createAuthoredIdentity(home.configDir, {
-      now: () => 900,
-      randomBytes: () => new Uint8Array(10).fill(5),
-    });
-    const repository = createPlanRepository(store);
-    const writeRows = await createLegacyPlanRowWriter({
-      repository,
-      identity,
-      fallbackDateKey: () => 19980706,
-      now: () => 900,
-    });
+  ])(
+    "rejects a new compatibility Plan starting %s",
+    async (_label, startDate, targetDate, error) => {
+      const identity = createAuthoredIdentity(home.configDir, {
+        now: () => 900,
+        randomBytes: () => new Uint8Array(10).fill(5),
+      });
+      const repository = createPlanRepository(store);
+      const writeRows = await createLegacyPlanRowWriter({
+        repository,
+        identity,
+        fallbackDateKey: () => 19980706,
+        now: () => 900,
+      });
 
-    await expect(writeRows({
-      ...legacyPlan(),
-      id: undefined,
-      startDate,
-      targetDate,
-    })).rejects.toEqual(error);
-    await expect(repository.count()).resolves.toBe(0);
-  });
+      await expect(
+        writeRows({
+          ...legacyPlan(),
+          id: undefined,
+          startDate,
+          targetDate,
+        }),
+      ).rejects.toEqual(error);
+      await expect(repository.count()).resolves.toBe(0);
+    },
+  );
 });

--- a/packages/kernel-node/tests/legacy-v11-upgrade.test.ts
+++ b/packages/kernel-node/tests/legacy-v11-upgrade.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,14 +15,14 @@ import { createLocalCoachComposition } from "../../coach/src/composition.js";
 import { createPlanCreationOperations } from "../../coach/src/plan-creation-operations.js";
 import { createAuthoredIdentity, type AthleteHome } from "../src/home/index.js";
 import { inertWriterProtocolListener } from "../src/lock/index.js";
-import { LEGACY_PLAN_IMPORT_MARKER, readLegacyCurrentPlanSummary } from "../src/planning/index.js";
+import { readLegacyCurrentPlanSummary } from "../src/planning/index.js";
 import {
   dumpLegacyV11Tables,
   legacyCurrentPlanJson,
   legacyV11Store,
 } from "./helpers/legacy-v11-store.js";
 
-describe("legacy v11 store upgrade and startup import", () => {
+describe("legacy v11 store upgrade and startup", () => {
   let root: string;
   let home: AthleteHome;
   let store: SqlStore & MigratorStore;
@@ -134,13 +134,11 @@ describe("legacy v11 store upgrade and startup import", () => {
     return tables;
   }
 
-  async function expectMarker() {
-    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER), "utf8")).resolves.toBe(
-      "completed\n",
-    );
+  async function expectNoMarker() {
+    expect(await readdir(home.configDir)).not.toContain("planning-current-plan-import-v1");
   }
 
-  it("upgrades v11 without changing seeded rows and creates empty tables", async () => {
+  it("upgrades v11 without changing seeded rows and initializes planning authority", async () => {
     expect(await store.getUserVersion()).toBe(11);
     const before = await dumpLegacyV11Tables(store);
     for (const rows of Object.values(before)) expect(rows).toHaveLength(1);
@@ -149,7 +147,7 @@ describe("legacy v11 store upgrade and startup import", () => {
     const result = await runMigrations(store, MIGRATIONS);
 
     expect(result.applied).toEqual([
-      12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+      12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
     ]);
     expect(await dumpLegacyV11Tables(store)).toEqual(before);
     const newTables = (await tableNames()).filter((name) => !previousTables.has(name));
@@ -185,6 +183,7 @@ describe("legacy v11 store upgrade and startup import", () => {
       "plan_workout",
       "plan_workout_drift",
       "plan_workout_match",
+      "planning_authority",
       "planning_command",
       "planning_plan",
       "planning_request",
@@ -195,21 +194,32 @@ describe("legacy v11 store upgrade and startup import", () => {
       "training_restriction",
     ]);
     const counts = await rowCounts();
-    for (const table of newTables) expect(counts[table], table).toBe(0);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+    for (const table of newTables) {
+      expect(counts[table], table).toBe(table === "planning_authority" ? 1 : 0);
+    }
+    expect(await store.all("SELECT * FROM planning_authority")).toEqual([
+      {
+        singleton: 1,
+        chat_authority_since_ms: null,
+        device_id: null,
+        hlc_physical_ms: null,
+        hlc_counter: null,
+      },
+    ]);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
   });
 
-  it("writes the startup marker without a Plan when the legacy JSON is absent", async () => {
+  it("creates no Plan or startup marker when the legacy JSON is absent", async () => {
     await runMigrations(store, MIGRATIONS);
 
     await startCompositionUntilReferenceBootstrap();
 
     expect(await createPlanRepository(store).count()).toBe(0);
-    await expectMarker();
+    await expectNoMarker();
   });
 
   it.each(["draft", "active", "with-workouts"] as const)(
-    "imports %s once, preserves its source and workout ids, and lists it as read-only legacy history",
+    "leaves %s unimported, preserves its source, and lists it as read-only legacy history",
     async (variant) => {
       await runMigrations(store, MIGRATIONS);
       const source = legacyCurrentPlanJson(variant);
@@ -222,62 +232,16 @@ describe("legacy v11 store upgrade and startup import", () => {
 
       const counts = await rowCounts();
       expect(counts).toMatchObject({
-        plan: 1,
-        plan_workout: source.workouts.length,
-        plan_settings: 1,
+        plan: 0,
+        plan_workout: 0,
+        plan_settings: 0,
         planning_plan: 0,
         plan_revision: 0,
         plan_reconciliation_job: 0,
       });
-      const plan = await store.get("SELECT * FROM plan");
-      expect(plan).toMatchObject({
-        id: expect.stringMatching(/^[0-9A-HJKMNP-TV-Z]{26}$/),
-        origin_id: source.id,
-        name: source.name,
-        primary_goal: source.primaryGoal,
-        start_date_key: Number(source.startDate.replaceAll("-", "")),
-        target_date_key: Number(source.targetDate.slice(0, 10).replaceAll("-", "")),
-        created_at_ms: Date.parse(source.createdAt),
-        updated_at_ms: Date.parse(source.updatedAt),
-        kind: "short_race_preparation",
-        week_start_day: 1,
-        total_weeks: source.totalWeeks,
-        status: source.status,
-      });
-      if (typeof plan?.structure_json !== "string") throw new Error("Expected Plan structure JSON");
-      expect(JSON.parse(plan.structure_json)).toEqual(source);
-      expect(await store.all("SELECT * FROM plan_settings")).toEqual([
-        {
-          plan_id: plan.id,
-          auto_apply: 0,
-          weekly_review: 1,
-          updated_at_ms: plan.updated_at_ms,
-          device_id: plan.device_id,
-          hlc_physical_ms: plan.hlc_physical_ms,
-          hlc_counter: plan.hlc_counter,
-        },
-      ]);
       expect(await readFile(sourcePath)).toEqual(sourceBytes);
       expect((await stat(sourcePath)).mtimeMs).toBe(sourceStat.mtimeMs);
-      await expectMarker();
-      expect(
-        await store.all(
-          "SELECT id, plan_id, date_key, sport, name, duration_s, origin, structure_json FROM plan_workout ORDER BY date_key",
-        ),
-      ).toEqual(
-        source.workouts
-          .map((workout) => ({
-            id: expect.stringMatching(/^[0-9A-HJKMNP-TV-Z]{26}$/),
-            plan_id: plan.id,
-            date_key: workout.dateKey ?? Number(workout.date.replaceAll("-", "")),
-            sport: workout.sport,
-            name: workout.name,
-            duration_s: workout.durationS ?? workout.totalDuration,
-            origin: workout.origin,
-            structure_json: JSON.stringify(workout),
-          }))
-          .sort((left, right) => left.date_key - right.date_key),
-      );
+      await expectNoMarker();
       const beforeSecondLaunch = await logicalDump();
 
       await startCompositionUntilReferenceBootstrap();
@@ -285,7 +249,7 @@ describe("legacy v11 store upgrade and startup import", () => {
       expect(await logicalDump()).toEqual(beforeSecondLaunch);
       expect(await readFile(sourcePath)).toEqual(sourceBytes);
       expect((await stat(sourcePath)).mtimeMs).toBe(sourceStat.mtimeMs);
-      await expectMarker();
+      await expectNoMarker();
 
       const operations = createPlanCreationOperations({
         legacyPlan: () => readLegacyCurrentPlanSummary({ home, logger: { warn: vi.fn() } }),
@@ -316,7 +280,7 @@ describe("legacy v11 store upgrade and startup import", () => {
     },
   );
 
-  it("imports on the next launch once the creation fence lifts", async () => {
+  it("keeps the fence durable after discard and a later creation", async () => {
     await runMigrations(store, MIGRATIONS);
     await writeFile(
       join(root, "plans", "current-plan.json"),
@@ -339,13 +303,14 @@ describe("legacy v11 store upgrade and startup import", () => {
     expect(started.outcome).toBe("created");
     const fence = createLegacyWriterFence(store);
     expect(await fence.fenced()).toBe(true);
+    expect(await store.get("SELECT chat_authority_since_ms FROM planning_authority")).toEqual({
+      chat_authority_since_ms: command.nowMs,
+    });
 
     await startCompositionUntilReferenceBootstrap();
 
     expect(await createPlanRepository(store).count()).toBe(0);
-    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    await expectNoMarker();
     await expect(
       repository.discard({
         creationId: started.snapshot.id,
@@ -358,12 +323,37 @@ describe("legacy v11 store upgrade and startup import", () => {
         },
       }),
     ).resolves.toEqual({ outcome: "discarded" });
-    expect(await fence.fenced()).toBe(false);
+    expect(await fence.fenced()).toBe(true);
+    expect(await store.get("SELECT chat_authority_since_ms FROM planning_authority")).toEqual({
+      chat_authority_since_ms: command.nowMs,
+    });
+    await expect(
+      store.run("UPDATE planning_authority SET chat_authority_since_ms = NULL WHERE singleton = 1"),
+    ).rejects.toThrow();
+    await expect(store.run("DELETE FROM planning_authority WHERE singleton = 1")).rejects.toThrow();
+
+    const laterStart = await repository.start({
+      creationId: "00000000000000000000000002",
+      seed: { schemaVersion: 1, eventCandidates: [] },
+      command: {
+        ...command,
+        commandId: "start-later-creation",
+        requestDigest: "c".repeat(64),
+        nowMs: command.nowMs + 1000,
+        hlcPhysicalMs: command.hlcPhysicalMs + 1000,
+        hlcCounter: 2,
+      },
+    });
+    expect(laterStart.outcome).toBe("created");
+    expect(await store.get("SELECT chat_authority_since_ms FROM planning_authority")).toEqual({
+      chat_authority_since_ms: command.nowMs,
+    });
+    expect(await fence.fenced()).toBe(true);
 
     await startCompositionUntilReferenceBootstrap();
 
-    expect(await createPlanRepository(store).count()).toBe(1);
-    expect(await store.get("SELECT COUNT(*) AS count FROM plan_workout")).toEqual({ count: 2 });
-    await expectMarker();
+    expect(await createPlanRepository(store).count()).toBe(0);
+    expect(await store.get("SELECT COUNT(*) AS count FROM plan_workout")).toEqual({ count: 0 });
+    await expectNoMarker();
   });
 });

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -32,9 +32,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 31", async () => {
+  it("applies the full migration list and advances user_version to 32", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -54,7 +54,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
   });
 
   it("upgrades the released Plan version 24 schema through the current schema", async () => {
@@ -66,10 +66,10 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 24,
-      toVersion: 31,
-      applied: [25, 26, 27, 28, 29, 30, 31],
+      toVersion: 32,
+      applied: [25, 26, 27, 28, 29, 30, 31, 32],
     });
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 31 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 32 });
     await expect(
       store.all(
         "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('chat_attachment','planning_request','chat_plan_outbox') ORDER BY name",
@@ -108,11 +108,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 31", async () => {
+  it("upgrades a version-1-on-disk store to version 32", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -134,13 +134,13 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 4,
-      toVersion: 31,
+      toVersion: 32,
       applied: [
         5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-        29, 30, 31,
+        29, 30, 31, 32,
       ],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -193,23 +193,24 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 6,
-      toVersion: 31,
+      toVersion: 32,
       applied: [
-        7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+        7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+        31, 32,
       ],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 31,
-      toVersion: 31,
+      fromVersion: 32,
+      toVersion: 32,
       applied: [],
     });
   });
 
-  it("upgrades version 11 through 31 while preserving existing rows", async () => {
+  it("upgrades version 11 through 32 while preserving existing rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 11));
     await store.run("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)", [
       "chronoBridge",
@@ -218,8 +219,8 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 11,
-      toVersion: 31,
-      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
+      toVersion: 32,
+      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
     });
     await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings")).resolves.toEqual({
       fixer: "chronoBridge",
@@ -228,7 +229,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     await expect(store.get("SELECT count(*) AS count FROM repair_fixer_settings")).resolves.toEqual(
       { count: 1 },
     );
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 31 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 32 });
   });
 
   it("rolls back a failed migration 12 without partial Planning tables", async () => {
@@ -593,7 +594,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("upgrades migration 28 through 31 without classifying legacy Planning rows", async () => {
+  it("upgrades migration 28 through 32 without classifying legacy Planning rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 28));
     const planId = `${"0".repeat(25)}A`;
     const workoutId = `${"0".repeat(25)}B`;
@@ -683,10 +684,10 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 28,
-      toVersion: 31,
-      applied: [29, 30, 31],
+      toVersion: 32,
+      applied: [29, 30, 31, 32],
     });
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 31 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 32 });
     await expect(
       Promise.all(legacyTables.map((table) => store.all(`SELECT * FROM ${table} ORDER BY 1`))),
     ).resolves.toEqual(rowsBefore);

--- a/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
+++ b/packages/kernel-node/tests/planning-store-export-roundtrip.test.ts
@@ -13,6 +13,7 @@ import {
   type ExportSource,
 } from "@enduragent/kernel/store/export";
 import {
+  createLegacyWriterFence,
   createPlanConversationRepository,
   createPlanReplacementRepository,
   createPlanRepository,
@@ -370,6 +371,85 @@ const completePresence: ArchivePresenceChecker = {
 };
 
 describe("planning-domain SQLite export round-trip", () => {
+  it.each([
+    { sourceVersion: 31, expectedInstant: BASE_MS },
+    { sourceVersion: 32, expectedInstant: BASE_MS - 1 },
+  ])(
+    "restores Chat ownership from a v$sourceVersion archive",
+    async ({ sourceVersion, expectedInstant }) => {
+      const source = openSqliteStorage(":memory:");
+      const destination = openSqliteStorage(":memory:");
+      try {
+        await runMigrations(source, MIGRATIONS.slice(0, sourceVersion));
+        await runMigrations(destination, MIGRATIONS);
+        for (const offset of [2, 0]) {
+          await source.run(
+            `INSERT INTO plan_creation (
+            id, status, version, seed_json, current_draft_revision_number, activated_plan_id,
+            created_at_ms, updated_at_ms, terminal_at_ms, device_id, hlc_physical_ms, hlc_counter
+          ) VALUES (?, 'discarded', 2, '{}', NULL, NULL, ?, ?, ?, ?, ?, 0)`,
+            [
+              id(20 + offset),
+              BASE_MS + offset,
+              BASE_MS + offset + 1,
+              BASE_MS + offset + 1,
+              DEVICE_ID,
+              BASE_MS + offset + 1,
+            ],
+          );
+        }
+        const authored: Record<string, readonly AuthoredRow[]> = {
+          plan_creation: await source.all(
+            "SELECT * FROM plan_creation ORDER BY created_at_ms DESC",
+          ),
+        };
+        if (sourceVersion === 32) {
+          await source.run(
+            "UPDATE planning_authority SET chat_authority_since_ms = ? WHERE singleton = 1",
+            [expectedInstant],
+          );
+          authored.planning_authority = await source.all("SELECT * FROM planning_authority");
+        }
+        const container = await encodeContainer(
+          {
+            kind: EXPORT_DOCUMENT_KIND,
+            formatVersion: EXPORT_FORMAT_VERSION,
+            store: { userVersion: await source.getUserVersion(), authored },
+            archiveManifest: [],
+          },
+          webCryptoExportEnv,
+          {},
+        );
+
+        await importExport(
+          {
+            sink: createSqliteImportSink(destination),
+            presence: completePresence,
+            targetUserVersion: 32,
+            ...webCryptoExportEnv,
+          },
+          { container },
+        );
+
+        await expect(
+          destination.all("SELECT * FROM plan_creation ORDER BY created_at_ms DESC"),
+        ).resolves.toEqual(authored.plan_creation);
+        await expect(
+          destination.get("SELECT MIN(created_at_ms) AS instant FROM plan_creation"),
+        ).resolves.toEqual({ instant: BASE_MS });
+        await expect(
+          destination.get(
+            "SELECT chat_authority_since_ms FROM planning_authority WHERE singleton = 1",
+          ),
+        ).resolves.toEqual({ chat_authority_since_ms: expectedInstant });
+        await expect(createLegacyWriterFence(destination).fenced()).resolves.toBe(true);
+      } finally {
+        await source.close();
+        await destination.close();
+      }
+    },
+  );
+
   it("restores a v28 replacement lineage without its derived cleanup table", async () => {
     const source = openSqliteStorage(":memory:");
     const destination = openSqliteStorage(":memory:");
@@ -384,7 +464,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 31,
+            targetUserVersion: 32,
             ...webCryptoExportEnv,
           },
           { container },
@@ -434,7 +514,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 31,
+            targetUserVersion: 32,
             ...webCryptoExportEnv,
           },
           { container },
@@ -457,6 +537,9 @@ describe("planning-domain SQLite export round-trip", () => {
       await runMigrations(source, MIGRATIONS);
       await runMigrations(destination, MIGRATIONS);
       await populatePlanningDomain(source);
+      await source.run(
+        "UPDATE planning_authority SET chat_authority_since_ms = (SELECT MIN(created_at_ms) FROM plan_creation) WHERE singleton = 1",
+      );
       await populateV28Replacement(source);
       const sourceDump = await dumpStore(source);
       const built = await buildExport(
@@ -479,7 +562,7 @@ describe("planning-domain SQLite export round-trip", () => {
         {
           sink: createSqliteImportSink(destination),
           presence: completePresence,
-          targetUserVersion: 31,
+          targetUserVersion: 32,
           ...webCryptoExportEnv,
         },
         { container: built.container },
@@ -495,7 +578,7 @@ describe("planning-domain SQLite export round-trip", () => {
         {
           sink: createSqliteImportSink(destination),
           presence: completePresence,
-          targetUserVersion: 31,
+          targetUserVersion: 32,
           ...webCryptoExportEnv,
         },
         { container: built.container },
@@ -528,7 +611,7 @@ describe("planning-domain SQLite export round-trip", () => {
           {
             sink: createSqliteImportSink(destination),
             presence: completePresence,
-            targetUserVersion: 31,
+            targetUserVersion: 32,
             ...webCryptoExportEnv,
           },
           { container },

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -239,8 +239,8 @@ describe("sync failure repository", () => {
     expect(dump).not.toContain("# sync_failure");
     expect(dump).toContain("# plan_reconciliation_job");
     expect(dump).toContain("# plan_reconciliation_item");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 31 });
-    expect(DUMP_TABLES).toHaveLength(69);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 32 });
+    expect(DUMP_TABLES).toHaveLength(70);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");
     expect(DUMP_TABLES.map(({ table }) => table)).toContain("plan_reconciliation_job");

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -295,6 +295,12 @@ terminal_at_ms,device_id,hlc_physical_ms,hlc_counter
               command.hlcCounter,
             ],
           );
+          await store.run(
+            `UPDATE planning_authority
+SET chat_authority_since_ms = ?, device_id = ?, hlc_physical_ms = ?, hlc_counter = ?
+WHERE singleton = 1 AND chat_authority_since_ms IS NULL`,
+            [command.nowMs, command.deviceId, command.hlcPhysicalMs, command.hlcCounter],
+          );
           snapshot = await requireUnfinished();
         }
         await recordCommand(

--- a/packages/kernel/src/planning/writer-fence.ts
+++ b/packages/kernel/src/planning/writer-fence.ts
@@ -4,23 +4,32 @@ import type { SqlReadStore } from "../store/ports.js";
 const FenceSchema = z.object({
   activePlanId: z.string().nullable(),
   creationId: z.string().nullable(),
+  chatAuthoritySinceMs: z.number().nullable(),
 });
 
+export type LegacyWriterFenceState = z.infer<typeof FenceSchema>;
+
 export function createLegacyWriterFence(store: Pick<SqlReadStore, "get">) {
-  const read = async (): Promise<{ activePlanId: string | null; creationId: string | null }> =>
+  const read = async (): Promise<LegacyWriterFenceState> =>
     FenceSchema.parse(
       (await store.get(`SELECT
         (SELECT plan_id FROM planning_plan WHERE status='active') AS activePlanId,
-        (SELECT id FROM plan_creation WHERE status IN ('in-progress','review')) AS creationId`)) ?? {
+        (SELECT id FROM plan_creation WHERE status IN ('in-progress','review')) AS creationId,
+        (SELECT chat_authority_since_ms FROM planning_authority WHERE singleton = 1) AS chatAuthoritySinceMs`)) ?? {
         activePlanId: null,
         creationId: null,
+        chatAuthoritySinceMs: null,
       },
     );
   return {
     read,
     async fenced(): Promise<boolean> {
       const state = await read();
-      return state.activePlanId !== null || state.creationId !== null;
+      return (
+        state.activePlanId !== null ||
+        state.creationId !== null ||
+        state.chatAuthoritySinceMs !== null
+      );
     },
   };
 }

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -41,6 +41,7 @@ export const DUMP_TABLES = [
   { table: "mean_max_cache", orderBy: "mmax_key" },
   { table: "metric_snapshot", orderBy: "snapshot_key" },
   { table: "plan", orderBy: "id" },
+  { table: "planning_authority", orderBy: "singleton" },
   { table: "planning_plan", orderBy: "plan_id" },
   { table: "plan_revision", orderBy: "plan_id, revision_number, id" },
   { table: "plan_creation", orderBy: "created_at_ms, id" },

--- a/packages/kernel/src/store/export/ports.ts
+++ b/packages/kernel/src/store/export/ports.ts
@@ -96,6 +96,7 @@ export const PURE_AUTHORED_TABLES = [
   "chat_plan_outbox",
   "plan",
   "plan_reconciliation_job",
+  "planning_authority",
   "planning_plan",
   "plan_revision",
   "plan_creation",

--- a/packages/kernel/src/store/migrations/032_planning_authority.sql
+++ b/packages/kernel/src/store/migrations/032_planning_authority.sql
@@ -1,0 +1,31 @@
+CREATE TABLE planning_authority (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  chat_authority_since_ms INTEGER
+    CHECK (chat_authority_since_ms IS NULL OR chat_authority_since_ms >= 0),
+  device_id TEXT,
+  hlc_physical_ms INTEGER,
+  hlc_counter INTEGER
+) STRICT;
+
+INSERT INTO planning_authority (singleton, chat_authority_since_ms, device_id, hlc_physical_ms, hlc_counter)
+VALUES (1, (SELECT MIN(created_at_ms) FROM plan_creation), NULL, NULL, NULL);
+
+CREATE TRIGGER planning_authority_no_delete
+BEFORE DELETE ON planning_authority
+BEGIN
+  SELECT RAISE(ABORT, 'planning authority is durable');
+END;
+
+CREATE TRIGGER planning_authority_no_insert
+BEFORE INSERT ON planning_authority
+BEGIN
+  SELECT RAISE(ABORT, 'planning authority already exists');
+END;
+
+CREATE TRIGGER planning_authority_no_release
+BEFORE UPDATE ON planning_authority
+WHEN OLD.chat_authority_since_ms IS NOT NULL
+  AND (NEW.chat_authority_since_ms IS NULL OR NEW.chat_authority_since_ms <> OLD.chat_authority_since_ms)
+BEGIN
+  SELECT RAISE(ABORT, 'Chat planning authority cannot change');
+END;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -29,6 +29,7 @@ import planWorkoutAdditions028 from "./028_plan_workout_additions.sql";
 import planningDomain029 from "./029_planning_domain.sql";
 import trainingHistoryCoverage030 from "./030_training_history_coverage.sql";
 import trainingHistoryGapEvidence031 from "./031_training_history_gap_evidence.sql";
+import planningAuthority032 from "./032_planning_authority.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -75,4 +76,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 29, name: "029_planning_domain", sql: planningDomain029 },
   { version: 30, name: "030_training_history_coverage", sql: trainingHistoryCoverage030 },
   { version: 31, name: "031_training_history_gap_evidence", sql: trainingHistoryGapEvidence031 },
+  { version: 32, name: "032_planning_authority", sql: planningAuthority032 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -31,6 +31,7 @@ const EXPECTED_FULL_TABLES = [
   ...EXPECTED_TABLES,
   "chat_plan_outbox",
   "plan",
+  "planning_authority",
   "planning_plan",
   "plan_revision",
   "plan_creation",
@@ -230,6 +231,7 @@ describe("001_init migration", () => {
       { version: 29, name: "029_planning_domain" },
       { version: 30, name: "030_training_history_coverage" },
       { version: 31, name: "031_training_history_gap_evidence" },
+      { version: 32, name: "032_planning_authority" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -321,7 +323,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies all migrations with exactly eighty-one tables and no foreign-key violations", () => {
+  it("applies all migrations with exactly eighty-two tables and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -331,7 +333,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(81);
+    expect(names).toHaveLength(82);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -585,6 +587,9 @@ describe("001_init migration", () => {
         "planning_request_tombstone_no_delete",
         "planning_plan_closed_no_update",
         "planning_plan_no_delete",
+        "planning_authority_no_delete",
+        "planning_authority_no_insert",
+        "planning_authority_no_release",
         "planning_plan_revision_requires_preview",
         "planning_plan_close_transition",
         "planning_plan_preview_clock",
@@ -856,6 +861,7 @@ describe("001_init migration", () => {
       { table: "mean_max_cache", orderBy: "mmax_key" },
       { table: "metric_snapshot", orderBy: "snapshot_key" },
       { table: "plan", orderBy: "id" },
+      { table: "planning_authority", orderBy: "singleton" },
       { table: "planning_plan", orderBy: "plan_id" },
       { table: "plan_revision", orderBy: "plan_id, revision_number, id" },
       { table: "plan_creation", orderBy: "created_at_ms, id" },
@@ -908,7 +914,7 @@ describe("001_init migration", () => {
       { table: "workout", orderBy: "workout_key" },
       { table: "zone_set_history", orderBy: "id" },
     ]);
-    expect(DUMP_TABLES).toHaveLength(69);
+    expect(DUMP_TABLES).toHaveLength(70);
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
@@ -965,7 +971,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     }>;
     expect(tables.find((row) => row.name === "sync_failure")?.strict).toBe(1);
     expect(db.prepare("PRAGMA foreign_key_list(sync_failure)").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(69);
+    expect(DUMP_TABLES).toHaveLength(70);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
     expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
@@ -1024,7 +1030,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       expect(tables.find((row) => row.name === name)?.strict).toBe(1);
     }
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(69);
+    expect(DUMP_TABLES).toHaveLength(70);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("analytics_curve_refresh_failure");
     expect(DERIVED_TABLES).not.toContain("analytics_curve_generation");
   });
@@ -1311,14 +1317,18 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       0,
     );
     expect(
-      (db.prepare("PRAGMA table_info(training_history_coverage_commit)").all() as Array<{
-        name: string;
-      }>).map(({ name }) => name),
+      (
+        db.prepare("PRAGMA table_info(training_history_coverage_commit)").all() as Array<{
+          name: string;
+        }>
+      ).map(({ name }) => name),
     ).toEqual(expect.arrayContaining(["dropped_local_dates_json", "gap_evidence_version"]));
     expect(
-      (db.prepare("PRAGMA table_info(training_history_backfill_checkpoint)").all() as Array<{
-        name: string;
-      }>).map(({ name }) => name),
+      (
+        db.prepare("PRAGMA table_info(training_history_backfill_checkpoint)").all() as Array<{
+          name: string;
+        }>
+      ).map(({ name }) => name),
     ).toEqual(expect.arrayContaining(["undated_dropped_count", "gap_evidence_version"]));
     expect(
       db
@@ -1360,7 +1370,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     expect(() => db!.prepare("DELETE FROM training_history_backfill_checkpoint").run()).toThrow(
       /append-only/,
     );
-    expect(DUMP_TABLES).toHaveLength(69);
+    expect(DUMP_TABLES).toHaveLength(70);
     expect(DERIVED_TABLES).toHaveLength(12);
   });
 });

--- a/packages/kernel/tests/planning-authority.test.ts
+++ b/packages/kernel/tests/planning-authority.test.ts
@@ -1,0 +1,92 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { MIGRATIONS } from "../src/store/migrations/index.js";
+
+let db: DatabaseSync | undefined;
+
+function openStore(version = 32): DatabaseSync {
+  const store = new DatabaseSync(":memory:");
+  store.exec("PRAGMA foreign_keys = ON");
+  for (const migration of MIGRATIONS.filter((entry) => entry.version <= version)) {
+    store.exec(migration.sql);
+  }
+  db = store;
+  return store;
+}
+
+afterEach(() => db?.close());
+
+describe("planning authority", () => {
+  it("seeds one unset STRICT singleton and prevents deletion or reinsertion", () => {
+    const store = openStore();
+    expect(store.prepare("SELECT * FROM planning_authority").all()).toEqual([
+      {
+        singleton: 1,
+        chat_authority_since_ms: null,
+        device_id: null,
+        hlc_physical_ms: null,
+        hlc_counter: null,
+      },
+    ]);
+    expect(store.prepare("PRAGMA table_list").all()).toContainEqual(
+      expect.objectContaining({ name: "planning_authority", strict: 1 }),
+    );
+    expect(() => store.exec("DELETE FROM planning_authority")).toThrow(
+      "planning authority is durable",
+    );
+    for (const singleton of [1, 2]) {
+      expect(() =>
+        store.prepare("INSERT INTO planning_authority (singleton) VALUES (?)").run(singleton),
+      ).toThrow("planning authority already exists");
+    }
+    expect(() =>
+      store.exec("INSERT OR REPLACE INTO planning_authority (singleton) VALUES (1)"),
+    ).toThrow("planning authority already exists");
+    expect(() => store.exec("UPDATE planning_authority SET singleton = 2")).toThrow();
+    expect(() =>
+      store.exec("UPDATE planning_authority SET chat_authority_since_ms = -1"),
+    ).toThrow();
+  });
+
+  it("allows the first instant and new stamps while refusing release or a different instant", () => {
+    const store = openStore();
+    store.exec(
+      "UPDATE planning_authority SET chat_authority_since_ms = 0, device_id = 'device-1', hlc_physical_ms = 1, hlc_counter = 0",
+    );
+    for (const instant of [null, 2]) {
+      expect(() =>
+        store.prepare("UPDATE planning_authority SET chat_authority_since_ms = ?").run(instant),
+      ).toThrow("Chat planning authority cannot change");
+    }
+    store.exec(
+      "UPDATE planning_authority SET chat_authority_since_ms = 0, device_id = 'device-2', hlc_physical_ms = 2, hlc_counter = 1",
+    );
+    expect(store.prepare("SELECT * FROM planning_authority").get()).toEqual({
+      singleton: 1,
+      chat_authority_since_ms: 0,
+      device_id: "device-2",
+      hlc_physical_ms: 2,
+      hlc_counter: 1,
+    });
+  });
+
+  it("backfills the earliest creation even when all creations were discarded", () => {
+    const store = openStore(31);
+    const insert = store.prepare(`INSERT INTO plan_creation (
+      id,status,version,seed_json,current_draft_revision_number,activated_plan_id,
+      created_at_ms,updated_at_ms,terminal_at_ms,device_id,hlc_physical_ms,hlc_counter
+    ) VALUES (?, 'discarded', 2, '{}', NULL, NULL, ?, ?, ?, 'device-1', ?, 0)`);
+    insert.run("1".repeat(26), 20, 21, 21, 21);
+    insert.run("2".repeat(26), 10, 11, 11, 11);
+    const migration = MIGRATIONS.find((entry) => entry.version === 32);
+    expect(migration).toBeDefined();
+    store.exec(migration!.sql);
+    expect(store.prepare("SELECT * FROM planning_authority").get()).toEqual({
+      singleton: 1,
+      chat_authority_since_ms: 10,
+      device_id: null,
+      hlc_physical_ms: null,
+      hlc_counter: null,
+    });
+  });
+});

--- a/packages/kernel/tests/store-dump.test.ts
+++ b/packages/kernel/tests/store-dump.test.ts
@@ -103,6 +103,7 @@ describe("INV-2 canonical dump (armed with real ingest at W2)", () => {
     const dumped = DUMP_TABLES.map(({ table }) => table);
     const planning = [
       "plan",
+      "planning_authority",
       "planning_plan",
       "plan_revision",
       "plan_creation",

--- a/packages/kernel/tests/store-export.test.ts
+++ b/packages/kernel/tests/store-export.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { createLegacyWriterFence } from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../../kernel-node/src/sqlite/index.js";
+import { createSqliteImportSink } from "../../kernel-node/src/store-export/sqlite-import.js";
 import {
   buildExport,
   importExport,
@@ -114,6 +119,19 @@ function makeSource(data: Populated): { source: ExportSource; calls: SourceCall[
     },
   };
   return { source, calls };
+}
+
+function makeSqliteSource(store: SqlStore & MigratorStore): ExportSource {
+  const tables = new Set<string>([...PURE_AUTHORED_TABLES, ...MIXED_AUTHORED_TABLES]);
+  return {
+    readUserVersion: () => store.getUserVersion(),
+    async readAuthoredTable(table, { manualOnly }) {
+      if (!tables.has(table)) throw new Error("Table is not exportable");
+      return store.all(
+        `SELECT * FROM "${table}"${manualOnly ? " WHERE provenance = 'manual'" : ""}`,
+      );
+    },
+  };
 }
 
 function makeManifest(data: Populated): ArchiveManifestReader {
@@ -259,6 +277,107 @@ describe("store export op", () => {
     expect(imported.manifest.total).toBe(data.artifacts.length);
   });
 
+  it("restores planning authority into SQLite and keeps repeated restores idempotent", async () => {
+    const sourceStore = openSqliteStorage(":memory:");
+    const restoredStore = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(sourceStore, MIGRATIONS);
+      await runMigrations(restoredStore, MIGRATIONS);
+      await sourceStore.run(
+        `UPDATE planning_authority SET chat_authority_since_ms = 900,
+         device_id = 'synthetic-device', hlc_physical_ms = 900, hlc_counter = 2
+         WHERE singleton = 1`,
+      );
+      const authority = await sourceStore.get("SELECT * FROM planning_authority");
+      const crypto = new FakeCrypto();
+      const built = await buildExport(
+        {
+          source: makeSqliteSource(sourceStore),
+          manifest: { listArtifacts: async () => [] },
+          crypto,
+          codec,
+        },
+        {},
+      );
+      const dependencies = {
+        sink: createSqliteImportSink(restoredStore),
+        presence: makePresence(),
+        crypto,
+        codec,
+        targetUserVersion: await restoredStore.getUserVersion(),
+      };
+      const first = await importExport(dependencies, { container: built.container });
+      expect(first.restored.find(({ table }) => table === "planning_authority")).toEqual({
+        table: "planning_authority",
+        inserted: 1,
+        skipped: 0,
+      });
+      expect(await restoredStore.get("SELECT * FROM planning_authority")).toEqual(authority);
+      expect(await createLegacyWriterFence(restoredStore).fenced()).toBe(true);
+
+      const second = await importExport(dependencies, { container: built.container });
+
+      expect(second.restored.every(({ inserted }) => inserted === 0)).toBe(true);
+      expect(second.restored.find(({ table }) => table === "planning_authority")).toEqual({
+        table: "planning_authority",
+        inserted: 0,
+        skipped: 1,
+      });
+      expect(await restoredStore.get("SELECT * FROM planning_authority")).toEqual(authority);
+      expect(await createLegacyWriterFence(restoredStore).fenced()).toBe(true);
+    } finally {
+      await sourceStore.close();
+      await restoredStore.close();
+    }
+  });
+
+  it("keeps existing planning authority when restoring an archive with no Chat authority", async () => {
+    const sourceStore = openSqliteStorage(":memory:");
+    const restoredStore = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(sourceStore, MIGRATIONS);
+      await runMigrations(restoredStore, MIGRATIONS);
+      await restoredStore.run(
+        `UPDATE planning_authority SET chat_authority_since_ms = 900,
+         device_id = 'synthetic-device', hlc_physical_ms = 900, hlc_counter = 2
+         WHERE singleton = 1`,
+      );
+      const authority = await restoredStore.get("SELECT * FROM planning_authority");
+      const crypto = new FakeCrypto();
+      const built = await buildExport(
+        {
+          source: makeSqliteSource(sourceStore),
+          manifest: { listArtifacts: async () => [] },
+          crypto,
+          codec,
+        },
+        {},
+      );
+
+      const imported = await importExport(
+        {
+          sink: createSqliteImportSink(restoredStore),
+          presence: makePresence(),
+          crypto,
+          codec,
+          targetUserVersion: await restoredStore.getUserVersion(),
+        },
+        { container: built.container },
+      );
+
+      expect(imported.restored.find(({ table }) => table === "planning_authority")).toEqual({
+        table: "planning_authority",
+        inserted: 0,
+        skipped: 1,
+      });
+      expect(await restoredStore.get("SELECT * FROM planning_authority")).toEqual(authority);
+      expect(await createLegacyWriterFence(restoredStore).fenced()).toBe(true);
+    } finally {
+      await sourceStore.close();
+      await restoredStore.close();
+    }
+  });
+
   it("orders every revision history parent-first before restore", async () => {
     const data = populated();
     data.rows.plan_draft_revision = [
@@ -296,6 +415,7 @@ describe("store export op", () => {
   it("restores planning domain tables in dependency-safe order", () => {
     const planning = [
       "plan",
+      "planning_authority",
       "planning_plan",
       "plan_revision",
       "plan_creation",


### PR DESCRIPTION
## Summary

Third and last END-13 cut. Once an athlete starts a Plan in Chat, the store records that Chat owns Plans, permanently and atomically, and the pre-Chat `current-plan.json` importer is retired.

- Migration 032 adds a `planning_authority` singleton (`chat_authority_since_ms`, device and clock stamps), backfilled from the earliest existing creation. Triggers forbid delete, a second row, and releasing or changing a set instant.
- `plan_creation.start` sets the instant inside its own transaction on the created path only.
- The legacy writer fence reads the instant, so the legacy Chat tools and Plan page stay read-only after discard, restart, or archive restore. Coverage in writer-fence, kernel-node upgrade and planning-authority suites.
- Archives export the row. Restoring an archive from before this migration backfills the instant from the restored creations; an archived instant takes precedence.
- The startup importer, its file marker and the import result type are removed. Startup never creates Plan rows from the file; the library shows it through the read-only entry from #922. The dual-write adapter for the legacy Chat tools is untouched.
- The legacy Plan page no longer renders the Intervals reconciliation panel; the library card carries calendar status for Chat-owned Plans.

Design note: the singleton has no legacy-import outcome column. The importer is retired in this same change, so the column would have no producer.

## Verification

- astra high read-only verifier: round 1 two blocking findings (pre-032 archive restore lost the instant; panel-absence test covered only two states), both fixed; round 2 `pass: true`, blocking 0.
- Root `pnpm check` green. Workspace suite 2825 passed, renderer-dom 699 passed, kernel + kernel-node + selected coach 1499 passed after the archive fix, full build green, E2E plan-legacy, plan-close-history, plan-calendar, plan-creation-slice5 all passed.
- Real app on a seeded v11 store with a legacy `current-plan.json`: daemon upgraded the store to user_version 32, the authority row exists with a null instant, and zero Plan rows were created at startup.

| Limit | Value |
|---|---|
| Migration version | 32 |
| Authority rows | exactly 1 |
| Triggers | 3 |
| Startup imports from the file | 0 |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
