### PR TITLE
feat(plan): refuse training increases inside the race window

### DIFF
--- a/.changeset/plan-change-race-window.md
+++ b/.changeset/plan-change-race-window.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Refuse training increases in the final week before your goal event.
+
+User-facing: In the final week before your goal event, you can reduce your training but cannot add longer or harder workouts before the event.

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -508,14 +508,17 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
     commitments: Extract<PlanCreationAnswerInput, { kind: "commitments" }>["commitments"] = {
       kind: "none",
     },
+    goal: Extract<PlanCreationAnswerInput, { kind: "goal" }>["goal"] = { kind: "fitness" },
   ): Promise<PlanCreationCardModel> {
     const host = this.requireHost();
     const started = await host["plan_creation.start"]({ commandId: "seed-training-start" });
     if (started.status !== "started") throw new TypeError("Training seed was not started");
     let card = started.planCreation;
     const answers: PlanCreationAnswerInput[] = [
-      { kind: "goal", goal: { kind: "fitness" } },
-      { kind: "plan-length", weeks: 4 },
+      { kind: "goal", goal },
+      ...(goal.kind === "fitness"
+        ? [{ kind: "plan-length", weeks: 4 } satisfies PlanCreationAnswerInput]
+        : []),
       { kind: "schedule-mode", mode: "fixed" },
       {
         kind: "availability",
@@ -543,9 +546,20 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
     return card;
   }
 
-  async seedActiveTraining() {
+  async seedActiveTraining(options: { readonly goal?: "fitness" | "event" } = {}) {
     const host = this.requireHost();
-    const card = await this.seedTrainingCreation();
+    const card = await this.seedTrainingCreation(
+      { kind: "none" },
+      options.goal === "event"
+        ? {
+            kind: "event-manual",
+            name: "Local cycling event",
+            date: new Date(Date.parse(`${this.civilDate}T00:00:00.000Z`) + 6 * 86_400_000)
+              .toISOString()
+              .slice(0, 10),
+          }
+        : { kind: "fitness" },
+    );
     const previewed = await host["plan_creation.preview"]({
       commandId: "seed-training-preview",
       creationId: card.creationId,

--- a/packages/coach-contract/src/plan-change.ts
+++ b/packages/coach-contract/src/plan-change.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TrainingExportCivilDateSchema } from "./training-export.js";
 import { PlanCloseRpcParamsSchema, PlanCreationDraftSchema } from "./plan-creation.js";
 
 const WeekdaySchema = z.number().int().min(1).max(7);
@@ -109,18 +110,29 @@ export const PlanChangePreviewResultSchema = z.discriminatedUnion("status", [
       version: z.number().int().positive(),
     })
     .strict(),
-  z
-    .object({
-      status: z.literal("rejected"),
-      reason: z.enum([
-        "stale-version",
-        "no-active-plan",
-        "command-conflict",
-        "invalid-intent",
-        "sync-stale",
-      ]),
-    })
-    .strict(),
+  z.discriminatedUnion("reason", [
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum([
+          "stale-version",
+          "no-active-plan",
+          "command-conflict",
+          "invalid-intent",
+          "sync-stale",
+        ]),
+      })
+      .strict(),
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.literal("race-window"),
+        window: z
+          .object({ start: TrainingExportCivilDateSchema, end: TrainingExportCivilDateSchema })
+          .strict(),
+      })
+      .strict(),
+  ]),
 ]);
 export type PlanChangePreviewResult = z.infer<typeof PlanChangePreviewResultSchema>;
 
@@ -155,6 +167,7 @@ export const PlanChangeApplyResultSchema = z.discriminatedUnion("status", [
         "no-active-plan",
         "command-conflict",
         "sync-stale",
+        "race-window",
       ]),
     })
     .strict(),

--- a/packages/coach-contract/tests/plan-change-contract.test.ts
+++ b/packages/coach-contract/tests/plan-change-contract.test.ts
@@ -274,3 +274,35 @@ describe("Plan Change contract", () => {
     },
   );
 });
+
+describe("race window rejections", () => {
+  const rejection = {
+    status: "rejected",
+    reason: "race-window",
+    window: { start: "1998-09-01", end: "1998-09-07" },
+  };
+
+  it("requires civil window dates only on race-window preview rejections", () => {
+    expect(PlanChangePreviewResultSchema.parse(rejection)).toEqual(rejection);
+    expect(
+      PlanChangePreviewResultSchema.safeParse({ status: "rejected", reason: "race-window" })
+        .success,
+    ).toBe(false);
+    expect(
+      PlanChangePreviewResultSchema.safeParse({ ...rejection, reason: "sync-stale" }).success,
+    ).toBe(false);
+    for (const window of [
+      { start: "1998-02-30", end: "1998-09-07" },
+      { start: "1998-09-01", end: "1998-09-07T00:00:00Z" },
+      { start: "1998-09-01" },
+      { ...rejection.window, extra: true },
+    ])
+      expect(PlanChangePreviewResultSchema.safeParse({ ...rejection, window }).success).toBe(false);
+  });
+
+  it("accepts the apply reason without a preview window", () => {
+    const applied = { status: "rejected", reason: "race-window" };
+    expect(PlanChangeApplyResultSchema.parse(applied)).toEqual(applied);
+    expect(PlanChangeApplyResultSchema.safeParse(rejection).success).toBe(false);
+  });
+});

--- a/packages/coach/src/plan-change-operations.ts
+++ b/packages/coach/src/plan-change-operations.ts
@@ -21,7 +21,7 @@ import {
 } from "@enduragent/kernel/planning";
 import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
-import { applyScheduleIntent } from "@enduragent/sport-cycling";
+import { applyScheduleIntent, planChangeRaceWindow } from "@enduragent/sport-cycling";
 import { z } from "zod";
 
 export const PROPOSAL_STALE_AFTER_HOURS = 24;
@@ -195,6 +195,12 @@ export function createPlanChangeOperations(input: {
               : applyScheduleIntent({ ...transformation, intent });
           if (intent.kind === "inverse" && diff.length === 0)
             return { status: "rejected", reason: "invalid-intent" };
+          const window = planChangeRaceWindow({
+            goal: draft.goal,
+            diff,
+            todayDateKey: transformation.todayDateKey,
+          });
+          if (window !== null) return { status: "rejected", reason: "race-window", window };
           return {
             afterSnapshotJson: canonicalJson(after),
             envelope: PlanChangeEnvelopeSchema.parse({
@@ -238,6 +244,16 @@ export function createPlanChangeOperations(input: {
       const command = await stamp(parsed);
       const result = await repository.apply({
         admit,
+        async admitChange(_store, { afterSnapshotJson, diff, todayDateKey }) {
+          const draft = PlanCreationDraftSchema.parse(JSON.parse(afterSnapshotJson));
+          return planChangeRaceWindow({
+            goal: draft.goal,
+            diff: PlanChangeModelSchema.shape.diff.parse(diff),
+            todayDateKey,
+          }) === null
+            ? null
+            : "race-window";
+        },
         command,
         planId: parsed.planId,
         changeId: parsed.changeId,

--- a/packages/coach/tests/plan-change-operations.test.ts
+++ b/packages/coach/tests/plan-change-operations.test.ts
@@ -21,6 +21,7 @@ async function activatedPlan(
     connected: false,
     lastSuccessfulSyncAtMs: null,
   },
+  eventDate: string | null = null,
 ) {
   const store = openSqliteStorage(":memory:");
   onTestFinished(() => store.close());
@@ -63,8 +64,14 @@ async function activatedPlan(
   if (start.status !== "started") throw new Error("Expected creation");
   let card = start.planCreation;
   const answers: PlanCreationAnswerInput[] = [
-    { kind: "goal", goal: { kind: "fitness" } },
-    { kind: "plan-length", weeks: 4 },
+    ...(eventDate === null
+      ? ([
+          { kind: "goal", goal: { kind: "fitness" } },
+          { kind: "plan-length", weeks: 4 },
+        ] satisfies PlanCreationAnswerInput[])
+      : ([
+          { kind: "goal", goal: { kind: "event-manual", name: "Autumn ride", date: eventDate } },
+        ] satisfies PlanCreationAnswerInput[])),
     { kind: "schedule-mode", mode: "fixed" },
     {
       kind: "availability",
@@ -76,7 +83,13 @@ async function activatedPlan(
     { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
     { kind: "commitments", commitments: { kind: "none" } },
     { kind: "baseline", baseline: "regular" },
-    { kind: "success", success: { kind: "fitness-choice", choice: "climb-stronger" } },
+    {
+      kind: "success",
+      success:
+        eventDate === null
+          ? { kind: "fitness-choice", choice: "climb-stronger" }
+          : { kind: "event-finish", choice: "finish-fast" },
+    },
     { kind: "restriction", restriction: { kind: "none" } },
   ];
   for (const answer of answers) {
@@ -1248,4 +1261,185 @@ describe("Plan Change sync age", () => {
       expect(await dumpStore(test.store)).toBe(before);
     },
   );
+});
+
+describe("race-window protection", () => {
+  it("checks stale sync before race-window and version rejections without changing pending previews", async () => {
+    const now = 904_694_400_000;
+    const staleNow = now + 86_400_000 + 1;
+    let today = 19980902;
+    const test = await activatedPlan(
+      () => today,
+      { connected: true, lastSuccessfulSyncAtMs: now },
+      "1998-09-09",
+    );
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 4 });
+    await applyChange(test, forward.change.changeId, 1, "reduce-training");
+    const intent: PlanChangeIntent = { kind: "inverse", changeId: forward.change.changeId };
+    const pending = await test.preview(intent, "restore-training", 2);
+    today = 19980903;
+    test.setNow(staleNow);
+    const before = await dumpStore(test.store);
+    for (const expectedVersion of [2, 1]) {
+      await expect(
+        test.changes["plan_change.preview"]({
+          commandId: `stale-preview-${expectedVersion}`,
+          planId: test.planId,
+          expectedVersion,
+          intent,
+        }),
+      ).resolves.toEqual({ status: "rejected", reason: "sync-stale" });
+      expect(await dumpStore(test.store)).toBe(before);
+      await expect(
+        test.changes["plan_change.apply"]({
+          commandId: `apply-restoration-${expectedVersion}`,
+          planId: test.planId,
+          expectedVersion,
+          changeId: pending.change.changeId,
+          decision: "apply",
+        }),
+      ).resolves.toEqual({ status: "rejected", reason: "sync-stale" });
+      expect(await dumpStore(test.store)).toBe(before);
+      expect((await test.creation["plan.list"]({})).changes).toContainEqual(pending.change);
+    }
+    await test.recordSync(staleNow);
+    const afterSync = await dumpStore(test.store);
+    await expect(
+      test.changes["plan_change.preview"]({
+        commandId: "stale-preview-2",
+        planId: test.planId,
+        expectedVersion: 2,
+        intent,
+      }),
+    ).resolves.toEqual({
+      status: "rejected",
+      reason: "race-window",
+      window: { start: "1998-09-03", end: "1998-09-09" },
+    });
+    expect(await dumpStore(test.store)).toBe(afterSync);
+    await expect(
+      test.changes["plan_change.apply"]({
+        commandId: "apply-restoration-2",
+        planId: test.planId,
+        expectedVersion: 2,
+        changeId: pending.change.changeId,
+        decision: "apply",
+      }),
+    ).resolves.toEqual({ status: "rejected", reason: "race-window" });
+    expect(await dumpStore(test.store)).toBe(afterSync);
+    expect((await test.creation["plan.list"]({})).changes).toContainEqual(pending.change);
+  });
+
+  it.each([
+    { kind: "weekday-unavailable", day: 4 },
+    { kind: "weekday-duration", day: 4, minutes: 20 },
+    { kind: "hard-weekday", day: 4 },
+  ] satisfies PlanChangeIntent[])(
+    "allows $kind reductions and refuses their inverse in the event window without writes",
+    async (intent) => {
+      const test = await activatedPlan(() => 19980903, undefined, "1998-09-09");
+      const forward = await test.preview(intent);
+      expect(forward.change.diff.some((row) => row.before?.date === "1998-09-03")).toBe(true);
+      await applyChange(test, forward.change.changeId, 1, "reduce-training");
+      const before = await dumpStore(test.store);
+      await expect(
+        test.changes["plan_change.preview"]({
+          commandId: "restore-training",
+          planId: test.planId,
+          expectedVersion: 2,
+          intent: { kind: "inverse", changeId: forward.change.changeId },
+        }),
+      ).resolves.toEqual({
+        status: "rejected",
+        reason: "race-window",
+        window: { start: "1998-09-03", end: "1998-09-09" },
+      });
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+
+  it("allows a fitness Plan inverse on the same civil day", async () => {
+    const test = await activatedPlan(() => 19980903);
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 4 });
+    await applyChange(test, forward.change.changeId, 1, "reduce-training");
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: forward.change.changeId },
+      "restore-training",
+      2,
+    );
+    await applyChange(test, inverse.change.changeId, 2, "apply-restoration");
+  });
+
+  it("allows increases dated outside the window while today is inside it", async () => {
+    const test = await activatedPlan(() => 19980903, undefined, "1998-09-03");
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 6 });
+    await applyChange(test, forward.change.changeId, 1, "reduce-training");
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: forward.change.changeId },
+      "restore-training",
+      2,
+    );
+    expect(inverse.change.diff.every((row) => row.after?.date === "1998-09-05")).toBe(true);
+    await applyChange(test, inverse.change.changeId, 2, "apply-restoration");
+  });
+
+  it("rechecks an inverse when today enters the window and preserves pending state, cancel, and replay", async () => {
+    let today = 19980902;
+    const todayDateKey = vi.fn(() => today);
+    const test = await activatedPlan(todayDateKey, undefined, "1998-09-09");
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 4 });
+    const applied = await applyChange(test, forward.change.changeId, 1, "reduce-training");
+    const inverseIntent: PlanChangeIntent = { kind: "inverse", changeId: forward.change.changeId };
+    const inverse = await test.preview(inverseIntent, "restore-training", 2);
+    const before = await dumpStore(test.store);
+    todayDateKey.mockClear();
+    const transaction = test.store.transaction.bind(test.store);
+    const hook = vi.spyOn(test.store, "transaction").mockImplementationOnce((fn) => {
+      today = 19980903;
+      return transaction(fn);
+    });
+    await expect(
+      test.changes["plan_change.apply"]({
+        commandId: "apply-restoration",
+        planId: test.planId,
+        expectedVersion: 2,
+        changeId: inverse.change.changeId,
+        decision: "apply",
+      }),
+    ).resolves.toEqual({ status: "rejected", reason: "race-window" });
+    expect(todayDateKey).toHaveBeenCalledOnce();
+    expect(hook).toHaveBeenCalledOnce();
+    hook.mockRestore();
+    expect(await dumpStore(test.store)).toBe(before);
+    expect((await test.creation["plan.list"]({})).changes).toContainEqual(inverse.change);
+    expect(await test.preview(inverseIntent, "restore-training", 2)).toEqual(inverse);
+    expect(await test.changes["plan_change.apply"](applied.request)).toEqual(applied.result);
+    expect(await dumpStore(test.store)).toBe(before);
+    await expect(
+      test.changes["plan_change.apply"]({
+        commandId: "cancel-restoration",
+        planId: test.planId,
+        expectedVersion: 2,
+        changeId: inverse.change.changeId,
+        decision: "cancel",
+      }),
+    ).resolves.toMatchObject({ status: "cancelled", version: 2 });
+  });
+
+  it("replays an applied increasing inverse after today enters the window", async () => {
+    let today = 19980902;
+    const test = await activatedPlan(() => today, undefined, "1998-09-09");
+    const forward = await test.preview({ kind: "weekday-unavailable", day: 4 });
+    await applyChange(test, forward.change.changeId, 1, "reduce-training");
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: forward.change.changeId },
+      "restore-training",
+      2,
+    );
+    const applied = await applyChange(test, inverse.change.changeId, 2, "apply-restoration");
+    today = 19980903;
+    const before = await dumpStore(test.store);
+    expect(await test.changes["plan_change.apply"](applied.request)).toEqual(applied.result);
+    expect(await dumpStore(test.store)).toBe(before);
+  });
 });

--- a/packages/kernel/src/planning/change-repository.ts
+++ b/packages/kernel/src/planning/change-repository.ts
@@ -45,18 +45,27 @@ export const PlanChangePreviewStoreResultSchema = z.discriminatedUnion("status",
       version: RevisionNumberSchema,
     })
     .strict(),
-  z
-    .object({
-      status: z.literal("rejected"),
-      reason: z.enum([
-        "stale-version",
-        "no-active-plan",
-        "command-conflict",
-        "invalid-intent",
-        "sync-stale",
-      ]),
-    })
-    .strict(),
+  z.discriminatedUnion("reason", [
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum([
+          "stale-version",
+          "no-active-plan",
+          "command-conflict",
+          "invalid-intent",
+          "sync-stale",
+        ]),
+      })
+      .strict(),
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.literal("race-window"),
+        window: z.object({ start: z.iso.date(), end: z.iso.date() }).strict(),
+      })
+      .strict(),
+  ]),
 ]);
 export const PlanChangeApplyStoreResultSchema = z.discriminatedUnion("status", [
   z
@@ -79,6 +88,7 @@ export const PlanChangeApplyStoreResultSchema = z.discriminatedUnion("status", [
         "no-active-plan",
         "command-conflict",
         "sync-stale",
+        "race-window",
       ]),
     })
     .strict(),
@@ -94,7 +104,10 @@ export interface PlanChangeUndoContext {
 export interface PreviewPlanChangeInput {
   readonly admit?: (
     store: SqlStore,
-  ) => Promise<Extract<PlanChangePreviewStoreResult, { status: "rejected" }>["reason"] | null>;
+  ) => Promise<Exclude<
+    Extract<PlanChangePreviewStoreResult, { status: "rejected" }>["reason"],
+    "race-window"
+  > | null>;
   readonly command: PlanCreationCommandStamp;
   readonly planId: string;
   readonly expectedVersion: number;
@@ -104,7 +117,8 @@ export interface PreviewPlanChangeInput {
     context: PlanChangeUndoContext & { readonly completedWorkoutIds: ReadonlySet<string> },
   ) =>
     | { readonly afterSnapshotJson: string; readonly envelope: PlanChangeEnvelope }
-    | { readonly status: "rejected"; readonly reason: "invalid-intent" };
+    | { readonly status: "rejected"; readonly reason: "invalid-intent" }
+    | Extract<PlanChangePreviewStoreResult, { reason: "race-window" }>;
 }
 export interface PlanChangeWorkoutMutations {
   readonly insert: readonly PlanWorkoutRecord[];
@@ -114,6 +128,17 @@ export interface PlanChangeWorkoutMutations {
 export interface ApplyPlanChangeInput {
   readonly admit?: (
     store: SqlStore,
+  ) => Promise<Exclude<
+    Extract<PlanChangeApplyStoreResult, { status: "rejected" }>["reason"],
+    "race-window"
+  > | null>;
+  readonly admitChange?: (
+    store: SqlStore,
+    context: {
+      readonly afterSnapshotJson: string;
+      readonly diff: PlanChangeEnvelope["diff"];
+      readonly todayDateKey: number;
+    },
   ) => Promise<Extract<PlanChangeApplyStoreResult, { status: "rejected" }>["reason"] | null>;
   readonly command: PlanCreationCommandStamp;
   readonly planId: string;
@@ -538,6 +563,12 @@ export function createPlanChangeRepository(
           const { afterSnapshotJson } = z
             .object({ afterSnapshotJson: z.string() })
             .parse(JSON.parse(change.reconciliation_effect_json));
+          const rejection = await input.admitChange?.(store, {
+            afterSnapshotJson,
+            diff: PlanChangeEnvelopeSchema.parse(JSON.parse(change.diff_json)).diff,
+            todayDateKey,
+          });
+          if (rejection != null) return { status: "rejected", reason: rejection };
           if (!(await writeWorkouts(input, change, afterSnapshotJson, todayDateKey)))
             return { status: "rejected", reason: "stale-version" };
           const revisionNumber = active.current_revision_number + 1;

--- a/packages/sport-cycling/src/index.ts
+++ b/packages/sport-cycling/src/index.ts
@@ -61,7 +61,11 @@ export {
 } from "./reference/index.js";
 
 export { buildCreationDraft } from "./creation-draft-builder.js";
-export { applyScheduleIntent } from "./plan-change.js";
+export {
+  applyScheduleIntent,
+  planChangeRaceWindow,
+  PLAN_CHANGE_RACE_WINDOW_DAYS,
+} from "./plan-change.js";
 export type { ScheduleIntent, ScheduleChangeDiff, ScheduleChangeTotals } from "./plan-change.js";
 export type {
   CreationDraftInput,

--- a/packages/sport-cycling/src/plan-change.ts
+++ b/packages/sport-cycling/src/plan-change.ts
@@ -1,4 +1,4 @@
-import { dateKeyFromText, weekdayForDateKey } from "@enduragent/kernel/planning";
+import { addCivilDays, dateKeyFromText, weekdayForDateKey } from "@enduragent/kernel/planning";
 import { type CreationDraft, digest } from "./creation-draft-builder.js";
 
 export type ScheduleIntent =
@@ -153,4 +153,38 @@ export function applyScheduleIntent<Draft extends CreationDraft>(
     week.workouts = week.workouts.filter((workout) => workout.minutes > 0);
   }
   return changeResult(draft, after);
+}
+
+export const PLAN_CHANGE_RACE_WINDOW_DAYS = 7;
+
+type IncreaseWorkout = Pick<Workout, "date" | "minutes" | "kind"> & { power: number | null };
+
+export function planChangeRaceWindow(input: {
+  goal: CreationDraft["goal"];
+  todayDateKey: number;
+  diff: readonly { before: IncreaseWorkout | null; after: IncreaseWorkout | null }[];
+}): { start: string; end: string } | null {
+  if (input.goal.kind !== "event") return null;
+  const end = dateKeyFromText(input.goal.date);
+  const start = addCivilDays(end, 1 - PLAN_CHANGE_RACE_WINDOW_DAYS);
+  if (input.todayDateKey < start || input.todayDateKey > end) return null;
+  const increases = input.diff.some(({ before, after }) => {
+    if (after?.date == null) return false;
+    const date = dateKeyFromText(after.date);
+    return (
+      date >= start &&
+      date <= end &&
+      (before === null ||
+        after.minutes > before.minutes ||
+        (before.kind !== "hard" && after.kind === "hard") ||
+        (after.power ?? 0) > (before.power ?? 0))
+    );
+  });
+  const startText = String(start).padStart(8, "0");
+  return increases
+    ? {
+        start: `${startText.slice(0, 4)}-${startText.slice(4, 6)}-${startText.slice(6, 8)}`,
+        end: input.goal.date,
+      }
+    : null;
 }

--- a/packages/sport-cycling/tests/plan-change.test.ts
+++ b/packages/sport-cycling/tests/plan-change.test.ts
@@ -2,7 +2,11 @@ import { createHash } from "node:crypto";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import { describe, expect, it } from "vitest";
 import { type CreationDraft } from "../src/creation-draft-builder.js";
-import { applyScheduleIntent, type ScheduleIntent } from "../src/plan-change.js";
+import {
+  applyScheduleIntent,
+  planChangeRaceWindow,
+  type ScheduleIntent,
+} from "../src/plan-change.js";
 
 const todayDateKey = 19980824;
 
@@ -416,5 +420,117 @@ describe("Inverse Plan Changes", () => {
     expect(result.after).toEqual(draft);
     expect(result.diff).toEqual([]);
     expect(result.totals.after).toEqual(result.totals.before);
+  });
+});
+
+describe("race window protection", () => {
+  const goal = { kind: "event", name: "Spring ride", date: "2000-03-03" } as const;
+  const window = { start: "2000-02-26", end: "2000-03-03" };
+  const workout = {
+    date: "2000-02-29",
+    minutes: 60,
+    kind: "easy",
+    power: null,
+  } as const;
+
+  it.each([20000225, 20000304])(
+    "allows increases when today %s is outside the window",
+    (todayDateKey) => {
+      expect(
+        planChangeRaceWindow({ goal, todayDateKey, diff: [{ before: null, after: workout }] }),
+      ).toBeNull();
+    },
+  );
+
+  it.each([20000226, 20000229, 20000303])(
+    "protects the inclusive window on %s across a leap day",
+    (todayDateKey) => {
+      expect(
+        planChangeRaceWindow({ goal, todayDateKey, diff: [{ before: null, after: workout }] }),
+      ).toEqual(window);
+    },
+  );
+
+  it.each(["2000-02-26", "2000-03-03"])("includes a new Workout dated %s", (date) => {
+    expect(
+      planChangeRaceWindow({
+        goal,
+        todayDateKey: 20000226,
+        diff: [{ before: null, after: { ...workout, date } }],
+      }),
+    ).toEqual(window);
+  });
+
+  it.each(["2000-02-25", "2000-03-04", null])(
+    "allows a new Workout dated %s outside the window",
+    (date) => {
+      expect(
+        planChangeRaceWindow({
+          goal,
+          todayDateKey: 20000226,
+          diff: [{ before: null, after: { ...workout, date } }],
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it.each([
+    { ...workout, minutes: 61 },
+    { ...workout, kind: "hard" as const },
+    { ...workout, power: 1 },
+  ])("refuses a training increase: %j", (after) => {
+    expect(
+      planChangeRaceWindow({ goal, todayDateKey: 20000226, diff: [{ before: workout, after }] }),
+    ).toEqual(window);
+  });
+
+  it.each(["endurance", "long", "event"] as const)(
+    "detects %s to hard even when duration decreases",
+    (kind) => {
+      expect(
+        planChangeRaceWindow({
+          goal,
+          todayDateKey: 20000226,
+          diff: [
+            { before: { ...workout, kind }, after: { ...workout, kind: "hard", minutes: 30 } },
+          ],
+        }),
+      ).toEqual(window);
+    },
+  );
+
+  it("compares numeric power and treats null as zero", () => {
+    const check = (before: number | null, after: number | null) =>
+      planChangeRaceWindow({
+        goal,
+        todayDateKey: 20000226,
+        diff: [{ before: { ...workout, power: before }, after: { ...workout, power: after } }],
+      });
+    expect(check(100, 101)).toEqual(window);
+    expect(check(100, 99)).toBeNull();
+    expect(check(100, null)).toBeNull();
+    expect(check(null, 0)).toBeNull();
+  });
+
+  it("allows reductions, removals, unchanged training and fitness Plans", () => {
+    expect(
+      planChangeRaceWindow({
+        goal,
+        todayDateKey: 20000226,
+        diff: [
+          { before: workout, after: { ...workout, minutes: 30 } },
+          { before: workout, after: null },
+          { before: { ...workout, kind: "hard" }, after: workout },
+          { before: workout, after: workout },
+        ],
+      }),
+    ).toBeNull();
+    expect(
+      planChangeRaceWindow({
+        goal: { kind: "fitness", weeks: 4 },
+        todayDateKey: 20000226,
+        diff: [{ before: null, after: workout }],
+      }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Window: for snapshot `goal.kind === "event"`, the seven civil days ending on the event date inclusive. Fitness Plans have no window. No taper block in this cut.
- Increase detector (sport-cycling) over the diff: new dated Workout, more minutes, non-hard to hard, or higher power, counted only when the after date is in the window.
- Preview rejects `race-window` with `window: { start, end }` and stores nothing. Apply rechecks inside the transaction through a change-phase admission with the transaction's today and the stored after-snapshot; rejection leaves the preview pending with no mutation. Cancel and replay unaffected; the inverse is checked identically.
- Admission is now two-phase: command phase (sync-age, before version and pending checks, same precedence as before) and change phase (race-window, after the pending row is read).
- Fixture backend gains an event-goal Plan seed. Renderer copy is the next PR.

## Verification
astra high read-only: round 1 two findings (admission order regressing sync-age precedence, missing precedence test), both fixed; round 2 pass.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project workspace` coach-contract, sport-cycling, coach, kernel, kernel-node change repo | all pass except the known package-exports 5 s load timeout |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn