### PR TITLE
feat(desktop): correct FTP from the Plan Change editor

### DIFF
--- a/.changeset/plan-change-ftp-editor.md
+++ b/.changeset/plan-change-ftp-editor.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Correct your FTP from Chat and see the power each Workout will use.
+
+User-facing: Choose Correct FTP in the Plan Change editor, enter your watts, and review which Workouts change and which FTP sources the coach compared before you confirm.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -1810,15 +1810,19 @@ export function createChatController(input: {
       const active = library?.active;
       if (disposed || readChange().busy || !active || changesPaused()) return;
       const parameterCopy =
-        intent.kind === "weekly-duration"
-          ? Number.isFinite(intent.hours) && intent.hours > 0 && !Number.isInteger(intent.hours * 4)
-            ? "Enter weekly hours in quarter-hour steps, like 2.25."
-            : "Enter a weekly duration above zero."
-          : "day" in intent && (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
-            ? "Choose the weekday to change."
-            : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
+        intent.kind === "ftp"
+          ? "Enter FTP above zero."
+          : intent.kind === "weekly-duration"
+            ? Number.isFinite(intent.hours) &&
+              intent.hours > 0 &&
+              !Number.isInteger(intent.hours * 4)
+              ? "Enter weekly hours in quarter-hour steps, like 2.25."
+              : "Enter a weekly duration above zero."
+            : "day" in intent && (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
               ? "Choose the weekday to change."
-              : "Enter a duration above zero.";
+              : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
+                ? "Choose the weekday to change."
+                : "Enter a duration above zero.";
       const parsedIntent = PlanChangeIntentSchema.safeParse(intent);
       if (!parsedIntent.success) {
         publishChange({ error: parameterCopy });
@@ -1885,10 +1889,12 @@ export function createChatController(input: {
         });
         await input.refreshPlanLibrary?.().catch(() => {});
         publishChange({ focusRequest: changeFocus("preview") });
-      } catch {
+      } catch (error) {
         publishChange({
           error:
-            "The preview result could not be confirmed. The Plan library will show the current state after refresh.",
+            error instanceof CoachRpcRemoteError && parsedIntent.data.kind === "ftp"
+              ? error.message
+              : "The preview result could not be confirmed. The Plan library will show the current state after refresh.",
         });
         await input.refreshPlanLibrary?.().catch(() => {});
       } finally {
@@ -1937,16 +1943,19 @@ export function createChatController(input: {
             notice:
               result.reason === "race-window"
                 ? "Only training reductions are allowed in the current race window. This Change was not applied."
-                : result.reason === "stale-version"
-                  ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
-                  : result.reason === "not-pending"
-                    ? "This preview is no longer pending. Training is unchanged."
-                    : "This Change could not be applied. Training and the pending preview are unchanged.",
+                : result.reason === "ftp-sources-changed"
+                  ? "The FTP sources changed. Request a fresh preview before applying this correction."
+                  : result.reason === "stale-version"
+                    ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
+                    : result.reason === "not-pending"
+                      ? "This preview is no longer pending. Training is unchanged."
+                      : "This Change could not be applied. Training and the pending preview are unchanged.",
           });
           if (
             result.reason === "stale-version" ||
             result.reason === "not-pending" ||
-            result.reason === "race-window"
+            result.reason === "race-window" ||
+            result.reason === "ftp-sources-changed"
           ) {
             await input.refreshPlanLibrary?.().catch(() => {});
           }

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -3,7 +3,7 @@ import type {
   PlanChangeModel,
   PlanChangeWorkout,
 } from "@enduragent/coach-contract";
-import { PlanChangeIntentSchema } from "@enduragent/coach-contract";
+import { PlanChangeFtpSourcesSchema, PlanChangeIntentSchema } from "@enduragent/coach-contract";
 import { useEffect, useRef, useState, type ReactElement, type ReactNode, type Ref } from "react";
 import { Button } from "@enduragent/ui";
 import { Card, CardContent } from "@enduragent/ui";
@@ -17,6 +17,7 @@ const changeOptions = [
   { value: "hard-weekday", label: "No hard training on a weekday" },
   { value: "weekly-duration", label: "Weekly duration cap" },
   { value: "longest-workout", label: "Longest-Workout cap" },
+  { value: "ftp", label: "Correct FTP" },
 ] satisfies Array<{ value: PlanChangeIntent["kind"]; label: string }>;
 const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const statusLabels = {
@@ -73,12 +74,12 @@ function Fact(props: { label: string; children: ReactNode }): ReactElement {
       <span role="rowheader" className="text-xs leading-4 text-ink-2">
         {props.label}
       </span>
-      <strong
+      <div
         role="cell"
         className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left"
       >
         {props.children}
-      </strong>
+      </div>
     </div>
   );
 }
@@ -94,7 +95,7 @@ function workoutValue(workout: PlanChangeWorkout | null): string {
           year: "numeric",
           timeZone: "UTC",
         }).format(new Date(`${workout.date}T12:00:00Z`));
-  return `${date} · ${workout.minutes} min`;
+  return `${date} · ${workout.minutes} min${workout.power === null ? "" : ` · ${workout.power} W`}`;
 }
 
 function Difference({ change }: { change: PlanChangeModel }): ReactElement {
@@ -137,7 +138,29 @@ function Difference({ change }: { change: PlanChangeModel }): ReactElement {
   );
 }
 
-function premiseValue(premise: PlanChangeModel["premises"][number]): string {
+function premiseValue(premise: PlanChangeModel["premises"][number]): ReactNode {
+  if (premise.id === "ftp-sources") {
+    const parsed = PlanChangeFtpSourcesSchema.safeParse(premise.value);
+    if (!parsed.success) return premise.label;
+    const labels = {
+      manual: "Saved athlete FTP",
+      "intervals-ftp": "Intervals.icu FTP",
+      "intervals-eftp": "Intervals.icu eFTP",
+    };
+    return (
+      <ul className="m-0 grid list-none gap-1 p-0">
+        {parsed.data.candidates.map((candidate) => (
+          <li key={candidate.source}>
+            {labels[candidate.source]} · {candidate.watts} W
+            {candidate.selected ? " · selected" : ""}
+          </li>
+        ))}
+        {parsed.data.requestedFtp !== null ? (
+          <li>Your entry · {parsed.data.requestedFtp} W</li>
+        ) : null}
+      </ul>
+    );
+  }
   if (premise.id === "undone-change") {
     const value = premise.value;
     return value !== null &&
@@ -173,6 +196,7 @@ function ChangeEditor(): ReactElement {
   const [day, setDay] = useState(3);
   const [minutes, setMinutes] = useState("30");
   const [hours, setHours] = useState("3");
+  const [watts, setWatts] = useState("220");
   const state = useEnduragentStore((store) => store.planChange);
   const actions = useEnduragentStore((store) => store.chatActions);
   const firstControl = useRef<HTMLButtonElement>(null);
@@ -200,6 +224,9 @@ function ChangeEditor(): ReactElement {
             case "weekly-duration":
               intent = { kind, hours: Number(hours) };
               break;
+            case "ftp":
+              intent = { kind, watts: Number(watts) };
+              break;
             case "longest-workout":
               intent = { kind, minutes: Number(minutes) };
               break;
@@ -222,6 +249,7 @@ function ChangeEditor(): ReactElement {
               setDay(option.value === "hard-weekday" ? 1 : 3);
               setMinutes(option.value === "longest-workout" ? "60" : "30");
               setHours("3");
+              setWatts("220");
             }}
           >
             <SelectTrigger id="plan-change-kind" ref={firstControl} className="w-full">
@@ -292,6 +320,23 @@ function ChangeEditor(): ReactElement {
               value={hours}
               disabled={state.busy}
               onChange={(event) => setHours(event.target.value)}
+            />
+          </div>
+        ) : null}
+        {kind === "ftp" ? (
+          <div className="grid gap-[calc(var(--inset)/2)]">
+            <label htmlFor="plan-change-watts" className="text-xs text-ink-2">
+              FTP in watts
+            </label>
+            <input
+              className="min-h-[var(--ctl-h-lg)] rounded-ctl border border-line-2 bg-sunk px-ctl-px-sm py-2 text-sm font-normal leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20"
+              id="plan-change-watts"
+              type="number"
+              min="1"
+              step="1"
+              value={watts}
+              disabled={state.busy}
+              onChange={(event) => setWatts(event.target.value)}
             />
           </div>
         ) : null}

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -544,7 +544,7 @@ describe("Plan Change cards", () => {
     );
   });
 
-  it("offers the five Schedule changes in order and submits their defaults", async () => {
+  it("offers Schedule and FTP changes in order and submits their defaults", async () => {
     patchChange({ editorOpen: true });
     render(<PlanChangeCards />);
     const actions = useEnduragentStore.getState().chatActions;
@@ -564,6 +564,7 @@ describe("Plan Change cards", () => {
       "No hard training on a weekday",
       "Weekly duration cap",
       "Longest-Workout cap",
+      "Correct FTP",
     ]);
     await userEvent.click(await screen.findByRole("option", { name: "Weekday unavailable" }));
     expect(screen.getByRole("combobox", { name: "Weekday" })).toHaveTextContent("Wed");
@@ -605,6 +606,151 @@ describe("Plan Change cards", () => {
       kind: "longest-workout",
       minutes: 60,
     });
+  });
+
+  it("edits FTP in whole watts and disables the field while busy", async () => {
+    patchChange({ editorOpen: true });
+    render(<PlanChangeCards />);
+    await userEvent.click(screen.getByRole("combobox", { name: "Change" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Correct FTP" }));
+    const field = screen.getByRole("spinbutton", { name: "FTP in watts" });
+    expect(field).toHaveValue(220);
+    expect(field).toHaveAttribute("step", "1");
+    expect(field).toHaveAttribute("min", "1");
+    expect(screen.queryByRole("combobox", { name: "Weekday" })).toBeNull();
+    await userEvent.clear(field);
+    await userEvent.type(field, "245");
+    await userEvent.click(screen.getByRole("button", { name: "Preview change" }));
+    expect(useEnduragentStore.getState().chatActions?.previewPlanChange).toHaveBeenCalledWith({
+      kind: "ftp",
+      watts: 245,
+    });
+    patchChange({ busy: true });
+    expect(field).toBeDisabled();
+  });
+
+  it("shows watts on either diff side while preserving absent and undated Workouts", () => {
+    setChanges([
+      change({
+        diff: [
+          { workoutId: "corrected", before: workout, after: { ...workout, power: 220 } },
+          { workoutId: "undone", before: { ...workout, power: 220 }, after: workout },
+          { workoutId: "added", before: null, after: { ...workout, date: null, power: 230 } },
+          { workoutId: "removed", before: { ...workout, date: null, power: 230 }, after: null },
+        ],
+      }),
+    ]);
+    render(<PlanChangeCards />);
+    const table = screen.getByRole("table", { name: "Affected individual Workouts" });
+    expect(
+      within(table)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent),
+    ).toEqual([
+      "9 Sept 1998 · 60 min → 9 Sept 1998 · 60 min · 220 W",
+      "9 Sept 1998 · 60 min · 220 W → 9 Sept 1998 · 60 min",
+      "Not in Plan → Undated · 60 min · 230 W",
+      "Undated · 60 min · 230 W → Not in Plan",
+    ]);
+  });
+
+  it.each([true, false])("renders FTP sources with synchronized evidence %s", async (synced) => {
+    setChanges([
+      change({
+        premises: [
+          {
+            id: "ftp-sources",
+            label: "FTP source comparison at this decision",
+            source: "Saved profile and synchronized FTP evidence",
+            value: {
+              acceptedPlanFtp: null,
+              requestedFtp: 220,
+              candidates: [
+                { source: "manual", watts: 210, selected: true },
+                ...(synced
+                  ? [
+                      { source: "intervals-ftp", watts: 205, selected: false },
+                      { source: "intervals-eftp", watts: 215, selected: false },
+                    ]
+                  : []),
+              ],
+            },
+          },
+        ],
+      }),
+    ]);
+    render(<PlanChangeCards />);
+    await userEvent.click(screen.getByRole("button", { name: "View evidence" }));
+    const source = screen.getByRole("region", { name: "Source details" });
+    expect(source).toHaveTextContent(
+      "FTP source comparison at this decision · Saved profile and synchronized FTP evidence",
+    );
+    expect(
+      within(source)
+        .getAllByRole("listitem")
+        .map((item) => item.textContent),
+    ).toEqual([
+      "Saved athlete FTP · 210 W · selected",
+      ...(synced ? ["Intervals.icu FTP · 205 W", "Intervals.icu eFTP · 215 W"] : []),
+      "Your entry · 220 W",
+    ]);
+  });
+
+  it("omits an entry when Undo restores an unset FTP and falls back for malformed evidence", async () => {
+    setChanges([
+      change({
+        premises: [
+          {
+            id: "ftp-sources",
+            label: "FTP comparison",
+            source: "Stored sources",
+            value: {
+              acceptedPlanFtp: 220,
+              requestedFtp: null,
+              candidates: [{ source: "manual", watts: 220, selected: true }],
+            },
+          },
+        ],
+      }),
+    ]);
+    const view = render(<PlanChangeCards />);
+    await userEvent.click(screen.getByRole("button", { name: "View evidence" }));
+    expect(screen.getByRole("listitem")).toHaveTextContent("Saved athlete FTP · 220 W · selected");
+    expect(screen.queryByText(/Your entry/)).toBeNull();
+    view.unmount();
+    setChanges([
+      change({
+        premises: [
+          {
+            id: "ftp-sources",
+            label: "FTP comparison unavailable",
+            source: "Stored sources",
+            value: { candidates: [{ source: "unknown", watts: 200, selected: true }] },
+          },
+        ],
+      }),
+    ]);
+    render(<PlanChangeCards />);
+    await userEvent.click(screen.getByRole("button", { name: "View evidence" }));
+    expect(
+      within(screen.getByRole("region", { name: "Source details" })).getByRole("cell"),
+    ).toHaveTextContent("FTP comparison unavailable");
+    expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  it("keeps a pending card actionable after FTP sources change", () => {
+    setChanges([change({ title: "Correct FTP", intent: { kind: "ftp", watts: 220 } })]);
+    patchChange({
+      notice: "The FTP sources changed. Request a fresh preview before applying this correction.",
+    });
+    render(<PlanChangeCards />);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "The FTP sources changed. Request a fresh preview before applying this correction.",
+    );
+    expect(screen.getByText("Pending", { exact: true })).toBeVisible();
+    expect(screen.getByRole("button", { name: "View evidence" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Change one thing" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
   });
 
   it("shows host totals and both null and undated sides with the changed after name", () => {

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -1,3 +1,4 @@
+import { CoachRpcRemoteError } from "@enduragent/coach-client";
 import type { CoachClient } from "@enduragent/coach-client";
 import type {
   ListPlansResult,
@@ -277,6 +278,34 @@ describe("Plan Change controller", () => {
     expect(h.call.mock.calls[1]).toEqual(h.call.mock.calls[0]);
   });
 
+  it("sends the FTP intent and keeps daemon rejection copy", async () => {
+    const h = harness({ status: "rejected", reason: "command-conflict" });
+    await h.controller.previewPlanChange({ kind: "ftp", watts: 220 });
+    expect(h.call).toHaveBeenCalledWith(
+      "plan_change.preview",
+      expect.objectContaining({ intent: { kind: "ftp", watts: 220 } }),
+    );
+    expect(h.surface().error).toBe("This Change could not be previewed. Training is unchanged.");
+  });
+
+  it("shows the daemon message when an FTP preview is refused remotely", async () => {
+    const h = harness(new CoachRpcRemoteError(-32000, "Enter 1–9999 whole watts."));
+    await h.controller.previewPlanChange({ kind: "ftp", watts: 220 });
+    expect(h.surface().error).toBe("Enter 1–9999 whole watts.");
+  });
+
+  it("preserves the FTP source notice when the library cannot be re-read", async () => {
+    const h = harness({ status: "rejected", reason: "ftp-sources-changed" });
+    h.refresh.mockRejectedValue(new Error("unavailable"));
+    await h.controller.applyPlanChange("apply");
+    expect(h.refresh).toHaveBeenCalledOnce();
+    expect(h.surface()).toMatchObject({
+      busy: false,
+      error: null,
+      notice: "The FTP sources changed. Request a fresh preview before applying this correction.",
+    });
+  });
+
   it("names the superseded preview", async () => {
     const h = harness({
       status: "previewed",
@@ -349,6 +378,10 @@ describe("Plan Change controller", () => {
     ],
     ["not-pending", "This preview is no longer pending. Training is unchanged."],
     [
+      "ftp-sources-changed",
+      "The FTP sources changed. Request a fresh preview before applying this correction.",
+    ],
+    [
       "command-conflict",
       "This Change could not be applied. Training and the pending preview are unchanged.",
     ],
@@ -361,11 +394,13 @@ describe("Plan Change controller", () => {
     await h.controller.applyPlanChange("apply");
     expect(h.surface()).toMatchObject({ busy: false, notice });
     expect(h.refresh).toHaveBeenCalledTimes(
-      reason === "stale-version" || reason === "not-pending" ? 1 : 0,
+      reason === "stale-version" || reason === "not-pending" || reason === "ftp-sources-changed"
+        ? 1
+        : 0,
     );
   });
 
-  it.each(["stale-version", "not-pending"])(
+  it.each(["stale-version", "not-pending", "ftp-sources-changed"])(
     "refreshes after %s apply so the next preview uses the new version",
     async (reason) => {
       const h = harness({ status: "rejected", reason });
@@ -426,6 +461,10 @@ describe("Plan Change controller", () => {
   });
 
   it.each([
+    ...[0, -1, Number.NaN, Infinity, 1.5, 10000].map((watts): [PlanChangeIntent, string] => [
+      { kind: "ftp", watts },
+      "Enter FTP above zero.",
+    ]),
     [{ kind: "weekday-duration", day: 2, minutes: 0 }, "Enter a duration above zero."],
     [{ kind: "longest-workout", minutes: Number.NaN }, "Enter a duration above zero."],
     [{ kind: "weekly-duration", hours: -1 }, "Enter a weekly duration above zero."],

--- a/apps/desktop/tests/e2e/plan-change-ftp.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change-ftp.spec.ts
@@ -1,0 +1,314 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import {
+  PlanChangePreviewRpcParamsSchema,
+  PlanChangeWorkoutSchema,
+  PlanCreationDraftSchema,
+} from "@enduragent/coach-contract";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+const previews = fileURLToPath(new URL("./previews/plan-change-ftp/", import.meta.url));
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  readonly seed: Awaited<ReturnType<PlanCreationBackend["seedActiveTraining"]>>;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Change renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-change-ftp-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    const seed = await backend.seedActiveTraining();
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    return { backend, fixture, scratch, seed, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  await mkdir(previews, { recursive: true });
+  const screenshotPath = join(previews, `${name}-${scenario.width}-${scenario.colorScheme}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-plan-change", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        activation: await scenario.backend.inspectActivation(),
+        requests: scenario.backend.creationRequests,
+        seed: scenario.seed,
+        library: await scenario.backend.library(),
+        responses: scenario.backend.changeApplyResponses,
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+type Stored = Awaited<ReturnType<PlanCreationBackend["inspectActivation"]>>;
+
+const appearances = [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const;
+const changeTitle = "Correct FTP";
+const inverseTitle = "Undo the latest Change";
+
+function changes(scenario: Scenario) {
+  return scenario.page.getByRole("region", { name: "Plan Changes", exact: true });
+}
+
+function changeCard(scenario: Scenario, title: string, status: string) {
+  return changes(scenario)
+    .getByRole("region", { name: title, exact: true })
+    .filter({ has: scenario.page.getByText(status, { exact: true }) });
+}
+
+function storedWorkouts(stored: Stored) {
+  return stored.workouts.map((row) =>
+    PlanChangeWorkoutSchema.parse(JSON.parse(String(row.structure_json))),
+  );
+}
+
+for (const appearance of appearances) {
+  test(`corrects FTP and restores power with Undo at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      const initial = await scenario.backend.inspectActivation();
+      expect(storedWorkouts(initial).every((workout) => workout.power === null)).toBe(true);
+      await scenario.page
+        .getByRole("navigation", { name: "Main navigation" })
+        .getByRole("button", { name: "Plan", exact: true })
+        .click();
+      await scenario.page
+        .getByRole("region", { name: "Plan library", exact: true })
+        .getByRole("button", { name: "Change in Chat", exact: true })
+        .click();
+      await changes(scenario)
+        .getByRole("button", { name: "Change one thing", exact: true })
+        .click();
+      const editor = changes(scenario).getByRole("region", {
+        name: "What needs to change?",
+        exact: true,
+      });
+      await editor.getByRole("combobox", { name: "Change", exact: true }).click();
+      await scenario.page.getByRole("option", { name: changeTitle, exact: true }).click();
+      const watts = editor.getByRole("spinbutton", { name: "FTP in watts", exact: true });
+      await expect(watts).toHaveValue("220");
+      await expect(watts).toHaveAttribute("step", "1");
+      await capture(scenario, "editor");
+      await editor.getByRole("button", { name: "Preview change", exact: true }).click();
+      const pending = changeCard(scenario, changeTitle, "Pending");
+      await expect(pending.getByRole("heading")).toBeFocused();
+      const request = [...scenario.backend.creationRequests]
+        .reverse()
+        .find((entry) => entry.method === "plan_change.preview");
+      expect(PlanChangePreviewRpcParamsSchema.parse(request?.params)).toMatchObject({
+        planId: scenario.seed.planId,
+        expectedVersion: 1,
+        intent: { kind: "ftp", watts: 220 },
+      });
+      const preview = (await scenario.backend.library()).changes.find(
+        (change) => change.status === "pending",
+      );
+      if (!preview) throw new TypeError("FTP preview is unavailable");
+      expect(preview.diff).toHaveLength(12);
+      expect(
+        preview.diff.every((row) => row.before?.power === null && row.after?.power === 220),
+      ).toBe(true);
+      const difference = pending.getByRole("table", {
+        name: "Affected individual Workouts",
+        exact: true,
+      });
+      await expect(difference.getByRole("cell")).toHaveText(
+        preview.diff.map(() => / → .* · \d+ min · 220 W$/),
+      );
+      expect((await scenario.backend.inspectActivation()).revisions).toEqual(initial.revisions);
+      await capture(scenario, "preview");
+      await pending.getByRole("button", { name: "View evidence", exact: true }).click();
+      const evidence = changes(scenario).getByRole("region", {
+        name: "Source details",
+        exact: true,
+      });
+      await expect(evidence.getByRole("heading")).toBeFocused();
+      await expect(
+        evidence.getByRole("rowheader").filter({
+          hasText: "Saved profile and synchronized FTP evidence",
+        }),
+      ).toBeVisible();
+      await expect(
+        evidence.getByRole("listitem").filter({ hasText: "Intervals.icu FTP" }),
+      ).toHaveText(/Intervals\.icu FTP.*210 W.*selected/i);
+      await expect(evidence.getByRole("listitem").filter({ hasText: "Your entry" })).toHaveText(
+        /Your entry.*220 W/,
+      );
+      await capture(scenario, "evidence");
+      await evidence.getByRole("button", { name: "Back", exact: true }).click();
+      await pending.getByRole("button", { name: "Apply to Plan", exact: true }).click();
+      await expect(changes(scenario).getByRole("status")).toHaveText(
+        "Change applied locally. Training now matches the confirmed preview.",
+      );
+      const applied = changeCard(scenario, changeTitle, "Applied");
+      await expect(applied.getByRole("button", { name: "Undo", exact: true })).toBeVisible();
+      const corrected = await scenario.backend.inspectActivation();
+      expect(corrected.planningPlans[0]).toMatchObject({ version: 2, current_revision_number: 2 });
+      expect(corrected.revisions).toHaveLength(2);
+      expect(corrected.revisions[1]).toMatchObject({
+        revision_number: 2,
+        parent_revision_number: 1,
+        source_kind: "plan-change",
+        source_id: preview.changeId,
+      });
+      const correctedDraft = PlanCreationDraftSchema.parse(
+        JSON.parse(String(corrected.revisions[1]?.snapshot_json)),
+      );
+      expect(correctedDraft.ftp).toBe(220);
+      expect(
+        correctedDraft.weeks.flatMap((week) => week.workouts).map((workout) => workout.power),
+      ).toEqual(Array.from({ length: 12 }, () => 220));
+      expect(storedWorkouts(corrected)).toEqual(
+        storedWorkouts(initial).map((workout) => ({
+          ...workout,
+          power: 220,
+          guidance: "Use your confirmed FTP of 220 W",
+        })),
+      );
+      await capture(scenario, "applied");
+      await applied.getByRole("button", { name: "Undo", exact: true }).click();
+      const inverse = changeCard(scenario, inverseTitle, "Pending");
+      await expect(inverse.getByRole("heading")).toBeFocused();
+      await expect(
+        inverse
+          .getByRole("table", { name: "Affected individual Workouts", exact: true })
+          .getByRole("cell"),
+      ).toHaveText(preview.diff.map(() => / · 220 W → .* · \d+ min/));
+      await capture(scenario, "undo-preview");
+      await inverse.getByRole("button", { name: "Apply to Plan", exact: true }).click();
+      await expect(changeCard(scenario, inverseTitle, "Applied")).toBeVisible();
+      const restored = await scenario.backend.inspectActivation();
+      expect(restored.planningPlans[0]).toMatchObject({ version: 3, current_revision_number: 3 });
+      expect(restored.revisions).toHaveLength(3);
+      const restoredDraft = PlanCreationDraftSchema.parse(
+        JSON.parse(String(restored.revisions[2]?.snapshot_json)),
+      );
+      expect(restoredDraft.ftp).toBeNull();
+      expect(restoredDraft.weeks).toEqual(scenario.seed.draft.weeks);
+      expect(storedWorkouts(restored)).toEqual(storedWorkouts(initial));
+      await expect(
+        changes(scenario).getByRole("button", { name: "Undo", exact: true }),
+      ).toHaveCount(0);
+      await capture(scenario, "restored");
+    } finally {
+      await close(scenario);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Editor option `Correct FTP` with numeric `FTP in watts` (default 220, step 1) and client validation `Enter FTP above zero.`; sends `{ kind: "ftp", watts }`.
- Diff rows show watts when either side has power: `{d MMM yyyy} · {min} min · {W} W`.
- Evidence renders the `ftp-sources` candidates (Saved athlete FTP, Intervals.icu FTP, Intervals.icu eFTP, Your entry) with the selected one marked.
- Apply refusal `ftp-sources-changed` shows `The FTP sources changed. Request a fresh preview before applying this correction.`, keeps the pending card and re-reads the library. A remotely refused FTP preview shows the daemon's message.
- New Playwright spec plan-change-ftp.spec.ts: synced FTP anchor seed, preview shows watts and candidates, apply writes power into revision 2, Undo restores null, at 1180/720 light and dark.

## Verification
astra high read-only: one finding (daemon message dropped in the preview catch), fixed inline with a unit test.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project renderer-dom --maxWorkers 2` | 722 passed |
| playwright ftp + undo + race-window + sync-age | 16 passed |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn