### PR TITLE
feat(plan): block activation until written commitments are acknowledged

### DIFF
--- a/.changeset/plan-creation-commitment-gate.md
+++ b/.changeset/plan-creation-commitment-gate.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Block Plan activation until written commitments are acknowledged.
+
+User-facing: When you type fixed commitments or time off that the Draft could not fit into Workouts, the Plan waits for you to confirm those limits before it activates.

--- a/apps/desktop-renderer/tests/boot-plan-change.test.ts
+++ b/apps/desktop-renderer/tests/boot-plan-change.test.ts
@@ -130,6 +130,7 @@ const creation: PlanCreationCardModel = {
   readiness: "incomplete",
   draft: null,
   draftStale: false,
+  commitmentsAcknowledgement: null,
   answeredSummaries: [],
   openQuestion: {
     kind: "start-timing-question",

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -236,6 +236,7 @@ describe("chat view adapter", () => {
     const model = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress" as const,
@@ -422,6 +423,7 @@ describe("chat view adapter", () => {
     const model: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -522,6 +524,7 @@ describe("chat view adapter", () => {
     const nextModel: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000001",
       version: 1,
       status: "in-progress",
@@ -579,6 +582,7 @@ describe("chat view adapter", () => {
           value: {
             draft: null,
             draftStale: false,
+            commitmentsAcknowledgement: null,
             creationId: "01J00000000000000000000000",
             version: 1,
             status: "in-progress",

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -1833,6 +1833,7 @@ describe("chat controller", () => {
     const planCreation: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",
@@ -1918,6 +1919,7 @@ describe("chat controller", () => {
               ? { ...draft, weeks: draft.weeks.map((week) => ({ ...week, workouts: [] })) }
               : draft,
         draftStale: kind === "stale",
+        commitmentsAcknowledgement: null,
       };
       const activatePlanCreation =
         vi.fn<(request: PlanCreationActivateRpcParams) => Promise<PlanCreationActivateRpcResult>>();
@@ -1948,6 +1950,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft: planCreationDraft(),
       draftStale: false,
+      commitmentsAcknowledgement: null,
     };
     let rejectRead!: (error: Error) => void;
     const read = new Promise<GetPlanStateRpcResult>((_, reject) => {
@@ -1999,6 +2002,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft: planCreationDraft(),
       draftStale: false,
+      commitmentsAcknowledgement: null,
     };
     let finishActivation!: (result: PlanCreationActivateRpcResult) => void;
     const pending = new Promise<PlanCreationActivateRpcResult>((resolve) => {
@@ -2056,6 +2060,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft: planCreationDraft(),
       draftStale: false,
+      commitmentsAcknowledgement: null,
     };
     const activatePlanCreation = vi
       .fn<(request: PlanCreationActivateRpcParams) => Promise<PlanCreationActivateRpcResult>>()
@@ -2105,6 +2110,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft: planCreationDraft(),
       draftStale: false,
+      commitmentsAcknowledgement: null,
     };
     const activatePlanCreation = vi
       .fn<(request: PlanCreationActivateRpcParams) => Promise<PlanCreationActivateRpcResult>>()
@@ -2141,6 +2147,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft: planCreationDraft(),
       draftStale: false,
+      commitmentsAcknowledgement: null,
     };
     const activatePlanCreation =
       vi.fn<(request: PlanCreationActivateRpcParams) => Promise<PlanCreationActivateRpcResult>>();
@@ -2171,6 +2178,7 @@ describe("chat controller", () => {
     const completeCard: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -2251,6 +2259,7 @@ describe("chat controller", () => {
     const card: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -2296,6 +2305,7 @@ describe("chat controller", () => {
     const completeCard: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -2326,6 +2336,7 @@ describe("chat controller", () => {
     const card: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -2382,6 +2393,7 @@ describe("chat controller", () => {
     const card: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 3,
       status: "in-progress",
@@ -2419,6 +2431,7 @@ describe("chat controller", () => {
     const planCreation: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 4,
       status: "in-progress",
@@ -2497,6 +2510,7 @@ describe("chat controller", () => {
     const planCreation: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",
@@ -2570,6 +2584,7 @@ describe("chat controller", () => {
     const goalCard: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",
@@ -2635,6 +2650,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
     };
     const review: PlanCreationCardModel = {
       ...ready,
@@ -2685,6 +2701,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft,
       draftStale: true,
+      commitmentsAcknowledgement: null,
     };
     const previewPlanCreation = vi
       .fn<(request: PlanCreationPreviewRpcParams) => Promise<PlanCreationPreviewRpcResult>>()
@@ -2715,6 +2732,7 @@ describe("chat controller", () => {
     const ready: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 10,
       status: "in-progress",
@@ -2765,6 +2783,7 @@ describe("chat controller", () => {
       openQuestion: null,
       draft: planCreationDraft(originalAnswers),
       draftStale: false,
+      commitmentsAcknowledgement: null,
     };
     const changed: PlanCreationCardModel = {
       ...review,
@@ -2799,6 +2818,7 @@ describe("chat controller", () => {
     const ready: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 10,
       status: "in-progress",
@@ -2828,6 +2848,7 @@ describe("chat controller", () => {
     const ready: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 10,
       status: "in-progress",
@@ -2866,6 +2887,7 @@ describe("chat controller", () => {
     const first: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 4,
       status: "in-progress",
@@ -2876,6 +2898,7 @@ describe("chat controller", () => {
     const replacement: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000001",
       version: 1,
       status: "in-progress",
@@ -2911,6 +2934,7 @@ describe("chat controller", () => {
     const planCreation: PlanCreationCardModel = {
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       creationId: "01J00000000000000000000000",
       version: 1,
       status: "in-progress",
@@ -3674,6 +3698,7 @@ describe("Plan library Chat entry", () => {
     openQuestion: goalQuestion("Goal?"),
     draft: null,
     draftStale: false,
+    commitmentsAcknowledgement: null,
   };
 
   it.each([null, { ...creation, creationId: "replacement-creation" }])(

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -364,6 +364,7 @@ function planCreationModel(
   return {
     draft: null,
     draftStale: false,
+    commitmentsAcknowledgement: null,
     creationId: "01J00000000000000000000000",
     version: patch.version ?? 1,
     status: "in-progress",

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -180,6 +180,7 @@ describe("Plan Change cards", () => {
       readiness: "incomplete",
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       answeredSummaries: [],
       openQuestion: null,
     };

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -154,6 +154,7 @@ const creation: PlanCreationCardModel = {
   readiness: "incomplete",
   draft: null,
   draftStale: false,
+  commitmentsAcknowledgement: null,
   answeredSummaries: [],
   openQuestion: {
     kind: "goal-question",

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -119,7 +119,13 @@ export const PlanCreationAnswerInputSchema = z.discriminatedUnion("kind", [
       kind: z.literal("commitments"),
       commitments: z.discriminatedUnion("kind", [
         z.object({ kind: z.literal("none") }).strict(),
-        z.object({ kind: z.literal("authored"), text: z.string().min(1).max(2_000) }).strict(),
+        z
+          .object({
+            kind: z.literal("authored"),
+            text: z.string().min(1).max(2_000),
+            acknowledged: z.boolean().optional(),
+          })
+          .strict(),
       ]),
     })
     .strict(),
@@ -543,6 +549,10 @@ export const PlanCreationCardModelSchema = z
     status: z.enum(["in-progress", "review"]),
     draft: PlanCreationDraftSchema.nullable(),
     draftStale: z.boolean(),
+    commitmentsAcknowledgement: z
+      .object({ text: z.string().min(1).max(2_000) })
+      .strict()
+      .nullable(),
     readiness: z.enum(["incomplete", "ready"]),
     answeredSummaries: z.array(PlanCreationAnswerSummarySchema).max(16),
     openQuestion: PlanCreationOpenQuestionSchema.nullable(),

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -56,6 +56,7 @@ const card = {
   status: "in-progress" as const,
   draft: null,
   draftStale: false,
+  commitmentsAcknowledgement: null,
   readiness: "incomplete" as const,
   answeredSummaries: [],
   openQuestion: goalQuestion,
@@ -513,6 +514,46 @@ describe("Plan Creation contract", () => {
     summaryFixtures.forEach((summary) =>
       expect(PlanCreationAnswerSummarySchema.parse(summary)).toEqual(summary),
     );
+  });
+
+  it("accepts legacy commitments and explicit acknowledgement while keeping strict objects", () => {
+    const commitments = { kind: "authored", text: "Strength training on Wednesdays" };
+    for (const value of [
+      commitments,
+      { ...commitments, acknowledged: false },
+      { ...commitments, acknowledged: true },
+    ]) {
+      expect(
+        PlanCreationAnswerInputSchema.parse({ kind: "commitments", commitments: value }),
+      ).toEqual({ kind: "commitments", commitments: value });
+    }
+    for (const value of [
+      { ...commitments, acknowledged: "yes" },
+      { ...commitments, extra: true },
+      { kind: "none", acknowledged: true },
+    ]) {
+      expect(
+        PlanCreationAnswerInputSchema.safeParse({ kind: "commitments", commitments: value })
+          .success,
+      ).toBe(false);
+    }
+  });
+
+  it("requires a nullable strict commitments acknowledgement projection", () => {
+    const pending = { text: "Strength training on Wednesdays" };
+    expect(
+      PlanCreationCardModelSchema.parse({ ...card, commitmentsAcknowledgement: pending })
+        .commitmentsAcknowledgement,
+    ).toEqual(pending);
+    expect(PlanCreationCardModelSchema.parse(card).commitmentsAcknowledgement).toBeNull();
+    const { commitmentsAcknowledgement: _pending, ...missing } = card;
+    expect(PlanCreationCardModelSchema.safeParse(missing).success).toBe(false);
+    expect(
+      PlanCreationCardModelSchema.safeParse({
+        ...card,
+        commitmentsAcknowledgement: { ...pending, acknowledged: false },
+      }).success,
+    ).toBe(false);
   });
 
   it("requires consistent Card readiness and open-question states", () => {

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -1955,6 +1955,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               if (
                 error instanceof PlanCreationStoreError &&
                 (error.code === "not-ready" ||
+                  error.code === "commitments-unacknowledged" ||
                   error.code === "version-conflict" ||
                   error.code === "command-conflict")
               ) {

--- a/packages/coach/src/plan-creation-answers.ts
+++ b/packages/coach/src/plan-creation-answers.ts
@@ -629,6 +629,34 @@ export function projectPlanCreationAnswerSummaries(
   });
 }
 
+export function isPlanCreationDraftCurrent(
+  snapshot: PlanCreationSnapshot,
+  inputVersion = snapshot.currentDraft?.inputVersion,
+): boolean {
+  if (inputVersion === undefined) return false;
+  if (inputVersion + 1 === snapshot.version) return true;
+  const answers = readPlanCreationAnswers(snapshot);
+  const original = answers
+    .filter(
+      (stored) =>
+        stored.record.creationVersion <= inputVersion && stored.answer.kind === "commitments",
+    )
+    .at(-1)?.answer;
+  return (
+    original?.kind === "commitments" &&
+    original.commitments.kind === "authored" &&
+    answers
+      .filter((stored) => stored.record.creationVersion > inputVersion)
+      .every(
+        ({ answer }) =>
+          answer.kind === "commitments" &&
+          answer.commitments.kind === "authored" &&
+          original.commitments.kind === "authored" &&
+          answer.commitments.text === original.commitments.text,
+      )
+  );
+}
+
 export function projectPlanCreationCard(
   snapshot: PlanCreationSnapshot,
   context: PlanCreationProjectionContext = {
@@ -638,6 +666,7 @@ export function projectPlanCreationCard(
   if (snapshot.status !== "in-progress" && snapshot.status !== "review") return corrupt();
   const flow = resolvePlanCreationAnswerFlow(snapshot);
   const question = flow.next === null ? null : questionForKey(snapshot, flow, context, flow.next);
+  const commitments = flow.valid.get("commitments")?.answer;
   return PlanCreationCardModelSchema.parse({
     creationId: snapshot.id,
     version: snapshot.version,
@@ -646,8 +675,13 @@ export function projectPlanCreationCard(
       snapshot.currentDraft === null
         ? null
         : PlanCreationDraftSchema.parse(JSON.parse(snapshot.currentDraft.outputSnapshotJson)),
-    draftStale:
-      snapshot.currentDraft !== null && snapshot.currentDraft.inputVersion + 1 !== snapshot.version,
+    draftStale: snapshot.currentDraft !== null && !isPlanCreationDraftCurrent(snapshot),
+    commitmentsAcknowledgement:
+      commitments?.kind === "commitments" &&
+      commitments.commitments.kind === "authored" &&
+      commitments.commitments.acknowledged !== true
+        ? { text: commitments.commitments.text }
+        : null,
     readiness: question === null ? "ready" : "incomplete",
     answeredSummaries: projectPlanCreationAnswerSummaries(snapshot, flow, context),
     openQuestion: question,
@@ -732,7 +766,10 @@ export function resolvePlanCreationDraftAnswers(
     goal: normalizedGoal(),
     availability: schedule,
     startTiming: startTiming.timing,
-    commitments: commitments.commitments,
+    commitments:
+      commitments.commitments.kind === "none"
+        ? { kind: "none" }
+        : { kind: "authored", text: commitments.commitments.text },
     baseline: baseline.baseline,
     success: success.success,
     restriction: restriction.restriction,

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -51,6 +51,7 @@ import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import {
   encodePlanCreationAnswer,
+  isPlanCreationDraftCurrent,
   projectPlanCreationCard,
   projectPlanCreationAnswerSummaries,
   resolvePlanCreationAnswerFlow,
@@ -225,7 +226,14 @@ export function createPlanCreationOperations(input: {
           ...card,
           status: "review" as const,
           draft: PlanCreationDraftSchema.parse(JSON.parse(recordedDraft.output_snapshot_json)),
-          draftStale: recordedDraft.input_version + 1 !== version,
+          draftStale: !isPlanCreationDraftCurrent(
+            {
+              ...snapshot,
+              version,
+              answers: snapshot.answers.filter((answer) => answer.creationVersion <= version),
+            },
+            recordedDraft.input_version,
+          ),
         };
   };
   const readCard = async (): Promise<PlanCreationCardModel | null> => {
@@ -626,9 +634,18 @@ export function createPlanCreationOperations(input: {
         mirrorJobId: input.identity.newUlid(),
         cleanupJobId: input.identity.newUlid(),
         revisionId: input.identity.newUlid(),
+        isDraftCurrent: isPlanCreationDraftCurrent,
         materialize(snapshot) {
           if (snapshot.currentDraft === null || resolvePlanCreationDraftAnswers(snapshot) === null)
             throw new PlanCreationStoreError("not-ready");
+          const commitments =
+            resolvePlanCreationAnswerFlow(snapshot).valid.get("commitments")?.answer;
+          if (
+            commitments?.kind === "commitments" &&
+            commitments.commitments.kind === "authored" &&
+            commitments.commitments.acknowledged !== true
+          )
+            throw new PlanCreationStoreError("commitments-unacknowledged");
           const draft = PlanCreationDraftSchema.parse(
             JSON.parse(snapshot.currentDraft.outputSnapshotJson),
           );

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -2436,6 +2436,7 @@ describe("local coach composition", () => {
           readiness: "ready",
           version: answers.length + 2,
           draftStale: false,
+          commitmentsAcknowledgement: null,
         });
         expect(card.draft).not.toBeNull();
         expect(await store.all("SELECT * FROM plan_creation_draft_revision")).toHaveLength(1);

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2294,6 +2294,10 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
 
   it.each([
     ["not-ready", "Build a current complete Draft and resolve pending answers before activation."],
+    [
+      "commitments-unacknowledged",
+      "Acknowledge your written commitments before activating this Plan.",
+    ],
     ["version-conflict", "version-conflict"],
     ["command-conflict", "command-conflict"],
   ] as const)(
@@ -2350,6 +2354,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       status: "in-progress",
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       readiness: "incomplete",
       answeredSummaries: [],
       openQuestion: {
@@ -2383,6 +2388,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       status: "in-progress",
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       readiness: "incomplete",
       answeredSummaries: [
         {

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -28,7 +28,10 @@ import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import { createPlanChangeOperations } from "../src/plan-change-operations.js";
 import { createPlanningReadService } from "../src/planning-read-service.js";
-import { readPlanCreationAnswers } from "../src/plan-creation-answers.js";
+import {
+  readPlanCreationAnswers,
+  resolvePlanCreationDraftAnswers,
+} from "../src/plan-creation-answers.js";
 
 const unusedStore = () => {
   const store = openSqliteStorage(":memory:");
@@ -1953,6 +1956,225 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     expect(await test.store.all("SELECT * FROM plan")).toEqual(plans);
     expect(await test.store.all("SELECT * FROM plan_workout")).toEqual(workouts);
     await expect(test.host.readCard()).resolves.toBeNull();
+  });
+
+  it.each([undefined, false])(
+    "blocks unacknowledged commitments (%s) without writes and activates the same Draft after acknowledgement",
+    async (acknowledged) => {
+      const test = await review();
+      const active = await test.host["plan_creation.activate"](test.request);
+      const started = await test.host["plan_creation.start"]({ commandId: "replacement" });
+      if (started.status !== "started") throw new Error("Expected replacement creation");
+      let card = started.planCreation;
+      const text = "Strength training on Wednesdays";
+      for (const answer of [
+        fitnessGoal,
+        { kind: "plan-length", weeks: 4 },
+        fixedMode,
+        fixedAvailability,
+        startTiming,
+        {
+          kind: "commitments",
+          commitments: {
+            kind: "authored",
+            text,
+            ...(acknowledged === undefined ? {} : { acknowledged }),
+          },
+        },
+        regularBaseline,
+        fitnessSuccess,
+        noRestriction,
+      ] satisfies PlanCreationAnswerInput[]) {
+        card = await answered(
+          test.host["plan_creation.answer"]({
+            commandId: `replacement-${answer.kind}`,
+            creationId: card.creationId,
+            expectedVersion: card.version,
+            answer,
+          }),
+        );
+      }
+      expect(card.commitmentsAcknowledgement).toEqual({ text });
+      const previewRequest = {
+        commandId: "replacement-preview",
+        creationId: card.creationId,
+        expectedVersion: card.version,
+      };
+      const previewed = await test.host["plan_creation.preview"](previewRequest);
+      if (previewed.status !== "previewed" || previewed.planCreation.draft === null)
+        throw new Error("Expected Draft with pending commitments");
+      card = previewed.planCreation;
+      expect(card.draft?.notes).toContain(
+        "Your written commitments are recorded for review and have not been applied to Workouts.",
+      );
+      const before = await test.repository.readUnfinished();
+      if (before === undefined) throw new Error("Expected creation");
+      const builderAnswers = resolvePlanCreationDraftAnswers(before);
+      expect(builderAnswers?.commitments).toEqual({ kind: "authored", text });
+      const incumbent = { planId: active.planId, version: 1 };
+      const request = {
+        commandId: "replacement-activate",
+        incumbent,
+        creationId: card.creationId,
+        expectedVersion: card.version,
+      };
+      const activeBefore = await test.store.all("SELECT * FROM planning_plan");
+      const plansBefore = await test.store.all("SELECT * FROM plan");
+      const writes = vi.spyOn(test.store, "run");
+      await expect(test.host["plan_creation.activate"](request)).rejects.toMatchObject({
+        code: "commitments-unacknowledged",
+      });
+      expect(writes).not.toHaveBeenCalled();
+      writes.mockRestore();
+      expect(await test.store.all("SELECT * FROM planning_plan")).toEqual(activeBefore);
+      expect(await test.store.all("SELECT * FROM plan")).toEqual(plansBefore);
+      expect(await test.repository.readUnfinished()).toEqual(before);
+      const acknowledgementRequest = {
+        commandId: "acknowledge",
+        creationId: card.creationId,
+        expectedVersion: card.version,
+        answer: {
+          kind: "commitments",
+          commitments: { kind: "authored", text, acknowledged: true },
+        },
+      } as const;
+      const confirmed = await answered(test.host["plan_creation.answer"](acknowledgementRequest));
+      expect(confirmed).toMatchObject({
+        draftStale: false,
+        commitmentsAcknowledgement: null,
+        draft: card.draft,
+      });
+      expect(
+        confirmed.answeredSummaries.find((summary) => summary.answerKey === "commitments")?.detail,
+      ).toBe(text);
+      const after = await test.repository.readUnfinished();
+      if (after === undefined) throw new Error("Expected acknowledged creation");
+      expect(resolvePlanCreationDraftAnswers(after)).toEqual(builderAnswers);
+      expect(
+        createHash("sha256")
+          .update(
+            canonicalJson({ answers: resolvePlanCreationDraftAnswers(after), today, ftp: null }),
+          )
+          .digest("hex"),
+      ).toBe(before.currentDraft?.inputFingerprint);
+      expect(after.currentDraft).toEqual(before.currentDraft);
+      await expect(test.host.readCard()).resolves.toEqual(confirmed);
+      await expect(test.host["plan_creation.answer"](acknowledgementRequest)).resolves.toEqual({
+        status: "answered",
+        planCreation: confirmed,
+      });
+      await expect(test.host["plan_creation.preview"](previewRequest)).resolves.toEqual(previewed);
+      const result = await test.host["plan_creation.activate"]({
+        ...request,
+        expectedVersion: confirmed.version,
+      });
+      expect(result.closedPlanId).toBe(active.planId);
+      await expect(
+        test.host["plan_creation.activate"]({ ...request, expectedVersion: confirmed.version }),
+      ).resolves.toEqual(result);
+      await expect(test.host["plan_creation.answer"](acknowledgementRequest)).resolves.toEqual({
+        status: "answered",
+        planCreation: confirmed,
+      });
+    },
+  );
+
+  it("keeps a built Draft and its input fingerprint current after acknowledging the same text", async () => {
+    const test = await previewHarness();
+    await test.ready();
+    const text = "Strength training on Wednesdays";
+    const pending = await test.answer({
+      kind: "commitments",
+      commitments: { kind: "authored", text },
+    });
+    const previewed = await test.host["plan_creation.preview"]({
+      commandId: "preview",
+      creationId: pending.creationId,
+      expectedVersion: pending.version,
+    });
+    if (previewed.status !== "previewed") throw new Error("Expected Draft");
+    const request = {
+      commandId: "acknowledge",
+      creationId: pending.creationId,
+      expectedVersion: previewed.planCreation.version,
+      answer: { kind: "commitments", commitments: { kind: "authored", text, acknowledged: true } },
+    } as const;
+    const card = await answered(test.host["plan_creation.answer"](request));
+    expect(card).toMatchObject({
+      draftStale: false,
+      commitmentsAcknowledgement: null,
+      draft: previewed.planCreation.draft,
+    });
+    const snapshot = await test.repository.readUnfinished();
+    if (snapshot === undefined) throw new Error("Expected creation");
+    const answers = resolvePlanCreationDraftAnswers(snapshot);
+    expect(answers?.commitments).toEqual({ kind: "authored", text });
+    expect(
+      createHash("sha256")
+        .update(canonicalJson({ answers, today, ftp: null }))
+        .digest("hex"),
+    ).toBe(card.draft?.inputFingerprint);
+    await expect(test.host["plan_creation.answer"](request)).resolves.toEqual({
+      status: "answered",
+      planCreation: card,
+    });
+    await expect(test.host.readCard()).resolves.toEqual(card);
+    const changed = await answered(
+      test.host["plan_creation.answer"]({
+        ...request,
+        commandId: "change-text",
+        expectedVersion: card.version,
+        answer: {
+          kind: "commitments",
+          commitments: {
+            kind: "authored",
+            text: "Strength training on Fridays",
+            acknowledged: true,
+          },
+        },
+      }),
+    );
+    expect(changed.draftStale).toBe(true);
+    await expect(test.host["plan_creation.answer"](request)).resolves.toEqual({
+      status: "answered",
+      planCreation: card,
+    });
+  });
+
+  it("projects acknowledgement changes without changing the commitments summary", async () => {
+    const test = await previewHarness();
+    expect((await test.ready()).commitmentsAcknowledgement).toBeNull();
+    const text = "Strength training on Wednesdays";
+    for (const acknowledged of [false, true, false]) {
+      const card = await test.answer({
+        kind: "commitments",
+        commitments: { kind: "authored", text, acknowledged },
+      });
+      expect(card.commitmentsAcknowledgement).toEqual(acknowledged ? null : { text });
+      expect(
+        card.answeredSummaries.find((summary) => summary.answerKey === "commitments")?.detail,
+      ).toBe(text);
+    }
+    expect((await test.answer(noCommitments)).commitmentsAcknowledgement).toBeNull();
+  });
+
+  it("keeps changed commitment text stale even when it is acknowledged", async () => {
+    const test = await review();
+    const card = await answered(
+      test.host["plan_creation.answer"]({
+        commandId: "changed-commitments",
+        creationId: test.request.creationId,
+        expectedVersion: test.request.expectedVersion,
+        answer: {
+          kind: "commitments",
+          commitments: { kind: "authored", text: "No riding on Wednesdays", acknowledged: true },
+        },
+      }),
+    );
+    expect(card).toMatchObject({ draftStale: true, commitmentsAcknowledgement: null });
+    await expect(
+      test.host["plan_creation.activate"]({ ...test.request, expectedVersion: card.version }),
+    ).rejects.toMatchObject({ code: "not-ready" });
   });
 
   it("rejects missing Drafts and stale versions without creating a Plan", async () => {

--- a/packages/coach/tests/planning-request-delivery.test.ts
+++ b/packages/coach/tests/planning-request-delivery.test.ts
@@ -279,6 +279,7 @@ describe("Planning request delivery", () => {
       status: "in-progress" as const,
       draft: null,
       draftStale: false,
+      commitmentsAcknowledgement: null,
       readiness: "incomplete" as const,
       answeredSummaries: [],
       openQuestion: {

--- a/packages/kernel/src/planning/command-ledger.ts
+++ b/packages/kernel/src/planning/command-ledger.ts
@@ -8,14 +8,17 @@ export type PlanCreationErrorCode =
   | "no-unfinished-creation"
   | "corrupt-record"
   | "version-conflict"
-  | "not-ready";
+  | "not-ready"
+  | "commitments-unacknowledged";
 
 export class PlanCreationStoreError extends Error {
   constructor(readonly code: PlanCreationErrorCode) {
     super(
       code === "not-ready"
         ? "Build a current complete Draft and resolve pending answers before activation."
-        : code,
+        : code === "commitments-unacknowledged"
+          ? "Acknowledge your written commitments before activating this Plan."
+          : code,
     );
     this.name = "PlanCreationStoreError";
   }

--- a/packages/kernel/src/planning/creation-repository.ts
+++ b/packages/kernel/src/planning/creation-repository.ts
@@ -139,6 +139,7 @@ export interface ActivatePlanCreationInput extends DiscardPlanCreationInput {
   readonly mirrorJobId: string;
   readonly cleanupJobId: string;
   readonly revisionId: string;
+  readonly isDraftCurrent?: (snapshot: PlanCreationSnapshot) => boolean;
   readonly materialize: (snapshot: PlanCreationSnapshot) => {
     readonly plan: PlanRecord;
     readonly workouts: readonly PlanWorkoutRecord[];
@@ -460,6 +461,7 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
       mirrorJobId,
       cleanupJobId,
       revisionId,
+      isDraftCurrent,
       materialize,
     }) {
       return store.transaction(async () => {
@@ -479,7 +481,7 @@ WHERE id=? AND status IN ('in-progress','review') AND version=?`,
         if (
           current.status !== "review" ||
           revision === null ||
-          revision.inputVersion + 1 !== current.version
+          !(isDraftCurrent?.(current) ?? revision.inputVersion + 1 === current.version)
         )
           throw new PlanCreationStoreError("not-ready");
         const draft = ActivationDraftSchema.safeParse(json(revision.outputSnapshotJson));


### PR DESCRIPTION
## Summary
- Authored commitments answer gains an optional `acknowledged` flag (missing or false = pending); schema stays strict and stored answers keep parsing.
- Card projection exposes `commitmentsAcknowledgement: { text } | null` so the renderer can draw the confirmation card (renderer PR follows).
- `plan_creation.activate` throws `PlanCreationStoreError("commitments-unacknowledged")` before any write and before the incumbent Plan is closed; the daemon RPC maps it like `not-ready`. Preview and the builder note are unchanged.
- Acknowledgement re-answers commitments with the same text through `plan_creation.answer`. The builder input and fingerprint ignore the flag; `isPlanCreationDraftCurrent` (coach) is passed to the kernel as `isDraftCurrent` so the same Draft activates after acknowledgement while any other answer change still marks it stale.

## Verification
astra high read-only verdict: pass, no findings. It exercised zero-write rejection, same-Draft activation after acknowledgement, incumbent closure, replay, and the sequence authored A → ack A → authored B → ack B (stays stale, rejects not-ready).

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project workspace packages/coach packages/coach-contract packages/sport-cycling packages/kernel` | 3181 passed, 1 skipped |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn