### PR TITLE
feat(coach): hide the retired file plan from Chat once Chat holds authority

### DIFF
--- a/.changeset/chat-context-plan-authority.md
+++ b/.changeset/chat-context-plan-authority.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Stop showing the retired file-based plan to the coach once Plans are managed in Chat.
+
+User-facing: Once you start creating a Plan in Chat, the coach no longer reads your old saved plan file, so its advice is based on the Plan you manage in Chat.

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -1298,7 +1298,7 @@ export async function createLocalCoachComposition(
       calendarTimeZone: () => resolveUserTimezone(approvedConfig().session.timezone),
       droppedActivitiesSource: () => runtime!.currentDroppedActivities(),
     });
-    const buildBundle = (config: Config): RuntimeBundle => {
+    const buildBundle = async (config: Config): Promise<RuntimeBundle> => {
       const timezone = resolveUserTimezone(config.session.timezone);
       const effectiveConfig =
         timezone === config.session.timezone
@@ -1310,11 +1310,16 @@ export async function createLocalCoachComposition(
       const memory = new Memory(input.home.root, timezone, {
         platform: dependencies.platform,
         persistPlan,
+        planReadGate: async () =>
+          (await legacyWriterFence.read()).chatAuthoritySinceMs !== null
+            ? "This Plan is managed in Chat. Open the Plan page or ask in Chat about your Plan."
+            : null,
         planWriteGate: async () =>
           (await legacyWriterFence.fenced())
             ? "This Plan is managed in Chat. Change or stop it from Chat or the Plan library."
             : null,
       });
+      await memory.refreshPlanReadGate?.();
       const conversationStore = createConversationStore(
         input.home.root,
         config.session.resetArchiveRetentionDays,
@@ -1483,7 +1488,7 @@ export async function createLocalCoachComposition(
         }),
       };
     };
-    const initialBundle = buildBundle(approvedConfig());
+    const initialBundle = await buildBundle(approvedConfig());
     let activeTimezone = initialBundle.timezone;
     const reconfigurable = createReconfigurableRuntimeBundle(initialBundle);
     const persistConfig = dependencies.persistRuntimeConfig ?? persistRuntimeConfig;
@@ -1638,7 +1643,7 @@ export async function createLocalCoachComposition(
         request.llm?.clear_credential === true && unapprovedConfig.llm.provider === "openai-codex";
       signal.throwIfAborted();
       await reconfigurable.replace(
-        () => {
+        async () => {
           signal.throwIfAborted();
           const latestCandidate = mergedRuntimeConfig(unapprovedConfig, effectiveRequest);
           if (
@@ -1659,7 +1664,9 @@ export async function createLocalCoachComposition(
             latestCandidate,
             latestIntervalsChanged,
             replacementOwnerReady,
-            replacement: buildBundle(approvedRuntimeConfig(latestCandidate, replacementOwnerReady)),
+            replacement: await buildBundle(
+              approvedRuntimeConfig(latestCandidate, replacementOwnerReady),
+            ),
           };
         },
         async ({ latestCandidate, latestIntervalsChanged, replacementOwnerReady, replacement }) => {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -2480,6 +2480,87 @@ describe("local coach composition", () => {
     },
   );
 
+  it("hides the file Plan only after Chat takes planning authority and after reopening", async () => {
+    const home = await freshHome();
+    await mkdir(home.storeDir, { recursive: true });
+    await mkdir(join(home.root, "plans"), { recursive: true });
+    await writeFile(
+      join(home.root, "plans", "current-plan.json"),
+      JSON.stringify({ name: "File endurance Plan", primaryGoal: "Ride consistently" }),
+    );
+    const store = openSqliteStorage(join(home.storeDir, "store.db"));
+    stores.push(store);
+    await runMigrations(store, MIGRATIONS);
+    const instant = Date.UTC(1998, 6, 13, 12);
+    const planId = "0000000000000000000000000A";
+    await createPlanRepository(store).replace(
+      {
+        id: planId,
+        originId: null,
+        name: "Stored endurance Plan",
+        primaryGoal: "Ride consistently",
+        startDateKey: 19980713,
+        targetDateKey: 19981004,
+        status: "active",
+        kind: "full_plan",
+        totalWeeks: 12,
+        weekStartDay: 1,
+        structureJson: "{}",
+        createdAtMs: instant,
+        updatedAtMs: instant,
+        deviceId: "fixture-device",
+        hlcPhysicalMs: instant,
+        hlcCounter: 0,
+      },
+      [],
+    );
+    await store.run(
+      `INSERT INTO planning_plan (plan_id,status,version,current_revision_number,activated_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,'active',1,1,?,?,'fixture-device',?,0)`,
+      [planId, instant, instant, instant],
+    );
+    let engineInput: CreateCoachEngineInput | undefined;
+    const dependencies: LocalCoachCompositionDependencies = {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: (input) => {
+        engineInput = input;
+        return backend();
+      },
+      now: () => instant,
+    };
+    const context = { home, store, listener: inertWriterProtocolListener };
+    let lifecycle = await compose(home, dependencies, context);
+    try {
+      if (engineInput === undefined) throw new TypeError("Production Chat ports are unavailable");
+      const memory = engineInput.ports.memory;
+      const visibleContext = memory.getContext();
+      expect(visibleContext).toContain("## Current Plan\n- Name: File endurance Plan");
+      await memory.refreshPlanReadGate?.();
+      expect(memory.getContext()).toBe(visibleContext);
+      expect(
+        await store.get("SELECT chat_authority_since_ms FROM planning_authority WHERE singleton=1"),
+      ).toEqual({ chat_authority_since_ms: null });
+
+      const started = await lifecycle.operations["plan_creation.start"]({
+        commandId: "start-chat-plan",
+      });
+      expect(started.status).toBe("started");
+      await memory.refreshPlanReadGate?.();
+      expect(memory.getContext()).not.toContain("## Current Plan");
+      expect(memory.getContext()).not.toContain("File endurance Plan");
+      expect(memory.getContextWithProvenance?.().text).not.toContain("## Current Plan");
+
+      await lifecycle.close();
+      lifecycle = await compose(home, dependencies, context);
+      expect(engineInput.ports.memory).not.toBe(memory);
+      expect(engineInput.ports.memory.getContext()).not.toContain("## Current Plan");
+      expect(engineInput.ports.memory.getContext()).not.toContain("File endurance Plan");
+    } finally {
+      await lifecycle.close();
+    }
+  });
+
   it("discards Plan Creation through real composition while preserving stored Plans and Chat", async () => {
     const home = await freshHome();
     await mkdir(home.storeDir, { recursive: true });

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -99,6 +99,7 @@ export interface MemoryOptions {
   readonly platform?: NodeJS.Platform;
   readonly persistPlan?: (plan: unknown) => Promise<void>;
   readonly planWriteGate?: () => Promise<string | null>;
+  readonly planReadGate?: () => Promise<string | null>;
 }
 
 /**
@@ -133,6 +134,8 @@ export class Memory implements MemoryStore {
   private readonly platform: NodeJS.Platform;
   private readonly persistPlan: ((plan: unknown) => Promise<void>) | undefined;
   private readonly planWriteGate: (() => Promise<string | null>) | undefined;
+  readonly refreshPlanReadGate?: () => Promise<string | null>;
+  private planReadMessage: string | null = null;
   private readonly writeProvenance = new AsyncLocalStorage<SourceProvenance>();
 
   constructor(dataDir: string, tz: string = "UTC", options: MemoryOptions = {}) {
@@ -142,6 +145,14 @@ export class Memory implements MemoryStore {
     this.platform = options.platform ?? process.platform;
     this.persistPlan = options.persistPlan;
     this.planWriteGate = options.planWriteGate;
+    const planReadGate = options.planReadGate;
+    if (planReadGate) {
+      this.refreshPlanReadGate = async () => {
+        const message = await planReadGate();
+        this.planReadMessage ??= message;
+        return this.planReadMessage;
+      };
+    }
     mkdirSync(this.memoryDir, { recursive: true, mode: 0o700 });
     mkdirSync(this.plansDir, { recursive: true, mode: 0o700 });
     this.provenance = new ProvenanceMetadata(this.memoryDir, { platform: this.platform });
@@ -486,6 +497,7 @@ export class Memory implements MemoryStore {
   }
 
   loadPlan(): unknown | null {
+    if (this.planReadMessage !== null) return null;
     return safeReadJson<Record<string, unknown>>(
       join(this.plansDir, "current-plan.json"),
       PlanFileSchema,
@@ -621,6 +633,7 @@ export class Memory implements MemoryStore {
   ): SourceProvenance {
     if (name === "memory_read") return this.getContextWithProvenance().provenance;
     if (name === "plan_load") {
+      if (this.planReadMessage !== null) return EMPTY_PROVENANCE;
       const path = join(this.plansDir, "current-plan.json");
       return existsSync(path)
         ? this.provenance.read("plan", readFileSync(path, "utf8"))

--- a/packages/core/tests/memory-plan-read-gate.test.ts
+++ b/packages/core/tests/memory-plan-read-gate.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Memory } from "../src/memory/store.js";
+import { createMemoryTools } from "../../engine/src/sport/memory-tools.js";
+import {
+  boundToolResultProvenance,
+  unwrapBoundToolResult,
+} from "../../engine/src/sport/bound-tool-result.js";
+import { EMPTY_PROVENANCE } from "../../engine/src/provenance.js";
+
+const message = "This Plan is managed in Chat. Open the Plan page or ask in Chat about your Plan.";
+const plan = { name: "Base", primaryGoal: "Ride consistently", totalWeeks: 8, status: "active" };
+const provenance = { garmin: true, nonGarmin: false, unknown: false };
+const sections = [{ name: "goals", description: "Athlete goals" }];
+const executeOptions = { toolCallId: "read-plan", messages: [] };
+
+describe("Memory plan read gate", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "memory-plan-read-gate-"));
+    new Memory(dataDir).savePlan(plan, "migration", provenance);
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("preserves context, provenance and tool results when the gate allows reading", async () => {
+    const original = new Memory(dataDir);
+    const memory = new Memory(dataDir, "UTC", { planReadGate: async () => null });
+    await expect(memory.refreshPlanReadGate!()).resolves.toBeNull();
+
+    expect(memory.getContext()).toBe(original.getContext());
+    expect(memory.getContext()).toContain("## Current Plan");
+    expect(memory.getContextWithProvenance()).toEqual(original.getContextWithProvenance());
+    expect(memory.getContextWithProvenance().provenance).toEqual(provenance);
+    expect(memory.provenanceForToolRead("plan_load", {})).toEqual(provenance);
+    const tools = createMemoryTools(memory, sections, { bindProvenance: true });
+    const result = await tools.plan_load.execute!({}, executeOptions);
+    expect(unwrapBoundToolResult(result)).toEqual(plan);
+    expect(boundToolResultProvenance(result)).toEqual(provenance);
+    const context = await tools.memory_read.execute!({}, executeOptions);
+    expect(unwrapBoundToolResult(context)).toBe(original.getContext());
+    expect(boundToolResultProvenance(context)).toEqual(provenance);
+  });
+
+  it("hides the file plan and its provenance after refreshing the gate", async () => {
+    const memory = new Memory(dataDir, "UTC", { planReadGate: async () => message });
+    const path = join(dataDir, "plans", "current-plan.json");
+    const original = readFileSync(path, "utf8");
+    await expect(memory.refreshPlanReadGate!()).resolves.toBe(message);
+
+    expect(memory.loadPlan()).toBeNull();
+    expect(memory.getContext()).toBe("");
+    expect(memory.getContextWithProvenance()).toEqual({ text: "", provenance: EMPTY_PROVENANCE });
+    expect(memory.provenanceForToolRead("plan_load", {})).toEqual(EMPTY_PROVENANCE);
+    expect(memory.provenanceForToolRead("memory_read", {})).toEqual(EMPTY_PROVENANCE);
+    const tools = createMemoryTools(memory, sections, { bindProvenance: true });
+    const result = await tools.plan_load.execute!({}, executeOptions);
+    expect(unwrapBoundToolResult(result)).toBe(message);
+    expect(boundToolResultProvenance(result)).toEqual(EMPTY_PROVENANCE);
+    const context = await tools.memory_read.execute!({}, executeOptions);
+    expect(unwrapBoundToolResult(context)).toBe("No athlete data stored yet.");
+    expect(boundToolResultProvenance(context)).toEqual(EMPTY_PROVENANCE);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it.each(["plan_load", "memory_read"] as const)(
+    "%s refreshes authority acquired after construction",
+    async (name) => {
+      let authority = false;
+      const memory = new Memory(dataDir, "UTC", {
+        planReadGate: async () => (authority ? message : null),
+      });
+      const tool = createMemoryTools(memory, sections)[name];
+      await tool.execute!({}, executeOptions);
+      expect(memory.getContext()).toContain("## Current Plan");
+
+      authority = true;
+      const result = await tool.execute!({}, executeOptions);
+
+      expect(result).toBe(name === "plan_load" ? message : "No athlete data stored yet.");
+      expect(memory.getContext()).not.toContain("## Current Plan");
+      expect(memory.getContextWithProvenance().provenance).toEqual(EMPTY_PROVENANCE);
+    },
+  );
+
+  it("keeps other context and its provenance when the plan is hidden", async () => {
+    const memory = new Memory(dataDir, "UTC", { planReadGate: async () => message });
+    memory.writeSection("goals", "Enjoy riding", "chat-tool", {
+      garmin: false,
+      nonGarmin: true,
+      unknown: false,
+    });
+    await memory.refreshPlanReadGate!();
+
+    const context = memory.getContextWithProvenance();
+    expect(context.text).toContain("Enjoy riding");
+    expect(context.text).not.toContain("## Current Plan");
+    expect(context.provenance).toEqual({ garmin: false, nonGarmin: true, unknown: false });
+  });
+
+  it("does not reopen reads when an older refresh finishes after authority was acquired", async () => {
+    let resolveOld: (value: string | null) => void = () => {};
+    const oldDecision = new Promise<string | null>((resolve) => {
+      resolveOld = resolve;
+    });
+    let reads = 0;
+    const memory = new Memory(dataDir, "UTC", {
+      planReadGate: () => (++reads === 1 ? oldDecision : Promise.resolve(message)),
+    });
+    const pending = memory.refreshPlanReadGate!();
+    await memory.refreshPlanReadGate!();
+    resolveOld(null);
+
+    await expect(pending).resolves.toBe(message);
+    expect(memory.getContext()).not.toContain("## Current Plan");
+  });
+});

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -912,6 +912,7 @@ export class CoachAgent {
           }
         }
 
+        if (this.memory.refreshPlanReadGate) await this.memory.refreshPlanReadGate();
         const turnTools = this.toolsForChat(chatId);
         this.systemPrompt = chatId.startsWith("plan:")
           ? buildPlanCoachSystemPrompt(this.memory, this.tz, this.buildDegradeBlock(), {
@@ -1874,6 +1875,7 @@ export class CoachAgent {
               : { [COACH_DECISION_TOOL_NAME]: this.decisionTool },
           model: this.config.llm.model,
         });
+    if (this.memory.refreshPlanReadGate) await this.memory.refreshPlanReadGate();
     const system =
       (isPlan
         ? buildPlanCoachSystemPrompt(this.memory, this.tz, this.buildDegradeBlock(), {

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -102,6 +102,7 @@ export interface MemoryStorePort {
     source?: MemoryWriteSource,
     provenance?: SourceProvenance,
   ): void | Promise<void>;
+  refreshPlanReadGate?(): Promise<string | null>;
   loadPlan(): unknown | null;
   /** Source labels bound to the exact visible result of a synchronous tool read. */
   provenanceForToolRead?(

--- a/packages/engine/src/sport/memory-tools.ts
+++ b/packages/engine/src/sport/memory-tools.ts
@@ -70,6 +70,7 @@ export function createMemoryReadTool(
     description,
     inputSchema: zodSchema(z.object({})),
     execute: async () => {
+      if (memory.refreshPlanReadGate) await memory.refreshPlanReadGate();
       const result = memory.getContext() || "No athlete data stored yet.";
       onRead?.(result);
       return bindProvenance ? bindMemoryToolResult(memory, "memory_read", {}, result) : result;
@@ -216,7 +217,8 @@ export function createMemoryTools(
       description: "Load the current active training plan",
       inputSchema: zodSchema(z.object({})),
       execute: async () => {
-        const result = memory.loadPlan() ?? { message: "No plan saved yet." };
+        const message = memory.refreshPlanReadGate ? await memory.refreshPlanReadGate() : null;
+        const result = message ?? memory.loadPlan() ?? { message: "No plan saved yet." };
         return bindProvenance ? bindMemoryToolResult(memory, "plan_load", {}, result) : result;
       },
     }),

--- a/packages/engine/tests/coach-agent-plan-read-gate.test.ts
+++ b/packages/engine/tests/coach-agent-plan-read-gate.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { Memory } from "../../core/src/memory/store.js";
+import { createCoachEngine } from "../src/index.js";
+import type { ModelTransportRequest } from "../src/host-ports.js";
+import type { GenerateResult, Sport } from "../src/sport.js";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+
+const dirs: string[] = [];
+
+const sport: Sport = {
+  id: "cycling",
+  soul: "Synthetic coach",
+  skills: {},
+  sessionClusterGapMinutes: 30,
+  memorySections: [],
+  mustPreserveTokens: [],
+  intervalsActivityTypes: [],
+  athleteProfileSchema: z.object({}),
+  tools: () => [],
+};
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function setup() {
+  const dataDir = mkdtempSync(join(tmpdir(), "coach-plan-read-gate-"));
+  dirs.push(dataDir);
+  let authority = false;
+  const memory = new Memory(dataDir, "UTC", {
+    planReadGate: async () =>
+      authority
+        ? "This Plan is managed in Chat. Open the Plan page or ask in Chat about your Plan."
+        : null,
+  });
+  memory.savePlan({ name: "Synthetic file Plan" });
+  const ports = baseAgentConfig(dataDir);
+  const prompts: string[] = [];
+  const engine = createCoachEngine({
+    sport,
+    ports: {
+      ...ports,
+      memory,
+      modelTransportDecorator: () => ({
+        async generate(request: ModelTransportRequest): Promise<GenerateResult> {
+          prompts.push(request.options.system ?? "");
+          return {
+            text: "Keep tomorrow easy.",
+            toolCalls: [],
+            finishReason: "stop",
+            usage: {
+              inputTokens: 1,
+              outputTokens: 1,
+              totalTokens: 2,
+              inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+              outputTokenDetails: { textTokens: 1, reasoningTokens: 0 },
+            },
+          };
+        },
+      }),
+    },
+  });
+  return {
+    engine,
+    prompts,
+    decisions: ports.coachDecisions,
+    claimAuthority: () => {
+      authority = true;
+    },
+  };
+}
+
+describe("coach prompt Plan read gate refresh", () => {
+  it.each(["desktop", "plan:synthetic"])(
+    "refreshes before each chat prompt for %s",
+    async (chatId) => {
+      const { engine, prompts, claimAuthority } = setup();
+
+      await engine.chat({ chatId, message: "Show my Plan." });
+      expect(prompts.at(-1)).toContain("## Current Plan");
+      expect(prompts.at(-1)).toContain("Synthetic file Plan");
+
+      claimAuthority();
+      await engine.chat({ chatId, message: "Show my Plan again." });
+
+      expect(prompts.at(-1)).not.toContain("## Current Plan");
+    },
+  );
+
+  it.each(["desktop", "plan:synthetic"])(
+    "refreshes before a decision continuation prompt for %s",
+    async (chatId) => {
+      const { engine, prompts, decisions, claimAuthority } = setup();
+      if (decisions === undefined) throw new Error("Decision store is required");
+      await engine.chat({ chatId, message: "Show my Plan." });
+      expect(prompts.at(-1)).toContain("## Current Plan");
+      decisions.appendDecisionRequested({
+        turnId: "decision-turn",
+        toolCallId: "decision-tool",
+        athleteText: "Choose tomorrow's priority.",
+        requestedAt: "1998-09-07T00:00:00.000Z",
+        decision: {
+          status: "unanswered",
+          decisionId: "decision-1",
+          chatId,
+          messageId: "message-1",
+          question: "Choose tomorrow's priority.",
+          options: [
+            {
+              id: "recovery",
+              label: "Recovery",
+              description: "Ride easy.",
+              recommended: true,
+              consequence: "Tomorrow becomes a recovery day.",
+            },
+            {
+              id: "tempo",
+              label: "Tempo",
+              description: "Keep the planned work.",
+              recommended: false,
+              consequence: "Tomorrow keeps the tempo session.",
+            },
+          ],
+        },
+      });
+
+      claimAuthority();
+      await engine.answerCoachDecision({
+        chatId,
+        decisionId: "decision-1",
+        answer: { kind: "option", optionId: "recovery" },
+      });
+
+      expect(prompts.at(-1)).toContain("# Decision Continuation");
+      expect(prompts.at(-1)).not.toContain("## Current Plan");
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- `Memory` gains an optional `planReadGate` beside the existing `planWriteGate`. When the `planning_authority` row is set (`chatAuthoritySinceMs !== null`, read from the same legacy writer fence instance in coach composition), `loadPlan()` returns null, so `getContext()` drops "## Current Plan", context and `plan_load` provenance are empty, and `plan_load` answers "This Plan is managed in Chat. Open the Plan page or ask in Chat about your Plan."
- The gate is a cached decision refreshed before each system-prompt build (regular and Plan chats, decision continuations), inside `memory_read` and `plan_load`, and at bundle build. It only moves from readable to blocked because authority is never released.
- An active legacy Plan row alone does not hide the file plan; only Chat authority does. Ungated Memory instances are unchanged.

## Verification
astra high read-only verdict: two findings, both bounded to the single turn in which authority flips (a memoized `plan_load` result and the turn's already-built prompt are reused for that turn's retries). The prompt was built before authority began, so nothing new reaches the model; accepted as non-blocking.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project workspace packages/core packages/engine packages/coach --maxWorkers=2` | 5694 passed, 14 skipped |
| new tests | memory-plan-read-gate, coach-agent-plan-read-gate, composition (start hides plan on next context build) |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn