### PR TITLE
chore(renderer): align shared UI package with prototypes

### DIFF
--- a/.changeset/little-doors-train.md
+++ b/.changeset/little-doors-train.md
@@ -1,0 +1,4 @@
+---
+---
+
+Align the renderer's shared UI package with the prototype catalogue release.

--- a/apps/desktop-renderer/package.json
+++ b/apps/desktop-renderer/package.json
@@ -12,7 +12,7 @@
     "@base-ui/react": "^1.7.0",
     "@enduragent/coach-client": "workspace:*",
     "@enduragent/coach-contract": "workspace:*",
-    "@enduragent/ui": "https://github.com/yerzhansa/enduragent-ui/releases/download/v0.2.0/enduragent-ui-0.2.0.tgz",
+    "@enduragent/ui": "https://github.com/yerzhansa/enduragent-ui/releases/download/v0.3.0/enduragent-ui-0.3.0.tgz",
     "lucide-react": "^1.39.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/coach-contract
       '@enduragent/ui':
-        specifier: https://github.com/yerzhansa/enduragent-ui/releases/download/v0.2.0/enduragent-ui-0.2.0.tgz
-        version: https://github.com/yerzhansa/enduragent-ui/releases/download/v0.2.0/enduragent-ui-0.2.0.tgz(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
+        specifier: https://github.com/yerzhansa/enduragent-ui/releases/download/v0.3.0/enduragent-ui-0.3.0.tgz
+        version: https://github.com/yerzhansa/enduragent-ui/releases/download/v0.3.0/enduragent-ui-0.3.0.tgz(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
       lucide-react:
         specifier: ^1.39.0
         version: 1.39.0(react@19.2.8)
@@ -1171,9 +1171,9 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@enduragent/ui@https://github.com/yerzhansa/enduragent-ui/releases/download/v0.2.0/enduragent-ui-0.2.0.tgz':
-    resolution: {integrity: sha512-EH8VBOVyKz58JFvPCODX+TOp2Pd4+wubbVgDeN1SohPh7j9lrkdFZl9SJzeLnMvACDp+t5WJwoMGpCZCO5dO5Q==, tarball: https://github.com/yerzhansa/enduragent-ui/releases/download/v0.2.0/enduragent-ui-0.2.0.tgz}
-    version: 0.2.0
+  '@enduragent/ui@https://github.com/yerzhansa/enduragent-ui/releases/download/v0.3.0/enduragent-ui-0.3.0.tgz':
+    resolution: {integrity: sha512-TMJFYmRK5tOWlzRvyKlPCs6V6bC2jT5sjmpfvCTBQomThKmFwf+eBkHtfOGx6JdgQg06ljgzu5Mf7aOv3mKE/g==, tarball: https://github.com/yerzhansa/enduragent-ui/releases/download/v0.3.0/enduragent-ui-0.3.0.tgz}
+    version: 0.3.0
     engines: {node: '>=24'}
     peerDependencies:
       react: ^19.2.8
@@ -6219,7 +6219,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@enduragent/ui@https://github.com/yerzhansa/enduragent-ui/releases/download/v0.2.0/enduragent-ui-0.2.0.tgz(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)':
+  '@enduragent/ui@https://github.com/yerzhansa/enduragent-ui/releases/download/v0.3.0/enduragent-ui-0.3.0.tgz(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)':
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1


### PR DESCRIPTION
Align the desktop renderer with the shared UI release used by the React Plan-in-Chat prototype. The dependency URL and lockfile pin the same immutable package artifact, so component comparisons use identical package contents.

Validation: the renderer and its dependencies build, renderer type checking passes, and all 1,172 renderer tests pass across the full run and focused timeout rechecks. The two consumers pass the package identity and lockfile integrity check.
