### PR TITLE
feat(desktop): explain race-window refusals on the Plan Change surface

### DIFF
--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -1846,6 +1846,14 @@ export function createChatController(input: {
             await input.refreshPlanLibrary?.().catch(() => {});
             return;
           }
+          if (result.reason === "race-window") {
+            publishChange({
+              notice:
+                "Only training reductions are allowed during this race window. Training is unchanged.",
+            });
+            await input.refreshPlanLibrary?.().catch(() => {});
+            return;
+          }
           if (result.reason === "invalid-intent" && parsedIntent.data.kind === "inverse") {
             publishChange({ notice: "The latest Change is no longer eligible for Undo." });
             await input.refreshPlanLibrary?.().catch(() => {});
@@ -1927,13 +1935,19 @@ export function createChatController(input: {
           }
           publishChange({
             notice:
-              result.reason === "stale-version"
-                ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
-                : result.reason === "not-pending"
-                  ? "This preview is no longer pending. Training is unchanged."
-                  : "This Change could not be applied. Training and the pending preview are unchanged.",
+              result.reason === "race-window"
+                ? "Only training reductions are allowed in the current race window. This Change was not applied."
+                : result.reason === "stale-version"
+                  ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
+                  : result.reason === "not-pending"
+                    ? "This preview is no longer pending. Training is unchanged."
+                    : "This Change could not be applied. Training and the pending preview are unchanged.",
           });
-          if (result.reason === "stale-version" || result.reason === "not-pending") {
+          if (
+            result.reason === "stale-version" ||
+            result.reason === "not-pending" ||
+            result.reason === "race-window"
+          ) {
             await input.refreshPlanLibrary?.().catch(() => {});
           }
           return;

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -293,9 +293,11 @@ function ChangeEditor(): ReactElement {
             />
           </div>
         ) : null}
-        <p role="alert" className="m-0 text-xs text-danger">
-          {state.error}
-        </p>
+        {state.error ? (
+          <p role="alert" className="m-0 text-xs text-danger">
+            {state.error}
+          </p>
+        ) : null}
         <div className="mt-row flex flex-wrap gap-inset">
           <Button
             type="button"

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -740,6 +740,8 @@ describe("Plan Change cards", () => {
     "Review the exact changes before confirming.",
     "This preview supersedes “Earlier limit”. Training is unchanged until confirmation.",
     "The latest Change is no longer eligible for Undo.",
+    "Only training reductions are allowed during this race window. Training is unchanged.",
+    "Only training reductions are allowed in the current race window. This Change was not applied.",
     "Change applied locally. Training now matches the confirmed preview.",
     "Change cancelled. Training is unchanged; the preview remains in history.",
     "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed.",
@@ -749,6 +751,32 @@ describe("Plan Change cards", () => {
     patchChange({ notice });
     render(<PlanChangeCards />);
     expect(screen.getByRole("status")).toHaveTextContent(notice);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("keeps the request editable alongside the race-window preview notice", () => {
+    patchChange({
+      editorOpen: true,
+      notice:
+        "Only training reductions are allowed during this race window. Training is unchanged.",
+    });
+    render(<PlanChangeCards />);
+    expect(screen.getByRole("region", { name: "What needs to change?" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Preview change" })).toBeEnabled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("keeps the pending preview alongside the race-window apply notice", () => {
+    setChanges([change()]);
+    patchChange({
+      notice:
+        "Only training reductions are allowed in the current race window. This Change was not applied.",
+    });
+    render(<PlanChangeCards />);
+    expect(screen.getByText("Pending", { exact: true })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Apply to Plan" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("renders parameter errors as alerts and disables submission while busy", () => {

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -226,6 +226,48 @@ describe("Plan Change controller", () => {
     },
   );
 
+  it.each([false, true])(
+    "keeps the editor open after a race-window refusal even when refresh fails: %s",
+    async (refreshFails) => {
+      const h = harness({
+        status: "rejected",
+        reason: "race-window",
+        window: { start: "1998-09-07", end: "1998-09-13" },
+      });
+      if (refreshFails) h.refresh.mockRejectedValue(new Error("unavailable"));
+      h.controller.openPlanChangeEditor();
+      await h.controller.previewPlanChange(change.intent);
+      expect(h.surface()).toMatchObject({
+        editorOpen: true,
+        busy: false,
+        error: null,
+        notice:
+          "Only training reductions are allowed during this race window. Training is unchanged.",
+      });
+      expect(h.refresh).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([false, true])(
+    "preserves the pending Change after a race-window apply refusal even when refresh fails: %s",
+    async (refreshFails) => {
+      const h = harness({ status: "rejected", reason: "race-window" });
+      if (refreshFails) h.refresh.mockRejectedValue(new Error("unavailable"));
+      await h.controller.applyPlanChange("apply");
+      expect(h.surface()).toMatchObject({
+        busy: false,
+        error: null,
+        notice:
+          "Only training reductions are allowed in the current race window. This Change was not applied.",
+      });
+      expect(h.refresh).toHaveBeenCalledOnce();
+      await h.controller.applyPlanChange("apply");
+      expect(h.call).toHaveBeenCalledTimes(2);
+      expect(h.call.mock.calls[1]?.[1]).toMatchObject({ changeId: change.changeId });
+      expect(h.call.mock.calls[1]?.[1]).not.toEqual(h.call.mock.calls[0]?.[1]);
+    },
+  );
+
   it("replays an inverse command after a lost response", async () => {
     const h = harness(new Error("lost response"));
     const intent: PlanChangeIntent = { kind: "inverse", changeId: "00000000000000000000000140" };

--- a/apps/desktop/tests/e2e/plan-change-race-window.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change-race-window.spec.ts
@@ -1,0 +1,258 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import {
+  PlanChangePreviewRpcParamsSchema,
+  PlanChangeWorkoutSchema,
+} from "@enduragent/coach-contract";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+const previews = fileURLToPath(new URL("./previews/plan-change-race-window/", import.meta.url));
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  readonly seed: Awaited<ReturnType<PlanCreationBackend["seedActiveTraining"]>>;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Change renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-change-race-window-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    const seed = await backend.seedActiveTraining({ goal: "event" });
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    return { backend, fixture, scratch, seed, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  await mkdir(previews, { recursive: true });
+  const screenshotPath = join(previews, `${name}-${scenario.width}-${scenario.colorScheme}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-plan-change", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        activation: await scenario.backend.inspectActivation(),
+        requests: scenario.backend.creationRequests,
+        seed: scenario.seed,
+        library: await scenario.backend.library(),
+        responses: scenario.backend.changeApplyResponses,
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+const appearances = [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const;
+const changeTitle = "Limit weekday duration";
+const refusalNotice =
+  "Only training reductions are allowed during this race window. Training is unchanged.";
+
+for (const appearance of appearances) {
+  test(`allows a race-window reduction and refuses its Undo at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      expect(scenario.seed.draft.goal).toMatchObject({ kind: "event", date: "1998-01-07" });
+      const initial = await scenario.backend.inspectActivation();
+      await scenario.page
+        .getByRole("navigation", { name: "Main navigation" })
+        .getByRole("button", { name: "Plan", exact: true })
+        .click();
+      await scenario.page
+        .getByRole("region", { name: "Plan library", exact: true })
+        .getByRole("button", { name: "Change in Chat", exact: true })
+        .click();
+      const changes = scenario.page.getByRole("region", { name: "Plan Changes", exact: true });
+      await changes.getByRole("button", { name: "Change one thing", exact: true }).click();
+      const editor = changes.getByRole("region", { name: "What needs to change?", exact: true });
+      await expect(editor.getByRole("combobox", { name: "Change", exact: true })).toContainText(
+        "Weekday duration cap",
+      );
+      await editor.getByRole("combobox", { name: "Weekday", exact: true }).click();
+      await scenario.page.getByRole("option", { name: "Mon", exact: true }).click();
+      await expect(
+        editor.getByRole("spinbutton", { name: "Duration limit in minutes", exact: true }),
+      ).toHaveValue("30");
+      await editor.getByRole("button", { name: "Preview change", exact: true }).click();
+      const changeCard = changes.getByRole("region", { name: changeTitle, exact: true });
+      await expect(changeCard.getByRole("heading")).toBeFocused();
+      await expect(changeCard.getByText("Pending", { exact: true })).toBeVisible();
+      const previewed = (await scenario.backend.library()).changes.find(
+        (change) => change.status === "pending",
+      );
+      if (!previewed) throw new TypeError("Reducing Change preview is unavailable");
+      expect(previewed.intent).toEqual({ kind: "weekday-duration", day: 1, minutes: 30 });
+      expect(previewed.diff.length).toBeGreaterThan(0);
+      for (const row of previewed.diff) {
+        expect(row.before?.minutes).toBe(60);
+        expect(row.after?.minutes).toBe(30);
+        expect(row.after?.date).toBe("1998-01-05");
+      }
+      const beforeApply = await scenario.backend.inspectActivation();
+      expect(beforeApply.workouts).toEqual(initial.workouts);
+      expect(beforeApply.revisions).toEqual(initial.revisions);
+      await capture(scenario, "reducing-preview");
+      await changeCard.getByRole("button", { name: "Apply to Plan", exact: true }).click();
+      await expect(changes.getByRole("status")).toHaveText(
+        "Change applied locally. Training now matches the confirmed preview.",
+      );
+      await expect(changeCard.getByText("Applied", { exact: true })).toBeVisible();
+      const applied = (await scenario.backend.library()).changes.find(
+        (change) => change.changeId === previewed.changeId,
+      );
+      expect(applied).toMatchObject({ status: "applied", undo: { eligible: true } });
+      const reduced = await scenario.backend.inspectActivation();
+      expect(reduced.planningPlans[0]).toMatchObject({ version: 2, current_revision_number: 2 });
+      expect(reduced.revisions).toHaveLength(2);
+      const reducedWorkouts = reduced.workouts.map((row) =>
+        PlanChangeWorkoutSchema.parse(JSON.parse(String(row.structure_json))),
+      );
+      expect(reducedWorkouts.find((workout) => workout.date === "1998-01-05")).toMatchObject({
+        name: "Endurance ride",
+        minutes: 30,
+      });
+      await capture(scenario, "reduction-applied");
+      const requestsBefore = scenario.backend.creationRequests.length;
+      const libraryReadsBefore = scenario.backend.planListRequests.length;
+      await changeCard.getByRole("button", { name: "Undo", exact: true }).click();
+      await expect(changes.getByRole("status")).toHaveText(refusalNotice);
+      await expect(scenario.page.getByRole("alert")).toHaveCount(0);
+      await expect(changes.getByText("Pending", { exact: true })).toHaveCount(0);
+      await expect(changeCard.getByText("Applied", { exact: true })).toBeVisible();
+      await expect(changeCard.getByRole("button", { name: "Undo", exact: true })).toBeEnabled();
+      await expect
+        .poll(() => scenario.backend.planListRequests.length)
+        .toBeGreaterThan(libraryReadsBefore);
+      const requests = scenario.backend.creationRequests.slice(requestsBefore);
+      expect(requests.map((request) => request.method)).toEqual(["plan_change.preview"]);
+      expect(PlanChangePreviewRpcParamsSchema.parse(requests[0]?.params)).toEqual({
+        commandId: expect.any(String),
+        planId: scenario.seed.planId,
+        expectedVersion: 2,
+        intent: { kind: "inverse", changeId: previewed.changeId },
+      });
+      const refused = await scenario.backend.inspectActivation();
+      expect(refused.plans).toEqual(reduced.plans);
+      expect(refused.planningPlans).toEqual(reduced.planningPlans);
+      expect(refused.revisions).toEqual(reduced.revisions);
+      expect(refused.workouts).toEqual(reduced.workouts);
+      expect(refused.changes).toEqual(reduced.changes);
+      await capture(scenario, "undo-refused");
+    } finally {
+      await close(scenario);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Preview rejected `race-window`: notice `Only training reductions are allowed during this race window. Training is unchanged.` (role status, no error alert), editor stays open, library re-read.
- Apply rejected `race-window`: notice `Only training reductions are allowed in the current race window. This Change was not applied.`, pending card stays, library re-read.
- Sync-stale and inverse rejection handling unchanged. The editor's error alert now renders only when an error exists.
- New Playwright spec plan-change-race-window.spec.ts: event Plan with the race in six days, a reducing Change previews and applies, its Undo is refused with the notice, at 1180/720 light and dark.

## Verification
astra high read-only: pass, no findings.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project renderer-dom --maxWorkers 2` | 709 passed |
| playwright race-window + undo + sync-age | pass |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn