### PR TITLE
fix(plan): close the whole-epic verification findings

### DIFF
--- a/.changeset/epic-verification-fixes.md
+++ b/.changeset/epic-verification-fixes.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Activating a Plan now double-checks the Plan it replaces, Chat-created rides reach intervals.icu as Ride events, past and completed Workouts stay untouched by later Changes, and a stopped Plan's final details keep their calendar status fresh with a Retry button.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -263,9 +263,11 @@ export function bootRenderer(): Disposer {
       void chatController.startPlanCreation();
     },
     continueCreation: (creation) => {
+      chatController.requestPlanLibraryFocus("continue");
       void chatController.continueCreationFromLibrary(creation.creationId);
     },
     changeInChat: () => {
+      chatController.requestPlanLibraryFocus("change");
       chatController.pausePlanCreation();
       const state = store.getState();
       const planId = state.planLibrary.value?.active?.planId ?? null;
@@ -300,6 +302,14 @@ export function bootRenderer(): Disposer {
   const disposePlanToChatRefresh = store.subscribe((state, previousState) => {
     if (previousState.activeView === "plan" && state.activeView === "chat") {
       chatController.refreshPlanningRequests();
+    }
+    const libraryTarget = state.chat.planCreationFocusRequest?.libraryTarget;
+    if (
+      previousState.activeView === "chat" &&
+      state.activeView === "plan" &&
+      libraryTarget !== undefined
+    ) {
+      chatController.requestPlanLibraryFocus(libraryTarget);
     }
   });
 

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -8,6 +8,7 @@ import {
   CoachClientCallTimeoutError,
   CoachClientDisconnectedError,
   CoachClientProtocolError,
+  CoachRpcRemoteError,
 } from "@enduragent/coach-client";
 import {
   PLAN_CREATION_ANSWER_KEYS,
@@ -24,6 +25,9 @@ import {
   type PlanHandoffSuggestion,
   type ListPlansResult,
   type PlanChangeIntent,
+  type PlanChangePreviewRpcParams,
+  type PlanChangeApplyRpcParams,
+  type PlanCreationActivateRpcParams,
   type PlanCreationAnswerInput,
   type PlanCreationAnswerSummary,
   type PlanCreationCardModel,
@@ -195,7 +199,8 @@ export interface ChatViewControls {
     readonly discardEvents: readonly PlanCreationDiscardEvent[];
     readonly notice: string | null;
     readonly focusRequest: {
-      readonly target: "discard" | "activate" | "start";
+      readonly target: "discard" | "activate" | "start" | "continue" | "change";
+      readonly libraryTarget?: "continue" | "change";
       readonly revision: number;
     } | null;
   };
@@ -248,6 +253,7 @@ export interface ChatController {
   refreshPlanningRequests(): void;
   focusPlanningRequest(requestId: string): void;
   clearPlanningRequestFocus(): void;
+  requestPlanLibraryFocus(target: "continue" | "change"): void;
   resumeCreation(model: PlanCreationCardModel | null): void;
   continueCreationFromLibrary(creationId: string): Promise<void>;
   startPlanCreation(): Promise<void>;
@@ -403,6 +409,9 @@ export function createChatController(input: {
   let planCreation: PlanCreationCardModel | null = null;
   let planCreationLoaded = false;
   let planCreationBusy = false;
+  let activationAttempt: PlanCreationActivateRpcParams | null = null;
+  let previewAttempt: PlanChangePreviewRpcParams | null = null;
+  let applyAttempt: PlanChangeApplyRpcParams | null = null;
   let planCreationError: string | null = null;
   let planCreationPaused = false;
   let planCreationEditingKey: PlanCreationAnswerSummary["answerKey"] | null = null;
@@ -414,7 +423,8 @@ export function createChatController(input: {
   let planCreationDiscardEvents: readonly PlanCreationDiscardEvent[] = [];
   let planCreationNotice: string | null = null;
   let planCreationFocusRequest: {
-    readonly target: "discard" | "activate" | "start";
+    readonly target: "discard" | "activate" | "start" | "continue" | "change";
+    readonly libraryTarget?: "continue" | "change";
     readonly revision: number;
   } | null = null;
   let planCreationActionFocusRevision = 0;
@@ -1092,11 +1102,13 @@ export function createChatController(input: {
 
   const installPlanCreation = (
     next: PlanCreationCardModel | null,
-    focusTarget?: "discard" | "activate" | "start",
+    focusTarget?: "discard" | "activate" | "start" | "continue" | "change",
   ): void => {
     const previous = planCreation;
     let actionFocusRequested = false;
-    const requestActionFocus = (target: "discard" | "activate" | "start"): void => {
+    const requestActionFocus = (
+      target: "discard" | "activate" | "start" | "continue" | "change",
+    ): void => {
       requestPlanCreationFocus(target);
       actionFocusRequested = true;
     };
@@ -1154,8 +1166,16 @@ export function createChatController(input: {
     mergeHydratedMessages(hydration.turns, state.messages, hydration.entries)
       .filter((message) => message.role === "athlete" || message.text.length > 0)
       .at(-1)?.id ?? null;
-  const requestPlanCreationFocus = (target: "discard" | "activate" | "start"): void => {
-    planCreationFocusRequest = { target, revision: ++planCreationActionFocusRevision };
+  const requestPlanCreationFocus = (
+    target: "discard" | "activate" | "start" | "continue" | "change",
+  ): void => {
+    planCreationFocusRequest = {
+      ...(target === "start" || planCreationFocusRequest?.libraryTarget === undefined
+        ? {}
+        : { libraryTarget: planCreationFocusRequest.libraryTarget }),
+      target,
+      revision: ++planCreationActionFocusRevision,
+    };
   };
   const planCreationDiscardNotice = (
     reason: "stale-version" | "command-conflict" | "no-unfinished-creation",
@@ -1756,6 +1776,15 @@ export function createChatController(input: {
 
   render();
   return {
+    requestPlanLibraryFocus(target) {
+      if (disposed) return;
+      planCreationFocusRequest = {
+        target,
+        libraryTarget: target,
+        revision: ++planCreationActionFocusRevision,
+      };
+      render();
+    },
     openPlanChangeEditor() {
       const active = input.readPlanLibrary?.()?.active;
       if (disposed || readChange().busy || !active) return;
@@ -1777,23 +1806,34 @@ export function createChatController(input: {
       if (disposed || readChange().busy || !active) return;
       const parameterCopy =
         intent.kind === "weekly-duration"
-          ? "Enter a weekly duration above zero."
+          ? Number.isFinite(intent.hours) && intent.hours > 0 && !Number.isInteger(intent.hours * 4)
+            ? "Enter weekly hours in quarter-hour steps, like 2.25."
+            : "Enter a weekly duration above zero."
           : "day" in intent && (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
             ? "Choose the weekday to change."
             : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
               ? "Choose the weekday to change."
               : "Enter a duration above zero.";
-      if (!PlanChangeIntentSchema.safeParse(intent).success) {
+      const parsedIntent = PlanChangeIntentSchema.safeParse(intent);
+      if (!parsedIntent.success) {
         publishChange({ error: parameterCopy });
         return;
       }
-      publishChange({ busy: true, error: null, notice: null });
-      try {
-        const result = await previewPlanChange(input.clients, {
+      if (
+        previewAttempt?.planId !== active.planId ||
+        JSON.stringify(previewAttempt.intent) !== JSON.stringify(parsedIntent.data)
+      ) {
+        previewAttempt = {
+          commandId: globalThis.crypto.randomUUID(),
           planId: active.planId,
           expectedVersion: active.version,
-          intent,
-        });
+          intent: parsedIntent.data,
+        };
+      }
+      publishChange({ busy: true, error: null, notice: null });
+      try {
+        const result = await previewPlanChange(input.clients, previewAttempt);
+        previewAttempt = null;
         if (disposed) return;
         if (result.status === "rejected") {
           publishChange({
@@ -1820,10 +1860,14 @@ export function createChatController(input: {
             ? `This preview supersedes “${superseded.title}”. Training is unchanged until confirmation.`
             : "Review the exact changes before confirming.",
         });
-        await input.refreshPlanLibrary?.();
+        await input.refreshPlanLibrary?.().catch(() => {});
         publishChange({ focusRequest: changeFocus("preview") });
       } catch {
-        publishChange({ error: "This Change could not be previewed. Training is unchanged." });
+        publishChange({
+          error:
+            "The preview result could not be confirmed. The Plan library will show the current state after refresh.",
+        });
+        await input.refreshPlanLibrary?.().catch(() => {});
       } finally {
         publishChange({ busy: false });
       }
@@ -1833,18 +1877,31 @@ export function createChatController(input: {
       const active = library?.active;
       if (disposed || readChange().busy || !active) return;
       const pending = library.changes.find((change) => change.status === "pending");
-      if (!pending) {
+      const retry =
+        applyAttempt?.decision === decision &&
+        applyAttempt.planId === active.planId &&
+        (!pending || pending.changeId === applyAttempt.changeId)
+          ? applyAttempt
+          : null;
+      if (!pending && retry === null) {
         publishChange({ notice: "This preview is no longer pending. Training is unchanged." });
         return;
       }
-      publishChange({ busy: true, error: null, notice: null });
-      try {
-        const result = await applyPlanChange(input.clients, {
+      if (retry !== null) applyAttempt = retry;
+      else if (pending) {
+        applyAttempt = {
+          commandId: globalThis.crypto.randomUUID(),
           planId: active.planId,
           changeId: pending.changeId,
           expectedVersion: active.version,
           decision,
-        });
+        };
+      }
+      if (applyAttempt === null) return;
+      publishChange({ busy: true, error: null, notice: null });
+      try {
+        const result = await applyPlanChange(input.clients, applyAttempt);
+        applyAttempt = null;
         if (disposed) return;
         if (result.status === "rejected") {
           publishChange({
@@ -1869,13 +1926,14 @@ export function createChatController(input: {
               ? "Change applied locally. Training now matches the confirmed preview."
               : "Change cancelled. Training is unchanged; the preview remains in history.",
         });
-        await input.refreshPlanLibrary?.();
+        await input.refreshPlanLibrary?.().catch(() => {});
         publishChange({ focusRequest: changeFocus("change") });
       } catch {
         publishChange({
           notice:
-            "This Change could not be applied. Training and the pending preview are unchanged.",
+            "The Change result could not be confirmed. The Plan library will show the current state after refresh.",
         });
+        await input.refreshPlanLibrary?.().catch(() => {});
       } finally {
         publishChange({ busy: false });
       }
@@ -2517,7 +2575,7 @@ export function createChatController(input: {
       } catch {
         if (disposed || activePlanKnowledge !== knowledge) return;
         planCreationError =
-          "Activation could not be saved locally. Your previous Plan is unchanged.";
+          "The current Plan could not be read. Refresh the Plan library before activating.";
       }
       planCreationBusy = false;
       render();
@@ -2539,21 +2597,57 @@ export function createChatController(input: {
         planCreation === null
       )
         return;
+      const library = input.readPlanLibrary?.();
+      if (library == null) {
+        planCreationError = "Read the Plan library and confirm again.";
+        render();
+        return;
+      }
+      const incumbent =
+        library.active === null
+          ? null
+          : { planId: library.active.planId, version: library.active.version };
       const target = planCreation;
+      if (
+        activationAttempt?.creationId !== target.creationId ||
+        activationAttempt.expectedVersion !== target.version
+      ) {
+        activationAttempt = {
+          commandId: globalThis.crypto.randomUUID(),
+          creationId: target.creationId,
+          expectedVersion: target.version,
+          incumbent,
+        };
+      }
       planCreationBusy = true;
       planCreationError = null;
       render();
       try {
-        await (
-          await input.clients.getClient()
-        ).call("plan_creation.activate", {
-          commandId: globalThis.crypto.randomUUID(),
-          creationId: target.creationId,
-          expectedVersion: target.version,
-        });
-      } catch {
-        planCreationError =
-          "Activation could not be saved locally. Your previous Plan is unchanged.";
+        await (await input.clients.getClient()).call("plan_creation.activate", activationAttempt);
+        activationAttempt = null;
+      } catch (error) {
+        const rejection =
+          error instanceof CoachRpcRemoteError &&
+          error.data !== null &&
+          typeof error.data === "object" &&
+          "code" in error.data
+            ? error.data.code
+            : null;
+        if (
+          rejection === "version-conflict" ||
+          rejection === "not-ready" ||
+          rejection === "command-conflict"
+        ) {
+          activationAttempt = null;
+          planCreationError =
+            rejection === "version-conflict"
+              ? "The Plan changed. Read the Plan library and confirm again."
+              : "Activation could not be saved locally. Your previous Plan is unchanged.";
+        } else {
+          planCreationError =
+            "The activation result could not be confirmed. The Plan library will show the current state after refresh.";
+        }
+        await input.refreshPlanLibrary?.().catch(() => {});
         planCreationBusy = false;
         render();
         return;

--- a/apps/desktop-renderer/src/plan/library-refresh.ts
+++ b/apps/desktop-renderer/src/plan/library-refresh.ts
@@ -1,3 +1,4 @@
+import type { PlanHistoryResult } from "@enduragent/coach-contract";
 import { planReadModel } from "../state/plan-slice";
 import { useEnduragentStore } from "../state/store";
 import type { PlanController } from "./controller";
@@ -96,6 +97,88 @@ export function subscribePlanLibraryRefresh(
           (creationNeedsRefresh && previousState.chat.planCreationLoaded) ||
           (activePlanNeedsRefresh && previousPlan !== null),
       );
+    schedule();
+  });
+  schedule();
+  return () => {
+    disposed = true;
+    retryListeners.delete(requestRetry);
+    cancel();
+    unsubscribe();
+  };
+}
+
+export function subscribePlanFinalDetailsRefresh(
+  options: {
+    readonly history: NonNullable<PlanHistoryResult>;
+    readonly readHistory: (planId: string) => Promise<PlanHistoryResult>;
+    readonly onHistory: (history: PlanHistoryResult) => void;
+  },
+  timers: {
+    readonly setTimeout: typeof globalThis.setTimeout;
+    readonly clearTimeout: typeof globalThis.clearTimeout;
+  } = globalThis,
+): () => void {
+  const planId = options.history.plan.planId;
+  let history: PlanHistoryResult = options.history;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let attempts = 0;
+  let refreshing = false;
+  let disposed = false;
+  let generation = 0;
+  const cancel = (): void => {
+    generation += 1;
+    if (timer !== undefined) timers.clearTimeout(timer);
+    timer = undefined;
+  };
+  const canPoll = (): boolean => {
+    const calendar = history?.plan.calendar;
+    return (
+      !disposed &&
+      useEnduragentStore.getState().activeView === "plan" &&
+      calendar !== undefined &&
+      (calendar.status === "pending" ||
+        calendar.status === "running" ||
+        (calendar.status === "failed" && calendar.error.endsWith("Retry available.")))
+    );
+  };
+  const schedule = (): void => {
+    if (!canPoll()) {
+      cancel();
+      return;
+    }
+    if (timer !== undefined || refreshing || attempts >= 20) return;
+    timer = timers.setTimeout(() => {
+      timer = undefined;
+      attempts += 1;
+      refreshing = true;
+      const currentGeneration = generation;
+      void options
+        .readHistory(planId)
+        .then(
+          (value) => {
+            if (currentGeneration !== generation || !canPoll()) return;
+            history = value;
+            options.onHistory(value);
+          },
+          () => {},
+        )
+        .finally(() => {
+          refreshing = false;
+          schedule();
+        });
+    }, 4_000);
+  };
+  const requestRetry = (requestedPlanId: string): void => {
+    if (disposed || requestedPlanId !== planId) return;
+    attempts = 0;
+    schedule();
+  };
+  retryListeners.add(requestRetry);
+  const unsubscribe = useEnduragentStore.subscribe((state, previousState) => {
+    if (state.activeView === previousState.activeView) return;
+    cancel();
+    attempts = 0;
     schedule();
   });
   schedule();

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -43,31 +43,28 @@ export async function readPlanHistory(
 
 export async function closePlan(
   clients: DesktopCoachClientProvider,
-  input: Omit<PlanCloseRpcParams, "commandId">,
+  input: PlanCloseRpcParams,
 ): Promise<PlanCloseResult> {
   return (await clients.getClient()).call("plan.close", {
     ...input,
-    commandId: globalThis.crypto.randomUUID(),
   });
 }
 
 export async function previewPlanChange(
   clients: DesktopCoachClientProvider,
-  input: Omit<PlanChangePreviewRpcParams, "commandId">,
+  input: PlanChangePreviewRpcParams,
 ) {
   return (await clients.getClient()).call("plan_change.preview", {
     ...input,
-    commandId: globalThis.crypto.randomUUID(),
   });
 }
 
 export async function applyPlanChange(
   clients: DesktopCoachClientProvider,
-  input: Omit<PlanChangeApplyRpcParams, "commandId">,
+  input: PlanChangeApplyRpcParams,
 ) {
   return (await clients.getClient()).call("plan_change.apply", {
     ...input,
-    commandId: globalThis.crypto.randomUUID(),
   });
 }
 

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -85,7 +85,8 @@ export interface ChatSurfaceState {
   readonly planCreationActivateConfirmationOpen: boolean;
   readonly planCreationActivePlanKnowledge: ActivePlanKnowledge;
   readonly planCreationFocusRequest: {
-    readonly target: "discard" | "activate" | "start";
+    readonly target: "discard" | "activate" | "start" | "continue" | "change";
+    readonly libraryTarget?: "continue" | "change";
     readonly revision: number;
   } | null;
   readonly timeline: readonly ChatTranscriptItemView[];
@@ -369,6 +370,8 @@ export function sameChatSurface(left: ChatSurfaceState, right: ChatSurfaceState)
     left.planCreationActivateConfirmationOpen === right.planCreationActivateConfirmationOpen &&
     left.planCreationActivePlanKnowledge === right.planCreationActivePlanKnowledge &&
     left.planCreationFocusRequest?.target === right.planCreationFocusRequest?.target &&
+    left.planCreationFocusRequest?.libraryTarget ===
+      right.planCreationFocusRequest?.libraryTarget &&
     left.planCreationFocusRequest?.revision === right.planCreationFocusRequest?.revision &&
     left.workBlocked === right.workBlocked &&
     left.sendDisabled === right.sendDisabled &&

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -64,7 +64,7 @@ export type PlanLibraryState =
   | { readonly status: "unavailable"; readonly value: ListPlansResult | null };
 
 export interface PlanLibraryActions {
-  closePlan(input: Omit<PlanCloseRpcParams, "commandId">): Promise<PlanCloseResult>;
+  closePlan(input: PlanCloseRpcParams): Promise<PlanCloseResult>;
   readPlanHistory(planId: string): Promise<PlanHistoryResult>;
   refresh(): Promise<void>;
   startCreation(): void;
@@ -164,6 +164,11 @@ export interface PlanSlice {
   readonly plan: PlanSurfaceState;
   readonly planSurface: PlanReadSurfaceState;
   readonly planLibrary: PlanLibraryState;
+  readonly planCloseAttempt: {
+    readonly command: PlanCloseRpcParams;
+    readonly busy: boolean;
+  } | null;
+  setPlanCloseAttempt: (attempt: PlanSlice["planCloseAttempt"]) => void;
   readonly planLibraryActions: PlanLibraryActions | null;
   setPlanLibrary: (value: PlanLibraryState) => void;
   bindPlanLibraryActions: (actions: PlanLibraryActions | null) => void;
@@ -212,6 +217,10 @@ export const createPlanSlice: StateCreator<EnduragentState, [], [], PlanSlice> =
   plan: EMPTY_PLAN_SURFACE,
   planLibrary: { status: "loading", value: null },
   planLibraryActions: null,
+  planCloseAttempt: null,
+  setPlanCloseAttempt(attempt) {
+    set({ planCloseAttempt: attempt });
+  },
   setPlanLibrary(value) {
     set({ planLibrary: value });
   },

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -269,8 +269,8 @@ function ChangeEditor(): ReactElement {
               className="min-h-[var(--ctl-h-lg)] rounded-ctl border border-line-2 bg-sunk px-ctl-px-sm py-2 text-sm font-normal leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20"
               id="plan-change-hours"
               type="number"
-              min="0"
-              step="any"
+              min="0.25"
+              step="0.25"
               value={hours}
               disabled={state.busy}
               onChange={(event) => setHours(event.target.value)}

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -100,9 +100,10 @@ export function PlanCreationActivateDialog(): ReactElement | null {
   const error = useEnduragentStore((state) => state.chat.planCreationError);
   const actions = useEnduragentStore((state) => state.chatActions);
   const knowledge = useEnduragentStore((state) => state.chat.planCreationActivePlanKnowledge);
-  const activePlanName = knowledge.kind === "active" ? knowledge.name : null;
+
   const library = useEnduragentStore((state) => state.planLibrary.value);
   const libraryStatus = useEnduragentStore((state) => state.planLibrary.status);
+  const activePlanName = library?.active?.name ?? null;
   const libraryActions = useEnduragentStore((state) => state.planLibraryActions);
   const cancelButton = useRef<HTMLButtonElement>(null);
   const [connection, setConnection] = useState<"checking" | "fresh" | "stale">("checking");
@@ -190,7 +191,13 @@ export function PlanCreationActivateDialog(): ReactElement | null {
           <Button
             variant="default"
             size="lg"
-            disabled={busy || actions === null}
+            disabled={
+              busy ||
+              actions === null ||
+              connection !== "fresh" ||
+              libraryStatus !== "ready" ||
+              library === null
+            }
             onClick={confirmActivation}
           >
             {activePlanName === null ? "Activate Plan" : "Activate new Plan"}

--- a/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
@@ -73,6 +73,7 @@ export function PlanFinalDetails(props: {
   readonly history: NonNullable<PlanHistoryResult>;
   readonly notice?: string | null;
   readonly backToLibrary: () => void;
+  readonly retryCalendar?: () => Promise<void>;
 }): ReactElement {
   const { plan, revision, cleanup } = props.history;
   const draft = revision.snapshot;
@@ -184,6 +185,15 @@ export function PlanFinalDetails(props: {
         </CardContent>
       </Card>
       <div className="flex flex-wrap gap-inset">
+        {plan.calendar?.status === "failed" && plan.calendar.error.endsWith("Retry available.") ? (
+          <Button
+            variant="outline"
+            disabled={props.retryCalendar === undefined}
+            onClick={() => void props.retryCalendar?.()}
+          >
+            Retry calendar
+          </Button>
+        ) : null}
         <Button variant="outline" onClick={props.backToLibrary}>
           Back to library
         </Button>

--- a/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
@@ -154,12 +154,15 @@ export function PlanLibrary(props: {
   const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
   const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
   const discard = useRef<HTMLButtonElement>(null);
+  const continueButton = useRef<HTMLButtonElement>(null);
+  const changeButton = useRef<HTMLButtonElement>(null);
   const stop = useRef<HTMLButtonElement>(null);
   const cancel = useRef<HTMLButtonElement>(null);
   const [closing, setClosing] = useState<PlanSummary | null>(null);
-  const [saving, setSaving] = useState(false);
+  const closeAttempt = useEnduragentStore((state) => state.planCloseAttempt);
+  const setCloseAttempt = useEnduragentStore((state) => state.setPlanCloseAttempt);
+  const saving = closeAttempt?.busy ?? false;
   const [closeError, setCloseError] = useState<string | null>(null);
-  const savePending = useRef(false);
   const mounted = useRef(true);
   useEffect(() => {
     mounted.current = true;
@@ -168,27 +171,36 @@ export function PlanLibrary(props: {
     };
   }, []);
   const confirmClose = async (): Promise<void> => {
-    if (closing === null || actions === null || savePending.current) return;
-    savePending.current = true;
-    setSaving(true);
+    const pending = useEnduragentStore.getState().planCloseAttempt;
+    if (closing === null || actions === null || pending?.busy) return;
+    setCloseError(null);
+    const command =
+      pending?.command.planId === closing.planId
+        ? pending.command
+        : {
+            commandId: crypto.randomUUID(),
+            planId: closing.planId,
+            expectedVersion: closing.version,
+          };
+    setCloseAttempt({ command, busy: true });
     let result;
     try {
-      result = await actions.closePlan({
-        planId: closing.planId,
-        expectedVersion: closing.version,
-      });
+      result = await actions.closePlan(command);
     } catch {
+      setCloseAttempt({ command, busy: false });
       if (mounted.current) {
-        setCloseError("Stopping could not be saved locally. Your Plan is unchanged.");
-        setClosing(null);
-        setSaving(false);
+        setCloseError(
+          "Stopping could not be confirmed. The library will show the current state after refresh.",
+        );
       }
-      savePending.current = false;
+      void actions.refresh();
       return;
     }
-    savePending.current = false;
-    if (!mounted.current) return;
-    setSaving(false);
+    setCloseAttempt(null);
+    if (!mounted.current) {
+      void actions.refresh();
+      return;
+    }
     if (result.status === "rejected") {
       if (result.reason === "stale-version") {
         setCloseError("The Plan changed. Review its current details before stopping.");
@@ -211,10 +223,17 @@ export function PlanLibrary(props: {
     creation?.answeredSummaries.length ??
     0;
   useEffect(() => {
-    if (focusRequest?.target === "discard") {
-      queueMicrotask(() => discard.current?.focus());
-    }
-  }, [focusRequest]);
+    const requestedTarget = focusRequest?.target;
+    const target =
+      requestedTarget === "discard"
+        ? discard
+        : requestedTarget === "continue"
+          ? continueButton
+          : requestedTarget === "change"
+            ? changeButton
+            : null;
+    if (target !== null) queueMicrotask(() => target.current?.focus());
+  }, [focusRequest, busy, creation?.creationId, active?.planId]);
   return (
     <section aria-label="Plan library" className="grid min-w-0 gap-inset">
       {closeError === null || closing !== null ? null : (
@@ -258,7 +277,9 @@ export function PlanLibrary(props: {
             <Button
               variant="destructive-solid"
               size="lg"
-              disabled={saving || actions === null || closeError !== null}
+              disabled={
+                saving || actions === null || (closeError !== null && closeAttempt === null)
+              }
               onClick={() => void confirmClose()}
             >
               Stop Plan
@@ -302,6 +323,7 @@ export function PlanLibrary(props: {
               Discard
             </Button>
             <Button
+              ref={continueButton}
               disabled={busy || actions === null}
               onClick={() => actions?.continueCreation(creation)}
             >
@@ -346,7 +368,11 @@ export function PlanLibrary(props: {
             <Button variant="outline" onClick={props.readDetails}>
               Read Plan details
             </Button>
-            <Button disabled={actions === null} onClick={() => actions?.changeInChat()}>
+            <Button
+              ref={changeButton}
+              disabled={actions === null}
+              onClick={() => actions?.changeInChat()}
+            >
               Change in Chat
             </Button>
           </div>

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -48,6 +48,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@enduragent/ui";
+import {
+  requestPlanCalendarRetry,
+  subscribePlanFinalDetailsRefresh,
+} from "../../plan/library-refresh";
 import { formatCivilDate } from "../../lib/date";
 import { planReadModel } from "../../state/plan-slice";
 import { useEnduragentStore } from "../../state/store";
@@ -4488,9 +4492,11 @@ export function PlanView(): ReactElement {
     | { status: "unavailable"; planId: string; justClosed: boolean }
   >({ status: "library" });
   const historyRequest = useRef(0);
+  const stopHistoryRefresh = useRef<(() => void) | null>(null);
   useEffect(
     () => () => {
       historyRequest.current += 1;
+      stopHistoryRefresh.current?.();
     },
     [],
   );
@@ -4499,11 +4505,22 @@ export function PlanView(): ReactElement {
   const readFinalDetails = (planId: string, justClosed = false): void => {
     if (libraryActions === null) return;
     const request = ++historyRequest.current;
+    stopHistoryRefresh.current?.();
     setFinalDetails({ status: "loading", planId, justClosed });
     void libraryActions.readPlanHistory(planId).then(
       (history) => {
-        if (request === historyRequest.current)
-          setFinalDetails({ status: "ready", history, justClosed });
+        if (request !== historyRequest.current) return;
+        setFinalDetails({ status: "ready", history, justClosed });
+        if (history !== null) {
+          stopHistoryRefresh.current = subscribePlanFinalDetailsRefresh({
+            history,
+            readHistory: (id) => libraryActions.readPlanHistory(id),
+            onHistory: (value) => {
+              if (request === historyRequest.current)
+                setFinalDetails({ status: "ready", history: value, justClosed });
+            },
+          });
+        }
       },
       () => {
         if (request === historyRequest.current)
@@ -4513,6 +4530,7 @@ export function PlanView(): ReactElement {
   };
   const backToLibrary = (): void => {
     historyRequest.current += 1;
+    stopHistoryRefresh.current?.();
     setFinalDetails({ status: "library" });
   };
   const planningActions = useEnduragentStore((state) => state.planningReadActions);
@@ -4572,6 +4590,15 @@ export function PlanView(): ReactElement {
             history={finalDetails.history}
             notice={notice}
             backToLibrary={backToLibrary}
+            retryCalendar={
+              libraryActions === null
+                ? undefined
+                : async () => {
+                    if (finalDetails.history === null) return;
+                    requestPlanCalendarRetry(finalDetails.history.plan.planId);
+                    await libraryActions.refresh();
+                  }
+            }
           />
         ) : (
           <div className="grid gap-inset">

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -5,11 +5,13 @@ import {
   CoachClientCallTimeoutError,
   CoachClientDisconnectedError,
   CoachClientProtocolError,
+  CoachRpcRemoteError,
   type CoachClient,
   type CoachClientCallOptions,
 } from "@enduragent/coach-client";
 import type {
   GetPlanStateRpcResult,
+  ListPlansResult,
   ChatAttachmentComposerReadModel,
   ChatQueueSnapshot,
   CoachDecisionReadModel,
@@ -688,6 +690,15 @@ function subject(
   const refresh = vi.fn(refreshImplementation);
   const refreshSpend = vi.fn(spendRefreshImplementation);
   const refreshPlan = vi.fn(async () => {});
+  const refreshPlanLibrary = vi.fn(async () => {});
+  const readPlanLibrary = vi.fn((): ListPlansResult => ({
+    calendarConnected: false,
+    legacy: null,
+    active: null,
+    creation: null,
+    closed: [],
+    changes: [],
+  }));
   const openChat = vi.fn();
   const provider: DesktopCoachClientProvider = {
     getClient: vi.fn(async () => first),
@@ -713,6 +724,8 @@ function subject(
     },
     refreshTrainingContext: refresh,
     refreshPlan,
+    refreshPlanLibrary,
+    readPlanLibrary,
     openChat,
     refreshSpend,
     canChat,
@@ -744,6 +757,8 @@ function subject(
     refresh,
     refreshSpend,
     refreshPlan,
+    refreshPlanLibrary,
+    readPlanLibrary,
     openChat,
     openPlanningRequest,
   };
@@ -1964,7 +1979,7 @@ describe("chat controller", () => {
     expect(getPlanState).toHaveBeenCalledOnce();
     expect(controls.at(-1)?.planCreation).toMatchObject({
       activePlanKnowledge: { kind: "unknown" },
-      error: "Activation could not be saved locally. Your previous Plan is unchanged.",
+      error: "The current Plan could not be read. Refresh the Plan library before activating.",
       activateConfirmationOpen: false,
       busy: false,
     });
@@ -2009,6 +2024,7 @@ describe("chat controller", () => {
       commandId: expect.any(String),
       creationId: card.creationId,
       expectedVersion: card.version,
+      incumbent: null,
     });
     expect(controls.at(-1)?.planCreation).toMatchObject({
       busy: true,
@@ -2030,7 +2046,7 @@ describe("chat controller", () => {
     expect(refreshPlan).toHaveBeenCalledOnce();
   });
 
-  it("keeps a failed activation open and retries with a fresh command id", async () => {
+  it("keeps an unconfirmed activation open and retries the exact command", async () => {
     const card: PlanCreationCardModel = {
       creationId: "01J00000000000000000000000",
       version: 3,
@@ -2052,7 +2068,7 @@ describe("chat controller", () => {
         closedPlanId: null,
         activatedAt: "1998-09-07",
       });
-    const { controller, controls, refreshPlan } = subject(
+    const { controller, controls, refreshPlan, refreshPlanLibrary } = subject(
       client(replies(), {
         listPlanningRequests: async () => ({ deliveries: [], planCreation: card }),
         activatePlanCreation,
@@ -2065,16 +2081,54 @@ describe("chat controller", () => {
       value: card,
       busy: false,
       activateConfirmationOpen: true,
-      error: "Activation could not be saved locally. Your previous Plan is unchanged.",
+      error:
+        "The activation result could not be confirmed. The Plan library will show the current state after refresh.",
     });
     expect(refreshPlan).not.toHaveBeenCalled();
+    expect(refreshPlanLibrary).toHaveBeenCalledOnce();
+    await controller.confirmPlanCreationActivate();
+    expect(activatePlanCreation).toHaveBeenCalledTimes(2);
+    expect(activatePlanCreation.mock.calls[1]?.[0]).toEqual(
+      activatePlanCreation.mock.calls[0]?.[0],
+    );
+    expect(controls.at(-1)?.planCreation?.value).toBeNull();
+    expect(refreshPlan).toHaveBeenCalledOnce();
+  });
+
+  it("starts a fresh activation command after a definitive rejection", async () => {
+    const card: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 3,
+      status: "review",
+      readiness: "ready",
+      answeredSummaries: [],
+      openQuestion: null,
+      draft: planCreationDraft(),
+      draftStale: false,
+    };
+    const activatePlanCreation = vi
+      .fn<(request: PlanCreationActivateRpcParams) => Promise<PlanCreationActivateRpcResult>>()
+      .mockRejectedValue(
+        new CoachRpcRemoteError(-32000, "Plan changed", { code: "version-conflict" }),
+      );
+    const { controller, controls, refreshPlanLibrary } = subject(
+      client(replies(), {
+        listPlanningRequests: async () => ({ deliveries: [], planCreation: card }),
+        activatePlanCreation,
+      }),
+    );
+    await controller.start();
+    await controller.openPlanCreationActivate();
+    await controller.confirmPlanCreationActivate();
     await controller.confirmPlanCreationActivate();
     expect(activatePlanCreation).toHaveBeenCalledTimes(2);
     expect(activatePlanCreation.mock.calls[1]?.[0].commandId).not.toEqual(
       activatePlanCreation.mock.calls[0]?.[0].commandId,
     );
-    expect(controls.at(-1)?.planCreation?.value).toBeNull();
-    expect(refreshPlan).toHaveBeenCalledOnce();
+    expect(controls.at(-1)?.planCreation?.error).toBe(
+      "The Plan changed. Read the Plan library and confirm again.",
+    );
+    expect(refreshPlanLibrary).toHaveBeenCalledTimes(2);
   });
 
   it("cancels activation without changing the Draft and does not restore a dialog after relaunch", async () => {
@@ -3706,13 +3760,11 @@ describe("Plan library Chat entry", () => {
   });
 
   it("prepares an empty library entry to start before Chat hydration", async () => {
-    const start = vi.fn(
-      async (): Promise<PlanCreationStartRpcResult> => ({
-        status: "started",
-        outcome: "created",
-        planCreation: creation,
-      }),
-    );
+    const start = vi.fn(async (): Promise<PlanCreationStartRpcResult> => ({
+      status: "started",
+      outcome: "created",
+      planCreation: creation,
+    }));
     const fake = client(replies(), { startPlanCreation: start });
     const { controller, controls } = subject(fake);
     controller.resumeCreation(null);

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -3073,6 +3073,39 @@ describe("chat surface", () => {
           status: "review",
           draft: planCreationDraft(),
         };
+        useEnduragentStore.setState({
+          planLibrary: {
+            status: "ready",
+            value: {
+              calendarConnected: false,
+              legacy: null,
+              creation: null,
+              closed: [],
+              changes: [],
+              active: hasActivePlan
+                ? {
+                    planId: "00000000000000000000000003",
+                    version: 2,
+                    name: "Steady autumn",
+                    start: "1998-07-06",
+                    end: "1998-10-04",
+                    weeks: 12,
+                    status: "active",
+                    closeReason: null,
+                    closedAt: null,
+                    activatedAt: "1998-07-06",
+                    creationId: null,
+                    calendar: {
+                      status: "pending",
+                      window: null,
+                      currentThrough: null,
+                      error: null,
+                    },
+                  }
+                : null,
+            },
+          },
+        });
         if (hasActivePlan) {
           useEnduragentStore.getState().setPlanHydration({
             status: "ready",
@@ -3191,6 +3224,27 @@ describe("chat surface", () => {
         status: "review",
         draft: planCreationDraft(),
       };
+      useEnduragentStore.setState({
+        planLibrary: {
+          status: "ready",
+          value: {
+            calendarConnected: false,
+            legacy: null,
+            creation: null,
+            active: null,
+            closed: [],
+            changes: [],
+          },
+        },
+        planLibraryActions: {
+          refresh: vi.fn(async () => {}),
+          closePlan: vi.fn(),
+          readPlanHistory: vi.fn(),
+          startCreation: vi.fn(),
+          continueCreation: vi.fn(),
+          changeInChat: vi.fn(),
+        },
+      });
       actions.confirmPlanCreationActivate = vi.fn(() =>
         setChat({
           planCreationError:
@@ -3206,6 +3260,9 @@ describe("chat surface", () => {
       });
       render(<Harness />);
       const dialog = screen.getByRole("dialog");
+      await waitFor(() =>
+        expect(within(dialog).getByRole("button", { name: "Activate Plan" })).toBeEnabled(),
+      );
       await userEvent.click(within(dialog).getByRole("button", { name: "Activate Plan" }));
       expect(
         within(dialog).getByText(

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -2089,9 +2089,8 @@ describe("Plan library RPC adapters", () => {
     });
   });
 
-  it("closes the current version with a new command id", async () => {
+  it("closes the confirmed version with its supplied command id", async () => {
     const commandId = "12345678-1234-1234-1234-123456789012";
-    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(commandId);
     const result = {
       status: "closed" as const,
       planId: "00000000000000000000000003",
@@ -2100,7 +2099,9 @@ describe("Plan library RPC adapters", () => {
     };
     const { clients, call } = clientProvider();
     call.mockResolvedValue(result);
-    expect(await closePlan(clients, { planId: result.planId, expectedVersion: 7 })).toEqual(result);
+    expect(
+      await closePlan(clients, { commandId, planId: result.planId, expectedVersion: 7 }),
+    ).toEqual(result);
     expect(call).toHaveBeenCalledWith("plan.close", {
       commandId,
       planId: result.planId,
@@ -2110,15 +2111,17 @@ describe("Plan library RPC adapters", () => {
 });
 
 describe("Plan Change RPC adapters", () => {
-  it("generates unique command ids and preserves preview and decision payloads", async () => {
+  it("preserves confirmed command ids and preview and decision payloads", async () => {
     const call = vi.fn().mockResolvedValue({ status: "rejected", reason: "stale-version" });
     const clients = { getClient: async () => ({ call }) } as unknown as DesktopCoachClientProvider;
     const preview = {
+      commandId: "preview-command",
       planId: "plan-active",
       expectedVersion: 4,
       intent: { kind: "weekly-duration", hours: 6 },
     } as const;
     const decision = {
+      commandId: "apply-command",
       planId: "plan-active",
       expectedVersion: 5,
       changeId: "change-pending",
@@ -2129,24 +2132,22 @@ describe("Plan Change RPC adapters", () => {
       reason: "stale-version",
     });
     await applyPlanChange(clients, decision);
-    await applyPlanChange(clients, { ...decision, decision: "cancel" });
+    await applyPlanChange(clients, {
+      ...decision,
+      commandId: "cancel-command",
+      decision: "cancel",
+    });
     expect(call).toHaveBeenNthCalledWith(1, "plan_change.preview", {
       ...preview,
-      commandId: expect.any(String),
     });
     expect(call).toHaveBeenNthCalledWith(2, "plan_change.apply", {
       ...decision,
-      commandId: expect.any(String),
     });
     expect(call).toHaveBeenNthCalledWith(3, "plan_change.apply", {
       ...decision,
       decision: "cancel",
-      commandId: expect.any(String),
+      commandId: "cancel-command",
     });
     expect(new Set(call.mock.calls.map(([, request]) => request.commandId)).size).toBe(3);
-    for (const [, request] of call.mock.calls)
-      expect(request.commandId).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
-      );
   });
 });

--- a/apps/desktop-renderer/tests/plan-calendar-dialog.test.tsx
+++ b/apps/desktop-renderer/tests/plan-calendar-dialog.test.tsx
@@ -1,5 +1,5 @@
 import type { ListPlansResult } from "@enduragent/coach-contract";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_CHAT_SURFACE } from "../src/state/chat-slice";
 import { useEnduragentStore } from "../src/state/store";
@@ -37,7 +37,10 @@ beforeEach(() => {
       continueCreation: vi.fn(),
       changeInChat: vi.fn(),
     } as never,
-    chatActions: null,
+    chatActions: {
+      confirmPlanCreationActivate: vi.fn(),
+      cancelPlanCreationActivate: vi.fn(),
+    } as never,
   });
 });
 afterEach(() => vi.restoreAllMocks());
@@ -50,7 +53,7 @@ describe("activation calendar consequence", () => {
         chat: {
           ...useEnduragentStore.getState().chat,
           planCreationActivePlanKnowledge: closing
-            ? { kind: "active", name: summary.name }
+            ? { kind: "active", name: "Previous training Plan" }
             : { kind: "none" },
         },
         planLibrary: {
@@ -78,6 +81,10 @@ describe("activation calendar consequence", () => {
             : "The new Plan activates now.",
         ),
       ).toBeVisible();
+      expect(screen.queryByText(/Previous training Plan/)).toBeNull();
+      expect(
+        screen.getByRole("button", { name: closing ? "Activate new Plan" : "Activate Plan" }),
+      ).toBeEnabled();
     },
   );
 
@@ -122,6 +129,8 @@ describe("activation calendar consequence", () => {
         await screen.findByText("Calendar updates wait until intervals.icu is connected."),
       ).toBeVisible();
       expect(screen.queryByText(/Dated Workouts sync/)).toBeNull();
+      if (kind === "unloaded")
+        expect(screen.getByRole("button", { name: "Activate Plan" })).toBeDisabled();
     },
   );
 
@@ -179,6 +188,12 @@ describe("activation calendar consequence", () => {
     });
     render(<PlanCreationActivateDialog />);
     expect(refresh).toHaveBeenCalledOnce();
+    const confirm = screen.getByRole("button", { name: "Activate Plan" });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(
+      useEnduragentStore.getState().chatActions?.confirmPlanCreationActivate,
+    ).not.toHaveBeenCalled();
     expect(screen.queryByText(/Dated Workouts sync/)).toBeNull();
     expect(screen.queryByText(/Calendar updates wait/)).toBeNull();
     useEnduragentStore.setState({
@@ -199,6 +214,11 @@ describe("activation calendar consequence", () => {
       await screen.findByText("Calendar updates wait until intervals.icu is connected."),
     ).toBeVisible();
     expect(screen.queryByText(/Dated Workouts sync/)).toBeNull();
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+    expect(
+      useEnduragentStore.getState().chatActions?.confirmPlanCreationActivate,
+    ).toHaveBeenCalledOnce();
   });
 
   it("treats a failed library read as disconnected even with a cached connected library", async () => {
@@ -239,5 +259,38 @@ describe("activation calendar consequence", () => {
       await screen.findByText("Calendar updates wait until intervals.icu is connected."),
     ).toBeVisible();
     expect(screen.queryByText(/Dated Workouts sync/)).toBeNull();
+    expect(screen.getByRole("button", { name: "Activate Plan" })).toBeDisabled();
+  });
+
+  it("blocks activation when refresh rejects despite a ready cached library", async () => {
+    useEnduragentStore.setState({
+      planLibrary: {
+        status: "ready",
+        value: {
+          calendarConnected: true,
+          legacy: null,
+          creation: null,
+          active: summary,
+          closed: [],
+          changes: [],
+        },
+      },
+      planLibraryActions: {
+        ...useEnduragentStore.getState().planLibraryActions,
+        refresh: vi.fn(async () => {
+          throw new Error("Library unavailable");
+        }),
+      } as never,
+    });
+    render(<PlanCreationActivateDialog />);
+    expect(
+      await screen.findByText("Calendar updates wait until intervals.icu is connected."),
+    ).toBeVisible();
+    const confirm = screen.getByRole("button", { name: "Activate new Plan" });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(
+      useEnduragentStore.getState().chatActions?.confirmPlanCreationActivate,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -299,6 +299,14 @@ describe("Plan Change cards", () => {
     await userEvent.click(await screen.findByRole("option", { name: "Weekly duration cap" }));
     expect(screen.queryByRole("combobox", { name: "Weekday" })).toBeNull();
     expect(screen.getByRole("spinbutton", { name: "Weekly limit in hours" })).toHaveValue(3);
+    expect(screen.getByRole("spinbutton", { name: "Weekly limit in hours" })).toHaveAttribute(
+      "min",
+      "0.25",
+    );
+    expect(screen.getByRole("spinbutton", { name: "Weekly limit in hours" })).toHaveAttribute(
+      "step",
+      "0.25",
+    );
     await userEvent.click(screen.getByRole("button", { name: "Preview change" }));
     expect(actions?.previewPlanChange).toHaveBeenLastCalledWith({
       kind: "weekly-duration",

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -261,20 +261,26 @@ describe("Plan Change controller", () => {
     },
   );
 
-  it("keeps the pending preview on transport failure", async () => {
+  it("refreshes the library without claiming an outcome on transport failure", async () => {
     const h = harness(new Error("offline"));
     await h.controller.applyPlanChange("apply");
     expect(h.surface()).toMatchObject({
       busy: false,
-      notice: "This Change could not be applied. Training and the pending preview are unchanged.",
+      notice:
+        "The Change result could not be confirmed. The Plan library will show the current state after refresh.",
     });
-    expect(h.refresh).not.toHaveBeenCalled();
+    expect(h.refresh).toHaveBeenCalledOnce();
   });
 
   it.each([
     [{ kind: "weekday-duration", day: 2, minutes: 0 }, "Enter a duration above zero."],
     [{ kind: "longest-workout", minutes: Number.NaN }, "Enter a duration above zero."],
     [{ kind: "weekly-duration", hours: -1 }, "Enter a weekly duration above zero."],
+    [{ kind: "weekly-duration", hours: 0 }, "Enter a weekly duration above zero."],
+    [
+      { kind: "weekly-duration", hours: 2.3 },
+      "Enter weekly hours in quarter-hour steps, like 2.25.",
+    ],
     [{ kind: "weekday-unavailable", day: 8 }, "Choose the weekday to change."],
   ] satisfies [PlanChangeIntent, string][])(
     "validates parameters before the RPC for %j",
@@ -285,6 +291,48 @@ describe("Plan Change controller", () => {
       expect(h.call).not.toHaveBeenCalled();
     },
   );
+
+  it.each(["preview", "apply"] as const)(
+    "replays the exact %s confirmation after a lost response and refresh",
+    async (action) => {
+      const h = harness(new Error("lost response"));
+      h.refresh.mockImplementation(async () => h.updateVersion(8));
+      const submit = () =>
+        action === "preview"
+          ? h.controller.previewPlanChange(change.intent)
+          : h.controller.applyPlanChange("apply");
+      await submit();
+      await submit();
+      expect(h.call).toHaveBeenCalledTimes(2);
+      expect(h.call.mock.calls[1]).toEqual(h.call.mock.calls[0]);
+      expect(h.refresh).toHaveBeenCalledTimes(2);
+      expect(h.surface().busy).toBe(false);
+    },
+  );
+
+  it.each(["preview", "apply"] as const)(
+    "clears a %s confirmation after a definitive rejection",
+    async (action) => {
+      const h = harness({ status: "rejected", reason: "stale-version" });
+      const submit = () =>
+        action === "preview"
+          ? h.controller.previewPlanChange(change.intent)
+          : h.controller.applyPlanChange("apply");
+      await submit();
+      await submit();
+      expect(h.call.mock.calls[1]?.[1]).not.toEqual(h.call.mock.calls[0]?.[1]);
+    },
+  );
+
+  it("starts a new command for a different preview intent after a lost response", async () => {
+    const h = harness(new Error("lost response"));
+    await h.controller.previewPlanChange(change.intent);
+    await h.controller.previewPlanChange({ kind: "weekly-duration", hours: 2.25 });
+    expect(h.call.mock.calls[1]?.[1]).toMatchObject({
+      intent: { kind: "weekly-duration", hours: 2.25 },
+    });
+    expect(h.call.mock.calls[1]?.[1]).not.toEqual(h.call.mock.calls[0]?.[1]);
+  });
 
   it("does not submit a retired preview", async () => {
     const h = harness(null, [{ ...change, status: "cancelled" }]);

--- a/apps/desktop-renderer/tests/plan-final-details-refresh.test.tsx
+++ b/apps/desktop-renderer/tests/plan-final-details-refresh.test.tsx
@@ -1,0 +1,198 @@
+import type { PlanHistoryResult } from "@enduragent/coach-contract";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { PlanView } from "../src/ui/plan/PlanView";
+import { EMPTY_CHAT_SURFACE } from "../src/state/chat-slice";
+import { EMPTY_PLAN_SURFACE } from "../src/state/plan-slice";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  requestPlanCalendarRetry,
+  subscribePlanFinalDetailsRefresh,
+} from "../src/plan/library-refresh";
+import { useEnduragentStore } from "../src/state/store";
+import { planCreationDraft } from "./plan-creation-draft-fixtures";
+
+function history(
+  calendar: NonNullable<PlanHistoryResult>["plan"]["calendar"],
+): NonNullable<PlanHistoryResult> {
+  const draft = planCreationDraft();
+  return {
+    plan: {
+      planId: "closed-plan",
+      version: 2,
+      name: "Build steady power",
+      start: draft.start,
+      end: draft.end,
+      weeks: draft.weeks.length,
+      status: "closed",
+      closeReason: "stopped",
+      closedAt: "1998-09-14",
+      activatedAt: "1998-09-07",
+      calendar,
+      creationId: "creation-closed",
+    },
+    closeActor: "fictional-device",
+    revision: { revisionNumber: 1, fingerprint: draft.outputFingerprint, snapshot: draft },
+    cleanup: calendar.status === "verified" ? "complete" : "pending",
+  };
+}
+
+const pending = history({ status: "pending", window: null, currentThrough: null, error: null });
+const running = history({ status: "running", window: null, currentThrough: null, error: null });
+const failed = history({
+  status: "failed",
+  window: null,
+  currentThrough: null,
+  error: "Calendar cleanup failed. Retry available.",
+});
+const complete = history({
+  status: "verified",
+  window: null,
+  currentThrough: "1998-09-13",
+  error: null,
+});
+
+describe("closed Plan history refresh", () => {
+  let unsubscribe = (): void => {};
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useEnduragentStore.setState({ activeView: "plan" });
+  });
+  afterEach(() => {
+    unsubscribe();
+    vi.useRealTimers();
+  });
+
+  it("reads the selected closed Plan every four seconds through cleanup completion", async () => {
+    const readHistory = vi.fn().mockResolvedValueOnce(running).mockResolvedValueOnce(complete);
+    const onHistory = vi.fn();
+    unsubscribe = subscribePlanFinalDetailsRefresh({ history: pending, readHistory, onHistory });
+    await vi.advanceTimersByTimeAsync(3_999);
+    expect(readHistory).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readHistory).toHaveBeenCalledExactlyOnceWith("closed-plan");
+    expect(onHistory).toHaveBeenLastCalledWith(running);
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(onHistory).toHaveBeenLastCalledWith(complete);
+    await vi.advanceTimersByTimeAsync(80_000);
+    expect(readHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps retryable cleanup at twenty reads and restarts only for that Plan's retry", async () => {
+    const readHistory = vi.fn().mockResolvedValue(failed);
+    unsubscribe = subscribePlanFinalDetailsRefresh({
+      history: failed,
+      readHistory,
+      onHistory: vi.fn(),
+    });
+    await vi.advanceTimersByTimeAsync(100_000);
+    expect(readHistory).toHaveBeenCalledTimes(20);
+    requestPlanCalendarRetry("another-plan");
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(readHistory).toHaveBeenCalledTimes(20);
+    requestPlanCalendarRetry("closed-plan");
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(readHistory).toHaveBeenCalledTimes(21);
+  });
+
+  it("keeps the last snapshot when a history read fails and retries on schedule", async () => {
+    const readHistory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(complete);
+    const onHistory = vi.fn();
+    unsubscribe = subscribePlanFinalDetailsRefresh({ history: pending, readHistory, onHistory });
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(onHistory).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(onHistory).toHaveBeenCalledExactlyOnceWith(complete);
+  });
+
+  it.each(["leave", "unsubscribe"])("ignores a late read after %s", async (action) => {
+    let resolveRead: (value: PlanHistoryResult) => void = () => {};
+    const readHistory = vi.fn(
+      () =>
+        new Promise<PlanHistoryResult>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    const onHistory = vi.fn();
+    unsubscribe = subscribePlanFinalDetailsRefresh({ history: pending, readHistory, onHistory });
+    await vi.advanceTimersByTimeAsync(4_000);
+    if (action === "leave") useEnduragentStore.setState({ activeView: "chat" });
+    else unsubscribe();
+    resolveRead(complete);
+    await vi.advanceTimersByTimeAsync(80_000);
+    expect(onHistory).not.toHaveBeenCalled();
+    expect(readHistory).toHaveBeenCalledOnce();
+  });
+
+  it("retries cleanup from final details, refreshes the library, and renders fresh history", async () => {
+    const readPlanHistory = vi.fn().mockResolvedValue(failed);
+    const refresh = vi.fn(async () => {
+      readPlanHistory.mockResolvedValue(complete);
+    });
+    useEnduragentStore.setState({
+      chat: EMPTY_CHAT_SURFACE,
+      chatActions: null,
+      plan: EMPTY_PLAN_SURFACE,
+      planActions: null,
+      planningReadActions: null,
+      planLibrary: {
+        status: "ready",
+        value: {
+          calendarConnected: true,
+          legacy: null,
+          creation: null,
+          active: null,
+          closed: [{ ...failed.plan, status: "closed" }],
+          changes: [],
+        },
+      },
+      planLibraryActions: {
+        refresh,
+        readPlanHistory,
+        closePlan: vi.fn(),
+        startCreation: vi.fn(),
+        continueCreation: vi.fn(),
+        changeInChat: vi.fn(),
+      },
+    });
+    const view = render(<PlanView />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Read final details" }));
+    });
+    expect(screen.getByRole("row", { name: /^Calendar/ })).toHaveTextContent(
+      "Calendar cleanup failed. Retry available.",
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry calendar" }));
+    });
+    expect(refresh).toHaveBeenCalledOnce();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+    expect(readPlanHistory).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("row", { name: /^Calendar/ })).toHaveTextContent("Cleanup complete");
+    expect(screen.queryByRole("button", { name: "Retry calendar" })).not.toBeInTheDocument();
+    view.unmount();
+    await vi.advanceTimersByTimeAsync(80_000);
+    expect(readPlanHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not poll a terminal cleanup failure", async () => {
+    const terminal = history({
+      status: "failed",
+      window: null,
+      currentThrough: null,
+      error: "Calendar cleanup failed.",
+    });
+    const readHistory = vi.fn();
+    unsubscribe = subscribePlanFinalDetailsRefresh({
+      history: terminal,
+      readHistory,
+      onHistory: vi.fn(),
+    });
+    await vi.advanceTimersByTimeAsync(80_000);
+    expect(readHistory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop-renderer/tests/plan-final-details.test.tsx
+++ b/apps/desktop-renderer/tests/plan-final-details.test.tsx
@@ -157,11 +157,40 @@ describe("final Plan details", () => {
       value.cleanup = "none";
       render(<PlanFinalDetails history={value} backToLibrary={vi.fn()} />);
       expect(screen.getByRole("row", { name: /^Calendar/ })).toHaveTextContent(copy);
-      expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
-        "Back to library",
-      ]);
+      expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual(
+        calendar.status === "failed" && calendar.error.endsWith("Retry available.")
+          ? ["Retry calendar", "Back to library"]
+          : ["Back to library"],
+      );
     },
   );
+
+  it("offers the calendar retry action only while cleanup remains retryable", () => {
+    const value = history();
+    value.plan.calendar = {
+      status: "failed",
+      window: null,
+      currentThrough: null,
+      error: "Calendar cleanup failed. Retry available.",
+    };
+    const retryCalendar = vi.fn().mockResolvedValue(undefined);
+    const view = render(
+      <PlanFinalDetails history={value} backToLibrary={vi.fn()} retryCalendar={retryCalendar} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Retry calendar" }));
+    expect(retryCalendar).toHaveBeenCalledOnce();
+    value.plan.calendar = {
+      status: "verified",
+      window: null,
+      currentThrough: "1998-09-13",
+      error: null,
+    };
+    view.rerender(
+      <PlanFinalDetails history={value} backToLibrary={vi.fn()} retryCalendar={retryCalendar} />,
+    );
+    expect(screen.queryByRole("button", { name: "Retry calendar" })).not.toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /^Calendar/ })).toHaveTextContent("Cleanup complete");
+  });
 
   it("retains undated Workouts as Not chosen and preserves dated and pinned Workouts", () => {
     const value = history();

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -216,6 +216,7 @@ const combinations = [false, true].flatMap((hasCreation) =>
 );
 
 beforeEach(() => {
+  useEnduragentStore.getState().setPlanCloseAttempt(null);
   useEnduragentStore.setState({
     chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation },
     chatActions: stubActions(),
@@ -223,14 +224,12 @@ beforeEach(() => {
     planActions: null,
     planLibrary: { status: "loading", value: null },
     planLibraryActions: {
-      closePlan: vi.fn(
-        async (): Promise<PlanCloseResult> => ({
-          status: "closed",
-          planId: active.planId,
-          closedAt: 904435200000,
-          cleanupJobId: "cleanup-job",
-        }),
-      ),
+      closePlan: vi.fn(async (): Promise<PlanCloseResult> => ({
+        status: "closed",
+        planId: active.planId,
+        closedAt: 904435200000,
+        cleanupJobId: "cleanup-job",
+      })),
       readPlanHistory: vi.fn(async () => null),
       refresh: vi.fn(async () => {}),
       startCreation: vi.fn(),
@@ -545,6 +544,32 @@ describe("Plan library", () => {
     expect(readDetails).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    ["continue", "Continue in Chat"],
+    ["change", "Change in Chat"],
+  ] as const)("restores the %s control after returning from Chat", async (target, label) => {
+    const library = {
+      calendarConnected: false,
+      legacy: null,
+      creation,
+      active,
+      closed,
+      changes: [],
+    };
+    const view = render(
+      <PlanLibrary library={library} readDetails={vi.fn()} readFinalDetails={vi.fn()} />,
+    );
+    view.unmount();
+    useEnduragentStore.setState({
+      chat: {
+        ...useEnduragentStore.getState().chat,
+        planCreationFocusRequest: { target, libraryTarget: target, revision: 2 },
+      },
+    });
+    render(<PlanLibrary library={library} readDetails={vi.fn()} readFinalDetails={vi.fn()} />);
+    await vi.waitFor(() => expect(screen.getByRole("button", { name: label })).toHaveFocus());
+  });
+
   it("shows Paused only for the matching creation and Draft takes precedence", () => {
     useEnduragentStore.setState({
       chat: { ...EMPTY_CHAT_SURFACE, planCreation: creation, planCreationPaused: true },
@@ -617,16 +642,14 @@ describe("Plan library", () => {
     async (entry) => {
       const store = useEnduragentStore;
       store.setState({ activeView: entry === "relaunch" ? "plan" : "chat" });
-      const listPlans = vi.fn(
-        async (): Promise<ListPlansResult> => ({
-          calendarConnected: false,
-          legacy: null,
-          creation,
-          active,
-          closed,
-          changes: [],
-        }),
-      );
+      const listPlans = vi.fn(async (): Promise<ListPlansResult> => ({
+        calendarConnected: false,
+        legacy: null,
+        creation,
+        active,
+        closed,
+        changes: [],
+      }));
       const controller = createPlanController({
         listPlans,
         read: async () => ({
@@ -1378,6 +1401,7 @@ describe("Stop Plan", () => {
     expect(actions?.closePlan).toHaveBeenCalledExactlyOnceWith({
       planId: active.planId,
       expectedVersion: active.version,
+      commandId: expect.any(String),
     });
     expect(actions?.refresh).toHaveBeenCalledOnce();
     expect(readFinalDetails).toHaveBeenCalledExactlyOnceWith(active.planId, true);
@@ -1402,17 +1426,90 @@ describe("Stop Plan", () => {
     await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
   });
 
-  it.each(["save", "no-active-plan", "command-conflict"])(
+  it("retries an unconfirmed stop with the original command and displayed version", async () => {
+    const actions = useEnduragentStore.getState().planLibraryActions;
+    if (actions === null) throw new Error("Missing library actions");
+    vi.mocked(actions.closePlan).mockRejectedValueOnce(new Error("Response lost"));
+    const readFinalDetails = renderLibrary();
+    fireEvent.click(screen.getByRole("button", { name: "Stop Plan" }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Stop Plan" }));
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(
+      "Stopping could not be confirmed. The library will show the current state after refresh.",
+    );
+    expect(actions.refresh).toHaveBeenCalledOnce();
+    expect(readFinalDetails).not.toHaveBeenCalled();
+    expect(within(dialog).getByRole("button", { name: "Stop Plan" })).toBeEnabled();
+    const first = vi.mocked(actions.closePlan).mock.calls[0]?.[0];
+    expect(first).toEqual({
+      planId: active.planId,
+      expectedVersion: active.version,
+      commandId: expect.any(String),
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Stop Plan" }));
+    await vi.waitFor(() => expect(readFinalDetails).toHaveBeenCalledWith(active.planId, true));
+    expect(actions.closePlan).toHaveBeenNthCalledWith(2, first);
+    expect(actions.refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses the stop command after cancelling and reopening an unconfirmed attempt", async () => {
+    const actions = useEnduragentStore.getState().planLibraryActions;
+    if (actions === null) throw new Error("Missing library actions");
+    vi.mocked(actions.closePlan).mockRejectedValue(new Error("Response lost"));
+    renderLibrary();
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      fireEvent.click(screen.getByRole("button", { name: "Stop Plan" }));
+      const dialog = await screen.findByRole("dialog");
+      fireEvent.click(within(dialog).getByRole("button", { name: "Stop Plan" }));
+      await within(dialog).findByRole("alert");
+      fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+      await vi.waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    }
+    const calls = vi.mocked(actions.closePlan).mock.calls;
+    expect(calls[0]?.[0]).toEqual(calls[1]?.[0]);
+  });
+
+  it("keeps an unconfirmed stop command across library remounts", async () => {
+    const actions = useEnduragentStore.getState().planLibraryActions;
+    if (actions === null) throw new Error("Missing library actions");
+    vi.mocked(actions.closePlan).mockRejectedValueOnce(new Error("Response lost"));
+    const library = {
+      calendarConnected: false,
+      legacy: null,
+      creation: null,
+      active,
+      closed,
+      changes: [],
+    };
+    const view = render(
+      <PlanLibrary library={library} readDetails={vi.fn()} readFinalDetails={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Stop Plan" }));
+    fireEvent.click(
+      within(await screen.findByRole("dialog")).getByRole("button", { name: "Stop Plan" }),
+    );
+    await screen.findByRole("alert");
+    const command = vi.mocked(actions.closePlan).mock.calls[0]?.[0];
+    view.unmount();
+    render(<PlanLibrary library={library} readDetails={vi.fn()} readFinalDetails={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Stop Plan" }));
+    fireEvent.click(
+      within(await screen.findByRole("dialog")).getByRole("button", { name: "Stop Plan" }),
+    );
+    await vi.waitFor(() => expect(actions.closePlan).toHaveBeenCalledTimes(2));
+    expect(actions.closePlan).toHaveBeenNthCalledWith(2, command);
+    await vi.waitFor(() => expect(useEnduragentStore.getState().planCloseAttempt).toBeNull());
+  });
+
+  it.each(["no-active-plan", "command-conflict"])(
     "closes the dialog after %s failure",
     async (failure) => {
       const actions = useEnduragentStore.getState().planLibraryActions;
       if (actions === null) throw new Error("Missing library actions");
-      if (failure === "save") vi.mocked(actions.closePlan).mockRejectedValue(new Error("Offline"));
-      else
-        vi.mocked(actions.closePlan).mockResolvedValue({
-          status: "rejected",
-          reason: failure === "no-active-plan" ? "no-active-plan" : "command-conflict",
-        });
+      vi.mocked(actions.closePlan).mockResolvedValue({
+        status: "rejected",
+        reason: failure === "no-active-plan" ? "no-active-plan" : "command-conflict",
+      });
       const readFinalDetails = renderLibrary();
       const stop = screen.getByRole("button", { name: "Stop Plan" });
       fireEvent.click(stop);

--- a/apps/desktop/tests/e2e/application-ui-states/fixture.ts
+++ b/apps/desktop/tests/e2e/application-ui-states/fixture.ts
@@ -176,11 +176,11 @@ class ApplicationStateBackend {
       if (request.method === "deleteArchivedConversation") {
         return response({ schemaVersion: 1, status: "not-found" });
       }
-      if (
-        request.method === "resumePlanningRequests" ||
-        request.method === "listPlanningRequests"
-      ) {
+      if (request.method === "resumePlanningRequests") {
         return response({ deliveries: [] });
+      }
+      if (request.method === "listPlanningRequests") {
+        return response({ deliveries: [], planCreation: null });
       }
       if (request.method === "getSpendSummary") {
         return response({

--- a/apps/desktop/tests/e2e/plan-close-history.spec.ts
+++ b/apps/desktop/tests/e2e/plan-close-history.spec.ts
@@ -272,7 +272,7 @@ for (const appearance of [
     }
   });
 
-  test(`rejects stale and failed stops, then completes after the final day at ${appearance.width} in ${appearance.colorScheme}`, async ({
+  test(`rejects stale stops and retries failed stops at ${appearance.width} in ${appearance.colorScheme}`, async ({
     playwright,
   }) => {
     test.setTimeout(120_000);
@@ -305,13 +305,55 @@ for (const appearance of [
       scenario.backend.failNextClose();
       await stop.click();
       await dialog.getByRole("button", { name: "Stop Plan", exact: true }).click();
-      await expect(dialog).not.toBeVisible();
-      await expect(scenario.page.getByRole("alert")).toHaveText(
-        "Stopping could not be saved locally. Your Plan is unchanged.",
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByRole("alert")).toHaveText(
+        "Stopping could not be confirmed. The library will show the current state after refresh.",
       );
+      await expect(dialog.getByRole("button", { name: "Stop Plan", exact: true })).toBeEnabled();
       expect(await scenario.backend.inspectActivation()).toEqual(stale);
       await capture(scenario, "failed-stop");
-      await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+      expect(scenario.backend.closeRequests).toHaveLength(2);
+      const failedRequest = scenario.backend.closeRequests[1];
+      expect(failedRequest?.params).toEqual({
+        commandId: expect.any(String),
+        planId: stale.planningPlans[0]?.plan_id,
+        expectedVersion: 2,
+      });
+      await dialog.getByRole("button", { name: "Stop Plan", exact: true }).click();
+      await expect(dialog).not.toBeVisible();
+      await assertFinalDetails(scenario, "Stopped");
+      expect(scenario.backend.closeRequests).toHaveLength(3);
+      expect(scenario.backend.closeRequests[2]?.params).toEqual(failedRequest?.params);
+      const stopped = await scenario.backend.inspectActivation();
+      expect(stopped.planningPlans).toEqual([
+        expect.objectContaining({
+          status: "closed",
+          version: 3,
+          close_reason: "stopped",
+          close_actor: "athlete",
+        }),
+      ]);
+      expect(stopped.plans).toEqual([expect.objectContaining({ status: "ended" })]);
+      expect(stopped.revisions).toEqual(stale.revisions);
+      expect(stopped.workouts).toEqual(stale.workouts);
+      await capture(scenario, "retried-stop");
+    } finally {
+      await close(scenario);
+    }
+  });
+
+  test(`completes after the final day at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      await scenario.backend.bumpActivePlanVersion();
+      const stale = await scenario.backend.inspectActivation();
+      const stop = scenario.page
+        .getByRole("region", { name: "Active Plan", exact: true })
+        .getByRole("button", { name: "Stop Plan", exact: true });
+      const navigation = scenario.page.getByRole("navigation", { name: "Main navigation" });
       scenario.backend.setCivilDate("1998-01-28");
       await openLibrary(scenario);
       await expect(stop).toBeVisible();

--- a/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
@@ -314,6 +314,7 @@ for (const appearance of [
         await completeFitness(scenario);
         const reviewed = await build(scenario);
         const before = await scenario.backend.inspectActivation();
+        const { active } = await scenario.backend.library();
         const unrelated = await scenario.backend.inspectUnrelated();
         const trigger = scenario.page.getByRole("button", { name: "Activate Plan", exact: true });
         const dialog = scenario.page.getByRole("dialog", {
@@ -387,6 +388,7 @@ for (const appearance of [
           params: {
             creationId: reviewed.creationId,
             expectedVersion: reviewed.version,
+            incumbent: active === null ? null : { planId: active.planId, version: active.version },
             commandId: expect.any(String),
           },
         });
@@ -417,13 +419,15 @@ test("keeps the dialog and stored Plans intact when activation rolls back, then 
     await completeFitness(scenario);
     const reviewed = await build(scenario);
     const before = await scenario.backend.inspectActivation();
+    const { active } = await scenario.backend.library();
+    expect(active).not.toBeNull();
     await scenario.backend.setActivationFailure(true);
     await scenario.page.getByRole("button", { name: "Activate Plan", exact: true }).click();
     const dialog = scenario.page.getByRole("dialog", { name: "Close and activate?", exact: true });
     await dialog.getByRole("button", { name: "Activate new Plan", exact: true }).click();
     await expect(dialog.getByRole("alert")).toBeVisible();
     await expect(dialog.getByRole("alert")).toHaveText(
-      "Activation could not be saved locally. Your previous Plan is unchanged.",
+      "The activation result could not be confirmed. The Plan library will show the current state after refresh.",
     );
     expect(await scenario.backend.inspectActivation()).toEqual(before);
     expect(await scenario.backend.card()).toEqual(reviewed);
@@ -435,7 +439,13 @@ test("keeps the dialog and stored Plans intact when activation rolls back, then 
       (request) => request.method === "plan_creation.activate",
     );
     expect(requests).toHaveLength(2);
-    expect(requests[0]?.params).not.toEqual(requests[1]?.params);
+    expect(requests[0]?.params).toEqual({
+      commandId: expect.any(String),
+      creationId: reviewed.creationId,
+      expectedVersion: reviewed.version,
+      incumbent: { planId: active?.planId, version: active?.version },
+    });
+    expect(requests[1]?.params).toEqual(requests[0]?.params);
     await showActivePlan(scenario);
   } finally {
     await close(scenario);
@@ -453,7 +463,7 @@ test("prevents activation when the current Plan cannot be read", async ({ playwr
     await scenario.page.getByRole("button", { name: "Activate Plan", exact: true }).click();
     const dialog = scenario.page.getByRole("dialog");
     await expect(scenario.page.getByRole("alert")).toHaveText(
-      "Activation could not be saved locally. Your previous Plan is unchanged.",
+      "The current Plan could not be read. Refresh the Plan library before activating.",
     );
     await expect(dialog).toHaveCount(0);
     await expect(scenario.page.getByRole("alert")).toBeInViewport();

--- a/apps/desktop/tests/e2e/plan-library.spec.ts
+++ b/apps/desktop/tests/e2e/plan-library.spec.ts
@@ -222,11 +222,17 @@ for (const appearance of [
       ).toBeFocused();
       await capture(scenario, "continue-in-chat");
       await openLibrary(scenario);
+      await expect(
+        scenario.page.getByRole("button", { name: "Continue in Chat", exact: true }),
+      ).toBeFocused();
       await scenario.page.getByRole("button", { name: "Change in Chat", exact: true }).click();
       await expect(scenario.page.locator("#message")).toBeFocused();
       expect(await scenario.backend.library()).toEqual(before);
       await capture(scenario, "change-in-chat");
       await openLibrary(scenario);
+      await expect(
+        scenario.page.getByRole("button", { name: "Change in Chat", exact: true }),
+      ).toBeFocused();
       await scenario.page.getByRole("button", { name: "Read Plan details", exact: true }).click();
       await expect(
         scenario.page.getByRole("heading", { name: "Plan active · week 1 of 4", exact: true }),

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -126,6 +126,7 @@ const response = (value: unknown): readonly string[] => [JSON.stringify(value)];
 export class PlanCreationBackend {
   readonly script: DesktopFixtureScript;
   readonly creationRequests: ScriptRequest[] = [];
+  readonly closeRequests: ScriptRequest[] = [];
   readonly changeApplyResponses: {
     readonly params: PlanChangeApplyRpcParams;
     readonly result: PlanChangeApplyResult;
@@ -251,6 +252,7 @@ export class PlanCreationBackend {
           );
         }
         if (request.method === "plan.close") {
+          this.closeRequests.push(request);
           const fail = this.closeFails;
           this.closeFails = false;
           if (fail) {
@@ -521,6 +523,7 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
       throw new TypeError("Training seed Draft is unavailable");
     const activated = await host["plan_creation.activate"]({
       commandId: "seed-training-activate",
+      incumbent: null,
       creationId: card.creationId,
       expectedVersion: previewed.planCreation.version,
     });

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -282,6 +282,7 @@ const rpcDeadlineCases = [
     "plan_creation.activate",
     {
       commandId: "plan-activate",
+      incumbent: null,
       creationId: "00000000000000000000000000",
       expectedVersion: 1,
     },

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -671,7 +671,12 @@ export const PlanCreationPreviewRpcResultSchema = z.discriminatedUnion("status",
 ]);
 export type PlanCreationPreviewRpcResult = z.infer<typeof PlanCreationPreviewRpcResultSchema>;
 
-export const PlanCreationActivateRpcParamsSchema = PlanCreationDiscardRpcParamsSchema;
+export const PlanCreationActivateRpcParamsSchema = PlanCreationDiscardRpcParamsSchema.extend({
+  incumbent: z
+    .object({ planId: PlanCreationUlidSchema, version: z.number().int().positive() })
+    .strict()
+    .nullable(),
+});
 export type PlanCreationActivateRpcParams = z.infer<typeof PlanCreationActivateRpcParamsSchema>;
 
 export const PlanCreationActivateRpcResultSchema = z

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -695,7 +695,7 @@ describe("Plan Creation contract", () => {
   });
 
   it("validates activation identity, command boundaries, and civil dates", () => {
-    const request = { commandId: "activate", creationId, expectedVersion: 2 };
+    const request = { commandId: "activate", creationId, expectedVersion: 2, incumbent: null };
     expect(PlanCreationActivateRpcParamsSchema.parse(request)).toEqual(request);
     for (const extra of [
       { expectedVersion: 0 },
@@ -705,6 +705,23 @@ describe("Plan Creation contract", () => {
       { planId: creationId },
     ]) {
       expect(PlanCreationActivateRpcParamsSchema.safeParse({ ...request, ...extra }).success).toBe(
+        false,
+      );
+    }
+    expect(
+      PlanCreationActivateRpcParamsSchema.parse({
+        ...request,
+        incumbent: { planId: creationId, version: 2 },
+      }).incumbent,
+    ).toEqual({ planId: creationId, version: 2 });
+    for (const incumbent of [
+      undefined,
+      {},
+      { planId: creationId, version: 0 },
+      { planId: creationId, version: 1, extra: true },
+      { planId: "invalid", version: 1 },
+    ]) {
+      expect(PlanCreationActivateRpcParamsSchema.safeParse({ ...request, incumbent }).success).toBe(
         false,
       );
     }
@@ -754,7 +771,7 @@ describe("Plan Creation contract", () => {
       },
       {
         method: "plan_creation.activate",
-        params: { commandId: "activate", creationId, expectedVersion: 1 },
+        params: { commandId: "activate", creationId, expectedVersion: 1, incumbent: null },
       },
     ] as const;
     requests.forEach((request, id) =>

--- a/packages/coach/src/plan-change-operations.ts
+++ b/packages/coach/src/plan-change-operations.ts
@@ -65,6 +65,20 @@ export function createPlanChangeOperations(input: {
         throw parsed.error;
       }
       const { intent, planId, expectedVersion } = parsed.data;
+      const completedRows = await input.store.all(
+        `SELECT workout.structure_json FROM plan_workout workout
+        WHERE workout.plan_id=? AND EXISTS (
+          SELECT 1 FROM plan_workout_match match
+          WHERE match.plan_workout_id=workout.id AND match.plan_id=workout.plan_id
+            AND match.decision='confirmed'
+        )`,
+        [planId],
+      );
+      const completedWorkoutIds = new Set(
+        completedRows.map(
+          (row) => DraftIdSchema.parse(JSON.parse(z.string().parse(row.structure_json))).id,
+        ),
+      );
       const result = await repository.preview({
         command: await stamp(parsed.data),
         planId,
@@ -76,6 +90,7 @@ export function createPlanChangeOperations(input: {
           const { after, diff, totals } = applyScheduleIntent({
             draft,
             intent,
+            completedWorkoutIds,
             todayDateKey: input.todayDateKey(),
           });
           return {
@@ -150,9 +165,8 @@ export function createPlanChangeOperations(input: {
             delete: currentWorkouts
               .filter(
                 (workout) =>
-                  diffIds.has(
-                    DraftIdSchema.parse(JSON.parse(workout.structureJson)).id,
-                  ) && !retained.has(workout.id),
+                  diffIds.has(DraftIdSchema.parse(JSON.parse(workout.structureJson)).id) &&
+                  !retained.has(workout.id),
               )
               .map((workout) => workout.id),
           };

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -174,6 +174,60 @@ export function createPlanCreationOperations(input: {
     const current = await persistDerivedBaseline(snapshot);
     return projectPlanCreationCard(current, { today: today() });
   };
+  const replayRow = async (
+    name: "plan_creation.start" | "plan_creation.answer",
+    commandId: string,
+    digest: string,
+  ) => {
+    const row = await input.store.get(
+      "SELECT request_digest,status,result_json FROM planning_command WHERE command_name=? AND command_id=?",
+      [name, commandId],
+    );
+    if (row === undefined) return undefined;
+    if (row.request_digest !== digest) throw new PlanCreationStoreError("command-conflict");
+    if (row.status !== "succeeded" || typeof row.result_json !== "string")
+      throw new PlanCreationStoreError("corrupt-record");
+    return z
+      .object({
+        creationId: z.string(),
+        outcome: z.enum(["created", "resumed"]).optional(),
+        version: z.number().int().positive().optional(),
+      })
+      .parse(JSON.parse(row.result_json));
+  };
+  const projectRecorded = async (snapshot: PlanCreationSnapshot, version: number) => {
+    const draftRow = await input.store.get(
+      "SELECT output_snapshot_json,input_version FROM plan_creation_draft_revision WHERE creation_id=? AND input_version+1<=? ORDER BY revision_number DESC LIMIT 1",
+      [snapshot.id, version],
+    );
+    const recordedDraft =
+      draftRow === undefined
+        ? null
+        : z
+            .object({
+              output_snapshot_json: z.string(),
+              input_version: z.number().int().positive(),
+            })
+            .parse(draftRow);
+    const card = projectPlanCreationCard(
+      {
+        ...snapshot,
+        status: "in-progress",
+        version,
+        currentDraft: null,
+        answers: snapshot.answers.filter((answer) => answer.creationVersion <= version),
+      },
+      { today: today() },
+    );
+    return recordedDraft === null
+      ? card
+      : {
+          ...card,
+          status: "review" as const,
+          draft: PlanCreationDraftSchema.parse(JSON.parse(recordedDraft.output_snapshot_json)),
+          draftStale: recordedDraft.input_version + 1 !== version,
+        };
+  };
   const readCard = async (): Promise<PlanCreationCardModel | null> => {
     const snapshot = await input.repository.readUnfinished();
     return snapshot === undefined ? null : project(snapshot);
@@ -261,17 +315,18 @@ export function createPlanCreationOperations(input: {
         const creation = await input.repository.readUnfinished();
         const records = await plans.listPlans();
         const reconciliation = createPlanReconciliationRepository(transactionStore);
-        const summaries = await Promise.all(
-          records.map(async (plan) => ({
-            ...summarizePlan(plan),
-            calendar: summarizeCalendar(
-              await reconciliation.readLatestJobByWindow(
-                plan.planId,
-                plan.status === "active" ? "mirror" : "cleanup",
-              ),
-            ),
-          })),
+        const jobs = new Map(
+          (await reconciliation.readLatestJobsForLibrary()).map((job) => [
+            `${job.planId}:${job.kind}`,
+            job,
+          ]),
         );
+        const summaries = records.map((plan) => ({
+          ...summarizePlan(plan),
+          calendar: summarizeCalendar(
+            jobs.get(`${plan.planId}:${plan.status === "active" ? "mirror" : "cleanup"}`),
+          ),
+        }));
         const active = summaries.find((plan) => plan.status === "active") ?? null;
         return ListPlansResultSchema.parse({
           calendarConnected: calendarConnected(),
@@ -336,25 +391,31 @@ export function createPlanCreationOperations(input: {
     },
     async "plan_creation.start"(request) {
       const parsed = PlanCreationStartRpcParamsSchema.parse(request);
-      const current = await input.repository.readUnfinished();
-      const candidates =
-        current === undefined
-          ? (await input.eventCandidates.read()).slice(0, 10).map((candidate) => ({
-              candidateId: input.identity.newUlid(),
-              ...candidate,
-            }))
-          : [];
+      const digest = await requestDigest(input.crypto, parsed);
       try {
+        const replay = await replayRow("plan_creation.start", parsed.commandId, digest);
+        const current = replay === undefined ? await input.repository.readUnfinished() : undefined;
+        const candidates =
+          current === undefined && replay === undefined
+            ? (await input.eventCandidates.read()).slice(0, 10).map((candidate) => ({
+                candidateId: input.identity.newUlid(),
+                ...candidate,
+              }))
+            : [];
         const result = await input.repository.start({
-          command: await stamp(parsed.commandId, await requestDigest(input.crypto, parsed)),
+          command: await stamp(parsed.commandId, digest),
           creationId: current?.id ?? input.identity.newUlid(),
           seed: { schemaVersion: 1, eventCandidates: candidates },
         });
-        return PlanCreationStartRpcResultSchema.parse({
+        const response = PlanCreationStartRpcResultSchema.parse({
           status: "started",
-          outcome: result.outcome === "created" ? "created" : "resumed",
-          planCreation: await project(result.snapshot),
+          outcome: replay?.outcome ?? (result.outcome === "created" ? "created" : "resumed"),
+          planCreation:
+            replay === undefined
+              ? await project(result.snapshot)
+              : await projectRecorded(result.snapshot, replay.version ?? result.snapshot.version),
         });
+        return response;
       } catch (error) {
         if (error instanceof PlanCreationStoreError && error.code === "command-conflict") {
           return PlanCreationStartRpcResultSchema.parse({
@@ -367,6 +428,36 @@ export function createPlanCreationOperations(input: {
     },
     async "plan_creation.answer"(request) {
       const parsed = PlanCreationAnswerRpcParamsSchema.parse(request);
+      const digest = await requestDigest(input.crypto, parsed);
+      try {
+        const replay = await replayRow("plan_creation.answer", parsed.commandId, digest);
+        if (replay !== undefined) {
+          const result = await input.repository.recordAnswer({
+            command: await stamp(parsed.commandId, digest),
+            creationId: parsed.creationId,
+            expectedVersion: parsed.expectedVersion,
+            answerId: input.identity.newUlid(),
+            answerKey: parsed.answer.kind,
+            valueJson: encodePlanCreationAnswer(parsed.answer, { kind: "athlete" }),
+          });
+          const response = PlanCreationAnswerRpcResultSchema.parse({
+            status: "answered",
+            planCreation: await projectRecorded(
+              result.snapshot,
+              replay.version ?? result.snapshot.version,
+            ),
+          });
+          return response;
+        }
+      } catch (error) {
+        if (error instanceof PlanCreationStoreError && error.code === "command-conflict")
+          return PlanCreationAnswerRpcResultSchema.parse({
+            status: "rejected",
+            reason: "command-conflict",
+            planCreation: null,
+          });
+        throw error;
+      }
       const snapshot = await input.repository.readUnfinished();
       if (snapshot === undefined || snapshot.id !== parsed.creationId) {
         return PlanCreationAnswerRpcResultSchema.parse({
@@ -375,7 +466,6 @@ export function createPlanCreationOperations(input: {
           planCreation: snapshot === undefined ? null : await project(snapshot),
         });
       }
-      const digest = await requestDigest(input.crypto, parsed);
       const stampValue = await stamp(parsed.commandId, digest);
       const answerId = input.identity.newUlid();
       const record = () =>
@@ -406,10 +496,11 @@ export function createPlanCreationOperations(input: {
       }
       try {
         const result = await record();
-        return PlanCreationAnswerRpcResultSchema.parse({
+        const response = PlanCreationAnswerRpcResultSchema.parse({
           status: "answered",
           planCreation: await project(result.snapshot),
         });
+        return response;
       } catch (error) {
         if (
           error instanceof PlanCreationStoreError &&
@@ -527,6 +618,7 @@ export function createPlanCreationOperations(input: {
       const command = await stamp(parsed.commandId, await requestDigest(input.crypto, parsed));
       const result = await input.repository.activate({
         command,
+        incumbent: parsed.incumbent,
         creationId: parsed.creationId,
         expectedVersion: parsed.expectedVersion,
         activatedAt: today(),

--- a/packages/coach/src/planning-calendar.ts
+++ b/packages/coach/src/planning-calendar.ts
@@ -23,7 +23,8 @@ function dateKey(value: string): number {
 
 function eventType(sport: string): NonNullable<EventInput["type"]> {
   const normalized = sport.toLowerCase();
-  if (normalized.includes("cycl") || normalized.includes("bike")) return "Ride";
+  if (normalized.includes("cycl") || normalized.includes("bike") || normalized.includes("ride"))
+    return "Ride";
   if (normalized.includes("run")) return "Run";
   if (normalized.includes("swim")) return "Swim";
   return "Workout";

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -1030,7 +1030,7 @@ function selectedPlanningRequestContext(input: {
     addCivilDays(input.plan.startDateKey, input.plan.totalWeeks * 7 - 1);
   const occupied = new Set(input.workouts.map((workout) => workout.dateKey));
   let recommendedDateKey: number | null = null;
-  for (let dateKey = addCivilDays(requestedDateKey, 1); dateKey <= maximumDateKey; ) {
+  for (let dateKey = addCivilDays(requestedDateKey, 1); dateKey <= maximumDateKey;) {
     if (!occupied.has(dateKey)) {
       recommendedDateKey = dateKey;
       break;
@@ -1038,7 +1038,7 @@ function selectedPlanningRequestContext(input: {
     dateKey = addCivilDays(dateKey, 1);
   }
   if (recommendedDateKey === null) {
-    for (let dateKey = minimumDateKey; dateKey < requestedDateKey; ) {
+    for (let dateKey = minimumDateKey; dateKey < requestedDateKey;) {
       if (!occupied.has(dateKey)) {
         recommendedDateKey = dateKey;
         break;
@@ -1284,6 +1284,8 @@ export function createPlanningOperations(
     "PL-T09",
     "PL-T10",
     "PL-T11",
+    "PL-T15",
+    "PL-T16",
     "PL-T17",
     "PL-T18",
     "PL-T19",
@@ -1293,6 +1295,8 @@ export function createPlanningOperations(
     "PL-T24",
     "PL-T25",
     "PL-T26",
+    "PL-T28",
+    "PL-T29",
     "PL-T40",
   ]);
   const conversations =
@@ -1517,26 +1521,18 @@ export function createPlanningOperations(
       week.kind === "inside" ? week.weekIndex : week.side === "before" ? 1 : plan.totalWeeks;
     const weekStartDateKey = addCivilDays(plan.startDateKey, (weekIndex - 1) * 7);
     const matchSync = await workoutMatches.readSyncStatus();
-    const refreshed = overrides.readOnly
-      ? {
-          activities: await workoutMatches.listActivities(
-            weekStartDateKey,
-            addCivilDays(weekStartDateKey, 6),
-          ),
-          matches: await workoutMatches.readForPlan(plan.id),
-        }
-      : await refreshPlanWorkoutMatches({
-          planId: plan.id,
-          workouts,
-          startDateKey: weekStartDateKey,
-          endDateKey: addCivilDays(weekStartDateKey, 6),
-          repository: workoutMatches,
-          identity: {
-            newId: () => input.identity.newUlid(),
-            deviceId: () => input.identity.deviceId(),
-            stamp: () => input.identity.hlcStamp(),
-          },
-        });
+    const refreshed = await refreshPlanWorkoutMatches({
+      planId: plan.id,
+      workouts,
+      startDateKey: weekStartDateKey,
+      endDateKey: addCivilDays(weekStartDateKey, 6),
+      repository: workoutMatches,
+      identity: {
+        newId: () => input.identity.newUlid(),
+        deviceId: () => input.identity.deviceId(),
+        stamp: () => input.identity.hlcStamp(),
+      },
+    });
     const matchRows = projectWorkoutMatches({
       workouts: workouts.filter(
         (workout) =>
@@ -1908,7 +1904,14 @@ export function createPlanningOperations(
     });
   };
 
-  const read = async (overrides: ReadOverrides = {}): Promise<PlanReadModel> => {
+  const read = async (
+    overrides: ReadOverrides = {},
+    activePlan?: PlanRecord,
+  ): Promise<PlanReadModel> => {
+    if (!overrides.readOnly && (await writerFence.fenced())) {
+      overrides = { ...overrides, readOnly: true };
+    }
+    if (activePlan !== undefined) return readActive(activePlan, 0, overrides);
     const fence = await writerFence.read();
     if (fence.activePlanId !== null) {
       const activePlan = await plans.read(fence.activePlanId);
@@ -2368,17 +2371,15 @@ export function createPlanningOperations(
       hlcPhysicalMs: stamp.physicalMs,
       hlcCounter: stamp.counter,
     };
-    const premiseRecords = build.premises.map(
-      (premise): PlanProposalPremiseRecord => ({
-        ...premise,
-        id: input.identity.newUlid(),
-        proposalId: next.id,
-        createdAtMs: timestamp,
-        deviceId,
-        hlcPhysicalMs: stamp.physicalMs,
-        hlcCounter: stamp.counter,
-      }),
-    );
+    const premiseRecords = build.premises.map((premise): PlanProposalPremiseRecord => ({
+      ...premise,
+      id: input.identity.newUlid(),
+      proposalId: next.id,
+      createdAtMs: timestamp,
+      deviceId,
+      hlcPhysicalMs: stamp.physicalMs,
+      hlcCounter: stamp.counter,
+    }));
     validatePlanProposal({
       proposal: next,
       premises: premiseRecords,
@@ -2464,13 +2465,22 @@ export function createPlanningOperations(
   return {
     async getPlanState(request) {
       GetPlanStateRpcParamsSchema.parse(request);
-      return GetPlanStateRpcResultSchema.parse({ status: "ready", state: await read() });
+      const readOnly = await writerFence.fenced();
+      return GetPlanStateRpcResultSchema.parse({
+        status: "ready",
+        state: await read({ readOnly }),
+      });
     },
     executePlanTransition(request, onEvent) {
       const command = ExecutePlanTransitionRpcParamsSchema.parse(request);
       return enqueue(async () => {
         const fenced = await writerFence.fenced();
-        if (fenced && fencedTransitions.has(command.transitionId)) {
+        if (
+          fenced &&
+          (fencedTransitions.has(command.transitionId) ||
+            ((command.transitionId === "PL-T12" || command.transitionId === "PL-T27") &&
+              command.mode !== "verify"))
+        ) {
           return reject(
             {
               code: "conflict",
@@ -3385,6 +3395,9 @@ export function createPlanningOperations(
           const existingJob = await reconciliations.readLatestJob(plan.id, "mirror");
           const existingItems =
             existingJob === undefined ? [] : await reconciliations.readItems(existingJob.id);
+          if (fenced && (existingJob === undefined || existingItems.length === 0)) {
+            return reject(UNAVAILABLE);
+          }
           const total = Math.max(existingItems.length, 1);
           const operationId = input.identity.newUlid();
           deliver(onEvent, {
@@ -4973,7 +4986,7 @@ export function createPlanningOperations(
             if (activePlan?.status !== "active") return reject(UNAVAILABLE);
             return ExecutePlanTransitionRpcResultSchema.parse({
               status: "completed",
-              state: await readActive(activePlan, 0, { activeScenario: "PL-S004" }),
+              state: await read({ activeScenario: "PL-S004" }, activePlan),
             });
           }
           const coachBackPair =

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2326,6 +2326,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
           method: "plan_creation.activate",
           params: {
             commandId: "activate",
+            incumbent: null,
             creationId: "01J00000000000000000000000",
             expectedVersion: 2,
           },
@@ -2542,7 +2543,12 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     };
     const previewParams = { commandId: "preview-1", creationId, expectedVersion: 2 };
     const discardParams = { commandId: "discard-1", creationId, expectedVersion: 2 };
-    const activateParams = { commandId: "activate-1", creationId, expectedVersion: 2 };
+    const activateParams = {
+      commandId: "activate-1",
+      incumbent: null,
+      creationId,
+      expectedVersion: 2,
+    };
     const closeParams = {
       commandId: "close-1",
       planId: activationResult.planId,

--- a/packages/coach/tests/plan-calendar-drain.test.ts
+++ b/packages/coach/tests/plan-calendar-drain.test.ts
@@ -90,8 +90,10 @@ async function harness() {
     });
     if (preview.status !== "previewed" || preview.planCreation.draft === null)
       throw new Error("Expected Draft");
+    const { active } = await creation["plan.list"]({});
     const result = await creation["plan_creation.activate"]({
       commandId: `activate-${++sequence}`,
+      incumbent: active === null ? null : { planId: active.planId, version: active.version },
       creationId: card.creationId,
       expectedVersion: preview.planCreation.version,
     });

--- a/packages/coach/tests/plan-change-operations.test.ts
+++ b/packages/coach/tests/plan-change-operations.test.ts
@@ -5,14 +5,17 @@ import {
   type PlanChangeIntent,
 } from "@enduragent/coach-contract";
 import { canonicalJson } from "@enduragent/kernel/archive";
-import { createPlanCreationRepository } from "@enduragent/kernel/planning";
+import {
+  createPlanWorkoutMatchRepository,
+  createPlanCreationRepository,
+} from "@enduragent/kernel/planning";
 import { dumpStore, runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import { createPlanCreationOperations } from "../src/plan-creation-operations.js";
 import { createPlanChangeOperations } from "../src/plan-change-operations.js";
 
-async function activatedPlan() {
+async function activatedPlan(todayDateKey = () => 19980902) {
   const store = openSqliteStorage(":memory:");
   onTestFinished(() => store.close());
   await runMigrations(store, MIGRATIONS);
@@ -26,7 +29,7 @@ async function activatedPlan() {
     store,
     identity,
     crypto: globalThis.crypto,
-    todayDateKey: () => 19980902,
+    todayDateKey,
     now: () => 904_694_400_000,
   };
   const creation = createPlanCreationOperations({
@@ -75,6 +78,7 @@ async function activatedPlan() {
     throw new Error("Expected Draft");
   const activated = await creation["plan_creation.activate"]({
     commandId: "activate",
+    incumbent: null,
     creationId: card.creationId,
     expectedVersion: draftResult.planCreation.version,
   });
@@ -108,7 +112,129 @@ async function activatedPlan() {
   };
 }
 
+async function matchWorkout(
+  test: Awaited<ReturnType<typeof activatedPlan>>,
+  workoutId: string,
+  source: "platform" | "heuristic",
+  decision: "suggested" | "confirmed" | "rejected" | "unpaired",
+) {
+  const workout = await test.store.get(
+    "SELECT id,date_key FROM plan_workout WHERE plan_id=? AND json_extract(structure_json,'$.id')=?",
+    [test.planId, workoutId],
+  );
+  if (typeof workout?.id !== "string" || typeof workout.date_key !== "number")
+    throw new Error("Expected dated Workout");
+  return createPlanWorkoutMatchRepository(test.store).observe({
+    id: "900".padStart(26, "0"),
+    planId: test.planId,
+    planWorkoutId: workout.id,
+    activityId: "a".repeat(64),
+    providerActivityId: source === "platform" ? "synthetic-activity" : null,
+    providerEventId: source === "platform" ? 42 : null,
+    source,
+    decision,
+    activityDateKey: workout.date_key,
+    activitySport: "Ride",
+    activityDurationS: 3600,
+    observedAtMs: 904_694_400_000,
+    decidedAtMs: decision === "suggested" ? null : 904_694_400_000,
+    deviceId: "plan-change-test-device",
+    hlcPhysicalMs: 904_694_400_000,
+    hlcCounter: 0,
+  });
+}
+
 describe("Plan Change operations", () => {
+  it.each(["platform", "heuristic"] as const)(
+    "excludes a Workout completed today through a %s match from preview and preserves it on apply",
+    async (source) => {
+      const test = await activatedPlan(() => 19980903);
+      const completed = test.draft.weeks
+        .flatMap((week) => week.workouts)
+        .find((workout) => workout.date === "1998-09-03");
+      if (completed === undefined) throw new Error("Expected today's Workout");
+      const match = await matchWorkout(test, completed.id, source, "confirmed");
+      const before = await test.workouts();
+      const preview = await test.preview({ kind: "weekday-unavailable", day: 4 });
+      expect(preview.change.diff.some((row) => row.workoutId === completed.id)).toBe(false);
+      expect(preview.change.diff.length).toBeGreaterThan(0);
+      await expect(
+        test.changes["plan_change.apply"]({
+          commandId: "apply-completed-preview",
+          planId: test.planId,
+          changeId: preview.change.changeId,
+          expectedVersion: 1,
+          decision: "apply",
+        }),
+      ).resolves.toMatchObject({ status: "applied" });
+      expect((await test.workouts()).find((row) => row.id === match.planWorkoutId)).toEqual(
+        before.find((row) => row.id === match.planWorkoutId),
+      );
+      expect(await createPlanWorkoutMatchRepository(test.store).readForPlan(test.planId)).toEqual([
+        match,
+      ]);
+    },
+  );
+
+  it.each([
+    { source: "heuristic", decision: "suggested" },
+    { source: "heuristic", decision: "rejected" },
+    { source: "platform", decision: "unpaired" },
+  ] as const)(
+    "keeps a $decision match eligible for preview and apply",
+    async ({ source, decision }) => {
+      const test = await activatedPlan(() => 19980903);
+      const workout = test.draft.weeks
+        .flatMap((week) => week.workouts)
+        .find((row) => row.date === "1998-09-03");
+      if (workout === undefined) throw new Error("Expected today's Workout");
+      await matchWorkout(test, workout.id, source, decision);
+      const preview = await test.preview({ kind: "weekday-unavailable", day: 4 });
+      expect(
+        preview.change.diff.some((row) => row.workoutId === workout.id && row.after === null),
+      ).toBe(true);
+      await expect(
+        test.changes["plan_change.apply"]({
+          commandId: "apply-uncompleted",
+          planId: test.planId,
+          changeId: preview.change.changeId,
+          expectedVersion: 1,
+          decision: "apply",
+        }),
+      ).resolves.toMatchObject({ status: "applied" });
+    },
+  );
+
+  it.each([
+    { kind: "weekday-unavailable", day: 4 },
+    { kind: "longest-workout", minutes: 15 },
+  ] satisfies PlanChangeIntent[])(
+    "rejects $kind when a completion appears after preview without any writes",
+    async (intent) => {
+      const test = await activatedPlan(() => 19980903);
+      const preview = await test.preview(intent);
+      const changed = preview.change.diff.find((row) => row.before?.date === "1998-09-03");
+      if (changed === undefined) throw new Error("Expected today's changed Workout");
+      await matchWorkout(test, changed.workoutId, "heuristic", "confirmed");
+      const before = await dumpStore(test.store);
+      await expect(
+        test.changes["plan_change.apply"]({
+          commandId: "apply-completed",
+          planId: test.planId,
+          changeId: preview.change.changeId,
+          expectedVersion: 1,
+          decision: "apply",
+        }),
+      ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+      expect(await dumpStore(test.store)).toBe(before);
+      expect((await test.creation["plan.list"]({})).changes).toMatchObject([
+        { status: "pending", resultRevisionNumber: null },
+      ]);
+      const fresh = await test.preview(intent, "fresh-preview");
+      expect(fresh.change.diff.some((row) => row.workoutId === changed.workoutId)).toBe(false);
+    },
+  );
+
   it("stores a pending preview in plan.list without changing training and replays its captured result", async () => {
     const test = await activatedPlan();
     const before = await test.workouts();

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -33,6 +33,9 @@ import { readPlanCreationAnswers } from "../src/plan-creation-answers.js";
 const unusedStore = () => {
   const store = openSqliteStorage(":memory:");
   onTestFinished(() => store.close());
+  void store.exec(
+    "CREATE TABLE planning_command (command_name TEXT, command_id TEXT, request_digest TEXT, status TEXT, result_json TEXT, created_at_ms INTEGER,aggregate_refs_json TEXT,error_code TEXT,error_json TEXT,version INTEGER,updated_at_ms INTEGER,device_id TEXT,hlc_physical_ms INTEGER,hlc_counter INTEGER)",
+  );
   return store;
 };
 
@@ -914,9 +917,13 @@ async function previewHarness(legacyPlan?: () => Promise<LegacyPlanSummary | nul
     store,
     repository,
     host,
+    started,
     ready,
     answer,
     card: () => card,
+    setCardVersion: (version: number) => {
+      card = { ...card, version };
+    },
     setConnected: (value: boolean) => {
       connected = value;
     },
@@ -928,6 +935,198 @@ async function previewHarness(legacyPlan?: () => Promise<LegacyPlanSummary | nul
     },
   };
 }
+
+describe("Plan Creation command replay", () => {
+  it("projects start and answer results from their recorded versions", async () => {
+    const test = await previewHarness();
+    await test.host["plan_creation.discard"]({
+      commandId: "discard-initial",
+      creationId: test.card().creationId,
+      expectedVersion: 1,
+    });
+    const startRequest = { commandId: "recorded-start" };
+    const command = (request: { commandId: string }) => ({
+      commandId: request.commandId,
+      requestDigest: createHash("sha256").update(canonicalJson(request)).digest("hex"),
+      nowMs: 883_612_800_000,
+      deviceId: "preview-test-device",
+      hlcPhysicalMs: 883_612_800_000,
+      hlcCounter: 0,
+    });
+    const started = await test.repository.start({
+      command: command(startRequest),
+      creationId: id("800"),
+      seed: { schemaVersion: 1, eventCandidates: [] },
+    });
+    const originalStart = {
+      status: "started",
+      outcome: "created",
+      planCreation: projectPlanCreationCard(started.snapshot, { today }),
+    };
+    const answerRequest = {
+      commandId: "recorded-answer",
+      creationId: started.snapshot.id,
+      expectedVersion: 1,
+      answer: fitnessGoal,
+    };
+    const result = await test.repository.recordAnswer({
+      command: command(answerRequest),
+      creationId: started.snapshot.id,
+      expectedVersion: 1,
+      answerId: id("801"),
+      answerKey: "goal",
+      valueJson: canonicalJson({ answer: fitnessGoal, source: { kind: "athlete" } }),
+    });
+    const originalAnswer = {
+      status: "answered",
+      planCreation: projectPlanCreationCard(result.snapshot, { today }),
+    };
+    await test.host["plan_creation.discard"]({
+      commandId: "discard-recorded",
+      creationId: started.snapshot.id,
+      expectedVersion: 2,
+    });
+    const next = await test.host["plan_creation.start"]({ commandId: "next" });
+    await expect(test.host["plan_creation.start"](startRequest)).resolves.toEqual(originalStart);
+    await expect(test.host["plan_creation.answer"](answerRequest)).resolves.toEqual(originalAnswer);
+    expect(next).toMatchObject({ status: "started" });
+    expect(await test.host.readCard()).not.toMatchObject({ creationId: started.snapshot.id });
+  });
+
+  it("replays the draft and status that existed at the command version", async () => {
+    const test = await previewHarness();
+    const ready = await test.ready();
+    const beforePreviewRequest = { commandId: "resume-before-preview" };
+    const beforePreview = await test.host["plan_creation.start"](beforePreviewRequest);
+    const preview = await test.host["plan_creation.preview"]({
+      commandId: "preview",
+      creationId: ready.creationId,
+      expectedVersion: ready.version,
+    });
+    if (preview.status !== "previewed") throw new Error("Expected preview");
+    await expect(test.host["plan_creation.start"](beforePreviewRequest)).resolves.toEqual(
+      beforePreview,
+    );
+    const reviewStartRequest = { commandId: "resume-review" };
+    const reviewStart = await test.host["plan_creation.start"](reviewStartRequest);
+    const answerRequest = {
+      commandId: "edit-length",
+      creationId: ready.creationId,
+      expectedVersion: preview.planCreation.version,
+      answer: { kind: "plan-length", weeks: 8 } as const,
+    };
+    const originalAnswer = await test.host["plan_creation.answer"](answerRequest);
+    if (originalAnswer.status !== "answered") throw new Error("Expected answer");
+    expect(originalAnswer.planCreation).toMatchObject({ status: "review", draftStale: true });
+    const rebuilt = await test.host["plan_creation.preview"]({
+      commandId: "rebuild",
+      creationId: ready.creationId,
+      expectedVersion: originalAnswer.planCreation.version,
+    });
+    if (rebuilt.status !== "previewed") throw new Error("Expected rebuilt preview");
+    await expect(test.host["plan_creation.answer"](answerRequest)).resolves.toEqual(originalAnswer);
+    await test.host["plan_creation.discard"]({
+      commandId: "discard-review",
+      creationId: ready.creationId,
+      expectedVersion: rebuilt.planCreation.version,
+    });
+    await test.host["plan_creation.start"]({ commandId: "start-next" });
+    await expect(test.host["plan_creation.start"](beforePreviewRequest)).resolves.toEqual(
+      beforePreview,
+    );
+    await expect(test.host["plan_creation.start"](reviewStartRequest)).resolves.toEqual(
+      reviewStart,
+    );
+    await expect(test.host["plan_creation.answer"](answerRequest)).resolves.toEqual(originalAnswer);
+  });
+
+  it.each(["discarded", "activated"] as const)(
+    "returns the original start and answer after %s and another start",
+    async (terminal) => {
+      const test = await previewHarness();
+      await test.answer(fitnessGoal);
+      const resumed = await test.host["plan_creation.start"]({ commandId: "resume" });
+      const request = {
+        commandId: "original-answer",
+        creationId: test.card().creationId,
+        expectedVersion: test.card().version,
+        answer: { kind: "plan-length", weeks: 4 } as const,
+      };
+      const originalAnswer = await test.host["plan_creation.answer"](request);
+      expect(originalAnswer.status).toBe("answered");
+      const current = await test.repository.readUnfinished();
+      if (current === undefined) throw new Error("Expected creation");
+      test.setCardVersion(current.version);
+      const ready = await test.ready();
+      await expect(test.host["plan_creation.answer"](request)).resolves.toEqual(originalAnswer);
+      if (terminal === "discarded") {
+        await test.host["plan_creation.discard"]({
+          commandId: "discard",
+          creationId: ready.creationId,
+          expectedVersion: ready.version,
+        });
+      } else {
+        const preview = await test.host["plan_creation.preview"]({
+          commandId: "preview",
+          creationId: ready.creationId,
+          expectedVersion: ready.version,
+        });
+        if (preview.status !== "previewed") throw new Error("Expected preview");
+        await test.host["plan_creation.activate"]({
+          commandId: "activate",
+          creationId: ready.creationId,
+          expectedVersion: preview.planCreation.version,
+          incumbent: null,
+        });
+      }
+      test.advanceDay();
+      await expect(test.host["plan_creation.answer"](request)).resolves.toEqual(originalAnswer);
+      const next = await test.host["plan_creation.start"]({ commandId: "next" });
+      if (next.status !== "started") throw new Error("Expected next creation");
+      const before = await test.store.all("SELECT * FROM plan_creation");
+      const readUnfinished = vi.spyOn(test.repository, "readUnfinished");
+      const unavailable = () => {
+        throw new Error("Replay must use the recorded result");
+      };
+      const restarted = createPlanCreationOperations({
+        store: test.store,
+        repository: test.repository,
+        identity: {
+          newUlid: () => id("999"),
+          deviceId: async () => "preview-test-device",
+          hlcStamp: () => ({ physicalMs: 883_612_800_000, counter: 0 }),
+        },
+        crypto: globalThis.crypto,
+        eventCandidates: { read: unavailable },
+        baselineEvidence: { read: unavailable },
+        today: () => today,
+      });
+      await expect(restarted["plan_creation.start"]({ commandId: "start" })).resolves.toEqual(
+        test.started,
+      );
+      await expect(restarted["plan_creation.answer"](request)).resolves.toEqual(originalAnswer);
+      await expect(test.host["plan_creation.start"]({ commandId: "start" })).resolves.toEqual(
+        test.started,
+      );
+      await expect(test.host["plan_creation.start"]({ commandId: "resume" })).resolves.toEqual(
+        resumed,
+      );
+      await expect(test.host["plan_creation.answer"](request)).resolves.toEqual(originalAnswer);
+      await expect(
+        test.host["plan_creation.answer"]({ ...request, creationId: next.planCreation.creationId }),
+      ).resolves.toMatchObject({
+        status: "rejected",
+        reason: "command-conflict",
+        planCreation: null,
+      });
+      expect(readUnfinished).not.toHaveBeenCalled();
+      expect(await test.repository.readUnfinished()).toMatchObject({
+        id: next.planCreation.creationId,
+      });
+      expect(await test.store.all("SELECT * FROM plan_creation")).toEqual(before);
+    },
+  );
+});
 
 describe("Plan Creation preview", () => {
   it("stores a complete Draft, replays its result, and rebuilds stale review answers", async () => {
@@ -1103,6 +1302,7 @@ describe("Plan Creation activation", () => {
       draft: result.planCreation.draft,
       request: {
         commandId: "activate",
+        incumbent: null,
         creationId: card.creationId,
         expectedVersion: result.planCreation.version,
       },
@@ -1163,6 +1363,59 @@ describe("Plan Creation activation", () => {
     });
     test.setConnected(false);
     expect((await test.host["plan.list"]({})).calendarConnected).toBe(false);
+  });
+
+  it("keeps library database reads constant as closed Plans are added", async () => {
+    const test = await review();
+    const activated = await test.host["plan_creation.activate"](test.request);
+    const all = vi.spyOn(test.store, "all");
+    const get = vi.spyOn(test.store, "get");
+    const initial = await test.host["plan.list"]({});
+    expect(initial.active?.planId).toBe(activated.planId);
+    expect(initial.closed).toEqual([]);
+    const initialQueries = all.mock.calls.length + get.mock.calls.length;
+    expect(initialQueries).toBeGreaterThan(0);
+    const reconciliation = createPlanReconciliationRepository(test.store);
+    for (const number of [800, 801, 802]) {
+      const planId = id(String(number));
+      await test.store.run(
+        `INSERT INTO plan (
+          id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,total_weeks,
+          week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+        ) SELECT ?,origin_id,name,primary_goal,start_date_key,target_date_key,'ended',kind,total_weeks,
+          week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+          FROM plan WHERE id=?`,
+        [planId, activated.planId],
+      );
+      await test.store.run(
+        `INSERT INTO planning_plan (
+          plan_id,status,version,current_revision_number,activated_at_ms,closed_at_ms,
+          close_reason,close_actor,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+        ) SELECT ?,'closed',2,current_revision_number,activated_at_ms,updated_at_ms,
+          'stopped',device_id,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+          FROM planning_plan WHERE plan_id=?`,
+        [planId, activated.planId],
+      );
+      await reconciliation.createOrGetJob({
+        id: id(String(number + 100)),
+        planId,
+        kind: "cleanup",
+        windowStartDateKey: 19980902,
+        windowEndDateKey: 19980929,
+        createdAtMs: 904_737_600_000,
+      });
+    }
+    all.mockClear();
+    get.mockClear();
+    const expanded = await test.host["plan.list"]({});
+    expect(expanded.active).toEqual(initial.active);
+    expect(expanded.closed).toHaveLength(3);
+    expect(expanded.closed.map((plan) => plan.calendar.window)).toEqual([
+      { start: "1998-09-02", end: "1998-09-29" },
+      { start: "1998-09-02", end: "1998-09-29" },
+      { start: "1998-09-02", end: "1998-09-29" },
+    ]);
+    expect(all.mock.calls.length + get.mock.calls.length).toBe(initialQueries);
   });
 
   it("projects pending, running, failed and verified mirror work across connection changes", async () => {
@@ -1431,7 +1684,10 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     const before = test.host["plan.list"]({});
     await entered;
     expect(transaction).toHaveBeenCalledTimes(1);
-    const activation = test.host["plan_creation.activate"](test.request);
+    const activation = test.host["plan_creation.activate"]({
+      ...test.request,
+      incumbent: { planId: incumbentId, version: 1 },
+    });
     await vi.waitFor(() => expect(transaction).toHaveBeenCalledTimes(2));
     releaseRead();
     await expect(before).resolves.toMatchObject({
@@ -1649,6 +1905,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     expect(draft.weeks).toHaveLength(12);
     const activated = await test.host["plan_creation.activate"]({
       commandId: "activate",
+      incumbent: null,
       creationId: card.creationId,
       expectedVersion: reviewed.planCreation.version,
     });
@@ -1703,6 +1960,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     const card = await test.ready();
     const request = {
       commandId: "activate",
+      incumbent: null,
       creationId: card.creationId,
       expectedVersion: card.version,
     };
@@ -1723,7 +1981,8 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     const test = await review();
     const edited = await answered(
       test.host["plan_creation.answer"]({
-        ...test.request,
+        creationId: test.request.creationId,
+        expectedVersion: test.request.expectedVersion,
         commandId: "edit",
         answer: { kind: "plan-length", weeks: 8 },
       }),

--- a/packages/coach/tests/planning-calendar.test.ts
+++ b/packages/coach/tests/planning-calendar.test.ts
@@ -1,5 +1,16 @@
-import type { IntervalsClient } from "intervals-icu-api";
-import { describe, expect, it, vi } from "vitest";
+import { IntervalsClient, type Event } from "intervals-icu-api";
+import { describe, expect, it, vi, onTestFinished } from "vitest";
+import type { PlanCreationAnswerInput } from "@enduragent/coach-contract";
+import { reconcileActivePlanWindow } from "@enduragent/engine";
+import {
+  createPlanCreationRepository,
+  createPlanRepository,
+  createPlanReconciliationRepository,
+} from "@enduragent/kernel/planning";
+import { runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanCreationOperations } from "../src/plan-creation-operations.js";
 import { createPlanMirrorCalendarAdapter } from "../src/planning-calendar.js";
 
 describe("Plan Intervals calendar adapter", () => {
@@ -65,6 +76,130 @@ describe("Plan Intervals calendar adapter", () => {
       { upsertOnUid: true },
     );
     expect(remove).toHaveBeenCalledWith(42);
+  });
+
+  it.each([
+    ["Ride", "Ride"],
+    ["cycling", "Ride"],
+    ["bike", "Ride"],
+    ["running", "Run"],
+    ["swimming", "Swim"],
+  ])("maps %s Workouts to %s events", async (sport, type) => {
+    const client = new IntervalsClient({ apiKey: "test-key", athleteId: "0" });
+    const create = vi.spyOn(client.events, "create").mockResolvedValue({
+      ok: true,
+      value: { id: 43, startDateLocal: "1998-09-02T00:00:00", category: "WORKOUT" },
+    });
+    await createPlanMirrorCalendarAdapter(() => client).createEvent({
+      planId: "00000000000000000000000001",
+      planWorkoutId: "00000000000000000000000002",
+      dateKey: 19980902,
+      externalId: "cycling-coach:plan:plan:workout",
+      name: "Endurance",
+      sport,
+      durationS: 3600,
+      structureJson: "{}",
+    });
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ type }), { upsertOnUid: true });
+  });
+
+  it("mirrors a Chat-activated Plan through the calendar adapter as Ride events", async () => {
+    const store = openSqliteStorage(":memory:");
+    onTestFinished(() => store.close());
+    await runMigrations(store, MIGRATIONS);
+    let sequence = 0;
+    const newId = () => String(++sequence).padStart(26, "0");
+    const now = () => 904_737_600_000;
+    const host = createPlanCreationOperations({
+      store,
+      repository: createPlanCreationRepository(store),
+      identity: {
+        deviceId: async () => "calendar-test-device",
+        newUlid: newId,
+        hlcStamp: () => ({ physicalMs: now(), counter: 0 }),
+      },
+      crypto: globalThis.crypto,
+      eventCandidates: { read: async () => [] },
+      today: () => "1998-09-02",
+      todayDateKey: () => 19980902,
+      now,
+    });
+    const started = await host["plan_creation.start"]({ commandId: "start" });
+    if (started.status !== "started") throw new Error("Expected creation");
+    let card = started.planCreation;
+    const answers: readonly PlanCreationAnswerInput[] = [
+      { kind: "goal", goal: { kind: "fitness" } },
+      { kind: "plan-length", weeks: 4 },
+      { kind: "schedule-mode", mode: "fixed" },
+      {
+        kind: "availability",
+        mode: "fixed",
+        weeklyHoursLimit: 8,
+        longestWorkoutHours: 3,
+        usableWeekdays: [2, 4, 6],
+      },
+      { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
+      { kind: "commitments", commitments: { kind: "none" } },
+      { kind: "baseline", baseline: "regular" },
+      { kind: "success", success: { kind: "fitness-choice", choice: "climb-stronger" } },
+      { kind: "restriction", restriction: { kind: "none" } },
+    ];
+    for (const answer of answers) {
+      const result = await host["plan_creation.answer"]({
+        commandId: `answer-${newId()}`,
+        creationId: card.creationId,
+        expectedVersion: card.version,
+        answer,
+      });
+      if (result.status !== "answered") throw new Error("Expected answer");
+      card = result.planCreation;
+    }
+    const preview = await host["plan_creation.preview"]({
+      commandId: "preview",
+      creationId: card.creationId,
+      expectedVersion: card.version,
+    });
+    if (preview.status !== "previewed") throw new Error("Expected preview");
+    const activated = await host["plan_creation.activate"]({
+      commandId: "activate",
+      creationId: card.creationId,
+      expectedVersion: preview.planCreation.version,
+      incumbent: null,
+    });
+    const plans = createPlanRepository(store);
+    const plan = await plans.read(activated.planId);
+    if (plan === undefined) throw new Error("Expected active Plan");
+    const client = new IntervalsClient({ apiKey: "test-key", athleteId: "0" });
+    const events: Event[] = [];
+    vi.spyOn(client.events, "list").mockImplementation(async () => ({ ok: true, value: events }));
+    const create = vi.spyOn(client.events, "create").mockImplementation(async (body) => {
+      if (!("startDateLocal" in body) || typeof body.startDateLocal !== "string")
+        throw new Error("Expected dated event");
+      const event = {
+        ...body,
+        id: events.length + 1,
+        startDateLocal: body.startDateLocal,
+        category: "WORKOUT",
+      };
+      events.push(event);
+      return { ok: true, value: event };
+    });
+    const result = await reconcileActivePlanWindow(
+      {
+        plan,
+        workouts: await plans.readWorkouts(plan.id),
+        todayDateKey: 19980902,
+      },
+      {
+        repository: createPlanReconciliationRepository(store),
+        calendar: createPlanMirrorCalendarAdapter(() => client),
+        identity: { newId },
+        now,
+      },
+    );
+    expect(result.state).toBe("reconcile-verified");
+    expect(create.mock.calls.length).toBeGreaterThan(0);
+    for (const [body] of create.mock.calls) expect(body).toMatchObject({ type: "Ride" });
   });
 
   it("fails closed when Intervals credentials are absent", async () => {

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -304,6 +304,7 @@ describe("Plan operations", () => {
       commandId: "activate",
       creationId: card.creationId,
       expectedVersion: reviewed.planCreation.version,
+      incumbent: null,
     });
     const operations = createPlanningOperations(
       { context, engine: engine(), identity: authored },

--- a/packages/coach/tests/writer-fence.test.ts
+++ b/packages/coach/tests/writer-fence.test.ts
@@ -5,11 +5,13 @@ import type {
   PlanCreationAnswerInput,
 } from "@enduragent/coach-contract";
 import { canonicalJson } from "@enduragent/kernel/archive";
+import { planMirrorExternalId, type PlanMirrorCalendarPort } from "@enduragent/engine";
 import {
   createLegacyWriterFence,
   createPlanConversationRepository,
   createPlanCreationRepository,
   createPlanRepository,
+  createPlanProposalRepository,
   createPlanWorkoutMatchRepository,
 } from "@enduragent/kernel/planning";
 import { dumpStore, runMigrations } from "@enduragent/kernel/store";
@@ -30,10 +32,11 @@ async function fixture(
   onTestFinished(() => store.close());
   await runMigrations(store, MIGRATIONS);
   let sequence = 100;
+  let clockCounter = 0;
   const identity = {
     deviceId: async () => "writer-fence-test-device",
     newUlid: () => String(++sequence).padStart(26, "0"),
-    hlcStamp: () => ({ physicalMs: 904_694_400_000, counter: sequence }),
+    hlcStamp: () => ({ physicalMs: 904_694_400_000, counter: ++clockCounter }),
   };
   const dependencies = {
     store,
@@ -101,6 +104,7 @@ async function fixture(
       commandId: "activate",
       creationId: card.creationId,
       expectedVersion: draftResult.planCreation.version,
+      incumbent: null,
     });
     expect(activated.planId).toBeTruthy();
     const listed = await creation["plan.list"]({});
@@ -140,12 +144,12 @@ async function fixture(
     { context, engine, identity },
     { todayDateKey: () => 19980902 },
   );
-  const openConversation = async () => {
+  const openConversation = async (replacesPlanId: string | null = null) => {
     const conversations = createPlanConversationRepository(store);
     await conversations.saveConversation({
       id: CONVERSATION_ID,
       planId: null,
-      replacesPlanId: null,
+      replacesPlanId,
       courseChoiceStatus: "omitted",
       raceCourseJson: null,
       status: "open",
@@ -172,6 +176,10 @@ async function fixture(
   return { store, operations, openConversation, creation, context, engine, identity, ...ids };
 }
 
+function withoutWorkoutMatches(dump: string): string {
+  return dump.replace(/(# plan_workout_match\n)[\s\S]*?(?=# |$)/, "$1");
+}
+
 function commands(planId: string): ExecutePlanTransitionRpcParams[] {
   return [
     { transitionId: "PL-T01", commandId: "start-legacy", sourceConversationId: null },
@@ -182,6 +190,13 @@ function commands(planId: string): ExecutePlanTransitionRpcParams[] {
       expectedRevision: 1,
     },
     {
+      transitionId: "PL-T15",
+      commandId: "adopt-provider-edit",
+      planId,
+      workoutId: CONVERSATION_ID,
+      eventId: "42",
+    },
+    {
       transitionId: "PL-T17",
       commandId: "proposal-legacy",
       planId,
@@ -190,6 +205,23 @@ function commands(planId: string): ExecutePlanTransitionRpcParams[] {
     },
     { transitionId: "PL-T21", commandId: "undo-legacy", planId, ledgerId: CONVERSATION_ID },
     { transitionId: "PL-T24", commandId: "stop-legacy", planId, mode: "cleanup" },
+    { transitionId: "PL-T29", commandId: "complete-legacy", planId, asOf: "1998-09-02" },
+    { transitionId: "PL-T12", commandId: "retry-mirror", planId, mode: "reconcile" },
+    {
+      transitionId: "PL-T16",
+      commandId: "restore-workout",
+      planId,
+      workoutId: CONVERSATION_ID,
+      eventId: "42",
+    },
+    {
+      transitionId: "PL-T27",
+      commandId: "retry-cleanup",
+      planId,
+      replacementPlanId: CONVERSATION_ID,
+      mode: "cleanup",
+    },
+    { transitionId: "PL-T28", commandId: "mirror-replacement", planId },
     {
       transitionId: "PL-T26",
       commandId: "replace-legacy",
@@ -202,6 +234,87 @@ function commands(planId: string): ExecutePlanTransitionRpcParams[] {
 }
 
 describe("legacy writer fence", () => {
+  it.each(["closed", "discarded"] as const)(
+    "reads an open legacy conversation after %s Chat ownership without creating intake",
+    async (status) => {
+      const test = await fixture(status);
+      await test.openConversation();
+      await expect(createLegacyWriterFence(test.store).read()).resolves.toMatchObject({
+        activePlanId: null,
+        creationId: null,
+        chatAuthoritySinceMs: 904_694_400_000,
+      });
+      const counts = async () =>
+        test.store.get(`SELECT
+          (SELECT COUNT(*) FROM plan_intake) AS intakes,
+          (SELECT COUNT(*) FROM plan_conversation) AS conversations`);
+      const beforeCounts = await counts();
+      expect(beforeCounts).toEqual({ intakes: 0, conversations: 1 });
+      const before = await dumpStore(test.store);
+
+      await expect(test.operations.getPlanState?.({})).resolves.toMatchObject({
+        status: "ready",
+        state: { projection: "coach", data: { intake: { goal: "Improve my climbing" } } },
+      });
+
+      expect(await counts()).toEqual(beforeCounts);
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+
+  it("projects pending intake turns without updating stored intake after Chat authority begins", async () => {
+    const test = await fixture("empty");
+    await test.openConversation();
+    await test.operations.getPlanState?.({});
+    const intake = await test.store.get("SELECT * FROM plan_intake");
+    expect(intake).toMatchObject({ source_turn_sequence: 1 });
+    await createPlanConversationRepository(test.store).appendTurn({
+      id: "00000000000000000000000003",
+      conversationId: CONVERSATION_ID,
+      sequence: 2,
+      athleteText: "Improve my endurance too.",
+      coachText: "We can build endurance.",
+      lineageJson: canonicalJson({ planIntakePatch: { goal: "Improve my endurance" } }),
+      completedAtMs: 102,
+      deviceId: "fence-test-device",
+      hlcPhysicalMs: 102,
+      hlcCounter: 0,
+    });
+    const started = await test.creation["plan_creation.start"]({ commandId: "chat-start" });
+    if (started.status !== "started") throw new Error("Expected creation");
+    await test.creation["plan_creation.discard"]({
+      commandId: "chat-discard",
+      creationId: started.planCreation.creationId,
+      expectedVersion: started.planCreation.version,
+    });
+    const before = await dumpStore(test.store);
+
+    await expect(test.operations.getPlanState?.({})).resolves.toMatchObject({
+      status: "ready",
+      state: { projection: "coach", data: { intake: { goal: "Improve my endurance" } } },
+    });
+
+    expect(await test.store.get("SELECT * FROM plan_intake")).toEqual(intake);
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it("keeps an unfenced navigation rejection read-only after Chat authority begins", async () => {
+    const test = await fixture("discarded");
+    await test.openConversation();
+    const before = await dumpStore(test.store);
+
+    await expect(
+      test.operations.executePlanTransition?.({
+        transitionId: "PL-T13",
+        commandId: "open-missing-workout",
+        planId: CONVERSATION_ID,
+        workoutId: CONVERSATION_ID,
+      }),
+    ).resolves.toMatchObject({ status: "rejected" });
+
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
   it.each(["in-progress", "review", "discarded"] as const)(
     "rejects with %s creation without engine reads or store writes",
     async (status) => {
@@ -229,7 +342,7 @@ describe("legacy writer fence", () => {
     },
   );
 
-  it("retains natural completion over an open legacy conversation while target ownership remains active", async () => {
+  it("rejects natural completion while Chat owns the active Plan", async () => {
     const test = await fixture("active");
     await test.openConversation();
     if (test.planId === null) throw new Error("Expected active Plan");
@@ -267,6 +380,7 @@ describe("legacy writer fence", () => {
     await expect(plans.read(planId)).resolves.toMatchObject({ status: "active" });
 
     todayDateKey = 19981005;
+    const before = await dumpStore(test.store);
     await expect(
       operations.executePlanTransition?.({
         transitionId: "PL-T29",
@@ -275,17 +389,16 @@ describe("legacy writer fence", () => {
         asOf: "1998-10-05",
       }),
     ).resolves.toMatchObject({
-      status: "completed",
-      state: { lifecycle: "ended", projection: "ended", scenarioId: "PL-S094" },
+      status: "rejected",
+      error: { code: "conflict", message: MESSAGE },
     });
-    await expect(plans.read(planId)).resolves.toMatchObject({ status: "ended" });
+    await expect(plans.read(planId)).resolves.toMatchObject({ status: "active" });
     await expect(createLegacyWriterFence(test.store).read()).resolves.toMatchObject({
       activePlanId: planId,
     });
-    const before = await dumpStore(test.store);
     await expect(operations.getPlanState?.({})).resolves.toMatchObject({
       status: "ready",
-      state: { lifecycle: "ended", projection: "ended", planId },
+      state: { lifecycle: "active", projection: "active", planId },
     });
     expect(await dumpStore(test.store)).toBe(before);
   });
@@ -307,7 +420,7 @@ describe("legacy writer fence", () => {
   );
 
   it.each(["in-progress", "review", "active", "closed", "discarded"] as const)(
-    "rejects authoring families with %s ownership and preserves the entire store",
+    "rejects authoring families with %s ownership and preserves authoring state",
     async (status) => {
       const test = await fixture(status);
       await test.openConversation();
@@ -335,7 +448,7 @@ describe("legacy writer fence", () => {
           },
         );
       }
-      const before = await dumpStore(test.store);
+      const before = withoutWorkoutMatches(await dumpStore(test.store));
       for (const command of commands(test.planId ?? CONVERSATION_ID)) {
         const result = await operations.executePlanTransition?.(command);
         expect(result).toMatchObject({
@@ -343,7 +456,7 @@ describe("legacy writer fence", () => {
           error: { code: "conflict", message: MESSAGE },
           state: { projection: status === "active" ? "active" : "coach" },
         });
-        expect(await dumpStore(test.store)).toBe(before);
+        expect(withoutWorkoutMatches(await dumpStore(test.store))).toBe(before);
       }
     },
   );
@@ -380,6 +493,64 @@ describe("legacy writer fence", () => {
       });
     },
   );
+
+  it("adopts a provider Workout edit when Chat authority has never begun", async () => {
+    const source = await fixture("active");
+    if (source.planId === null) throw new Error("Expected active Plan");
+    const sourcePlans = createPlanRepository(source.store);
+    const plan = await sourcePlans.read(source.planId);
+    if (plan === undefined) throw new Error("Expected Plan record");
+    const workouts = await sourcePlans.readWorkouts(plan.id);
+    const target = workouts.find((workout) => workout.dateKey > 19980902);
+    if (target === undefined) throw new Error("Expected future Workout");
+    const test = await fixture("empty");
+    const plans = createPlanRepository(test.store);
+    await plans.replace(plan, workouts);
+    const providerEvent = {
+      id: 42,
+      dateKey: target.dateKey,
+      externalId: planMirrorExternalId(plan.id, target.id),
+      category: "WORKOUT",
+      name: target.name,
+      durationS: (target.durationS ?? 0) + 300,
+      description: "Adjusted duration",
+      workoutDoc: null,
+      updated: "1998-09-02T10:00:00Z",
+    };
+    const calendar: PlanMirrorCalendarPort = {
+      listEvents: async () => [providerEvent],
+      readEvent: async () => providerEvent,
+      createEvent: vi.fn(),
+      updateEvent: vi.fn(),
+      deleteEvent: vi.fn(),
+    };
+    const operations = createPlanningOperations(
+      { context: test.context, engine: test.engine, identity: test.identity },
+      { todayDateKey: () => 19980902, workoutDriftCalendar: calendar },
+    );
+    await expect(createLegacyWriterFence(test.store).fenced()).resolves.toBe(false);
+    await operations.getPlanState?.({});
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T15",
+        commandId: "adopt-provider-edit",
+        planId: plan.id,
+        workoutId: target.id,
+        eventId: "42",
+      }),
+    ).resolves.toMatchObject({ status: "completed", state: { scenarioId: "PL-S034" } });
+
+    expect(await plans.readWorkouts(plan.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: target.id, durationS: providerEvent.durationS }),
+      ]),
+    );
+    expect(await test.store.all("SELECT kind FROM plan_adaptation_ledger")).toEqual([
+      { kind: "drift-adopted" },
+    ]);
+    expect(calendar.updateEvent).not.toHaveBeenCalled();
+  });
 
   it("prefers the active Chat Plan over an open legacy conversation without intake writes", async () => {
     const test = await fixture("active");
@@ -438,6 +609,218 @@ describe("legacy writer fence", () => {
     await expect(queued).resolves.toMatchObject({
       status: "rejected",
       error: { code: "conflict", message: MESSAGE },
+    });
+  });
+
+  it("does not create a calendar mirror when fenced verification has no prior items", async () => {
+    const test = await fixture("active");
+    if (test.planId === null) throw new Error("Expected active Plan");
+    const calendar: PlanMirrorCalendarPort = {
+      listEvents: vi.fn(async () => []),
+      createEvent: vi.fn(),
+      updateEvent: vi.fn(),
+      deleteEvent: vi.fn(),
+    };
+    const operations = createPlanningOperations(
+      { context: test.context, engine: test.engine, identity: test.identity },
+      { todayDateKey: () => 19980902, calendar },
+    );
+    const before = await dumpStore(test.store);
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T12",
+        commandId: "verify-missing-mirror",
+        planId: test.planId,
+        mode: "verify",
+      }),
+    ).resolves.toMatchObject({ status: "rejected" });
+
+    expect(calendar.listEvents).not.toHaveBeenCalled();
+    expect(calendar.createEvent).not.toHaveBeenCalled();
+    expect(calendar.updateEvent).not.toHaveBeenCalled();
+    expect(calendar.deleteEvent).not.toHaveBeenCalled();
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it("matches a synced ride completed today under Chat authority without changing authoring state", async () => {
+    const test = await fixture("active");
+    if (test.planId === null) throw new Error("Expected active Plan");
+    const plans = createPlanRepository(test.store);
+    const plan = await plans.read(test.planId);
+    const workouts = await plans.readWorkouts(test.planId);
+    const workout = workouts[0];
+    if (plan === undefined || workout === undefined) throw new Error("Expected Plan and Workout");
+    const todayDateKey = workout.dateKey;
+    const activityEpochS =
+      Date.UTC(
+        Math.floor(todayDateKey / 10_000),
+        (Math.floor(todayDateKey / 100) % 100) - 1,
+        todayDateKey % 100,
+        12,
+      ) / 1_000;
+    const operations = createPlanningOperations(
+      { context: test.context, engine: test.engine, identity: test.identity },
+      { todayDateKey: () => todayDateKey },
+    );
+    const activityId = "a".repeat(64);
+    const workoutKey = "b".repeat(64);
+    const jobId = "00000000000000000000000004";
+    await test.store.run(
+      "INSERT INTO workout(workout_key,start_utc,is_multisport,dedup_cluster_id) VALUES(?,?,?,?)",
+      [workoutKey, activityEpochS, 0, "synthetic-completed-ride"],
+    );
+    await test.store.run(
+      "INSERT INTO session(session_key,workout_key,session_seq,sport,start_utc,local_date_key,elapsed_s,is_transition) VALUES(?,?,?,?,?,?,?,?)",
+      [
+        activityId,
+        workoutKey,
+        0,
+        workout.sport,
+        activityEpochS,
+        todayDateKey,
+        workout.durationS,
+        0,
+      ],
+    );
+    await test.store.run(
+      "INSERT INTO source_record(id,session_key,source,external_id,quality_rank,payload_json) VALUES(?,?,?,?,?,?)",
+      [
+        "c".repeat(64),
+        activityId,
+        "intervals-icu",
+        "synthetic-completed-ride",
+        1,
+        JSON.stringify({ paired_event_id: 42 }),
+      ],
+    );
+    await test.store.run(
+      "INSERT INTO source_artifact(artifact_key,source,lane,external_id,artifact_kind,archive_address,archive_rel_path,archive_epoch_s) VALUES(?,?,?,?,?,?,?,?)",
+      [
+        "d".repeat(64),
+        "intervals-icu",
+        "activities",
+        "synthetic-completed-ride",
+        "snapshot",
+        "e".repeat(64),
+        "synthetic/ride.json",
+        activityEpochS,
+      ],
+    );
+    await test.store.run(
+      "INSERT INTO plan_reconciliation_job(id,plan_id,kind,status,window_start_date_key,window_end_date_key,created_at_ms,updated_at_ms,completed_at_ms) VALUES(?,?,?,?,?,?,?,?,?)",
+      [jobId, plan.id, "mirror", "verified", todayDateKey, todayDateKey, 100, 100, 100],
+    );
+    await test.store.run(
+      "INSERT INTO plan_reconciliation_item(id,job_id,plan_workout_id,operation,status,date_key,external_id,provider_event_id,expected_json,created_at_ms,updated_at_ms,completed_at_ms) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+      [
+        "00000000000000000000000005",
+        jobId,
+        workout.id,
+        "create",
+        "verified",
+        todayDateKey,
+        planMirrorExternalId(plan.id, workout.id),
+        42,
+        "{}",
+        100,
+        100,
+        100,
+      ],
+    );
+    const matches = createPlanWorkoutMatchRepository(test.store);
+    expect(await matches.readForPlan(plan.id)).toEqual([]);
+    const before = withoutWorkoutMatches(await dumpStore(test.store));
+
+    await expect(operations.getPlanState?.({})).resolves.toMatchObject({ status: "ready" });
+
+    expect(await matches.readForWorkout(workout.id)).toMatchObject([
+      { activityId, source: "platform", decision: "confirmed", activityDateKey: todayDateKey },
+    ]);
+    expect(withoutWorkoutMatches(await dumpStore(test.store))).toBe(before);
+  });
+
+  it("returns from a legacy replacement conversation without refreshing drift or refusing proposals after Chat authority", async () => {
+    const source = await fixture("active");
+    if (source.planId === null) throw new Error("Expected active Plan");
+    const sourcePlans = createPlanRepository(source.store);
+    const plan = await sourcePlans.read(source.planId);
+    if (plan === undefined) throw new Error("Expected Plan");
+    const workouts = await sourcePlans.readWorkouts(plan.id);
+    const test = await fixture("discarded");
+    await createPlanRepository(test.store).replace(plan, workouts);
+    await test.openConversation(plan.id);
+    const proposals = createPlanProposalRepository(test.store);
+    await proposals.save(
+      {
+        id: "00000000000000000000000004",
+        planId: plan.id,
+        parentProposalId: null,
+        revision: 1,
+        status: "proposed",
+        title: "Adjust training",
+        rationale: "Review training.",
+        confidence: "High",
+        mutationJson: "{}",
+        baseSnapshotJson: "{}",
+        refusalReason: null,
+        createdAtMs: 100,
+        updatedAtMs: 100,
+        resolvedAtMs: null,
+        deviceId: "fence-test-device",
+        hlcPhysicalMs: 100,
+        hlcCounter: 0,
+      },
+      [
+        {
+          id: "00000000000000000000000005",
+          proposalId: "00000000000000000000000004",
+          sourceType: "chat",
+          sourceId: "synthetic-turn",
+          sourceLabel: "Training request",
+          sourceDateKey: null,
+          confidence: "High",
+          snapshotJson: "{}",
+          createdAtMs: 100,
+          deviceId: "fence-test-device",
+          hlcPhysicalMs: 100,
+          hlcCounter: 0,
+        },
+      ],
+    );
+    const calendar: PlanMirrorCalendarPort = {
+      listEvents: vi.fn(async () => []),
+      createEvent: vi.fn(),
+      updateEvent: vi.fn(),
+      deleteEvent: vi.fn(),
+    };
+    const operations = createPlanningOperations(
+      { context: test.context, engine: test.engine, identity: test.identity },
+      { todayDateKey: () => 19980902, workoutDriftCalendar: calendar },
+    );
+    const before = await dumpStore(test.store);
+    await expect(operations.getPlanState?.({})).resolves.toMatchObject({
+      state: { scenarioId: "PL-S079", projection: "coach" },
+    });
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T39",
+        commandId: "close-replacement",
+        action: "close",
+        sourceScenarioId: "PL-S079",
+        destinationScenarioId: "PL-S004",
+        returnFocusId: "plan",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: { scenarioId: "PL-S004", projection: "active", planId: plan.id },
+    });
+
+    expect(calendar.listEvents).not.toHaveBeenCalled();
+    expect(await dumpStore(test.store)).toBe(before);
+    expect(await proposals.read("00000000000000000000000004")).toMatchObject({
+      status: "proposed",
     });
   });
 

--- a/packages/engine/tests/plan-reconciler.test.ts
+++ b/packages/engine/tests/plan-reconciler.test.ts
@@ -174,6 +174,22 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
     return this.beginAttempt(id, nowMs);
   }
 
+  async readLatestJobsForLibrary(): Promise<readonly PlanReconciliationJobRecord[]> {
+    const latest = new Map<string, PlanReconciliationJobRecord>();
+    for (const job of [...this.jobs.values()].sort(
+      (left, right) =>
+        left.planId.localeCompare(right.planId) ||
+        left.kind.localeCompare(right.kind) ||
+        right.windowStartDateKey - left.windowStartDateKey ||
+        right.windowEndDateKey - left.windowEndDateKey ||
+        right.id.localeCompare(left.id),
+    )) {
+      const key = `${job.planId}:${job.kind}`;
+      if (!latest.has(key)) latest.set(key, job);
+    }
+    return Object.freeze([...latest.values()]);
+  }
+
   async readLatestJobByWindow(
     planId: string,
     kind: PlanReconciliationKind,

--- a/packages/kernel-node/tests/plan-change-repository.test.ts
+++ b/packages/kernel-node/tests/plan-change-repository.test.ts
@@ -97,7 +97,12 @@ describe("Plan Change repository", () => {
   });
   afterEach(async () => store.close());
 
-  const activate = async () => {
+  const activate = async (pinned = false) => {
+    const removed = pinned ? { ...removedWorkout, pinned: true } : removedWorkout;
+    const snapshot = {
+      ...draft,
+      weeks: [{ ...draft.weeks[0], workouts: [keptWorkout, removed, poolWorkout] }],
+    };
     const creation = createPlanCreationRepository(store);
     await creation.start({
       command: stamp("start", 1),
@@ -111,7 +116,7 @@ describe("Plan Change repository", () => {
       draftId: id("2"),
       inputSnapshotJson: "{}",
       inputFingerprint: "e".repeat(64),
-      outputSnapshotJson: JSON.stringify(draft),
+      outputSnapshotJson: JSON.stringify(snapshot),
       builderId: "cycling",
       builderVersion: "1",
       activationFingerprint: fingerprint,
@@ -119,6 +124,7 @@ describe("Plan Change repository", () => {
     const command = stamp("activate", 3);
     await creation.activate({
       command,
+      incumbent: null,
       creationId: id("1"),
       expectedVersion: 2,
       activatedAt: "1998-01-01",
@@ -145,7 +151,7 @@ describe("Plan Change repository", () => {
           hlcPhysicalMs: command.hlcPhysicalMs,
           hlcCounter: command.hlcCounter,
         },
-        workouts: [keptWorkout, removedWorkout].map((workout, index) => ({
+        workouts: [keptWorkout, removed].map((workout, index) => ({
           id: id(String(31 + index)),
           planId,
           dateKey: 19980101 + index,
@@ -200,6 +206,57 @@ describe("Plan Change repository", () => {
         delete: [id("32")],
       };
     },
+  });
+
+  it.each(["delete", "update"] as const)(
+    "rejects a %s after midnight and leaves the preview pending without any writes",
+    async (operation) => {
+      await activate();
+      const changed = { ...removedWorkout, minutes: 30 };
+      const next =
+        operation === "delete"
+          ? after
+          : {
+              ...draft,
+              weeks: [{ ...draft.weeks[0], workouts: [keptWorkout, changed, poolWorkout] }],
+            };
+      await repository.preview({
+        ...previewInput(),
+        build: () => ({
+          afterSnapshotJson: JSON.stringify(next),
+          envelope: { ...envelope, diff: [] },
+        }),
+      });
+      const before = await dumpStore(store);
+      const materialize = vi.fn(applyInput().materialize);
+      await expect(
+        repository.apply({
+          ...applyInput(),
+          todayDateKey: 19980103,
+          materialize,
+        }),
+      ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+      expect(materialize).not.toHaveBeenCalled();
+      expect(await dumpStore(store)).toBe(before);
+      expect(await store.get("SELECT id FROM plan_workout WHERE id=?", [id("32")])).toEqual({
+        id: id("32"),
+      });
+      await expect(repository.listChanges(planId)).resolves.toMatchObject([
+        { status: "pending", resultRevisionNumber: null },
+      ]);
+    },
+  );
+
+  it("rejects changes to a pinned Workout in the saved revision", async () => {
+    await activate(true);
+    await repository.preview(previewInput());
+    const before = await dumpStore(store);
+    await expect(repository.apply(applyInput())).resolves.toEqual({
+      status: "rejected",
+      reason: "stale-version",
+    });
+    expect(await dumpStore(store)).toBe(before);
+    await expect(repository.listChanges(planId)).resolves.toMatchObject([{ status: "pending" }]);
   });
 
   it("previews the current revision without changing training or Plan version", async () => {

--- a/packages/kernel-node/tests/plan-creation-activation.test.ts
+++ b/packages/kernel-node/tests/plan-creation-activation.test.ts
@@ -31,13 +31,17 @@ const draft = {
   weeks: [{ workouts: [datedWorkout, poolWorkout] }, { workouts: [] }],
 };
 
-const activationInput = (key = "1") => {
+const activationInput = (
+  key = "1",
+  incumbent: Parameters<PlanCreationRepository["activate"]>[0]["incumbent"] = null,
+) => {
   const command = stamp(`activate-${key}`, Number(key) * 10 + 2);
   const planId = id(`1${key}`);
   return {
     command,
     creationId: id(key),
     expectedVersion: 2,
+    incumbent,
     activatedAt: "1998-01-01",
     todayDateKey: 19980101,
     mirrorJobId: id(`5${key}`),
@@ -122,6 +126,15 @@ describe("Plan Creation activation repository", () => {
       activatedAt: "1998-01-01",
     });
     await expect(repository.readUnfinished()).resolves.toBeUndefined();
+    await expect(start()).resolves.toMatchObject({
+      outcome: "replayed",
+      snapshot: {
+        id: id("1"),
+        status: "activated",
+        version: 3,
+        currentDraft: { revisionNumber: 1 },
+      },
+    });
     expect(
       await store.get("SELECT status,version,activated_plan_id,terminal_at_ms FROM plan_creation"),
     ).toEqual({
@@ -190,7 +203,9 @@ describe("Plan Creation activation repository", () => {
     await review();
     const first = await repository.activate(activationInput());
     await review("2");
-    const second = await repository.activate(activationInput("2"));
+    const second = await repository.activate(
+      activationInput("2", { planId: id("11"), version: 1 }),
+    );
     expect(second.closedPlanId).toBe(first.planId);
     expect(
       await store.get(
@@ -259,12 +274,47 @@ describe("Plan Creation activation repository", () => {
     expect(await dumpStore(store)).toBe(before);
   });
 
+  it.each(["version", "closed", "different", "unexpected"])(
+    "rejects a changed incumbent when it is %s without changing stored rows",
+    async (change) => {
+      await review();
+      const first = await repository.activate(activationInput());
+      await review("2");
+      if (change === "version")
+        await store.run("UPDATE planning_plan SET version=version+1 WHERE plan_id=?", [
+          first.planId,
+        ]);
+      if (change === "closed") {
+        await store.run(
+          "UPDATE planning_plan SET status='closed',close_reason='stopped',close_actor=?,closed_at_ms=?,updated_at_ms=?,version=version+1 WHERE plan_id=?",
+          ["test-device-1998", nowMs + 23, nowMs + 23, first.planId],
+        );
+        await store.run("UPDATE plan SET status='ended' WHERE id=?", [first.planId]);
+      }
+      const before = await dumpStore(store);
+      await expect(
+        repository.activate(
+          activationInput(
+            "2",
+            change === "unexpected"
+              ? null
+              : {
+                  planId: change === "different" ? id("99") : first.planId,
+                  version: 1,
+                },
+          ),
+        ),
+      ).rejects.toMatchObject({ code: "version-conflict" });
+      expect(await dumpStore(store)).toBe(before);
+    },
+  );
+
   it("uses civil-day windows and keeps cleanup nonempty after the incumbent's final day", async () => {
     await review();
     await repository.activate(activationInput());
     await review("2");
     await repository.activate({
-      ...activationInput("2"),
+      ...activationInput("2", { planId: id("11"), version: 1 }),
       activatedAt: "1998-01-31",
       todayDateKey: 19980131,
     });
@@ -306,7 +356,7 @@ describe("Plan Creation activation repository", () => {
       const before = await dumpStore(store);
       await expect(
         repository.activate({
-          ...activationInput("2"),
+          ...activationInput("2", { planId: id("11"), version: 1 }),
           expectedVersion: kind === "stale" ? 3 : kind === "missing" || kind === "version" ? 1 : 2,
         }),
       ).rejects.toMatchObject({
@@ -369,12 +419,14 @@ describe("Plan Creation activation repository", () => {
       close: () => store.close(),
       transaction: (operation) => store.transaction(operation),
     });
-    await expect(failing.activate(activationInput("2"))).rejects.toThrow(
-      "Synthetic activation ledger failure",
-    );
+    await expect(
+      failing.activate(activationInput("2", { planId: id("11"), version: 1 })),
+    ).rejects.toThrow("Synthetic activation ledger failure");
     expect(closureObserved).toBe(true);
     expect(await dumpStore(store)).toBe(before);
-    await expect(repository.activate(activationInput("2"))).resolves.toMatchObject({
+    await expect(
+      repository.activate(activationInput("2", { planId: id("11"), version: 1 })),
+    ).resolves.toMatchObject({
       closedPlanId: id("11"),
     });
   });

--- a/packages/kernel-node/tests/plan-creation-repository.test.ts
+++ b/packages/kernel-node/tests/plan-creation-repository.test.ts
@@ -224,6 +224,25 @@ describe("Plan Creation repository", () => {
     ).resolves.toMatchObject({ outcome: "resumed", snapshot: { id: creationId, seed } });
   });
 
+  it("records the resulting creation version in each start and answer command", async () => {
+    await start();
+    await answer();
+    await repository.start({ command: stamp("resume", "c"), creationId: secondId, seed });
+    const rows = await store.all(
+      "SELECT command_id,result_json FROM planning_command ORDER BY command_id",
+    );
+    expect(
+      rows.map((row) => ({
+        commandId: row.command_id,
+        result: JSON.parse(String(row.result_json)),
+      })),
+    ).toEqual([
+      { commandId: "answer", result: { creationId, answerId: id("3"), version: 2 } },
+      { commandId: "resume", result: { creationId, outcome: "resumed", version: 2 } },
+      { commandId: "start", result: { creationId, outcome: "created", version: 1 } },
+    ]);
+  });
+
   it("replays effects and rejects a changed digest", async () => {
     await start();
     await expect(start()).resolves.toMatchObject({ outcome: "replayed" });
@@ -247,6 +266,46 @@ describe("Plan Creation repository", () => {
     ).rejects.toMatchObject({ code: "command-conflict" });
     expect(await store.all("SELECT id FROM plan_creation_answer")).toHaveLength(1);
   });
+
+  it.each([false, true])(
+    "replays the recorded creation after discard with a later creation: %s",
+    async (startLater) => {
+      await start();
+      await answer();
+      await discard(2);
+      if (startLater)
+        await repository.start({ command: stamp("later-start", "d"), creationId: secondId, seed });
+      const before = await dumpStore(store);
+      for (const replay of [start, answer]) {
+        await expect(replay()).resolves.toMatchObject({
+          outcome: "replayed",
+          snapshot: { id: creationId, status: "discarded", version: 3, answers: [{ id: id("3") }] },
+        });
+      }
+      expect(await dumpStore(store)).toBe(before);
+      await expect(repository.readUnfinished()).resolves.toEqual(
+        startLater ? expect.objectContaining({ id: secondId }) : undefined,
+      );
+    },
+  );
+
+  it.each(["{}", JSON.stringify({ creationId: secondId })])(
+    "rejects an unresolved recorded creation",
+    async (resultJson) => {
+      await start();
+      await store.run(
+        `INSERT INTO planning_command (
+command_name,command_id,request_digest,status,aggregate_refs_json,result_json,error_code,error_json,
+version,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+) SELECT command_name,'unresolved',request_digest,status,aggregate_refs_json,?,error_code,error_json,
+version,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter FROM planning_command WHERE command_name='plan_creation.start'`,
+        [resultJson],
+      );
+      await expect(
+        repository.start({ command: stamp("unresolved", "a"), creationId, seed }),
+      ).rejects.toMatchObject({ code: "corrupt-record" });
+    },
+  );
 
   it("leaves no partial effect for a stale version", async () => {
     await start();

--- a/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
+++ b/packages/kernel-node/tests/plan-lifecycle-repository.test.ts
@@ -39,6 +39,7 @@ const activationInput = (key = "1") => {
   const planId = id(`1${key}`);
   return {
     command,
+    incumbent: null,
     creationId: id(key),
     expectedVersion: 2,
     activatedAt: "1998-01-01",

--- a/packages/kernel-node/tests/plan-reconciliation-repository.test.ts
+++ b/packages/kernel-node/tests/plan-reconciliation-repository.test.ts
@@ -113,6 +113,66 @@ describe("Plan reconciliation repository", () => {
     expect(await repository.readItems(JOB_ID)).toEqual([savedItem]);
   });
 
+  it("reads the latest library jobs for three Plans and both kinds in one query", async () => {
+    const repository = await fresh();
+    if (store === undefined) throw new Error("missing store");
+    const planIds = [PLAN_ID, "01K00000000000000000000009", "01K00000000000000000000010"];
+    for (const planId of planIds.slice(1)) {
+      await store.run(
+        `INSERT INTO plan (
+          id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,total_weeks,
+          week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+        ) SELECT ?,origin_id,name,primary_goal,start_date_key,target_date_key,'ended',kind,total_weeks,
+          week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+          FROM plan WHERE id=?`,
+        [planId, PLAN_ID],
+      );
+    }
+    let sequence = 20;
+    for (const planId of planIds) {
+      for (const kind of ["mirror", "cleanup"] as const) {
+        for (const window of [
+          { windowStartDateKey: 19980825, windowEndDateKey: 19980831, createdAtMs: 100 },
+          { windowStartDateKey: 19980826, windowEndDateKey: 19980901, createdAtMs: 20 },
+          { windowStartDateKey: 19980826, windowEndDateKey: 19980902, createdAtMs: 10 },
+        ]) {
+          await repository.createOrGetJob({
+            ...job(),
+            ...window,
+            id: `01K${String(sequence++).padStart(23, "0")}`,
+            planId,
+            kind,
+          });
+        }
+      }
+    }
+    const expected = [];
+    for (const planId of planIds) {
+      for (const kind of ["cleanup", "mirror"] as const) {
+        expected.push(await repository.readLatestJobByWindow(planId, kind));
+      }
+    }
+    let queryCount = 0;
+    const source = store;
+    const counted = createPlanReconciliationRepository({
+      exec: source.exec.bind(source),
+      run: source.run.bind(source),
+      all: async (...args) => {
+        queryCount += 1;
+        return source.all(...args);
+      },
+      get: async (...args) => {
+        queryCount += 1;
+        return source.get(...args);
+      },
+      close: source.close.bind(source),
+      transaction: source.transaction.bind(source),
+    });
+    expect(await counted.readLatestJobsForLibrary()).toEqual(expected);
+    expect(queryCount).toBe(1);
+    expect(expected).toHaveLength(6);
+  });
+
   it("lists runnable jobs across Plans by window, creation time, and identity", async () => {
     const repository = await fresh();
     if (store === undefined) throw new Error("missing store");

--- a/packages/kernel/src/planning/change-repository.ts
+++ b/packages/kernel/src/planning/change-repository.ts
@@ -142,6 +142,7 @@ const SnapshotSchema = z.object({
             date: z.string().nullable(),
             name: z.string(),
             minutes: z.number(),
+            pinned: z.boolean().optional(),
           })
           .passthrough(),
       ),
@@ -222,11 +223,6 @@ export function createPlanChangeRepository(
     const plan = await plans.read(input.planId);
     if (plan === undefined) return fail();
     const current = await plans.readWorkouts(input.planId);
-    const diffIds = new Set(
-      PlanChangeEnvelopeSchema.parse(JSON.parse(change.diff_json)).diff.map(
-        (item) => item.workoutId,
-      ),
-    );
     const revision = z
       .object({ snapshot_json: z.string() })
       .parse(
@@ -238,7 +234,36 @@ export function createPlanChangeRepository(
     const baseWorkouts = SnapshotSchema.parse(JSON.parse(revision.snapshot_json)).weeks.flatMap(
       (week) => week.workouts,
     );
+    const afterWorkouts = SnapshotSchema.parse(JSON.parse(afterSnapshotJson)).weeks.flatMap(
+      (week) => week.workouts,
+    );
+    const afterById = new Map(afterWorkouts.map((workout) => [workout.id, workout]));
+    const baseIds = new Set(baseWorkouts.map((workout) => workout.id));
+    const changedWorkouts = baseWorkouts.filter(
+      (workout) => canonicalJson(workout) !== canonicalJson(afterById.get(workout.id) ?? null),
+    );
+    const diffIds = new Set([
+      ...changedWorkouts.map((workout) => workout.id),
+      ...afterWorkouts.filter((workout) => !baseIds.has(workout.id)).map((workout) => workout.id),
+    ]);
+    const completedRows = await store.all(
+      "SELECT plan_workout_id FROM plan_workout_match WHERE plan_id=? AND decision='confirmed'",
+      [input.planId],
+    );
+    const completedWorkoutIds = new Set(
+      completedRows.map((row) => z.string().parse(row.plan_workout_id)),
+    );
     const currentByDraftId = new Map(current.map((workout) => [draftId(workout), workout]));
+    for (const workout of changedWorkouts) {
+      const row = currentByDraftId.get(workout.id);
+      if (
+        workout.pinned ||
+        workout.date === null ||
+        dateKeyFromText(workout.date) < input.todayDateKey ||
+        (row !== undefined && completedWorkoutIds.has(row.id))
+      )
+        return false;
+    }
     for (const workout of baseWorkouts) {
       if (!diffIds.has(workout.id)) continue;
       const row = currentByDraftId.get(workout.id);

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -133,6 +133,7 @@ export const PlanCreationActivationResultSchema = z
 export type PlanCreationActivationResult = z.infer<typeof PlanCreationActivationResultSchema>;
 
 export interface ActivatePlanCreationInput extends DiscardPlanCreationInput {
+  readonly incumbent: { readonly planId: string; readonly version: number } | null;
   readonly activatedAt: string;
   readonly todayDateKey: number;
   readonly mirrorJobId: string;
@@ -192,16 +193,16 @@ const parseSeed = (value: unknown): PlanCreationSeedV1 => {
 
 export function createPlanCreationRepository(store: PlanCreationStore): PlanCreationRepository {
   const { hasReplay, recordCommand } = createPlanningCommandLedger(store);
-  const readUnfinished = async (): Promise<PlanCreationSnapshot | undefined> => {
-    const rows = await store.all(
-      "SELECT * FROM plan_creation WHERE status IN ('in-progress','review') ORDER BY created_at_ms,id",
-    );
-    if (rows.length > 1) fail();
-    const row = rows[0];
-    if (row === undefined) return undefined;
+  const readSnapshot = async (row: Row): Promise<PlanCreationSnapshot> => {
     const id = text(row, "id");
     const status = text(row, "status");
-    if (status !== "in-progress" && status !== "review") fail();
+    if (
+      status !== "in-progress" &&
+      status !== "review" &&
+      status !== "activated" &&
+      status !== "discarded"
+    )
+      return fail();
     const seedJson = row.seed_json;
     const seed =
       seedJson === null ? null : typeof seedJson === "string" ? parseSeed(json(seedJson)) : fail();
@@ -235,7 +236,7 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
     }
     return {
       id,
-      status: status === "review" ? "review" : "in-progress",
+      status,
       version: integer(row, "version"),
       seed,
       currentDraft,
@@ -255,6 +256,14 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
       }),
     };
   };
+  const readUnfinished = async (): Promise<PlanCreationSnapshot | undefined> => {
+    const rows = await store.all(
+      "SELECT * FROM plan_creation WHERE status IN ('in-progress','review') ORDER BY created_at_ms,id",
+    );
+    if (rows.length > 1) fail();
+    const row = rows[0];
+    return row === undefined ? undefined : readSnapshot(row);
+  };
   const requireUnfinished = async () => {
     const snapshot = await readUnfinished();
     if (snapshot === undefined) throw new PlanCreationStoreError("missing-creation");
@@ -263,7 +272,16 @@ export function createPlanCreationRepository(store: PlanCreationStore): PlanCrea
   const replay = async (
     name: "plan_creation.start" | "plan_creation.answer",
     command: PlanCreationCommandStamp,
-  ) => ((await hasReplay(name, command)) ? requireUnfinished() : undefined);
+  ) => {
+    const commandRow = await hasReplay(name, command);
+    if (commandRow === undefined) return undefined;
+    const parsed = z
+      .object({ creationId: z.string() })
+      .safeParse(json(text(commandRow, "result_json")));
+    if (!parsed.success) return fail();
+    const row = await store.get("SELECT * FROM plan_creation WHERE id=?", [parsed.data.creationId]);
+    return row === undefined ? fail() : readSnapshot(row);
+  };
   const replayDraft = async (command: PlanCreationCommandStamp) => {
     const row = await hasReplay("plan_creation.preview", command);
     if (row === undefined) return undefined;
@@ -310,6 +328,7 @@ WHERE singleton = 1 AND chat_authority_since_ms IS NULL`,
           {
             creationId: snapshot.id,
             outcome,
+            version: snapshot.version,
           },
         );
         return { outcome, snapshot };
@@ -364,7 +383,7 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
           {
             creationId,
             answerId,
-            version,
+            version: snapshot.version,
           },
         );
         return { outcome: "recorded", snapshot };
@@ -435,6 +454,7 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
       command,
       creationId,
       expectedVersion,
+      incumbent,
       activatedAt,
       todayDateKey,
       mirrorJobId,
@@ -470,10 +490,18 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
         validatePlanRecord(plan);
         for (const workout of workouts) validatePlanWorkoutRecord(plan, workout);
         if (plan.status !== "active") return fail();
-        const incumbent = await store.get(
-          "SELECT plan_id FROM planning_plan WHERE status='active'",
+        const activePlan = await store.get(
+          "SELECT plan_id,version FROM planning_plan WHERE status='active'",
         );
-        const closedPlanId = incumbent === undefined ? null : text(incumbent, "plan_id");
+        if (
+          incumbent === null
+            ? activePlan !== undefined
+            : activePlan === undefined ||
+              text(activePlan, "plan_id") !== incumbent.planId ||
+              integer(activePlan, "version") !== incumbent.version
+        )
+          throw new PlanCreationStoreError("version-conflict");
+        const closedPlanId = activePlan === undefined ? null : text(activePlan, "plan_id");
         const result = PlanCreationActivationResultSchema.parse({
           creationId,
           planId: plan.id,

--- a/packages/kernel/src/planning/reconciliation-repository.ts
+++ b/packages/kernel/src/planning/reconciliation-repository.ts
@@ -92,6 +92,7 @@ export interface PlanReconciliationRepository {
     planId: string,
     kind: PlanReconciliationKind,
   ): Promise<PlanReconciliationJobRecord | undefined>;
+  readLatestJobsForLibrary(): Promise<readonly PlanReconciliationJobRecord[]>;
   beginAttempt(id: string, updatedAtMs: number): Promise<PlanReconciliationJobRecord>;
   reopenJob(id: string, updatedAtMs: number): Promise<PlanReconciliationJobRecord>;
   failJob(
@@ -456,6 +457,17 @@ export function createPlanReconciliationRepository(
         [planId, kind],
       );
       return row === undefined ? undefined : jobFromRow(row);
+    },
+    async readLatestJobsForLibrary() {
+      const rows = await store.all(
+        `SELECT ${JOB_COLUMNS} FROM (
+           SELECT ${JOB_COLUMNS},ROW_NUMBER() OVER (
+             PARTITION BY plan_id,kind
+             ORDER BY window_start_date_key DESC,window_end_date_key DESC,id DESC
+           ) AS job_rank FROM plan_reconciliation_job
+         ) WHERE job_rank=1 ORDER BY plan_id,kind`,
+      );
+      return Object.freeze(rows.map(jobFromRow));
     },
     async beginAttempt(id, updatedAtMs) {
       if (!ULID.test(id) || !validTimestamp(updatedAtMs)) {

--- a/packages/sport-cycling/src/plan-change.ts
+++ b/packages/sport-cycling/src/plan-change.ts
@@ -33,8 +33,17 @@ function totals(draft: CreationDraft): ScheduleChangeTotals["before"] {
   return { plan: weeks.reduce((sum, week) => sum + week.minutes, 0), weeks };
 }
 
-function mutable(workout: Workout, todayDateKey: number): boolean {
-  return !workout.pinned && workout.date !== null && dateKeyFromText(workout.date) >= todayDateKey;
+function mutable(
+  workout: Workout,
+  todayDateKey: number,
+  completedWorkoutIds: ReadonlySet<string>,
+): boolean {
+  return (
+    !workout.pinned &&
+    !completedWorkoutIds.has(workout.id) &&
+    workout.date !== null &&
+    dateKeyFromText(workout.date) >= todayDateKey
+  );
 }
 
 function changed(before: Workout, after: Workout): boolean {
@@ -51,10 +60,12 @@ export function applyScheduleIntent<Draft extends CreationDraft>({
   draft,
   intent,
   todayDateKey,
+  completedWorkoutIds = new Set<string>(),
 }: {
   draft: Draft;
   intent: ScheduleIntent;
   todayDateKey: number;
+  completedWorkoutIds?: ReadonlySet<string>;
 }): { after: Draft; diff: ScheduleChangeDiff[]; totals: ScheduleChangeTotals } {
   const after = structuredClone(draft);
   for (const week of after.weeks) {
@@ -62,7 +73,7 @@ export function applyScheduleIntent<Draft extends CreationDraft>({
       const budgetMinutes = Math.floor(intent.hours * 60);
       let used = totalMinutes(week.workouts);
       for (const workout of [...week.workouts].reverse()) {
-        if (!mutable(workout, todayDateKey) || used <= budgetMinutes) continue;
+        if (!mutable(workout, todayDateKey, completedWorkoutIds) || used <= budgetMinutes) continue;
         const remaining = workout.minutes - (used - budgetMinutes);
         const minutes = remaining < 15 ? 0 : remaining;
         used -= workout.minutes - minutes;
@@ -70,7 +81,7 @@ export function applyScheduleIntent<Draft extends CreationDraft>({
       }
     } else {
       for (const workout of week.workouts) {
-        if (!mutable(workout, todayDateKey) || workout.date === null) continue;
+        if (!mutable(workout, todayDateKey, completedWorkoutIds) || workout.date === null) continue;
         const weekday = weekdayForDateKey(dateKeyFromText(workout.date)) || 7;
         switch (intent.kind) {
           case "weekday-duration":

--- a/packages/sport-cycling/tests/plan-change.test.ts
+++ b/packages/sport-cycling/tests/plan-change.test.ts
@@ -240,6 +240,19 @@ describe("Schedule Plan Changes", () => {
     expect(result.after.answeredSummaries).toEqual([]);
   });
 
+  it.each(intents)("preserves completed Workouts today for $kind", (intent) => {
+    const draft = fixture();
+    const completedWorkoutIds = new Set(["w2-hard"]);
+    const result = applyScheduleIntent({ draft, intent, todayDateKey, completedWorkoutIds });
+    const completed = workouts(draft).find((workout) => workout.id === "w2-hard");
+    expect(completed?.date).toBe("1998-08-24");
+    expect(workouts(result.after).find((workout) => workout.id === "w2-hard")).toEqual(completed);
+    expect(result.diff.some((row) => row.workoutId === "w2-hard")).toBe(false);
+    expect(result.diff.length).toBeGreaterThan(0);
+    expect(draft).toEqual(fixture());
+    expect(completedWorkoutIds).toEqual(new Set(["w2-hard"]));
+  });
+
   it.each(intents)("is deterministic and fingerprints the changed content for $kind", (intent) => {
     const first = run(intent);
     expect(run(intent)).toEqual(first);


### PR DESCRIPTION
## Summary

Follow-up to the whole-epic verification pass on `epic/plan-in-chat` (after merging `origin/main`). A codex astra high read-only review of the full epic diff against issues 318 to 322 returned 14 blocking findings; every cited line was confirmed at HEAD. Two are design decisions with the operator (written commitments gating activation; the retired JSON Plan still fed to Chat context). The other twelve are closed here.

- Activation revalidates the incumbent: `plan_creation.activate` requires `incumbent: {planId, version} | null`; the kernel compares identity and version inside the transaction before closing anything; the dialog submits the same library read it displayed.
- Start and answer replay resolve the recorded Creation (kernel records the version) and project the card as of that version, even after discard or activation. No extra ledger rows.
- `plan.list` reads the latest calendar job per Plan in one query.
- Cycling Workouts mirror to intervals.icu as Ride events (adapter recognises the "Ride" label).
- Legacy Plan page: reads are read-only once Chat owns Plans (derived completion-match refresh still runs); provider-edit adoption, end-plan and the replacement-navigation branch are fenced.
- Change safety: apply rejects when any changed or deleted Workout is no longer in the future or has a completion match, leaving the Change pending; previews exclude completed Workouts.
- Renderer: one command id per confirmed attempt reused on retry; transport-failure copy no longer asserts the outcome; Continue and Change restore focus on return; stopped-Plan final details poll cleanup status on the library schedule and offer Retry calendar; weekly hours use quarter-hour steps with matching copy.

Residual, judged non-blocking and recorded in issue 319: replaying an availability answer on a later civil date projects the card with that day's earliest-allowed date, and two overlapping identical Start requests can label the second outcome resumed instead of created. Both keep the recorded Creation identity.

## Verification

- Verifier rounds on the fix diff: round 1 six blocking (terminal replay at the RPC boundary, match refresh under the fence, PL-T39, PL-T29, two stale E2E specs) all fixed; round 2 replaced companion ledger rows with kernel-recorded versions; round 3 two residuals above, everything else confirmed closed.
- Full gate on this branch: root `pnpm check` green, workspace selection 4436 passed with one known load timeout, renderer-dom green, full build green, all 92 E2E cases passed.

| Limit | Value |
|---|---|
| Findings closed | 12 of 14 |
| Final-details polling | 4 s x 20 |
| Weekly-hours step | 0.25 h |
| E2E cases | 92 passed |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
