### PR TITLE
feat(desktop): confirm written commitments before Plan activation

### DIFF
--- a/.changeset/plan-creation-commitment-card.md
+++ b/.changeset/plan-creation-commitment-card.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Show a confirmation card for written commitments before Plan activation.
+
+User-facing: When your typed commitments could not be fitted into Workouts, the Draft shows them for you to confirm or edit before the Activate button becomes available.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -2357,12 +2357,17 @@ export function createChatController(input: {
       }
     },
     async answerPlanCreation(answer) {
+      const acknowledgingCommitments =
+        answer.kind === "commitments" &&
+        answer.commitments.kind === "authored" &&
+        answer.commitments.acknowledged === true &&
+        planCreation?.commitmentsAcknowledgement != null;
       if (
         disposed ||
         planCreationBusy ||
         planCreationDiscardConfirmationOpen ||
         planCreationActivateConfirmationOpen ||
-        !planCreationBlocksWork() ||
+        (!planCreationBlocksWork() && !acknowledgingCommitments) ||
         planCreation === null
       )
         return;
@@ -2400,6 +2405,13 @@ export function createChatController(input: {
             planCreationPaused = false;
           }
           planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
+        } else if (
+          acknowledgingCommitments &&
+          result.planCreation.commitmentsAcknowledgement === null &&
+          result.planCreation.draft !== null &&
+          !result.planCreation.draftStale
+        ) {
+          requestPlanCreationFocus("activate");
         }
       } catch {
         planCreationError = CHAT_PLAN_CREATION_FAILURE_COPY;
@@ -2551,6 +2563,7 @@ export function createChatController(input: {
         planCreation === null ||
         planCreation.draft === null ||
         planCreation.draftStale ||
+        planCreation.commitmentsAcknowledgement !== null ||
         !planCreation.draft.weeks.some((week) => week.workouts.length > 0)
       )
         return;
@@ -2633,7 +2646,12 @@ export function createChatController(input: {
           "code" in error.data
             ? error.data.code
             : null;
-        if (
+        if (rejection === "commitments-unacknowledged" && error instanceof CoachRpcRemoteError) {
+          activationAttempt = null;
+          planCreationActivateConfirmationOpen = false;
+          planCreationError = error.message;
+          await loadPlanningRequests().catch(() => {});
+        } else if (
           rejection === "version-conflict" ||
           rejection === "not-ready" ||
           rejection === "command-conflict"

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
@@ -3,7 +3,7 @@ import type {
   PlanCreationCardModel,
   PlanCreationDraft,
 } from "@enduragent/coach-contract";
-import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import { useEffect, useId, useRef, type ReactElement, type ReactNode } from "react";
 import { Button } from "@enduragent/ui";
 import { Card, CardContent } from "@enduragent/ui";
 import { useEnduragentStore } from "../../state/store";
@@ -78,6 +78,7 @@ function ReviewCard(props: {
   readonly title: string;
   readonly status?: string;
   readonly summary?: string;
+  readonly summaryId?: string;
   readonly children: ReactNode;
 }): ReactElement {
   return (
@@ -103,7 +104,11 @@ function ReviewCard(props: {
             </span>
           ) : null}
         </div>
-        {props.summary ? <p className="m-0 text-sm leading-5 text-ink-2">{props.summary}</p> : null}
+        {props.summary ? (
+          <p id={props.summaryId} className="m-0 text-sm leading-5 text-ink-2">
+            {props.summary}
+          </p>
+        ) : null}
         {props.children}
       </CardContent>
     </Card>
@@ -127,18 +132,53 @@ export function PlanCreationDraftCards(props: {
   const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
   const discardButton = useRef<HTMLButtonElement>(null);
   const activateButton = useRef<HTMLButtonElement>(null);
+  const acknowledgementSummaryId = useId();
   useEffect(() => {
     if (focusRequest?.target === "discard") queueMicrotask(() => discardButton.current?.focus());
     if (focusRequest?.target === "activate") queueMicrotask(() => activateButton.current?.focus());
   }, [focusRequest?.revision, focusRequest?.target]);
   const draft = props.draft;
   const stale = props.model.draftStale;
+  const acknowledgement = stale ? null : props.model.commitmentsAcknowledgement;
   const workouts = draft.weeks.flatMap((week) => week.workouts);
   const goal = draft.answeredSummaries.find((answer) => answer.answerKey === "goal");
   const title =
     draft.goal.kind === "event" ? draft.goal.name : (draft.goal.outcome ?? "Improve fitness");
   return (
     <section className="grid min-w-0 gap-inset" aria-label="Plan Draft review">
+      {acknowledgement === null ? null : (
+        <ReviewCard
+          eyebrow="Written commitments"
+          title="Confirm your written commitments"
+          status="Not yet confirmed"
+          summary="These commitments are recorded but were not applied to Workouts. Activation waits for your confirmation."
+          summaryId={acknowledgementSummaryId}
+        >
+          <div role="table" aria-label="Written commitments">
+            <Fact label="Submitted">{acknowledgement.text}</Fact>
+          </div>
+          <div className="mt-inset flex flex-wrap gap-inset">
+            <Button
+              variant="outline"
+              disabled={busy || actions === null || editingKey !== null}
+              onClick={() => actions?.editPlanCreation("commitments")}
+            >
+              Edit commitments
+            </Button>
+            <Button
+              disabled={busy || actions === null || editingKey !== null}
+              onClick={() =>
+                actions?.answerPlanCreation({
+                  kind: "commitments",
+                  commitments: { kind: "authored", text: acknowledgement.text, acknowledged: true },
+                })
+              }
+            >
+              Confirm limits
+            </Button>
+          </div>
+        </ReviewCard>
+      )}
       {stale ? (
         <ReviewCard title="Changed answers">
           <div role="table" aria-label="Changed answers">
@@ -264,7 +304,10 @@ export function PlanCreationDraftCards(props: {
             <Button
               ref={activateButton}
               aria-haspopup="dialog"
-              disabled={busy || actions === null || workouts.length === 0}
+              aria-describedby={acknowledgement === null ? undefined : acknowledgementSummaryId}
+              disabled={
+                busy || actions === null || workouts.length === 0 || acknowledgement !== null
+              }
               onClick={() => actions?.openPlanCreationActivate()}
             >
               Activate Plan

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -1901,7 +1901,7 @@ describe("chat controller", () => {
     ]);
   });
 
-  it.each(["missing", "stale", "empty"] as const)(
+  it.each(["missing", "stale", "empty", "commitments-pending"] as const)(
     "does not open activation for a %s Draft",
     async (kind) => {
       const draft = planCreationDraft();
@@ -1919,7 +1919,8 @@ describe("chat controller", () => {
               ? { ...draft, weeks: draft.weeks.map((week) => ({ ...week, workouts: [] })) }
               : draft,
         draftStale: kind === "stale",
-        commitmentsAcknowledgement: null,
+        commitmentsAcknowledgement:
+          kind === "commitments-pending" ? { text: "Keep Sundays free." } : null,
       };
       const activatePlanCreation =
         vi.fn<(request: PlanCreationActivateRpcParams) => Promise<PlanCreationActivateRpcResult>>();
@@ -2135,6 +2136,53 @@ describe("chat controller", () => {
       "The Plan changed. Read the Plan library and confirm again.",
     );
     expect(refreshPlanLibrary).toHaveBeenCalledTimes(2);
+  });
+
+  it("rereads the Draft and shows the daemon message when commitments need acknowledgement", async () => {
+    const stale: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 3,
+      status: "review",
+      readiness: "ready",
+      answeredSummaries: [],
+      openQuestion: null,
+      draft: planCreationDraft(),
+      draftStale: false,
+      commitmentsAcknowledgement: null,
+    };
+    const current: PlanCreationCardModel = {
+      ...stale,
+      version: 4,
+      commitmentsAcknowledgement: { text: "Keep Sundays free." },
+    };
+    const message = "Acknowledge your written commitments before activating this Plan.";
+    const activatePlanCreation = vi
+      .fn<(request: PlanCreationActivateRpcParams) => Promise<PlanCreationActivateRpcResult>>()
+      .mockRejectedValue(
+        new CoachRpcRemoteError(-32000, message, { code: "commitments-unacknowledged" }),
+      );
+    const listPlanningRequests = vi
+      .fn(async () => ({ deliveries: [], planCreation: current }))
+      .mockResolvedValueOnce({ deliveries: [], planCreation: stale });
+    const { controller, controls } = subject(
+      client(replies(), { listPlanningRequests, activatePlanCreation }),
+    );
+    await controller.start();
+    await controller.openPlanCreationActivate();
+    expect(controls.at(-1)?.planCreation?.activateConfirmationOpen).toBe(true);
+    await controller.confirmPlanCreationActivate();
+    expect(activatePlanCreation).toHaveBeenCalledOnce();
+    expect(listPlanningRequests).toHaveBeenCalledTimes(2);
+    expect(controls.at(-1)?.planCreation).toMatchObject({
+      value: current,
+      error: message,
+      busy: false,
+      activateConfirmationOpen: false,
+    });
+    await controller.openPlanCreationActivate();
+    await controller.confirmPlanCreationActivate();
+    expect(activatePlanCreation).toHaveBeenCalledOnce();
+    controller.dispose();
   });
 
   it("cancels activation without changing the Draft and does not restore a dialog after relaunch", async () => {

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -2904,6 +2904,99 @@ describe("chat surface", () => {
       expect(composer()).toBeEnabled();
     });
 
+    it("requires written commitments confirmation before activation and focuses activation after confirmation", async () => {
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null),
+        status: "review",
+        draft: planCreationDraft(),
+        commitmentsAcknowledgement: { text: "Keep Fridays free for family." },
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+      const card = screen.getByRole("region", { name: "Confirm your written commitments" });
+      const activate = screen.getByRole("button", { name: "Activate Plan" });
+      expect(within(card).getByText("Written commitments")).toBeVisible();
+      expect(within(card).getByText("Not yet confirmed")).toBeVisible();
+      expect(within(card).getByRole("rowheader", { name: "Submitted" })).toBeVisible();
+      expect(within(card).getByRole("cell")).toHaveTextContent("Keep Fridays free for family.");
+      expect(activate).toBeDisabled();
+      expect(activate).toHaveAccessibleDescription(
+        "These commitments are recorded but were not applied to Workouts. Activation waits for your confirmation.",
+      );
+      expect(
+        card.compareDocumentPosition(activate) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(
+        within(card)
+          .getAllByRole("button")
+          .map((button) => button.textContent),
+      ).toEqual(["Edit commitments", "Confirm limits"]);
+      await userEvent.click(within(card).getByRole("button", { name: "Confirm limits" }));
+      expect(actions.answerPlanCreation).toHaveBeenCalledExactlyOnceWith({
+        kind: "commitments",
+        commitments: {
+          kind: "authored",
+          text: "Keep Fridays free for family.",
+          acknowledged: true,
+        },
+      });
+      setChat({ planCreationBusy: true });
+      for (const button of within(card).getAllByRole("button")) expect(button).toBeDisabled();
+      await userEvent.click(within(card).getByRole("button", { name: "Confirm limits" }));
+      expect(actions.answerPlanCreation).toHaveBeenCalledOnce();
+      const confirmed = { ...model, version: model.version + 1, commitmentsAcknowledgement: null };
+      setChat({
+        planCreationBusy: false,
+        planCreation: confirmed,
+        timeline: [{ kind: "plan-creation", model: confirmed }],
+        planCreationFocusRequest: { target: "activate", revision: 1 },
+      });
+      expect(screen.queryByRole("region", { name: "Confirm your written commitments" })).toBeNull();
+      expect(activate).toBeEnabled();
+      expect(activate).not.toHaveAttribute("aria-describedby");
+      await waitFor(() => expect(activate).toHaveFocus());
+    });
+
+    it("edits pending written commitments in the existing prefilled editor", async () => {
+      const text = "Keep Fridays free for family.";
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null, {
+          answeredSummaries: [
+            {
+              answerKey: "commitments",
+              title: "Commitments",
+              detail: text,
+              question: commitmentsQuestion("What should this Plan work around?", "Your limits"),
+              answer: { kind: "commitments", commitments: { kind: "authored", text } },
+            },
+          ],
+        }),
+        status: "review",
+        draft: planCreationDraft(),
+        commitmentsAcknowledgement: { text },
+      };
+      vi.mocked(actions.editPlanCreation).mockImplementation((answerKey) => {
+        setChat({ planCreationEditingKey: answerKey, planCreationFocusRevision: 1 });
+      });
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+      await userEvent.click(screen.getByRole("button", { name: "Edit commitments" }));
+      expect(actions.editPlanCreation).toHaveBeenCalledExactlyOnceWith("commitments");
+      const editor = screen.getByRole("textbox", { name: "Scheduling details" });
+      expect(editor).toHaveValue(text);
+      await waitFor(() => expect(editor).toHaveFocus());
+      expect(screen.getByRole("button", { name: "Confirm limits" })).toBeDisabled();
+      expect(actions.answerPlanCreation).not.toHaveBeenCalled();
+    });
+
     it("keeps fixed Workout dates and pinned status visible during Draft review", () => {
       const draft = planCreationDraft();
       draft.mode = "fixed";

--- a/apps/desktop-renderer/tests/plan-creation-commitments-controller.test.tsx
+++ b/apps/desktop-renderer/tests/plan-creation-commitments-controller.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CoachClient } from "@enduragent/coach-client";
+import {
+  COACH_RPC_METHOD_REGISTRY,
+  createAcceptedServerHandshakeFrame,
+  PROTOCOL_VERSION,
+  type PlanCreationAnswerRpcParams,
+  type PlanCreationAnswerRpcResult,
+  type PlanCreationCardModel,
+  type CoachRpcResponse,
+} from "@enduragent/coach-contract";
+import { createChatController, type ChatViewControls } from "../src/chat/controller";
+import { planCreationDraft } from "./plan-creation-draft-fixtures";
+
+describe("written commitments acknowledgement", () => {
+  it("sends one acknowledgement command during confirmation and focuses Activate after success", async () => {
+    const text = "Keep Sundays free.";
+    const pending: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 3,
+      status: "review",
+      readiness: "ready",
+      answeredSummaries: [],
+      openQuestion: null,
+      draft: planCreationDraft(),
+      draftStale: false,
+      commitmentsAcknowledgement: { text },
+    };
+    const confirmed: PlanCreationCardModel = {
+      ...pending,
+      version: 4,
+      commitmentsAcknowledgement: null,
+      draftStale: false,
+    };
+    const finishAnswer = vi.fn<(result: PlanCreationAnswerRpcResult) => void>();
+    const answerResult = new Promise<PlanCreationAnswerRpcResult>((resolve) => {
+      finishAnswer.mockImplementation(resolve);
+    });
+    const call = vi.fn<CoachClient["call"]>().mockReturnValue(answerResult);
+    const client: CoachClient = {
+      handshake: createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
+        athleteHome: "/synthetic/athlete",
+        rendererCapability: "A".repeat(43),
+      }),
+      call: async (method, request) => {
+        const result = await call(method, request);
+        return COACH_RPC_METHOD_REGISTRY[method].responseSchema.parse(result) as CoachRpcResponse<
+          typeof method
+        >;
+      },
+      close: vi.fn(async () => {}),
+    };
+    const controls: ChatViewControls[] = [];
+    const controller = createChatController({
+      clients: {
+        getClient: vi.fn(async () => client),
+        reconnect: vi.fn(async () => client),
+        close: vi.fn(async () => {}),
+      },
+      view: {
+        render: (_state, next) => {
+          if (next !== undefined) controls.push(structuredClone(next));
+        },
+      },
+      refreshTrainingContext: vi.fn(async () => {}),
+      refreshSpend: vi.fn(async () => {}),
+    });
+    controller.resumeCreation(pending);
+    const initialFocusRevision = controls.at(-1)?.planCreation?.focusRequest?.revision ?? 0;
+    const answer: PlanCreationAnswerRpcParams["answer"] = {
+      kind: "commitments",
+      commitments: { kind: "authored", text, acknowledged: true },
+    };
+    const first = controller.answerPlanCreation(answer);
+    const second = controller.answerPlanCreation(answer);
+    await vi.waitFor(() => expect(call).toHaveBeenCalledOnce());
+    expect(call).toHaveBeenCalledWith("plan_creation.answer", {
+      commandId: expect.any(String),
+      creationId: pending.creationId,
+      expectedVersion: pending.version,
+      answer: {
+        kind: "commitments",
+        commitments: { kind: "authored", text, acknowledged: true },
+      },
+    });
+    expect(controls.at(-1)?.planCreation).toMatchObject({ value: pending, busy: true });
+    finishAnswer({ status: "answered", planCreation: confirmed });
+    await Promise.all([first, second]);
+    expect(call).toHaveBeenCalledOnce();
+    expect(controls.at(-1)?.planCreation).toMatchObject({
+      value: confirmed,
+      busy: false,
+      focusRequest: { target: "activate" },
+    });
+    expect(controls.at(-1)?.planCreation?.focusRequest?.revision).toBeGreaterThan(
+      initialFocusRevision,
+    );
+    controller.dispose();
+  });
+});

--- a/apps/desktop/tests/e2e/plan-creation-commitments.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-commitments.spec.ts
@@ -1,0 +1,141 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Browser, type Page } from "@playwright/test";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const commitments = "Keep Tuesday evenings free and finish Sunday rides before noon.";
+const previews = fileURLToPath(new URL("./previews/plan-creation-commitments/", import.meta.url));
+
+async function capture(page: Page, name: string): Promise<void> {
+  const path = join(previews, `${name}.png`);
+  await mkdir(dirname(path), { recursive: true });
+  await page.screenshot({ path });
+  await test.info().attach(name, { path, contentType: "image/png" });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+}
+
+for (const appearance of [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const) {
+  test(`confirms written commitments before opening Plan activation at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scratch = await mkdtemp(join(tmpdir(), "plan-commitments-"));
+    const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+    let fixture: RunningDesktopFixture | undefined;
+    let browser: Browser | undefined;
+    try {
+      await backend.open();
+      const creation = await backend.seedTrainingCreation({ kind: "authored", text: commitments });
+      fixture = await launchDesktopFixture({
+        script: backend.script,
+        token: "d".repeat(43),
+        width: appearance.width,
+        height: 1000,
+        colorScheme: appearance.colorScheme,
+        reducedMotion: true,
+        hidden: true,
+        routeChatAttachmentComposer: true,
+      });
+      await fixture.setViewport(appearance.width, 1000);
+      browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+      const page = browser
+        .contexts()[0]
+        ?.pages()
+        .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+      if (page === undefined) throw new TypeError("Plan Creation renderer is unavailable");
+      await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+        timeout: 30_000,
+      });
+      await page.emulateMedia({ colorScheme: appearance.colorScheme, reducedMotion: "reduce" });
+      const navigation = page.getByRole("navigation", { name: "Main navigation" });
+      await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+      await page
+        .getByRole("group", { name: "Appearance", exact: true })
+        .getByRole("button", {
+          name: appearance.colorScheme === "light" ? "Light" : "Dark",
+          exact: true,
+        })
+        .click();
+      await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+      await expect(page.locator("html")).toHaveAttribute("data-theme", appearance.colorScheme);
+      await page.getByRole("button", { name: "Build Draft", exact: true }).click();
+      await expect.poll(async () => (await backend.card())?.version).toBe(creation.version + 1);
+      const draft = await backend.card();
+      if (draft === null) throw new TypeError("Built Draft is unavailable");
+      expect(draft).toMatchObject({
+        status: "review",
+        draftStale: false,
+        commitmentsAcknowledgement: { text: commitments },
+      });
+      const heading = page.getByRole("heading", {
+        name: "Confirm your written commitments",
+        exact: true,
+      });
+      await expect(heading).toBeVisible();
+      await expect(page.getByText("Not yet confirmed", { exact: true })).toBeVisible();
+      const activate = page.getByRole("button", { name: "Activate Plan", exact: true });
+      await expect(activate).toBeDisabled();
+      await expect(activate).toHaveAttribute("aria-describedby", /\S+/);
+      const edit = page.getByRole("button", { name: "Edit commitments", exact: true });
+      await expect(edit).toBeVisible();
+      await heading.scrollIntoViewIfNeeded();
+      await capture(page, `pending-commitments-${appearance.width}-${appearance.colorScheme}`);
+      await edit.click();
+      await expect(page.locator('[data-parity="custom.textarea"]')).toHaveValue(commitments);
+      await capture(page, `edit-commitments-${appearance.width}-${appearance.colorScheme}`);
+      await page.getByRole("button", { name: "Back to answers", exact: true }).click();
+      await expect(heading).toBeVisible();
+      await expect(activate).toBeDisabled();
+      await page.getByRole("button", { name: "Confirm limits", exact: true }).click();
+      await expect.poll(async () => (await backend.card())?.commitmentsAcknowledgement).toBeNull();
+      expect(await backend.card()).toMatchObject({ draftStale: false });
+      await expect(heading).toHaveCount(0);
+      await expect(activate).toBeEnabled();
+      await expect(activate).toBeFocused();
+      const answers = backend.creationRequests.filter(
+        (request) => request.method === "plan_creation.answer",
+      );
+      expect(answers).toHaveLength(1);
+      expect(answers[0]?.params).toEqual({
+        commandId: expect.any(String),
+        creationId: draft.creationId,
+        expectedVersion: draft.version,
+        answer: {
+          kind: "commitments",
+          commitments: { kind: "authored", text: commitments, acknowledged: true },
+        },
+      });
+      await activate.click();
+      const dialog = page.getByRole("dialog", { name: "Activate Plan?", exact: true });
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeFocused();
+      await capture(page, `activation-confirmation-${appearance.width}-${appearance.colorScheme}`);
+    } finally {
+      await browser?.close().catch(() => {});
+      try {
+        if (fixture !== undefined) {
+          const cleanup = await fixture.close();
+          await test.info().attach("cleanup", {
+            body: JSON.stringify(cleanup),
+            contentType: "application/json",
+          });
+          expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+        }
+      } finally {
+        try {
+          await backend.close();
+        } finally {
+          await rm(scratch, { recursive: true, force: true });
+        }
+      }
+    }
+  });
+}

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -482,7 +482,11 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
     return this.requireHost()["plan.list"]({});
   }
 
-  async seedActiveTraining() {
+  async seedTrainingCreation(
+    commitments: Extract<PlanCreationAnswerInput, { kind: "commitments" }>["commitments"] = {
+      kind: "none",
+    },
+  ): Promise<PlanCreationCardModel> {
     const host = this.requireHost();
     const started = await host["plan_creation.start"]({ commandId: "seed-training-start" });
     if (started.status !== "started") throw new TypeError("Training seed was not started");
@@ -499,7 +503,7 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
         usableWeekdays: [1, 3, 6],
       },
       { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
-      { kind: "commitments", commitments: { kind: "none" } },
+      { kind: "commitments", commitments },
       { kind: "baseline", baseline: "regular" },
       { kind: "success", success: { kind: "authored", text: "Ride four steady hours" } },
       { kind: "restriction", restriction: { kind: "none" } },
@@ -514,6 +518,12 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
       if (answered.status !== "answered") throw new TypeError("Training seed answer was rejected");
       card = answered.planCreation;
     }
+    return card;
+  }
+
+  async seedActiveTraining() {
+    const host = this.requireHost();
+    const card = await this.seedTrainingCreation();
     const previewed = await host["plan_creation.preview"]({
       commandId: "seed-training-preview",
       creationId: card.creationId,


### PR DESCRIPTION
## Summary
- Draft review shows a "Confirm your written commitments" card (eyebrow Written commitments, status Not yet confirmed, Submitted fact row, Edit commitments / Confirm limits) when the card projection carries a pending acknowledgement and the Draft is current. While the Draft is stale the card hides and the existing Rebuild path applies.
- Activate Plan stays visible but disabled, with the card summary as its `aria-describedby` reason; the store guard also refuses to open the activation dialog while acknowledgement is pending.
- Confirm limits sends one `plan_creation.answer` with the acknowledgement payload and the same text, one command id per confirmed attempt; on success focus moves to Activate. Edit commitments reopens the authored editor prefilled.
- A stale renderer whose activation is rejected with `commitments-unacknowledged` shows the daemon message inline and re-reads the card.
- Fixture backend gains creation seeding with authored commitments; new Playwright spec plan-creation-commitments.spec.ts covers build, edit, confirm, focus, and the activation dialog at 1180/720 in light and dark.

## Verification
astra high read-only verdict round 1: one blocking finding (card stayed visible when the Draft was stale), fixed by hiding the card while `draftStale` is true; renderer-dom suites rerun green after the fix.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project renderer-dom --maxWorkers 2` | 696 passed |
| playwright plan-creation-commitments.spec.ts | 4 passed |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn