### PR TITLE
feat(plan): preview and apply the inverse of the latest applied Change

### DIFF
--- a/.changeset/plan-change-undo-backend.md
+++ b/.changeset/plan-change-undo-backend.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Prepare Undo for the latest applied Plan Change as a previewed inverse.
+
+User-facing: The coach can now work out the exact opposite of your latest applied Plan Change so you can review and confirm it before anything moves back.

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -3,6 +3,7 @@ import type {
   PlanChangeModel,
   PlanChangeWorkout,
 } from "@enduragent/coach-contract";
+import { PlanChangeIntentSchema } from "@enduragent/coach-contract";
 import { useEffect, useRef, useState, type ReactElement, type ReactNode, type Ref } from "react";
 import { Button } from "@enduragent/ui";
 import { Card, CardContent } from "@enduragent/ui";
@@ -135,7 +136,10 @@ function Difference({ change }: { change: PlanChangeModel }): ReactElement {
   );
 }
 
-function premiseValue(intent: PlanChangeIntent): string {
+function premiseValue(premise: PlanChangeModel["premises"][number]): string {
+  const parsed = PlanChangeIntentSchema.safeParse(premise.value);
+  if (!parsed.success) return premise.label;
+  const intent = parsed.data;
   switch (intent.kind) {
     case "weekday-duration":
       return `${days[intent.day - 1]} · ${intent.minutes} min`;
@@ -147,11 +151,13 @@ function premiseValue(intent: PlanChangeIntent): string {
       return `${intent.hours} hours each week`;
     case "longest-workout":
       return `${intent.minutes} min`;
+    case "inverse":
+      return premise.label;
   }
 }
 
 function ChangeEditor(): ReactElement {
-  const [kind, setKind] = useState<PlanChangeIntent["kind"]>("weekday-duration");
+  const [kind, setKind] = useState<(typeof changeOptions)[number]["value"]>("weekday-duration");
   const [day, setDay] = useState(3);
   const [minutes, setMinutes] = useState("30");
   const [hours, setHours] = useState("3");
@@ -440,7 +446,7 @@ export function PlanChangeCards(): ReactElement | null {
           <div role="table" aria-label="Source details">
             {source.change.premises.map((premise) => (
               <Fact key={premise.id} label={`${premise.label} · ${premise.source}`}>
-                {premiseValue(premise.value)}
+                {premiseValue(premise)}
               </Fact>
             ))}
           </div>

--- a/apps/desktop-renderer/tests/boot-plan-change.test.ts
+++ b/apps/desktop-renderer/tests/boot-plan-change.test.ts
@@ -185,6 +185,7 @@ function library(planId: string, pending = false): ListPlansResult {
             supersedes: null,
             supersededBy: null,
             resultRevisionNumber: null,
+            undo: null,
             confidence: "High",
             premises: [],
           },

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -103,6 +103,7 @@ function change(patch: Partial<PlanChangeModel> = {}): PlanChangeModel {
     supersedes: null,
     supersededBy: null,
     resultRevisionNumber: null,
+    undo: null,
     confidence: "Confirmed schedule limits",
     premises: [
       {
@@ -380,6 +381,37 @@ describe("Plan Change cards", () => {
     ).toBeVisible();
     expect(within(history).queryByRole("button", { name: "Apply to Plan" })).toBeNull();
     expect(within(history).queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("renders unrecognized premise values as their plain labels", async () => {
+    const values: PlanChangeModel["premises"][number]["value"][] = [
+      null,
+      true,
+      42,
+      "text",
+      ["nested"],
+      { changeId: "prior-change", title: "Earlier limit" },
+      { kind: "weekday-duration", day: "invalid", minutes: 30 },
+      { kind: "inverse", changeId: "00000000000000000000000140" },
+    ];
+    setChanges([
+      change({
+        premises: values.map((value, index) => ({
+          id: `premise-${index}`,
+          label: `Evidence ${index}`,
+          source: "Your confirmed request",
+          value,
+        })),
+      }),
+    ]);
+    render(<PlanChangeCards />);
+    await userEvent.click(screen.getByRole("button", { name: "View evidence" }));
+    const source = screen.getByRole("region", { name: "Source details" });
+    expect(
+      within(source)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent),
+    ).toEqual(values.map((_, index) => `Evidence ${index}`));
   });
 
   it("moves focus to the editor, back to Change one thing, and to a new preview heading", async () => {

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -23,6 +23,7 @@ const change: PlanChangeModel = {
   supersedes: null,
   supersededBy: null,
   resultRevisionNumber: null,
+  undo: null,
   confidence: "High",
   premises: [],
 };

--- a/packages/coach-contract/src/plan-change.ts
+++ b/packages/coach-contract/src/plan-change.ts
@@ -17,6 +17,9 @@ export const PlanChangeIntentSchema = z.discriminatedUnion("kind", [
     .object({ kind: z.literal("weekly-duration"), hours: z.number().positive().multipleOf(0.25) })
     .strict(),
   z.object({ kind: z.literal("longest-workout"), minutes: z.number().int().positive() }).strict(),
+  z
+    .object({ kind: z.literal("inverse"), changeId: PlanCloseRpcParamsSchema.shape.planId })
+    .strict(),
 ]);
 export type PlanChangeIntent = z.infer<typeof PlanChangeIntentSchema>;
 
@@ -54,6 +57,17 @@ export const PlanChangeModelSchema = z
     supersedes: PlanCloseRpcParamsSchema.shape.planId.nullable(),
     supersededBy: PlanCloseRpcParamsSchema.shape.planId.nullable(),
     resultRevisionNumber: z.number().int().positive().nullable(),
+    undo: z
+      .discriminatedUnion("eligible", [
+        z.object({ eligible: z.literal(true) }).strict(),
+        z
+          .object({
+            eligible: z.literal(false),
+            reason: z.enum(["not-newest", "inverse", "nothing-to-restore", "plan-changed"]),
+          })
+          .strict(),
+      ])
+      .nullable(),
     confidence: z.string(),
     premises: z.array(
       z
@@ -61,12 +75,16 @@ export const PlanChangeModelSchema = z
           id: z.string().min(1),
           label: z.string().min(1),
           source: z.string().min(1),
-          value: PlanChangeIntentSchema,
+          value: z.json(),
         })
         .strict(),
     ),
   })
-  .strict();
+  .strict()
+  .refine((change) => (change.status === "applied") === (change.undo !== null), {
+    path: ["undo"],
+    message: "Undo eligibility is required only for applied Changes",
+  });
 export type PlanChangeModel = z.infer<typeof PlanChangeModelSchema>;
 
 export const PlanChangePreviewRpcParamsSchema = PlanCloseRpcParamsSchema.extend({

--- a/packages/coach-contract/tests/plan-change-contract.test.ts
+++ b/packages/coach-contract/tests/plan-change-contract.test.ts
@@ -42,6 +42,7 @@ const change = {
   supersedes: null,
   supersededBy: null,
   resultRevisionNumber: null,
+  undo: null,
   confidence:
     "Moderate confidence. Based on your confirmed limits and the available training record.",
   premises: [
@@ -64,6 +65,7 @@ describe("Plan Change contract", () => {
     { kind: "weekly-duration", hours: 2.5 },
     { kind: "weekly-duration", hours: 2.75 },
     { kind: "longest-workout", minutes: 45 },
+    { kind: "inverse", changeId },
   ])("accepts Schedule intent $kind", (value) => {
     expect(PlanChangeIntentSchema.parse(value)).toEqual(value);
   });
@@ -84,6 +86,8 @@ describe("Plan Change contract", () => {
     { kind: "longest-workout", minutes: Infinity },
     { kind: "hard-weekday", day: 3, minutes: 30 },
     { kind: "inverse" },
+    { kind: "inverse", changeId: "invalid" },
+    { kind: "inverse", changeId, extra: true },
     { kind: "ftp", ftp: 220 },
   ])("rejects invalid or deferred intent %j", (value) => {
     expect(PlanChangeIntentSchema.safeParse(value).success).toBe(false);
@@ -111,9 +115,64 @@ describe("Plan Change contract", () => {
   it.each(["pending", "applied", "cancelled", "superseded", "stale"])(
     "accepts athlete status %s",
     (status) => {
-      expect(PlanChangeModelSchema.parse({ ...change, status }).status).toBe(status);
+      expect(
+        PlanChangeModelSchema.parse({
+          ...change,
+          status,
+          undo: status === "applied" ? { eligible: true } : null,
+        }).status,
+      ).toBe(status);
     },
   );
+
+  it("validates Undo eligibility only on applied Changes", () => {
+    for (const undo of [
+      { eligible: true },
+      ...["not-newest", "inverse", "nothing-to-restore", "plan-changed"].map((reason) => ({
+        eligible: false,
+        reason,
+      })),
+    ]) {
+      expect(PlanChangeModelSchema.parse({ ...change, status: "applied", undo }).undo).toEqual(
+        undo,
+      );
+      expect(PlanChangeModelSchema.safeParse({ ...change, undo }).success).toBe(false);
+    }
+    for (const undo of [
+      null,
+      { eligible: false },
+      { eligible: false, reason: "unknown" },
+      { eligible: true, reason: "inverse" },
+    ]) {
+      expect(PlanChangeModelSchema.safeParse({ ...change, status: "applied", undo }).success).toBe(
+        false,
+      );
+    }
+  });
+
+  it("preserves arbitrary JSON premise values including the undone Change", () => {
+    const values = [
+      { changeId, title: "Limit weekday duration" },
+      null,
+      true,
+      42,
+      "source",
+      [1, { nested: false }],
+    ];
+    for (const value of values) {
+      const model = {
+        ...change,
+        premises: [{ id: "undone-change", label: "Applied Change", source: "Plan history", value }],
+      };
+      expect(PlanChangeModelSchema.parse(model)).toEqual(model);
+    }
+    expect(
+      PlanChangeModelSchema.safeParse({
+        ...change,
+        premises: [{ id: "bad", label: "Bad", source: "Bad", value: undefined }],
+      }).success,
+    ).toBe(false);
+  });
 
   it("preserves the successor id in superseded history", () => {
     const superseded = {

--- a/packages/coach/src/plan-change-operations.ts
+++ b/packages/coach/src/plan-change-operations.ts
@@ -1,4 +1,5 @@
 import {
+  PlanChangeModelSchema,
   PlanChangeApplyRpcParamsSchema,
   PlanChangeApplyResultSchema,
   PlanChangePreviewRpcParamsSchema,
@@ -6,6 +7,7 @@ import {
   PlanCreationDraftSchema,
   type PlanChangeIntent,
   type PlanChangeOperations,
+  type PlanChangeModel,
 } from "@enduragent/coach-contract";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import {
@@ -13,6 +15,7 @@ import {
   PlanChangeEnvelopeSchema,
   dateKeyFromText,
   type PlanWorkoutRecord,
+  type PlanChangeRepository,
 } from "@enduragent/kernel/planning";
 import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
@@ -27,7 +30,68 @@ const titles = {
   "hard-weekday": "No hard training on a weekday",
   "weekly-duration": "Limit weekly duration",
   "longest-workout": "Limit the longest Workout",
+  inverse: "Undo the latest Change",
 } satisfies Record<PlanChangeIntent["kind"], string>;
+
+async function readCompletedWorkoutIds(
+  store: SqlStore,
+  planId: string,
+): Promise<ReadonlySet<string>> {
+  const rows = await store.all(
+    `SELECT workout.structure_json FROM plan_workout workout
+    WHERE workout.plan_id=? AND EXISTS (
+      SELECT 1 FROM plan_workout_match match
+      WHERE match.plan_workout_id=workout.id AND match.plan_id=workout.plan_id
+        AND match.decision='confirmed'
+    )`,
+    [planId],
+  );
+  return new Set(
+    rows.map((row) => DraftIdSchema.parse(JSON.parse(z.string().parse(row.structure_json))).id),
+  );
+}
+
+export async function projectPlanChanges(input: {
+  repository: PlanChangeRepository;
+  store: SqlStore;
+  planId: string;
+  todayDateKey: number;
+}): Promise<PlanChangeModel[]> {
+  const changes = await input.repository.listChanges(input.planId);
+  if (!changes.some((change) => change.status === "applied"))
+    return changes.map((change) => PlanChangeModelSchema.parse({ ...change, undo: null }));
+  const context = await input.repository.readUndoContext(input.planId);
+  const completedWorkoutIds = await readCompletedWorkoutIds(input.store, input.planId);
+  return changes.map((change) => {
+    let undo: PlanChangeModel["undo"] = null;
+    if (change.status === "applied") {
+      if (context === null) undo = { eligible: false, reason: "plan-changed" };
+      else if (context.newestApplied?.changeId !== change.changeId)
+        undo = { eligible: false, reason: "not-newest" };
+      else if (PlanChangeModelSchema.shape.intent.parse(change.intent).kind === "inverse")
+        undo = { eligible: false, reason: "inverse" };
+      else if (
+        change.resultRevisionNumber !== context.currentRevisionNumber ||
+        context.previousSnapshotJson === null
+      )
+        undo = { eligible: false, reason: "plan-changed" };
+      else {
+        const restored = applyScheduleIntent({
+          draft: PlanCreationDraftSchema.parse(JSON.parse(context.snapshotJson)),
+          previousDraft: PlanCreationDraftSchema.parse(JSON.parse(context.previousSnapshotJson)),
+          intent: { kind: "inverse", changeId: change.changeId },
+          completedWorkoutIds,
+          todayDateKey: input.todayDateKey,
+        });
+        undo =
+          restored.diff.length > 0
+            ? { eligible: true }
+            : { eligible: false, reason: "nothing-to-restore" };
+      }
+    }
+    return PlanChangeModelSchema.parse({ ...change, undo });
+  });
+}
 
 export function createPlanChangeOperations(input: {
   store: SqlStore & Pick<MigratorStore, "transaction">;
@@ -65,34 +129,45 @@ export function createPlanChangeOperations(input: {
         throw parsed.error;
       }
       const { intent, planId, expectedVersion } = parsed.data;
-      const completedRows = await input.store.all(
-        `SELECT workout.structure_json FROM plan_workout workout
-        WHERE workout.plan_id=? AND EXISTS (
-          SELECT 1 FROM plan_workout_match match
-          WHERE match.plan_workout_id=workout.id AND match.plan_id=workout.plan_id
-            AND match.decision='confirmed'
-        )`,
-        [planId],
-      );
-      const completedWorkoutIds = new Set(
-        completedRows.map(
-          (row) => DraftIdSchema.parse(JSON.parse(z.string().parse(row.structure_json))).id,
-        ),
-      );
       const result = await repository.preview({
         command: await stamp(parsed.data),
         planId,
         expectedVersion,
         nowMs: input.now(),
         changeId: input.identity.newUlid(),
-        build(snapshotJson) {
+        build({
+          snapshotJson,
+          previousSnapshotJson,
+          newestApplied,
+          currentRevisionNumber,
+          completedWorkoutIds,
+        }) {
           const draft = PlanCreationDraftSchema.parse(JSON.parse(snapshotJson));
-          const { after, diff, totals } = applyScheduleIntent({
+          if (
+            intent.kind === "inverse" &&
+            (newestApplied?.changeId !== intent.changeId ||
+              newestApplied.resultRevisionNumber !== currentRevisionNumber ||
+              previousSnapshotJson === null ||
+              PlanChangeModelSchema.shape.intent.parse(newestApplied.intent).kind === "inverse")
+          )
+            return { status: "rejected", reason: "invalid-intent" };
+          const transformation = {
             draft,
-            intent,
             completedWorkoutIds,
             todayDateKey: input.todayDateKey(),
-          });
+          };
+          const { after, diff, totals } =
+            intent.kind === "inverse"
+              ? applyScheduleIntent({
+                  ...transformation,
+                  intent,
+                  previousDraft: PlanCreationDraftSchema.parse(
+                    JSON.parse(previousSnapshotJson ?? "null"),
+                  ),
+                })
+              : applyScheduleIntent({ ...transformation, intent });
+          if (intent.kind === "inverse" && diff.length === 0)
+            return { status: "rejected", reason: "invalid-intent" };
           return {
             afterSnapshotJson: canonicalJson(after),
             envelope: PlanChangeEnvelopeSchema.parse({
@@ -108,6 +183,16 @@ export function createPlanChangeOperations(input: {
                   source: "Your confirmed answers",
                   value: intent,
                 },
+                ...(intent.kind === "inverse" && newestApplied !== null
+                  ? [
+                      {
+                        id: "undone-change",
+                        label: "Applied Change",
+                        source: "Plan history",
+                        value: { changeId: newestApplied.changeId, title: newestApplied.title },
+                      },
+                    ]
+                  : []),
               ],
               confidence:
                 "Moderate confidence. Based on your confirmed limits and the available training record.",
@@ -115,7 +200,11 @@ export function createPlanChangeOperations(input: {
           };
         },
       });
-      return PlanChangePreviewResultSchema.parse(result);
+      return PlanChangePreviewResultSchema.parse(
+        result.status === "previewed"
+          ? { ...result, change: { ...result.change, undo: null } }
+          : result,
+      );
     },
     async "plan_change.apply"(request) {
       const parsed = PlanChangeApplyRpcParamsSchema.parse(request);
@@ -127,7 +216,7 @@ export function createPlanChangeOperations(input: {
         expectedVersion: parsed.expectedVersion,
         decision: parsed.decision,
         nowMs: input.now(),
-        todayDateKey: input.todayDateKey(),
+        todayDateKey: input.todayDateKey,
         mirrorJobId: input.identity.newUlid(),
         materialize(snapshotJson, currentWorkouts, diffIds) {
           const draft = PlanCreationDraftSchema.parse(JSON.parse(snapshotJson));

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import {
-  PlanChangeModelSchema,
   PlanCloseRpcParamsSchema,
   PlanCloseResultSchema,
   PlanHistoryParamsSchema,
@@ -60,6 +59,8 @@ import {
   type PlanCreationAnswerKey,
   type PlanCreationBaselineEvidence,
 } from "./plan-creation-answers.js";
+
+import { projectPlanChanges } from "./plan-change-operations.js";
 
 export { projectPlanCreationCard } from "./plan-creation-answers.js";
 
@@ -345,9 +346,12 @@ export function createPlanCreationOperations(input: {
           changes:
             active === null
               ? []
-              : (await planChanges.listChanges(active.planId)).map((change) =>
-                  PlanChangeModelSchema.parse(change),
-                ),
+              : await projectPlanChanges({
+                  repository: planChanges,
+                  store: transactionStore,
+                  planId: active.planId,
+                  todayDateKey: todayDateKey(),
+                }),
           closed: summaries.filter((plan) => plan.status === "closed"),
         });
       });

--- a/packages/coach/tests/plan-calendar-drain.test.ts
+++ b/packages/coach/tests/plan-calendar-drain.test.ts
@@ -134,7 +134,7 @@ async function harness() {
       expectedVersion: plan.version,
       nowMs: 904_694_400_000,
       changeId: identity.newUlid(),
-      build(snapshotJson) {
+      build({ snapshotJson }) {
         const snapshot = PlanCreationDraftSchema.parse(JSON.parse(snapshotJson));
         const before = snapshot.weeks
           .flatMap((week) => week.workouts)
@@ -429,7 +429,7 @@ describe("Plan calendar drain", () => {
       expectedVersion: 1,
       nowMs: 904_694_400_000,
       changeId: test.identity.newUlid(),
-      build(snapshotJson) {
+      build({ snapshotJson }) {
         const snapshot = PlanCreationDraftSchema.parse(JSON.parse(snapshotJson));
         for (const week of snapshot.weeks) {
           week.workouts = week.workouts.map((row) => (row.id === before.id ? after : row));

--- a/packages/coach/tests/plan-change-operations.test.ts
+++ b/packages/coach/tests/plan-change-operations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, onTestFinished } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import {
   PlanCreationDraftSchema,
   type PlanCreationAnswerInput,
@@ -89,11 +89,12 @@ async function activatedPlan(todayDateKey = () => 19980902) {
   const preview = async (
     intent: PlanChangeIntent = { kind: "longest-workout", minutes: 30 },
     commandId = "change-preview",
+    expectedVersion = 1,
   ) => {
     const result = await changes["plan_change.preview"]({
       commandId,
       planId,
-      expectedVersion: 1,
+      expectedVersion,
       intent,
     });
     if (result.status !== "previewed") throw new Error(`Expected Change preview: ${result.reason}`);
@@ -482,5 +483,502 @@ describe("Plan Change operations", () => {
       expectedVersion: 1,
     });
     expect((await test.creation["plan.list"]({})).changes).toEqual([]);
+  });
+});
+
+async function applyChange(
+  test: Awaited<ReturnType<typeof activatedPlan>>,
+  changeId: string,
+  expectedVersion: number,
+  commandId: string,
+) {
+  const request = {
+    commandId,
+    planId: test.planId,
+    changeId,
+    expectedVersion,
+    decision: "apply" as const,
+  };
+  const result = await test.changes["plan_change.apply"](request);
+  expect(result).toMatchObject({ status: "applied", revisionNumber: expectedVersion + 1 });
+  return { request, result };
+}
+
+async function revisionSnapshot(test: Awaited<ReturnType<typeof activatedPlan>>, revision: number) {
+  const row = await test.store.get(
+    "SELECT snapshot_json FROM plan_revision WHERE plan_id=? AND revision_number=?",
+    [test.planId, revision],
+  );
+  return PlanCreationDraftSchema.parse(JSON.parse(String(row?.snapshot_json)));
+}
+
+describe("confirmed inverse Changes", () => {
+  it.each([
+    { kind: "weekday-duration", day: 4, minutes: 20 },
+    { kind: "weekday-unavailable", day: 4 },
+    { kind: "hard-weekday", day: 4 },
+    { kind: "weekly-duration", hours: 1 },
+    { kind: "longest-workout", minutes: 20 },
+  ] satisfies PlanChangeIntent[])(
+    "restores the exact prior snapshot after $kind and replays the inverse apply",
+    async (intent) => {
+      const test = await activatedPlan();
+      const original = await revisionSnapshot(test, 1);
+      const beforeRows = await test.workouts();
+      const forward = await test.preview(intent);
+      expect(forward.change.diff.length).toBeGreaterThan(0);
+      await applyChange(test, forward.change.changeId, 1, "apply-forward");
+      expect((await test.creation["plan.list"]({})).changes).toMatchObject([
+        { changeId: forward.change.changeId, undo: { eligible: true } },
+      ]);
+      const changedRows = await test.workouts();
+      const inverse = await test.preview(
+        { kind: "inverse", changeId: forward.change.changeId },
+        "inverse-preview",
+        2,
+      );
+      expect(inverse.change).toMatchObject({
+        title: "Undo the latest Change",
+        status: "pending",
+        undo: null,
+        intent: { kind: "inverse", changeId: forward.change.changeId },
+        premises: [
+          { id: "confirmed-limits", value: { kind: "inverse", changeId: forward.change.changeId } },
+          {
+            id: "undone-change",
+            value: { changeId: forward.change.changeId, title: forward.change.title },
+          },
+        ],
+      });
+      expect(
+        [...inverse.change.diff].sort((a, b) => a.workoutId.localeCompare(b.workoutId)),
+      ).toEqual(
+        forward.change.diff
+          .map((row) => ({ workoutId: row.workoutId, before: row.after, after: row.before }))
+          .sort((a, b) => a.workoutId.localeCompare(b.workoutId)),
+      );
+      expect(inverse.change.totals).toEqual({
+        before: forward.change.totals.after,
+        after: forward.change.totals.before,
+      });
+      expect(await test.workouts()).toEqual(changedRows);
+      const applied = await applyChange(test, inverse.change.changeId, 2, "apply-inverse");
+      expect(await revisionSnapshot(test, 3)).toEqual(original);
+      const restoredRows = await test.workouts();
+      expect(restoredRows.map((row) => row.structure_json).sort()).toEqual(
+        beforeRows.map((row) => row.structure_json).sort(),
+      );
+      for (const row of changedRows) {
+        expect(restoredRows.find((restored) => restored.id === row.id)?.structure_json).toBe(
+          beforeRows.find((before) => before.id === row.id)?.structure_json,
+        );
+      }
+      expect((await test.creation["plan.list"]({})).changes).toMatchObject([
+        {
+          changeId: forward.change.changeId,
+          status: "applied",
+          undo: { eligible: false, reason: "not-newest" },
+        },
+        {
+          changeId: inverse.change.changeId,
+          status: "applied",
+          resultRevisionNumber: 3,
+          undo: { eligible: false, reason: "inverse" },
+        },
+      ]);
+      const beforeReplay = await dumpStore(test.store);
+      expect(await test.changes["plan_change.apply"](applied.request)).toEqual(applied.result);
+      expect(await dumpStore(test.store)).toBe(beforeReplay);
+      expect(
+        await test.changes["plan_change.preview"]({
+          commandId: "redo",
+          planId: test.planId,
+          expectedVersion: 3,
+          intent: { kind: "inverse", changeId: inverse.change.changeId },
+        }),
+      ).toEqual({ status: "rejected", reason: "invalid-intent" });
+    },
+  );
+
+  it("rejects pending and unknown targets without replacing the current preview", async () => {
+    const test = await activatedPlan();
+    const pending = await test.preview();
+    for (const changeId of [pending.change.changeId, "01J00000000000000000000999"]) {
+      const before = await dumpStore(test.store);
+      expect(
+        await test.changes["plan_change.preview"]({
+          commandId: `inverse-${changeId}`,
+          planId: test.planId,
+          expectedVersion: 1,
+          intent: { kind: "inverse", changeId },
+        }),
+      ).toEqual({ status: "rejected", reason: "invalid-intent" });
+      expect(await dumpStore(test.store)).toBe(before);
+    }
+  });
+
+  it("rejects changed input under a reused inverse preview command id", async () => {
+    const test = await activatedPlan();
+    const forward = await test.preview();
+    await applyChange(test, forward.change.changeId, 1, "apply-forward");
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: forward.change.changeId },
+      "inverse",
+      2,
+    );
+    const before = await dumpStore(test.store);
+    expect(
+      await test.changes["plan_change.preview"]({
+        commandId: "inverse",
+        planId: test.planId,
+        expectedVersion: 2,
+        intent: { kind: "inverse", changeId: inverse.change.changeId },
+      }),
+    ).toEqual({ status: "rejected", reason: "command-conflict" });
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it("preserves eligibility across replacement, cancellation, replay, and rejects a target after a newer apply", async () => {
+    const test = await activatedPlan();
+    const forward = await test.preview();
+    await applyChange(test, forward.change.changeId, 1, "apply-forward");
+    const current = await test.workouts();
+    const inverseIntent: PlanChangeIntent = { kind: "inverse", changeId: forward.change.changeId };
+    const inverse = await test.preview(inverseIntent, "inverse-preview", 2);
+    const replacement = await test.preview(
+      { kind: "longest-workout", minutes: 20 },
+      "replacement",
+      2,
+    );
+    expect((await test.creation["plan.list"]({})).changes).toMatchObject([
+      { undo: { eligible: true } },
+      { status: "superseded", undo: null },
+      { status: "pending", undo: null },
+    ]);
+    await test.changes["plan_change.apply"]({
+      commandId: "cancel-replacement",
+      planId: test.planId,
+      changeId: replacement.change.changeId,
+      expectedVersion: 2,
+      decision: "cancel",
+    });
+    expect(await test.preview(inverseIntent, "inverse-preview", 2)).toEqual(inverse);
+    expect((await test.creation["plan.list"]({})).changes).toMatchObject([
+      { undo: { eligible: true } },
+      { status: "superseded", undo: null },
+      { status: "cancelled", undo: null },
+    ]);
+    const cancelledInverse = await test.preview(inverseIntent, "cancelled-inverse", 2);
+    await test.changes["plan_change.apply"]({
+      commandId: "cancel-inverse",
+      planId: test.planId,
+      changeId: cancelledInverse.change.changeId,
+      expectedVersion: 2,
+      decision: "cancel",
+    });
+    expect(await test.workouts()).toEqual(current);
+    expect(
+      await test.store.all("SELECT * FROM plan_revision WHERE plan_id=?", [test.planId]),
+    ).toHaveLength(2);
+    const second = await test.preview(
+      { kind: "longest-workout", minutes: 15 },
+      "second-forward",
+      2,
+    );
+    await applyChange(test, second.change.changeId, 2, "apply-second");
+    const listed = (await test.creation["plan.list"]({})).changes;
+    expect(listed.find((row) => row.changeId === forward.change.changeId)?.undo).toEqual({
+      eligible: false,
+      reason: "not-newest",
+    });
+    expect(listed.find((row) => row.changeId === second.change.changeId)?.undo).toEqual({
+      eligible: true,
+    });
+    const before = await dumpStore(test.store);
+    expect(
+      await test.changes["plan_change.preview"]({
+        commandId: "old-inverse",
+        planId: test.planId,
+        expectedVersion: 3,
+        intent: inverseIntent,
+      }),
+    ).toEqual({ status: "rejected", reason: "invalid-intent" });
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it("keeps completed and past training from the current snapshot while restoring today's and future training", async () => {
+    let today = 19980902;
+    const test = await activatedPlan(() => today);
+    const forward = await test.preview();
+    await applyChange(test, forward.change.changeId, 1, "apply-forward");
+    const current = await revisionSnapshot(test, 2);
+    const completed = current.weeks
+      .flatMap((week) => week.workouts)
+      .find((workout) => workout.date === "1998-09-10");
+    if (!completed) throw new Error("Expected completed Workout");
+    await matchWorkout(test, completed.id, "heuristic", "confirmed");
+    today = 19980908;
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: forward.change.changeId },
+      "inverse",
+      2,
+    );
+    expect(inverse.change.diff.length).toBeGreaterThan(0);
+    expect(inverse.change.diff.length).toBeLessThan(forward.change.diff.length);
+    expect(
+      inverse.change.diff.every(
+        (row) => row.before?.date !== null && String(row.before?.date) >= "1998-09-08",
+      ),
+    ).toBe(true);
+    expect(inverse.change.diff.some((row) => row.before?.date === "1998-09-08")).toBe(true);
+    await applyChange(test, inverse.change.changeId, 2, "apply-inverse");
+    const restored = await revisionSnapshot(test, 3);
+    const restoredRows = new Map(
+      restored.weeks.flatMap((week) => week.workouts).map((row) => [row.id, row]),
+    );
+    for (const workout of current.weeks.flatMap((week) => week.workouts)) {
+      if (workout.id === completed.id || String(workout.date) < "1998-09-08")
+        expect(restoredRows.get(workout.id)).toEqual(workout);
+    }
+  });
+
+  it("reports nothing to restore for an elapsed-only difference and preserves the pending preview on refusal", async () => {
+    let today = 19980902;
+    const test = await activatedPlan(() => today);
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 4 });
+    await applyChange(test, forward.change.changeId, 1, "apply-forward");
+    const pending = await test.preview({ kind: "longest-workout", minutes: 20 }, "pending", 2);
+    today = 19980925;
+    expect(
+      (await test.creation["plan.list"]({})).changes.find(
+        (row) => row.changeId === forward.change.changeId,
+      )?.undo,
+    ).toEqual({ eligible: false, reason: "nothing-to-restore" });
+    const before = await dumpStore(test.store);
+    expect(
+      await test.changes["plan_change.preview"]({
+        commandId: "empty-inverse",
+        planId: test.planId,
+        expectedVersion: 2,
+        intent: { kind: "inverse", changeId: forward.change.changeId },
+      }),
+    ).toEqual({ status: "rejected", reason: "invalid-intent" });
+    expect(await dumpStore(test.store)).toBe(before);
+    expect(
+      (await test.creation["plan.list"]({})).changes.find(
+        (row) => row.changeId === pending.change.changeId,
+      )?.status,
+    ).toBe("pending");
+  });
+
+  it("rejects inverse restoration when a removed Workout becomes past during review", async () => {
+    let today = 19980902;
+    const test = await activatedPlan(() => today);
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 4 });
+    await applyChange(test, forward.change.changeId, 1, "apply-forward");
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: forward.change.changeId },
+      "inverse",
+      2,
+    );
+    expect(inverse.change.diff.every((row) => row.before === null)).toBe(true);
+    today = 19980904;
+    const before = await dumpStore(test.store);
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "apply-inverse",
+        planId: test.planId,
+        changeId: inverse.change.changeId,
+        expectedVersion: 2,
+        decision: "apply",
+      }),
+    ).toEqual({ status: "rejected", reason: "stale-version" });
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it("rejects inverse restoration when a current row was absent from the base snapshot", async () => {
+    const test = await activatedPlan();
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 4 });
+    await applyChange(test, forward.change.changeId, 1, "apply-forward");
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: forward.change.changeId },
+      "inverse",
+      2,
+    );
+    const restored = inverse.change.diff[0]?.after;
+    if (!restored) throw new Error("Expected restored Workout");
+    await test.store.run(
+      "INSERT INTO plan_workout (id,plan_id,date_key,sport,name,duration_s,structure_json,origin,device_id,hlc_physical_ms,hlc_counter) SELECT ?,plan_id,date_key,sport,?,?,?,'athlete',device_id,hlc_physical_ms,hlc_counter FROM plan_workout WHERE plan_id=? LIMIT 1",
+      [
+        "00000000000000000000000999",
+        restored.name,
+        restored.minutes * 60,
+        canonicalJson(restored),
+        test.planId,
+      ],
+    );
+    const before = await dumpStore(test.store);
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "apply-inverse",
+        planId: test.planId,
+        changeId: inverse.change.changeId,
+        expectedVersion: 2,
+        decision: "apply",
+      }),
+    ).toEqual({ status: "rejected", reason: "stale-version" });
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it.each(["elapsed", "completed", "ownership", "snapshot"] as const)(
+    "rejects inverse apply after %s drift without writes",
+    async (drift) => {
+      let today = 19980902;
+      const test = await activatedPlan(() => today);
+      const forward = await test.preview();
+      await applyChange(test, forward.change.changeId, 1, "apply-forward");
+      const inverse = await test.preview(
+        { kind: "inverse", changeId: forward.change.changeId },
+        "inverse",
+        2,
+      );
+      const changed = inverse.change.diff[0];
+      if (!changed?.before) throw new Error("Expected changed Workout");
+      if (drift === "elapsed") today = 19980925;
+      if (drift === "completed")
+        await matchWorkout(test, changed.workoutId, "platform", "confirmed");
+      if (drift === "ownership")
+        await test.store.run(
+          "UPDATE plan_workout SET origin='athlete' WHERE plan_id=? AND json_extract(structure_json,'$.id')=?",
+          [test.planId, changed.workoutId],
+        );
+      if (drift === "snapshot")
+        await test.store.run(
+          "UPDATE plan_workout SET structure_json=? WHERE plan_id=? AND json_extract(structure_json,'$.id')=?",
+          [canonicalJson({ ...changed.before, minutes: 17 }), test.planId, changed.workoutId],
+        );
+      const before = await dumpStore(test.store);
+      expect(
+        await test.changes["plan_change.apply"]({
+          commandId: "apply-inverse",
+          planId: test.planId,
+          changeId: inverse.change.changeId,
+          expectedVersion: 2,
+          decision: "apply",
+        }),
+      ).toEqual({ status: "rejected", reason: "stale-version" });
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+});
+
+describe("Plan Change transaction races", () => {
+  it.each(["schedule", "inverse"] as const)(
+    "excludes completion committed before the %s preview transaction",
+    async (kind) => {
+      const test = await activatedPlan();
+      const forward = await test.preview();
+      if (kind === "inverse") await applyChange(test, forward.change.changeId, 1, "apply-forward");
+      const completed = forward.change.diff[0];
+      if (!completed) throw new Error("Expected changed Workout");
+      const transaction = test.store.transaction.bind(test.store);
+      const hook = vi.spyOn(test.store, "transaction").mockImplementationOnce(async (fn) => {
+        await matchWorkout(test, completed.workoutId, "platform", "confirmed");
+        return transaction(fn);
+      });
+      const preview = await test.preview(
+        kind === "inverse"
+          ? { kind: "inverse", changeId: forward.change.changeId }
+          : { kind: "longest-workout", minutes: 30 },
+        "racing-preview",
+        kind === "inverse" ? 2 : 1,
+      );
+      hook.mockRestore();
+      expect(preview.change.diff.length).toBeGreaterThan(0);
+      expect(preview.change.diff.some((row) => row.workoutId === completed.workoutId)).toBe(false);
+      const before = await test.workouts();
+      await applyChange(test, preview.change.changeId, kind === "inverse" ? 2 : 1, "apply-race");
+      const protectedRow = before.find(
+        (row) =>
+          PlanCreationDraftSchema.shape.weeks.element.shape.workouts.element.parse(
+            JSON.parse(String(row.structure_json)),
+          ).id === completed.workoutId,
+      );
+      expect(protectedRow).toBeDefined();
+      expect((await test.workouts()).find((row) => row.id === protectedRow?.id)).toEqual(
+        protectedRow,
+      );
+    },
+  );
+
+  it.each(["changed", "restored"] as const)(
+    "rejects a %s Workout that elapses before apply enters its transaction",
+    async (kind) => {
+      let today = 19980903;
+      const todayDateKey = vi.fn(() => today);
+      const test = await activatedPlan(todayDateKey);
+      const forward = await test.preview(
+        kind === "restored"
+          ? { kind: "weekday-unavailable", day: 4 }
+          : { kind: "longest-workout", minutes: 30 },
+      );
+      await applyChange(test, forward.change.changeId, 1, "apply-forward");
+      const inverse = await test.preview(
+        { kind: "inverse", changeId: forward.change.changeId },
+        "inverse",
+        2,
+      );
+      expect(inverse.change.diff.some((row) => row.after?.date === "1998-09-03")).toBe(true);
+      const before = await dumpStore(test.store);
+      todayDateKey.mockClear();
+      const transaction = test.store.transaction.bind(test.store);
+      const hook = vi.spyOn(test.store, "transaction").mockImplementationOnce((fn) => {
+        today = 19980904;
+        return transaction(fn);
+      });
+      expect(
+        await test.changes["plan_change.apply"]({
+          commandId: "apply-midnight",
+          planId: test.planId,
+          changeId: inverse.change.changeId,
+          expectedVersion: 2,
+          decision: "apply",
+        }),
+      ).toEqual({ status: "rejected", reason: "stale-version" });
+      hook.mockRestore();
+      expect(todayDateKey).toHaveBeenCalledTimes(1);
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+
+  it("uses the transaction date for preview and the entire apply mirror window", async () => {
+    let today = 19980903;
+    const todayDateKey = vi.fn(() => today);
+    const test = await activatedPlan(todayDateKey);
+    const transaction = test.store.transaction.bind(test.store);
+    const hook = vi.spyOn(test.store, "transaction").mockImplementationOnce((fn) => {
+      today = 19980904;
+      return transaction(fn);
+    });
+    todayDateKey.mockClear();
+    const preview = await test.preview();
+    expect(todayDateKey).toHaveBeenCalledTimes(1);
+    expect(preview.change.diff.length).toBeGreaterThan(0);
+    expect(preview.change.diff.every((row) => String(row.before?.date) >= "1998-09-04")).toBe(true);
+    hook.mockImplementationOnce((fn) => {
+      today = 19980905;
+      return transaction(fn);
+    });
+    todayDateKey.mockClear();
+    todayDateKey.mockImplementation(() => today++);
+    await applyChange(test, preview.change.changeId, 1, "apply-midnight");
+    hook.mockRestore();
+    expect(todayDateKey).toHaveBeenCalledTimes(1);
+    expect(
+      await test.store.all(
+        "SELECT window_start_date_key,window_end_date_key FROM plan_reconciliation_job WHERE kind='mirror' AND window_start_date_key=?",
+        [19980905],
+      ),
+    ).toEqual([{ window_start_date_key: 19980905, window_end_date_key: 19980911 }]);
   });
 });

--- a/packages/kernel-node/tests/plan-change-repository.test.ts
+++ b/packages/kernel-node/tests/plan-change-repository.test.ts
@@ -7,6 +7,7 @@ import {
   createPlanLifecycleRepository,
   createPlanReconciliationRepository,
   type PlanCreationCommandStamp,
+  type PreviewPlanChangeInput,
 } from "@enduragent/kernel/planning";
 import {
   dumpStore,
@@ -83,7 +84,10 @@ const envelope = {
     },
   ],
 };
-const build = (_snapshotJson: string) => ({ afterSnapshotJson: JSON.stringify(after), envelope });
+const build: PreviewPlanChangeInput["build"] = () => ({
+  afterSnapshotJson: JSON.stringify(after),
+  envelope,
+});
 
 describe("Plan Change repository", () => {
   let store: SqlStore & MigratorStore;
@@ -182,7 +186,7 @@ describe("Plan Change repository", () => {
     expectedVersion: 1,
     decision,
     nowMs: nowMs + 30,
-    todayDateKey: 19980102,
+    todayDateKey: () => 19980102,
     mirrorJobId: id("6"),
     materialize: (
       snapshotJson: string,
@@ -232,7 +236,7 @@ describe("Plan Change repository", () => {
       await expect(
         repository.apply({
           ...applyInput(),
-          todayDateKey: 19980103,
+          todayDateKey: () => 19980103,
           materialize,
         }),
       ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
@@ -266,7 +270,13 @@ describe("Plan Change repository", () => {
     const builder = vi.fn(build);
     const result = await repository.preview({ ...previewInput(), build: builder });
     expect(builder).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(builder.mock.calls[0]?.[0] ?? "null")).toEqual(draft);
+    expect(builder).toHaveBeenCalledWith({
+      completedWorkoutIds: new Set(),
+      currentRevisionNumber: 1,
+      snapshotJson: JSON.stringify(draft),
+      previousSnapshotJson: null,
+      newestApplied: null,
+    });
     expect(result).toMatchObject({
       status: "previewed",
       version: 1,
@@ -430,7 +440,158 @@ describe("Plan Change repository", () => {
     ]);
     const builder = vi.fn(build);
     await repository.preview({ ...previewInput(40), expectedVersion: 2, build: builder });
-    expect(JSON.parse(builder.mock.calls[0]?.[0] ?? "null")).toEqual(after);
+    expect(builder).toHaveBeenCalledWith({
+      completedWorkoutIds: new Set(),
+      currentRevisionNumber: 2,
+      snapshotJson: canonicalJson(after),
+      previousSnapshotJson: JSON.stringify(draft),
+      newestApplied: expect.objectContaining({
+        changeId: id("90"),
+        status: "applied",
+        baseRevisionNumber: 1,
+        resultRevisionNumber: 2,
+      }),
+    });
+  });
+
+  it("restores removed Workouts with their Draft ids in a new revision", async () => {
+    await activate();
+    await repository.preview(previewInput());
+    await repository.apply(applyInput());
+    const restoredPreview = await repository.preview({
+      ...previewInput(40),
+      expectedVersion: 2,
+      build: ({ snapshotJson, previousSnapshotJson, newestApplied }) => {
+        expect(JSON.parse(snapshotJson)).toEqual(after);
+        expect(previousSnapshotJson).toBe(JSON.stringify(draft));
+        expect(newestApplied?.changeId).toBe(id("90"));
+        if (previousSnapshotJson === null) throw new Error("Expected previous snapshot");
+        return {
+          afterSnapshotJson: previousSnapshotJson,
+          envelope: {
+            ...envelope,
+            title: "Undo the latest Change",
+            intent: { kind: "inverse", changeId: id("90") },
+            diff: envelope.diff.map((row) => ({
+              workoutId: row.workoutId,
+              before: row.after,
+              after: row.before,
+            })),
+            totals: { before: envelope.totals.after, after: envelope.totals.before },
+          },
+        };
+      },
+    });
+    expect(restoredPreview).toMatchObject({
+      status: "previewed",
+      change: {
+        changeId: id("120"),
+        baseRevisionNumber: 2,
+        diff: expect.arrayContaining([
+          { workoutId: "removed", before: null, after: removedWorkout },
+        ]),
+      },
+    });
+    const materialize: Parameters<typeof repository.apply>[0]["materialize"] = (
+      snapshotJson,
+      current,
+      diffIds,
+    ) => {
+      expect(JSON.parse(snapshotJson)).toEqual(draft);
+      expect(diffIds).toEqual(new Set(["removed", "added"]));
+      const kept = current.find((row) => row.id === id("31"));
+      if (kept === undefined) throw new Error("Expected kept Workout");
+      return {
+        insert: [
+          {
+            ...kept,
+            id: id("34"),
+            dateKey: 19980102,
+            name: removedWorkout.name,
+            durationS: removedWorkout.minutes * 60,
+            structureJson: JSON.stringify(removedWorkout),
+          },
+        ],
+        update: [],
+        delete: [id("33")],
+      };
+    };
+    const input = {
+      ...applyInput(),
+      command: stamp("restore", 50),
+      changeId: id("120"),
+      expectedVersion: 2,
+      nowMs: nowMs + 50,
+      materialize,
+    };
+    const result = await repository.apply(input);
+    expect(result).toEqual({
+      status: "applied",
+      changeId: id("120"),
+      revisionNumber: 3,
+      version: 3,
+    });
+    expect(await store.all("SELECT id,structure_json FROM plan_workout ORDER BY id")).toEqual([
+      { id: id("31"), structure_json: JSON.stringify(keptWorkout) },
+      { id: id("34"), structure_json: JSON.stringify(removedWorkout) },
+    ]);
+    expect(
+      await store.get(
+        "SELECT snapshot_json,parent_revision_number,source_kind,source_id FROM plan_revision WHERE revision_number=3",
+      ),
+    ).toEqual({
+      snapshot_json: canonicalJson(draft),
+      parent_revision_number: 2,
+      source_kind: "plan-change",
+      source_id: id("120"),
+    });
+    await expect(repository.listChanges(planId)).resolves.toMatchObject([
+      { changeId: id("90"), status: "applied", resultRevisionNumber: 2 },
+      { changeId: id("120"), status: "applied", resultRevisionNumber: 3 },
+    ]);
+    const beforeReplay = await dumpStore(store);
+    await expect(repository.apply(input)).resolves.toEqual(result);
+    expect(await dumpStore(store)).toBe(beforeReplay);
+    await expect(repository.readUndoContext(planId)).resolves.toMatchObject({
+      currentRevisionNumber: 3,
+      snapshotJson: canonicalJson(draft),
+      previousSnapshotJson: canonicalJson(after),
+      newestApplied: { changeId: id("120"), intent: { kind: "inverse", changeId: id("90") } },
+    });
+  });
+
+  it("reads the newest applied revision despite cancelled and superseded previews", async () => {
+    await expect(repository.readUndoContext(planId)).resolves.toBeNull();
+    await activate();
+    await expect(repository.readUndoContext(id("88"))).resolves.toBeNull();
+    await expect(repository.readUndoContext(planId)).resolves.toEqual({
+      currentRevisionNumber: 1,
+      snapshotJson: JSON.stringify(draft),
+      previousSnapshotJson: null,
+      newestApplied: null,
+    });
+    await repository.preview(previewInput());
+    await repository.apply(applyInput());
+    const applied = await repository.readUndoContext(planId);
+    await repository.preview({ ...previewInput(40), expectedVersion: 2 });
+    await repository.preview({ ...previewInput(50), expectedVersion: 2 });
+    await repository.apply({
+      ...applyInput("cancel"),
+      command: stamp("cancel-later", 55),
+      nowMs: nowMs + 55,
+      changeId: id("130"),
+      expectedVersion: 2,
+    });
+    await expect(repository.readUndoContext(planId)).resolves.toEqual(applied);
+    const builder = vi.fn(build);
+    await repository.preview({ ...previewInput(60), expectedVersion: 2, build: builder });
+    expect(builder).toHaveBeenCalledWith({
+      completedWorkoutIds: new Set(),
+      currentRevisionNumber: 2,
+      snapshotJson: canonicalJson(after),
+      previousSnapshotJson: JSON.stringify(draft),
+      newestApplied: expect.objectContaining({ changeId: id("90"), resultRevisionNumber: 2 }),
+    });
   });
 
   it("enqueues a pending mirror job for a fresh seven-day window on apply", async () => {
@@ -482,7 +643,7 @@ describe("Plan Change repository", () => {
     const items = await reconciliation.readItems(id("4"));
     await repository.preview(previewInput(12));
     await expect(
-      repository.apply({ ...applyInput(), changeId: id("92"), todayDateKey: 19980101 }),
+      repository.apply({ ...applyInput(), changeId: id("92"), todayDateKey: () => 19980101 }),
     ).resolves.toMatchObject({ status: "applied" });
     expect(await reconciliation.readJob(id("4"))).toEqual({
       ...verified,
@@ -564,7 +725,7 @@ describe("Plan Change repository", () => {
     await expect(
       repository.apply({
         ...applyInput(),
-        todayDateKey: 19980101,
+        todayDateKey: () => 19980101,
         materialize: (_snapshotJson, current) => {
           const moved = current.find((workout) => workout.id === id("32"));
           if (moved === undefined) throw new Error("Expected moved Workout");
@@ -608,7 +769,7 @@ describe("Plan Change repository", () => {
         changeId: id("120"),
         expectedVersion: 2,
         nowMs: nowMs + 50,
-        todayDateKey: 19980101,
+        todayDateKey: () => 19980101,
         materialize: (_snapshotJson, current) => {
           const moved = current.find((workout) => workout.id === id("32"));
           if (moved === undefined) throw new Error("Expected moved Workout");
@@ -752,7 +913,7 @@ describe("Plan Change repository", () => {
           await repository.apply({
             ...input,
             mirrorJobId: id("8"),
-            todayDateKey: 19980103,
+            todayDateKey: () => 19980103,
             materialize,
           }),
         ),

--- a/packages/kernel/src/planning/change-repository.ts
+++ b/packages/kernel/src/planning/change-repository.ts
@@ -72,6 +72,12 @@ export const PlanChangeApplyStoreResultSchema = z.discriminatedUnion("status", [
 ]);
 export type PlanChangePreviewStoreResult = z.infer<typeof PlanChangePreviewStoreResultSchema>;
 export type PlanChangeApplyStoreResult = z.infer<typeof PlanChangeApplyStoreResultSchema>;
+export interface PlanChangeUndoContext {
+  readonly currentRevisionNumber: number;
+  readonly snapshotJson: string;
+  readonly previousSnapshotJson: string | null;
+  readonly newestApplied: PlanChangeRecord | null;
+}
 export interface PreviewPlanChangeInput {
   readonly command: PlanCreationCommandStamp;
   readonly planId: string;
@@ -79,7 +85,7 @@ export interface PreviewPlanChangeInput {
   readonly nowMs: number;
   readonly changeId: string;
   readonly build: (
-    snapshotJson: string,
+    context: PlanChangeUndoContext & { readonly completedWorkoutIds: ReadonlySet<string> },
   ) =>
     | { readonly afterSnapshotJson: string; readonly envelope: PlanChangeEnvelope }
     | { readonly status: "rejected"; readonly reason: "invalid-intent" };
@@ -96,7 +102,7 @@ export interface ApplyPlanChangeInput {
   readonly expectedVersion: number;
   readonly decision: "apply" | "cancel";
   readonly nowMs: number;
-  readonly todayDateKey: number;
+  readonly todayDateKey: () => number;
   readonly mirrorJobId: string;
   readonly materialize: (
     afterSnapshotJson: string,
@@ -108,6 +114,7 @@ export interface PlanChangeRepository {
   preview(input: PreviewPlanChangeInput): Promise<PlanChangePreviewStoreResult>;
   apply(input: ApplyPlanChangeInput): Promise<PlanChangeApplyStoreResult>;
   listChanges(planId: string): Promise<PlanChangeRecord[]>;
+  readUndoContext(planId: string): Promise<PlanChangeUndoContext | null>;
 }
 const ActiveRowSchema = z.object({
   plan_id: UlidSchema,
@@ -199,6 +206,39 @@ export function createPlanChangeRepository(
       resultRevisionNumber: row.result_revision_number,
     });
   };
+  const readUndoContext = async (active: z.infer<typeof ActiveRowSchema>) => {
+    const revision = z
+      .object({ snapshot_json: z.string() })
+      .parse(
+        await store.get(
+          "SELECT snapshot_json FROM plan_revision WHERE plan_id=? AND revision_number=?",
+          [active.plan_id, active.current_revision_number],
+        ),
+      );
+    const newest = await store.get(
+      "SELECT * FROM plan_change WHERE plan_id=? AND status='applied' ORDER BY result_revision_number DESC LIMIT 1",
+      [active.plan_id],
+    );
+    const newestApplied =
+      newest === undefined ? null : project(ChangeRowSchema.parse(newest), new Map());
+    const previous =
+      newestApplied === null
+        ? null
+        : z
+            .object({ snapshot_json: z.string() })
+            .parse(
+              await store.get(
+                "SELECT snapshot_json FROM plan_revision WHERE plan_id=? AND revision_number=?",
+                [active.plan_id, newestApplied.baseRevisionNumber],
+              ),
+            );
+    return {
+      currentRevisionNumber: active.current_revision_number,
+      snapshotJson: revision.snapshot_json,
+      previousSnapshotJson: previous?.snapshot_json ?? null,
+      newestApplied,
+    };
+  };
   const retire = async (
     row: ChangeRow,
     input: { command: PlanCreationCommandStamp; nowMs: number },
@@ -219,6 +259,7 @@ export function createPlanChangeRepository(
     input: ApplyPlanChangeInput,
     change: ChangeRow,
     afterSnapshotJson: string,
+    todayDateKey: number,
   ) => {
     const plan = await plans.read(input.planId);
     if (plan === undefined) return fail();
@@ -254,12 +295,21 @@ export function createPlanChangeRepository(
       completedRows.map((row) => z.string().parse(row.plan_workout_id)),
     );
     const currentByDraftId = new Map(current.map((workout) => [draftId(workout), workout]));
+    if (current.some((workout) => !baseIds.has(draftId(workout)))) return false;
+    for (const workout of afterWorkouts) {
+      if (
+        !baseIds.has(workout.id) &&
+        workout.date !== null &&
+        dateKeyFromText(workout.date) < todayDateKey
+      )
+        return false;
+    }
     for (const workout of changedWorkouts) {
       const row = currentByDraftId.get(workout.id);
       if (
         workout.pinned ||
         workout.date === null ||
-        dateKeyFromText(workout.date) < input.todayDateKey ||
+        dateKeyFromText(workout.date) < todayDateKey ||
         (row !== undefined && completedWorkoutIds.has(row.id))
       )
         return false;
@@ -271,6 +321,7 @@ export function createPlanChangeRepository(
         row === undefined
           ? workout.date !== null
           : workout.date === null ||
+            row.origin !== "coach" ||
             row.name !== workout.name ||
             row.durationS !== workout.minutes * 60 ||
             row.dateKey !== dateKeyFromText(workout.date) ||
@@ -366,15 +417,21 @@ export function createPlanChangeRepository(
         if (active === null) return { status: "rejected", reason: "no-active-plan" };
         if (active.plan_id !== input.planId || active.version !== input.expectedVersion)
           return { status: "rejected", reason: "stale-version" };
-        const revision = z
-          .object({ snapshot_json: z.string() })
-          .parse(
-            await store.get(
-              "SELECT snapshot_json FROM plan_revision WHERE plan_id=? AND revision_number=?",
-              [input.planId, active.current_revision_number],
-            ),
-          );
-        const built = input.build(revision.snapshot_json);
+        const completedRows = await store.all(
+          `SELECT workout.structure_json FROM plan_workout workout
+          WHERE workout.plan_id=? AND EXISTS (
+            SELECT 1 FROM plan_workout_match match
+            WHERE match.plan_workout_id=workout.id AND match.plan_id=workout.plan_id
+              AND match.decision='confirmed'
+          )`,
+          [input.planId],
+        );
+        const completedWorkoutIds = new Set(
+          completedRows.map(
+            (row) => DraftIdSchema.parse(JSON.parse(z.string().parse(row.structure_json))).id,
+          ),
+        );
+        const built = input.build({ ...(await readUndoContext(active)), completedWorkoutIds });
         if ("status" in built) return built;
         const afterSnapshotJson = canonicalJson(JSON.parse(built.afterSnapshotJson));
         const fingerprint = await dependencies.sha256(afterSnapshotJson);
@@ -430,6 +487,7 @@ export function createPlanChangeRepository(
     },
     async apply(input) {
       return store.transaction(async () => {
+        const todayDateKey = input.todayDateKey();
         const prior = await replay("plan_change.apply", input.command);
         if (prior !== undefined) return PlanChangeApplyStoreResultSchema.parse(prior);
         const active = await readActive();
@@ -455,7 +513,7 @@ export function createPlanChangeRepository(
           const { afterSnapshotJson } = z
             .object({ afterSnapshotJson: z.string() })
             .parse(JSON.parse(change.reconciliation_effect_json));
-          if (!(await writeWorkouts(input, change, afterSnapshotJson)))
+          if (!(await writeWorkouts(input, change, afterSnapshotJson, todayDateKey)))
             return { status: "rejected", reason: "stale-version" };
           const revisionNumber = active.current_revision_number + 1;
           await store.run(
@@ -496,7 +554,7 @@ export function createPlanChangeRepository(
               input.planId,
             ],
           );
-          const windowEnd = addCivilDays(input.todayDateKey, 6);
+          const windowEnd = addCivilDays(todayDateKey, 6);
           await store.run(
             `INSERT INTO plan_reconciliation_job (
             id,plan_id,kind,status,window_start_date_key,window_end_date_key,
@@ -504,20 +562,13 @@ export function createPlanChangeRepository(
             created_at_ms,updated_at_ms,completed_at_ms
             ) VALUES (?,?,'mirror','pending',?,?,0,0,0,NULL,NULL,?,?,NULL)
             ON CONFLICT(plan_id,kind,window_start_date_key,window_end_date_key) DO NOTHING`,
-            [
-              input.mirrorJobId,
-              input.planId,
-              input.todayDateKey,
-              windowEnd,
-              input.nowMs,
-              input.nowMs,
-            ],
+            [input.mirrorJobId, input.planId, todayDateKey, windowEnd, input.nowMs, input.nowMs],
           );
           const job = z.object({ id: UlidSchema }).parse(
             await store.get(
               `SELECT id FROM plan_reconciliation_job
               WHERE plan_id=? AND kind='mirror' AND window_start_date_key=? AND window_end_date_key=?`,
-              [input.planId, input.todayDateKey, windowEnd],
+              [input.planId, todayDateKey, windowEnd],
             ),
           );
           await store.run(
@@ -528,7 +579,7 @@ export function createPlanChangeRepository(
                   AND origin='coach' AND date_key BETWEEN ? AND ?
               )
             )))`,
-            [job.id, input.todayDateKey, windowEnd],
+            [job.id, todayDateKey, windowEnd],
           );
           await store.run(
             `UPDATE plan_reconciliation_job SET status='pending',last_error_code=NULL,
@@ -549,6 +600,12 @@ export function createPlanChangeRepository(
           result,
         );
         return result;
+      });
+    },
+    async readUndoContext(planId) {
+      return store.transaction(async () => {
+        const active = await readActive();
+        return active === null || active.plan_id !== planId ? null : readUndoContext(active);
       });
     },
     async listChanges(planId) {

--- a/packages/sport-cycling/src/plan-change.ts
+++ b/packages/sport-cycling/src/plan-change.ts
@@ -56,17 +56,61 @@ function changed(before: Workout, after: Workout): boolean {
   );
 }
 
-export function applyScheduleIntent<Draft extends CreationDraft>({
-  draft,
-  intent,
-  todayDateKey,
-  completedWorkoutIds = new Set<string>(),
-}: {
-  draft: Draft;
-  intent: ScheduleIntent;
-  todayDateKey: number;
-  completedWorkoutIds?: ReadonlySet<string>;
-}): { after: Draft; diff: ScheduleChangeDiff[]; totals: ScheduleChangeTotals } {
+function changeResult<Draft extends CreationDraft>(draft: Draft, after: Draft) {
+  const current = new Map(draft.weeks.flatMap((week) => week.workouts).map((w) => [w.id, w]));
+  const remaining = new Map(after.weeks.flatMap((week) => week.workouts).map((w) => [w.id, w]));
+  const diff: ScheduleChangeDiff[] = [];
+  for (const before of current.values()) {
+    const next = remaining.get(before.id) ?? null;
+    if (next === null || changed(before, next)) {
+      diff.push({ workoutId: before.id, before: structuredClone(before), after: next });
+    }
+  }
+  for (const next of remaining.values()) {
+    if (!current.has(next.id)) diff.push({ workoutId: next.id, before: null, after: next });
+  }
+  const { inputFingerprint: _input, outputFingerprint: _output, ...snapshot } = after;
+  after.outputFingerprint = digest(snapshot);
+  return { after, diff, totals: { before: totals(draft), after: totals(after) } };
+}
+
+export function applyScheduleIntent<Draft extends CreationDraft>(
+  input: {
+    draft: Draft;
+    todayDateKey: number;
+    completedWorkoutIds?: ReadonlySet<string>;
+  } & (
+    | { intent: ScheduleIntent }
+    | { intent: { kind: "inverse"; changeId: string }; previousDraft: Draft }
+  ),
+): { after: Draft; diff: ScheduleChangeDiff[]; totals: ScheduleChangeTotals } {
+  const { draft, todayDateKey, completedWorkoutIds = new Set<string>() } = input;
+  if ("previousDraft" in input) {
+    const after = structuredClone(input.previousDraft);
+    const current = new Map(draft.weeks.flatMap((week) => week.workouts).map((w) => [w.id, w]));
+    for (const week of after.weeks) {
+      week.workouts = week.workouts
+        .filter(
+          (workout) =>
+            current.has(workout.id) || mutable(workout, todayDateKey, completedWorkoutIds),
+        )
+        .map((workout) => {
+          const present = current.get(workout.id);
+          return present && !mutable(present, todayDateKey, completedWorkoutIds)
+            ? structuredClone(present)
+            : workout;
+        });
+      const restoredIds = new Set(week.workouts.map((workout) => workout.id));
+      const currentWeek = draft.weeks.find((candidate) => candidate.number === week.number);
+      for (const workout of currentWeek?.workouts ?? []) {
+        if (!mutable(workout, todayDateKey, completedWorkoutIds) && !restoredIds.has(workout.id)) {
+          week.workouts.push(structuredClone(workout));
+        }
+      }
+    }
+    return changeResult(draft, after);
+  }
+  const { intent } = input;
   const after = structuredClone(draft);
   for (const week of after.weeks) {
     if (intent.kind === "weekly-duration") {
@@ -108,15 +152,5 @@ export function applyScheduleIntent<Draft extends CreationDraft>({
     }
     week.workouts = week.workouts.filter((workout) => workout.minutes > 0);
   }
-  const remaining = new Map(after.weeks.flatMap((week) => week.workouts).map((w) => [w.id, w]));
-  const diff: ScheduleChangeDiff[] = [];
-  for (const before of draft.weeks.flatMap((week) => week.workouts)) {
-    const next = remaining.get(before.id) ?? null;
-    if (next === null || changed(before, next)) {
-      diff.push({ workoutId: before.id, before: structuredClone(before), after: next });
-    }
-  }
-  const { inputFingerprint: _input, outputFingerprint: _output, ...snapshot } = after;
-  after.outputFingerprint = digest(snapshot);
-  return { after, diff, totals: { before: totals(draft), after: totals(after) } };
+  return changeResult(draft, after);
 }

--- a/packages/sport-cycling/tests/plan-change.test.ts
+++ b/packages/sport-cycling/tests/plan-change.test.ts
@@ -277,3 +277,144 @@ describe("Schedule Plan Changes", () => {
     ]);
   });
 });
+
+describe("Inverse Plan Changes", () => {
+  const intents: ScheduleIntent[] = [
+    { kind: "weekday-duration", day: 1, minutes: 20 },
+    { kind: "weekday-unavailable", day: 1 },
+    { kind: "hard-weekday", day: 1 },
+    { kind: "weekly-duration", hours: 1 },
+    { kind: "longest-workout", minutes: 20 },
+  ];
+
+  it.each(intents)("restores the exact prior snapshot after $kind", (intent) => {
+    const previousDraft = fixture();
+    const changed = applyScheduleIntent({ draft: previousDraft, intent, todayDateKey });
+    const current = structuredClone(changed.after);
+    const result = applyScheduleIntent({
+      draft: current,
+      previousDraft,
+      intent: { kind: "inverse", changeId: "applied-change" },
+      todayDateKey,
+    });
+    expect(result.after).toEqual(previousDraft);
+    expect(result.totals.after).toEqual(changed.totals.before);
+    expect(result.totals.before).toEqual(changed.totals.after);
+    expect(result.diff).toHaveLength(changed.diff.length);
+    for (const row of changed.diff) {
+      expect(result.diff.find((inverse) => inverse.workoutId === row.workoutId)).toEqual({
+        workoutId: row.workoutId,
+        before: row.after,
+        after: row.before,
+      });
+    }
+    expect(current).toEqual(changed.after);
+    expect(previousDraft).toEqual(fixture());
+  });
+
+  it("keeps current copies of completed, past, pinned and undated Workouts", () => {
+    const previousDraft = fixture();
+    const { after: draft } = applyScheduleIntent({
+      draft: previousDraft,
+      intent: { kind: "longest-workout", minutes: 20 },
+      todayDateKey,
+    });
+    draft.weeks[2].workouts[0].pinned = true;
+    draft.weeks[2].workouts[1].date = null;
+    const completedWorkoutIds = new Set(["w3-long"]);
+    const result = applyScheduleIntent({
+      draft,
+      previousDraft,
+      intent: { kind: "inverse", changeId: "applied-change" },
+      todayDateKey: 19980831,
+      completedWorkoutIds,
+    });
+    const protectedIds = [
+      "w2-hard",
+      "w2-endurance",
+      "w2-long",
+      "w3-hard",
+      "w3-endurance",
+      "w3-long",
+    ];
+    for (const id of protectedIds) {
+      expect(workouts(result.after).find((workout) => workout.id === id)).toEqual(
+        workouts(draft).find((workout) => workout.id === id),
+      );
+      expect(result.diff.some((row) => row.workoutId === id)).toBe(false);
+    }
+    expect(result.diff).toHaveLength(9);
+  });
+
+  it("restores removed Workouts dated today and skips removed Workouts that are no longer mutable", () => {
+    const previousDraft = fixture();
+    const { after: draft } = applyScheduleIntent({
+      draft: previousDraft,
+      intent: { kind: "weekday-unavailable", day: 1 },
+      todayDateKey,
+    });
+    previousDraft.weeks[3].workouts[0].pinned = true;
+    previousDraft.weeks[4].workouts[0].date = null;
+    const result = applyScheduleIntent({
+      draft,
+      previousDraft,
+      intent: { kind: "inverse", changeId: "applied-change" },
+      todayDateKey: 19980831,
+      completedWorkoutIds: new Set(["w6-hard"]),
+    });
+    expect(result.diff).toEqual([
+      { workoutId: "w3-hard", before: null, after: previousDraft.weeks[2].workouts[0] },
+    ]);
+    expect(
+      workouts(result.after)
+        .filter((workout) => workout.kind === "hard")
+        .map((workout) => workout.id),
+    ).toEqual(["w1-hard", "w3-hard"]);
+  });
+
+  it("preserves non-mutable Workouts present only in the current snapshot", () => {
+    const previousDraft = fixture();
+    const draft = structuredClone(previousDraft);
+    const base = draft.weeks[1].workouts[0];
+    draft.weeks[1].workouts.push(
+      { ...base, id: "new-pinned", pinned: true },
+      { ...base, id: "new-undated", date: null },
+      { ...base, id: "new-past", date: "1998-08-23" },
+      { ...base, id: "new-completed" },
+      { ...base, id: "new-mutable" },
+    );
+    const result = applyScheduleIntent({
+      draft,
+      previousDraft,
+      intent: { kind: "inverse", changeId: "applied-change" },
+      todayDateKey,
+      completedWorkoutIds: new Set(["new-completed"]),
+    });
+    expect(result.after.weeks[1].workouts.map((workout) => workout.id)).toEqual(
+      draft.weeks[1].workouts
+        .filter((workout) => workout.id !== "new-mutable")
+        .map((workout) => workout.id),
+    );
+    expect(result.diff).toEqual([
+      { workoutId: "new-mutable", before: { ...base, id: "new-mutable" }, after: null },
+    ]);
+  });
+
+  it("returns no difference when all changed Workouts have passed", () => {
+    const previousDraft = fixture();
+    const { after: draft } = applyScheduleIntent({
+      draft: previousDraft,
+      intent: { kind: "longest-workout", minutes: 20 },
+      todayDateKey,
+    });
+    const result = applyScheduleIntent({
+      draft,
+      previousDraft,
+      intent: { kind: "inverse", changeId: "applied-change" },
+      todayDateKey: 19980928,
+    });
+    expect(result.after).toEqual(draft);
+    expect(result.diff).toEqual([]);
+    expect(result.totals.after).toEqual(result.totals.before);
+  });
+});


### PR DESCRIPTION
## Summary
- Contract: intent `{ kind: "inverse", changeId }`; `PlanChangeModel.undo` is `{ eligible: true } | { eligible: false, reason: not-newest | inverse | nothing-to-restore | plan-changed }` on applied Changes, null otherwise; `premises[].value` widened to JSON.
- Eligibility: newest applied Change by result revision, equal to the Plan's current revision, intent not inverse. Cancelled, superseded and stale previews never affect it. An applied inverse is terminal.
- Preview: `after` is the revision snapshot before the target Change, with Workouts that are no longer mutable (pinned, undated, completed, before today) kept from the current Plan; today is mutable. The differ now emits additions. Empty diff rejects as invalid-intent. New premise `undone-change`.
- Apply: ordinary revision n+1; restored Workouts insert rows keeping their Draft id; elapsed restores and ownership drift refuse as stale-version with no partial mutation. Completion status and the apply-day today are read inside the transactions.
- Renderer: type-level only (premise fallback rendering, fixtures). No Undo UI yet; that is the next PR.

## Verification
astra high read-only: round 1 two blocking findings (completion read and apply-day captured outside the transactions), both fixed with regression tests; round 2 pass, no findings.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project workspace` coach-contract, coach, sport-cycling, kernel, kernel-node change repo | 3217 passed, 1 skipped; daemon-handoff and package-exports 5 s load timeouts under parallel load pass in isolation |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn