### PR TITLE
feat(plan): add, edit and remove Supporting Events through Plan Changes

### DIFF
--- a/.changeset/plan-change-events.md
+++ b/.changeset/plan-change-events.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Preview and confirm supporting event changes to adjust your training around an event. Important events shorten nearby workouts, and Undo restores your previous Plan.

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -162,6 +162,7 @@ function premiseValue(premise: PlanChangeModel["premises"][number]): string {
     case "longest-workout":
       return `${intent.minutes} min`;
     case "inverse":
+    case "supporting-event":
       return premise.label;
     case "ftp":
       return `${intent.watts} W`;

--- a/apps/desktop-renderer/tests/plan-creation-draft-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-creation-draft-fixtures.ts
@@ -5,6 +5,7 @@ export function planCreationDraft(
 ): PlanCreationDraft {
   return {
     kind: "draft",
+    supportingEvents: [],
     answeredSummaries,
     goal: { kind: "fitness", outcome: "Build steady power", weeks: 4 },
     mode: "flexible",

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -6,6 +6,7 @@ import {
   PlanChangePreviewRpcParamsSchema,
   PlanChangeApplyRpcParamsSchema,
   type PlanChangeOperations,
+  type SupportingEvent,
   type PlanChangeApplyRpcParams,
   type PlanChangeApplyResult,
   type PlanChangePreviewRpcParams,
@@ -37,6 +38,7 @@ import {
   type PlanCreationHost,
 } from "../../../../packages/coach/src/plan-creation-operations.js";
 import { createPlanChangeOperations } from "../../../../packages/coach/src/plan-change-operations.js";
+import { createPlanChangeEventSourceReader } from "../../../../packages/coach/src/plan-change-event-source-reader.js";
 import type { DesktopFixtureScript } from "./desktop-fixture.js";
 import { createPlanQaFixtureScript } from "./plan-qa-live.js";
 import {
@@ -148,6 +150,23 @@ export class PlanCreationBackend {
   private queueRevision = 0;
   private queue: QueuedMessage[] = [];
   private transcript: TranscriptTurn[] = [];
+  private syncedEventCandidate = {
+    id: 17,
+    name: "Local supporting ride",
+    start_date_local: "1998-01-10T09:00:00",
+    category: "RACE_B",
+  };
+
+  setSyncedEventCandidate(candidate: Partial<typeof this.syncedEventCandidate>): void {
+    this.syncedEventCandidate = { ...this.syncedEventCandidate, ...candidate };
+  }
+
+  async readSyncedEventCandidates() {
+    return createPlanChangeEventSourceReader({
+      calendarConnected: () => this.options.calendarConnected ?? Boolean(this.options.calendar),
+      readLatest: () => ({ planned_workouts: [this.syncedEventCandidate] }),
+    }).read();
+  }
 
   constructor(
     private readonly databasePath: string,
@@ -384,6 +403,7 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
     });
     this.changes = createPlanChangeOperations({
       ftp,
+      eventSources: { read: () => this.readSyncedEventCandidates() },
       logger: { warn: () => {} },
       store: this.store,
       identity,
@@ -603,6 +623,50 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
       expectedVersion: previewed.planCreation.version,
     });
     return { planId: activated.planId, draft: previewed.planCreation.draft };
+  }
+
+  async seedActiveTrainingWithManualEvent(
+    event: { name?: string; date?: string; role?: SupportingEvent["role"] } = {},
+  ) {
+    const active = await this.seedActiveTraining();
+    if (active.planId === null) throw new TypeError("Training Plan was not activated");
+    const date =
+      event.date ??
+      active.draft.weeks.flatMap((week) => week.workouts).find((workout) => workout.date !== null)
+        ?.date;
+    if (date === null || date === undefined) throw new TypeError("Training seed has no event date");
+    const preview = await this.previewChange({
+      commandId: "seed-manual-event-preview",
+      planId: active.planId,
+      expectedVersion: 1,
+      intent: {
+        kind: "supporting-event",
+        operation: "add",
+        name: event.name ?? "Local supporting ride",
+        date,
+        role: event.role ?? "Training",
+      },
+    });
+    if (preview.status !== "previewed")
+      throw new TypeError(`Event seed was rejected: ${preview.reason}`);
+    const applied = await this.applyChange({
+      commandId: "seed-manual-event-apply",
+      planId: active.planId,
+      changeId: preview.change.changeId,
+      expectedVersion: 1,
+      decision: "apply",
+    });
+    if (applied.status !== "applied") throw new TypeError("Event seed was not applied");
+    const revision = await this.requireStore().get(
+      "SELECT snapshot_json FROM plan_revision WHERE plan_id=? ORDER BY revision_number DESC LIMIT 1",
+      [active.planId],
+    );
+    if (typeof revision?.snapshot_json !== "string")
+      throw new TypeError("Event revision is unavailable");
+    return {
+      planId: active.planId,
+      draft: PlanCreationDraftSchema.parse(JSON.parse(revision.snapshot_json)),
+    };
   }
 
   async previewChange(params: PlanChangePreviewRpcParams) {

--- a/packages/coach-contract/src/plan-change.ts
+++ b/packages/coach-contract/src/plan-change.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { TrainingExportCivilDateSchema } from "./training-export.js";
-import { PlanCloseRpcParamsSchema, PlanCreationDraftSchema } from "./plan-creation.js";
+import {
+  PlanCloseRpcParamsSchema,
+  PlanCreationDraftSchema,
+  SupportingEventRoleSchema,
+} from "./plan-creation.js";
 
 const FtpWattsSchema = z.number().int().min(1).max(9_999);
 
@@ -21,9 +25,73 @@ export const PlanChangeFtpSourcesSchema = z
   .strict();
 export type PlanChangeFtpSources = z.infer<typeof PlanChangeFtpSourcesSchema>;
 
+export const PlanChangeEventSourceSchema = z
+  .object({
+    providerId: z.string().min(1),
+    sourceRevision: z.string().regex(/^[0-9a-f]{64}$/u),
+    name: z.string().trim().min(1).max(512),
+    date: TrainingExportCivilDateSchema,
+    category: z.enum(["RACE_A", "RACE_B", "RACE_C"]),
+  })
+  .strict();
+export type PlanChangeEventSource = z.infer<typeof PlanChangeEventSourceSchema>;
+
+const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
+  z
+    .object({
+      kind: z.literal("supporting-event"),
+      operation: z.literal("add"),
+      name: z.string().trim().min(1).max(512),
+      date: TrainingExportCivilDateSchema,
+      role: SupportingEventRoleSchema,
+      providerId: z.string().min(1).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("supporting-event"),
+      operation: z.literal("remove"),
+      eventId: z.string().min(1).max(128),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("supporting-event"),
+      operation: z.literal("role"),
+      eventId: z.string().min(1).max(128),
+      role: SupportingEventRoleSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("supporting-event"),
+      operation: z.literal("manual"),
+      eventId: z.string().min(1).max(128),
+      name: z.string().trim().min(1).max(512),
+      date: TrainingExportCivilDateSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("supporting-event"),
+      operation: z.literal("source-update"),
+      eventId: z.string().min(1).max(128),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("supporting-event"),
+      operation: z.literal("name"),
+      eventId: z.string().min(1).max(128),
+      name: z.string().trim().min(1).max(512),
+    })
+    .strict(),
+]);
+
 const WeekdaySchema = z.number().int().min(1).max(7);
 
 export const PlanChangeIntentSchema = z.discriminatedUnion("kind", [
+  SupportingEventIntentSchema,
   z.object({ kind: z.literal("ftp"), watts: FtpWattsSchema }).strict(),
   z
     .object({
@@ -134,13 +202,14 @@ export const PlanChangePreviewResultSchema = z.discriminatedUnion("status", [
     z
       .object({
         status: z.literal("rejected"),
-        reason: z.enum([
-          "stale-version",
-          "no-active-plan",
-          "command-conflict",
-          "invalid-intent",
-          "sync-stale",
-        ]),
+        reason: z.enum(["stale-version", "no-active-plan", "command-conflict", "sync-stale"]),
+      })
+      .strict(),
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.literal("invalid-intent"),
+        explanation: z.string().min(1).optional(),
       })
       .strict(),
     z
@@ -189,6 +258,7 @@ export const PlanChangeApplyResultSchema = z.discriminatedUnion("status", [
         "sync-stale",
         "race-window",
         "ftp-sources-changed",
+        "event-source-changed",
       ]),
     })
     .strict(),

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -479,6 +479,28 @@ export const PlanCreationAnswerSummarySchema = z
   });
 export type PlanCreationAnswerSummary = z.infer<typeof PlanCreationAnswerSummarySchema>;
 
+export const SupportingEventRoleSchema = z.enum(["Important", "Training"]);
+
+export const SupportingEventSchema = z
+  .object({
+    id: z.string().min(1).max(128),
+    name: z.string().trim().min(1).max(512),
+    date: PlanCreationCivilDateSchema,
+    role: SupportingEventRoleSchema,
+    source: z.discriminatedUnion("kind", [
+      z.object({ kind: z.literal("manual") }).strict(),
+      z
+        .object({
+          kind: z.literal("synced"),
+          providerId: z.string().min(1),
+          sourceRevision: z.string().regex(/^[0-9a-f]{64}$/u),
+        })
+        .strict(),
+    ]),
+  })
+  .strict();
+export type SupportingEvent = z.infer<typeof SupportingEventSchema>;
+
 const PlanCreationDraftWorkoutSchema = z
   .object({
     id: z.string().min(1).max(128),
@@ -488,6 +510,7 @@ const PlanCreationDraftWorkoutSchema = z
     minutes: z.number().positive().max(1440),
     pinned: z.boolean(),
     guidance: z.string().min(1).max(512),
+    supportingEventId: z.string().min(1).max(128).optional(),
     power: z.number().int().min(1).max(9_999).nullable(),
   })
   .strict();
@@ -534,6 +557,7 @@ export const PlanCreationDraftSchema = z
     notes: z.array(z.string().min(1).max(2_000)).max(1_000),
     guidance: z.string().min(1).max(512),
     ftp: z.number().int().min(1).max(9_999).nullable(),
+    supportingEvents: z.array(SupportingEventSchema).default([]),
     builderId: z.string().min(1).max(128),
     builderVersion: z.string().min(1).max(128),
     inputFingerprint: z.string().regex(/^[0-9a-f]{64}$/u),

--- a/packages/coach-contract/tests/plan-change-contract.test.ts
+++ b/packages/coach-contract/tests/plan-change-contract.test.ts
@@ -7,6 +7,8 @@ import {
   PlanChangeApplyRpcParamsSchema,
   PlanChangeIntentSchema,
   PlanChangeFtpSourcesSchema,
+  PlanChangeEventSourceSchema,
+  SupportingEventSchema,
   PlanChangeModelSchema,
   PlanChangePreviewResultSchema,
   PlanChangePreviewRpcParamsSchema,
@@ -348,5 +350,120 @@ describe("race window rejections", () => {
     const applied = { status: "rejected", reason: "race-window" };
     expect(PlanChangeApplyResultSchema.parse(applied)).toEqual(applied);
     expect(PlanChangeApplyResultSchema.safeParse(rejection).success).toBe(false);
+  });
+});
+
+describe("Supporting Event contracts", () => {
+  const event = {
+    id: "supporting-event-one",
+    name: "Autumn ride",
+    date: "1998-09-12",
+    role: "Important",
+    source: { kind: "manual" },
+  };
+  const source = {
+    providerId: "fixture-event",
+    sourceRevision: "a".repeat(64),
+    name: event.name,
+    date: event.date,
+    category: "RACE_B",
+  };
+
+  it.each([
+    { operation: "add", name: event.name, date: event.date, role: "Important" },
+    {
+      operation: "add",
+      name: event.name,
+      date: event.date,
+      role: "Training",
+      providerId: source.providerId,
+    },
+    { operation: "remove", eventId: event.id },
+    { operation: "role", eventId: event.id, role: "Training" },
+    { operation: "manual", eventId: event.id, name: event.name, date: event.date },
+    { operation: "source-update", eventId: event.id },
+    { operation: "name", eventId: event.id, name: "Renamed ride" },
+  ])("accepts operation $operation", (operation) => {
+    const value = { kind: "supporting-event", ...operation };
+    expect(PlanChangeIntentSchema.parse(value)).toEqual(value);
+  });
+
+  it.each([
+    { operation: "add", name: event.name, date: event.date, role: "Ignore" },
+    { operation: "add", name: " ", date: event.date, role: "Important" },
+    { operation: "add", name: event.name, date: "1998-02-30", role: "Important" },
+    { operation: "add", name: event.name, date: event.date, role: "Training", providerId: "" },
+    { operation: "remove" },
+    { operation: "remove", eventId: "" },
+    { operation: "remove", eventId: event.id, name: event.name },
+    { operation: "role", eventId: event.id, role: "Main" },
+    { operation: "manual", eventId: event.id, name: event.name },
+    { operation: "source-update", eventId: event.id, date: event.date },
+    { operation: "name", eventId: event.id, name: "" },
+    { operation: "unknown", eventId: event.id },
+  ])("rejects malformed operation %j", (operation) => {
+    expect(
+      PlanChangeIntentSchema.safeParse({ kind: "supporting-event", ...operation }).success,
+    ).toBe(false);
+  });
+
+  it("preserves manual and synchronized events and validates source identity", () => {
+    expect(SupportingEventSchema.parse(event)).toEqual(event);
+    const synced = {
+      ...event,
+      source: {
+        kind: "synced",
+        providerId: source.providerId,
+        sourceRevision: source.sourceRevision,
+      },
+    };
+    expect(SupportingEventSchema.parse(synced)).toEqual(synced);
+    for (const invalid of [
+      { ...event, role: "Ignore" },
+      { ...event, date: "1998-02-30" },
+      { ...event, source: { kind: "manual", providerId: source.providerId } },
+      { ...synced, source: { ...synced.source, sourceRevision: "not-a-hash" } },
+      { ...synced, source: { kind: "synced", providerId: source.providerId } },
+    ]) {
+      expect(SupportingEventSchema.safeParse(invalid).success).toBe(false);
+    }
+    expect(PlanChangeWorkoutSchema.parse(workout)).toEqual(workout);
+    expect(
+      PlanChangeWorkoutSchema.parse({ ...workout, supportingEventId: event.id }).supportingEventId,
+    ).toBe(event.id);
+  });
+
+  it("preserves by-value synchronized event premises", () => {
+    expect(PlanChangeEventSourceSchema.parse(source)).toEqual(source);
+    const value = {
+      ...change,
+      premises: [
+        { id: "event-source", label: "Event", source: "Intervals.icu event", value: source },
+      ],
+    };
+    expect(PlanChangeModelSchema.parse(value)).toEqual(value);
+    for (const invalid of [
+      { ...source, category: "WORKOUT" },
+      { ...source, sourceRevision: "invalid" },
+      { ...source, date: "1998-09-12T12:00:00" },
+      { ...source, providerId: "" },
+      { ...source, unexpected: true },
+    ]) {
+      expect(PlanChangeEventSourceSchema.safeParse(invalid).success).toBe(false);
+    }
+  });
+
+  it("permits explanations only for invalid intents and rejects source drift", () => {
+    const rejection = {
+      status: "rejected",
+      reason: "invalid-intent",
+      explanation: "Choose a Supporting Event already accepted in this Plan.",
+    };
+    expect(PlanChangePreviewResultSchema.parse(rejection)).toEqual(rejection);
+    expect(
+      PlanChangePreviewResultSchema.safeParse({ ...rejection, reason: "sync-stale" }).success,
+    ).toBe(false);
+    const drift = { status: "rejected", reason: "event-source-changed" };
+    expect(PlanChangeApplyResultSchema.parse(drift)).toEqual(drift);
   });
 });

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -879,6 +879,7 @@ const draft = {
   notes: [],
   guidance: "Use comfortable perceived effort or your known heart-rate guidance",
   ftp: null,
+  supportingEvents: [],
   builderId: "cycling-creation-draft",
   builderVersion: "1",
   inputFingerprint: "a".repeat(64),
@@ -886,6 +887,15 @@ const draft = {
 };
 
 describe("Plan Creation Draft contract", () => {
+  it("defaults Supporting Events for existing revisions and creations", () => {
+    const { supportingEvents, ...previousDraft } = draft;
+    expect(supportingEvents).toEqual([]);
+    expect(PlanCreationDraftSchema.parse(previousDraft)).toEqual(draft);
+    expect(PlanCreationDraftSchema.parse(previousDraft).weeks[0]?.workouts[0]).not.toHaveProperty(
+      "supportingEventId",
+    );
+  });
+
   it("round-trips a review Draft through preview and planning request hydration", () => {
     const review = { ...card, status: "review", readiness: "ready", openQuestion: null, draft };
     const result = { status: "previewed", planCreation: review };

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -148,6 +148,7 @@ import {
 } from "./intervals-credential-approval.js";
 import { createCoachEngineAdapter } from "./coach-engine-adapter.js";
 import { createPlanChangeOperations } from "./plan-change-operations.js";
+import { createPlanChangeEventSourceReader } from "./plan-change-event-source-reader.js";
 import { createPlanCreationOperations } from "./plan-creation-operations.js";
 import {
   createStoreRuntime,
@@ -2021,6 +2022,10 @@ export async function createLocalCoachComposition(
     });
     const planChangeOperations = createPlanChangeOperations({
       ftp,
+      eventSources: createPlanChangeEventSourceReader({
+        calendarConnected: () => approvedConfig().intervals.apiKey.length > 0,
+        readLatest: () => readLatestReference(input.home.root),
+      }),
       logger,
       store: input.context.store,
       identity: planningIdentity,

--- a/packages/coach/src/plan-change-event-source-reader.ts
+++ b/packages/coach/src/plan-change-event-source-reader.ts
@@ -1,0 +1,38 @@
+import { createHash } from "node:crypto";
+import {
+  PlanChangeEventSourceSchema,
+  type PlanChangeEventSource,
+} from "@enduragent/coach-contract";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import { PlannedEventSchema, type LatestJson } from "@enduragent/kernel/reference/schemas";
+
+export function createPlanChangeEventSourceReader(deps: {
+  calendarConnected(): boolean | Promise<boolean>;
+  readLatest():
+    | Pick<LatestJson, "planned_workouts">
+    | null
+    | Promise<Pick<LatestJson, "planned_workouts"> | null>;
+}): { read(): Promise<PlanChangeEventSource[]> } {
+  return {
+    async read() {
+      if (!(await deps.calendarConnected())) return [];
+      const latest = await deps.readLatest();
+      return (latest?.planned_workouts ?? []).flatMap((value) => {
+        const parsed = PlannedEventSchema.safeParse(value);
+        if (!parsed.success) return [];
+        const { id, name, start_date_local, category } = parsed.data;
+        if (category !== "RACE_A" && category !== "RACE_B" && category !== "RACE_C") return [];
+        const source = PlanChangeEventSourceSchema.safeParse({
+          providerId: String(id),
+          name,
+          date: start_date_local.slice(0, 10),
+          category,
+          sourceRevision: createHash("sha256")
+            .update(canonicalJson({ id, name, start_date_local, category }))
+            .digest("hex"),
+        });
+        return source.success ? [source.data] : [];
+      });
+    },
+  };
+}

--- a/packages/coach/src/plan-change-operations.ts
+++ b/packages/coach/src/plan-change-operations.ts
@@ -1,12 +1,15 @@
 import {
   PlanChangeModelSchema,
   PlanChangeFtpSourcesSchema,
+  PlanChangeEventSourceSchema,
   PlanChangeApplyRpcParamsSchema,
   PlanChangeApplyResultSchema,
   PlanChangePreviewRpcParamsSchema,
   PlanChangePreviewResultSchema,
   PlanCreationDraftSchema,
   type PlanChangeIntent,
+  type PlanChangeEventSource,
+  type PlanCreationDraft,
   type PlanChangeOperations,
   type PlanChangeModel,
   type PlanChangesPaused,
@@ -24,6 +27,8 @@ import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import {
   applyScheduleIntent,
+  applySupportingEventIntent,
+  supportingEventWorkoutLimitExplanation,
   planChangeRaceWindow,
   readCyclingPlanFtpCandidates,
 } from "@enduragent/sport-cycling";
@@ -55,7 +60,43 @@ const titles = {
   "longest-workout": "Limit the longest Workout",
   inverse: "Undo the latest Change",
   ftp: "Correct FTP",
-} satisfies Record<PlanChangeIntent["kind"], string>;
+} satisfies Record<Exclude<PlanChangeIntent["kind"], "supporting-event">, string>;
+
+const eventTitles = {
+  add: "Add a Supporting Event",
+  remove: "Remove a Supporting Event",
+  role: "Change a Supporting Event role",
+  manual: "Correct a Supporting Event",
+  "source-update": "Accept synchronized event details",
+  name: "Rename a Supporting Event",
+} satisfies Record<Extract<PlanChangeIntent, { kind: "supporting-event" }>["operation"], string>;
+
+function supportingEventRules(draft: PlanCreationDraft) {
+  const answers = draft.answeredSummaries.map((summary) => summary.answer);
+  const availability = answers.find((answer) => answer.kind === "availability");
+  const restriction = answers.find((answer) => answer.kind === "restriction");
+  if (availability === undefined || restriction === undefined)
+    throw new Error("The Plan snapshot is missing confirmed training limits.");
+  return { availability, restriction: restriction.restriction };
+}
+
+function metadataChanged(before: PlanCreationDraft, after: PlanCreationDraft): boolean {
+  return (
+    before.ftp !== after.ftp ||
+    canonicalJson(before.supportingEvents) !== canonicalJson(after.supportingEvents)
+  );
+}
+
+function invalidEventExplanation(issues: readonly z.core.$ZodIssue[]): string {
+  const paths = issues.flatMap((issue) =>
+    issue.code === "invalid_union"
+      ? issue.errors.flatMap((errors) => errors.flatMap((error) => error.path))
+      : issue.path,
+  );
+  if (paths.includes("role")) return "Choose Important or Training.";
+  if (paths.includes("eventId")) return "Choose a Supporting Event already accepted in this Plan.";
+  return "Enter the event name and exact date.";
+}
 
 async function readCompletedWorkoutIds(
   store: SqlStore,
@@ -75,19 +116,39 @@ async function readCompletedWorkoutIds(
   );
 }
 
-async function inverseCorrectsFtp(
+async function readAppliedIntent(
   store: SqlStore,
   planId: string,
   changeId: string,
-): Promise<boolean> {
+): Promise<PlanChangeIntent | null> {
   const original = await store.get(
     "SELECT diff_json FROM plan_change WHERE id=? AND plan_id=? AND status='applied'",
     [changeId, planId],
   );
-  if (original === undefined) return false;
+  if (original === undefined) return null;
   const envelope = PlanChangeEnvelopeSchema.parse(JSON.parse(z.string().parse(original.diff_json)));
-  const intent = PlanChangeModelSchema.shape.intent.safeParse(envelope.intent);
-  return intent.success && intent.data.kind === "ftp";
+  return PlanChangeModelSchema.shape.intent.parse(envelope.intent);
+}
+
+async function eventNeedsSource(
+  store: SqlStore,
+  planId: string,
+  intent: Extract<PlanChangeIntent, { kind: "supporting-event" }>,
+  inverse: boolean,
+): Promise<boolean> {
+  if (intent.operation === "add") return intent.providerId !== undefined;
+  if (intent.operation === "manual") return false;
+  const revisions = await store.all(
+    "SELECT snapshot_json FROM plan_revision WHERE plan_id=? ORDER BY revision_number DESC LIMIT ?",
+    [planId, inverse ? 2 : 1],
+  );
+  return revisions.some((revision) =>
+    PlanCreationDraftSchema.parse(
+      JSON.parse(z.string().parse(revision.snapshot_json)),
+    ).supportingEvents.some(
+      (event) => event.id === intent.eventId && event.source.kind === "synced",
+    ),
+  );
 }
 
 export async function projectPlanChanges(input: {
@@ -124,7 +185,7 @@ export async function projectPlanChanges(input: {
           todayDateKey: input.todayDateKey,
         });
         undo =
-          restored.diff.length > 0 || restored.after.ftp !== draft.ftp
+          restored.diff.length > 0 || metadataChanged(draft, restored.after)
             ? { eligible: true }
             : { eligible: false, reason: "nothing-to-restore" };
       }
@@ -142,6 +203,7 @@ export function createPlanChangeOperations(input: {
   calendarConnected: () => Promise<boolean>;
   ftp: Pick<PlanFtpAdapter, "read" | "saveManual">;
   logger: { warn(event: string): void };
+  eventSources: { read(): Promise<PlanChangeEventSource[]> };
 }): PlanChangeOperations {
   const sha256 = async (text: string): Promise<string> => {
     const digest = await input.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
@@ -176,21 +238,39 @@ export function createPlanChangeOperations(input: {
       const parsed = PlanChangePreviewRpcParamsSchema.safeParse(request);
       if (!parsed.success) {
         if (parsed.error.issues.every((issue) => issue.path[0] === "intent"))
-          return { status: "rejected", reason: "invalid-intent" };
+          return {
+            status: "rejected",
+            reason: "invalid-intent",
+            ...(request.intent?.kind === "supporting-event"
+              ? { explanation: invalidEventExplanation(parsed.error.issues) }
+              : {}),
+          };
         throw parsed.error;
       }
       const { intent, planId, expectedVersion } = parsed.data;
       let ftpCandidates: Awaited<ReturnType<typeof readCyclingPlanFtpCandidates>> = [];
+      let eventSources: PlanChangeEventSource[] = [];
       const result = await repository.preview({
         async admit(store) {
           const rejection = await admit(store);
           if (rejection !== null) return rejection;
-          if (
-            intent.kind === "ftp" ||
-            (intent.kind === "inverse" &&
-              (await inverseCorrectsFtp(store, planId, intent.changeId)))
-          )
+          const original =
+            intent.kind === "inverse"
+              ? await readAppliedIntent(store, planId, intent.changeId)
+              : null;
+          if (intent.kind === "ftp" || original?.kind === "ftp")
             ftpCandidates = await readCyclingPlanFtpCandidates(input.ftp);
+          const eventIntent =
+            intent.kind === "supporting-event"
+              ? intent
+              : original?.kind === "supporting-event"
+                ? original
+                : null;
+          if (
+            eventIntent !== null &&
+            (await eventNeedsSource(store, planId, eventIntent, intent.kind === "inverse"))
+          )
+            eventSources = await input.eventSources.read();
           return null;
         },
         command: await stamp(parsed.data),
@@ -219,17 +299,71 @@ export function createPlanChangeOperations(input: {
             completedWorkoutIds,
             todayDateKey: input.todayDateKey(),
           };
-          const { after, diff, totals } =
-            intent.kind === "inverse"
-              ? applyScheduleIntent({
+          const originalIntent =
+            intent.kind === "inverse" && newestApplied !== null
+              ? PlanChangeModelSchema.shape.intent.parse(newestApplied.intent)
+              : null;
+          const eventIntent =
+            intent.kind === "supporting-event"
+              ? intent
+              : originalIntent?.kind === "supporting-event"
+                ? originalIntent
+                : null;
+          const previousDraft =
+            intent.kind === "inverse" && previousSnapshotJson !== null
+              ? PlanCreationDraftSchema.parse(JSON.parse(previousSnapshotJson))
+              : null;
+          const existingEvent =
+            eventIntent !== null && "eventId" in eventIntent
+              ? [...draft.supportingEvents, ...(previousDraft?.supportingEvents ?? [])].find(
+                  (event) => event.id === eventIntent.eventId,
+                )
+              : undefined;
+          const providerId =
+            eventIntent?.operation === "add"
+              ? eventIntent.providerId
+              : existingEvent?.source.kind === "synced"
+                ? existingEvent.source.providerId
+                : undefined;
+          const eventSource = eventSources.find((source) => source.providerId === providerId);
+          if (providerId !== undefined && eventSource === undefined)
+            return {
+              status: "rejected",
+              reason: "invalid-intent",
+              explanation:
+                "Accept synchronized event updates through a fresh source-update preview.",
+            };
+          const transformed =
+            intent.kind === "supporting-event"
+              ? applySupportingEventIntent({
                   ...transformation,
                   intent,
-                  previousDraft: PlanCreationDraftSchema.parse(
-                    JSON.parse(previousSnapshotJson ?? "null"),
-                  ),
+                  ...(intent.operation === "add" ? { eventId: input.identity.newUlid() } : {}),
+                  ...(eventSource === undefined ? {} : { source: eventSource }),
+                  rules: supportingEventRules(draft),
                 })
-              : applyScheduleIntent({ ...transformation, intent });
-          if (intent.kind === "inverse" && diff.length === 0 && after.ftp === draft.ftp)
+              : intent.kind === "inverse"
+                ? applyScheduleIntent({
+                    ...transformation,
+                    intent,
+                    previousDraft: previousDraft ?? PlanCreationDraftSchema.parse(null),
+                  })
+                : applyScheduleIntent({ ...transformation, intent });
+          if (!("after" in transformed))
+            return {
+              status: "rejected",
+              reason: "invalid-intent",
+              explanation: transformed.explanation,
+            };
+          const { after, diff, totals } = transformed;
+          if (eventIntent !== null) {
+            const explanation = supportingEventWorkoutLimitExplanation(after);
+            if (explanation !== null)
+              return { status: "rejected", reason: "invalid-intent", explanation };
+          }
+          if (!PlanCreationDraftSchema.safeParse(after).success)
+            return { status: "rejected", reason: "invalid-intent" };
+          if (intent.kind === "inverse" && diff.length === 0 && !metadataChanged(draft, after))
             return { status: "rejected", reason: "invalid-intent" };
           const correctsFtp =
             intent.kind === "ftp" ||
@@ -247,12 +381,25 @@ export function createPlanChangeOperations(input: {
           return {
             afterSnapshotJson: canonicalJson(after),
             envelope: PlanChangeEnvelopeSchema.parse({
-              title: titles[intent.kind],
+              title:
+                intent.kind === "supporting-event"
+                  ? eventTitles[intent.operation]
+                  : titles[intent.kind],
               intent,
               diff,
               totals,
               supersedes: null,
               premises: [
+                ...(eventSource === undefined
+                  ? []
+                  : [
+                      {
+                        id: "event-source",
+                        label: "Supporting Event source at this decision",
+                        source: "Intervals.icu event",
+                        value: eventSource,
+                      },
+                    ]),
                 ...(correctsFtp
                   ? [
                       {
@@ -309,6 +456,14 @@ export function createPlanChangeOperations(input: {
           const draft = PlanCreationDraftSchema.parse(JSON.parse(afterSnapshotJson));
           const parsedIntent = PlanChangeModelSchema.shape.intent.safeParse(rawIntent);
           const intent = parsedIntent.success ? parsedIntent.data : null;
+          const eventPremise = premises.find((premise) => premise.id === "event-source");
+          if (eventPremise !== undefined) {
+            const source = PlanChangeEventSourceSchema.parse(eventPremise.value);
+            const current = (await input.eventSources.read()).find(
+              (candidate) => candidate.providerId === source.providerId,
+            );
+            if (current?.sourceRevision !== source.sourceRevision) return "event-source-changed";
+          }
           const ftpPremise = premises.find((premise) => premise.id === "ftp-sources");
           if (ftpPremise !== undefined) {
             const sources = PlanChangeFtpSourcesSchema.parse(ftpPremise.value);
@@ -320,18 +475,32 @@ export function createPlanChangeOperations(input: {
             correctedWatts = intent.watts;
             return null;
           }
+          const original =
+            intent?.kind === "inverse"
+              ? await readAppliedIntent(store, parsed.planId, intent.changeId)
+              : null;
+          if (original?.kind === "ftp") return null;
+          const workouts = PlanChangeModelSchema.shape.diff.parse(diff);
+          if (planChangeRaceWindow({ goal: draft.goal, diff: workouts, todayDateKey }) !== null)
+            return "race-window";
+          const changesEvents =
+            intent?.kind === "supporting-event" || original?.kind === "supporting-event";
           if (
-            intent?.kind === "inverse" &&
-            (await inverseCorrectsFtp(store, parsed.planId, intent.changeId))
+            changesEvents &&
+            workouts.some(
+              ({ after }) => after?.date != null && dateKeyFromText(after.date) < todayDateKey,
+            )
           )
-            return null;
-          return planChangeRaceWindow({
-            goal: draft.goal,
-            diff: PlanChangeModelSchema.shape.diff.parse(diff),
-            todayDateKey,
-          }) === null
-            ? null
-            : "race-window";
+            return "stale-version";
+          return changesEvents
+            ? {
+                mutablePinnedWorkoutIds: workouts.flatMap(({ before }) =>
+                  before?.kind === "event" && before.supportingEventId !== undefined
+                    ? [before.id]
+                    : [],
+                ),
+              }
+            : null;
         },
         command,
         planId: parsed.planId,

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -589,6 +589,7 @@ export function createPlanCreationOperations(input: {
         const { inputFingerprint, outputFingerprint: _builderOutputFingerprint, ...output } = built;
         const draftOutput = {
           ...output,
+          supportingEvents: [],
           answeredSummaries: projectPlanCreationAnswerSummaries(
             snapshot,
             resolvePlanCreationAnswerFlow(snapshot),

--- a/packages/coach/tests/plan-calendar-drain.test.ts
+++ b/packages/coach/tests/plan-calendar-drain.test.ts
@@ -46,6 +46,7 @@ async function harness() {
     today: () => String(today).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3"),
   });
   const changes = createPlanChangeOperations({
+    eventSources: { read: async () => [] },
     ftp: createCyclingPlanFtpAdapter({
       readManual: async () => null,
       readIntervalsFtp: async () => null,

--- a/packages/coach/tests/plan-change-event-source-reader.test.ts
+++ b/packages/coach/tests/plan-change-event-source-reader.test.ts
@@ -1,0 +1,105 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import { describe, expect, it, vi } from "vitest";
+import { createPlanChangeEventSourceReader } from "../src/plan-change-event-source-reader.js";
+
+const event = {
+  id: 17,
+  name: "Autumn ride",
+  start_date_local: "1998-09-12T09:00:00",
+  category: "RACE_B",
+};
+
+const reader = (planned_workouts: unknown[]) =>
+  createPlanChangeEventSourceReader({
+    calendarConnected: () => true,
+    readLatest: () => ({ planned_workouts }),
+  });
+
+describe("Plan Change event sources", () => {
+  it("reads only race categories and fingerprints the exact provider fields", async () => {
+    const sources = await reader([
+      event,
+      { ...event, id: 18, category: "RACE_A" },
+      { ...event, id: 19, category: "RACE_C" },
+      { ...event, category: "WORKOUT" },
+      { ...event, category: "RACE" },
+      null,
+    ]).read();
+    expect(sources).toHaveLength(3);
+    expect(sources[0]).toEqual({
+      providerId: "17",
+      name: "Autumn ride",
+      date: "1998-09-12",
+      category: "RACE_B",
+      sourceRevision: createHash("sha256").update(canonicalJson(event)).digest("hex"),
+    });
+  });
+
+  it("ignores unrelated fields and object key order", async () => {
+    const original = await reader([event]).read();
+    const reordered = {
+      category: event.category,
+      start_date_local: event.start_date_local,
+      description: "Changed provider description",
+      moving_time: 7200,
+      name: event.name,
+      id: event.id,
+    };
+    expect(await reader([reordered]).read()).toEqual(original);
+  });
+
+  it.each([
+    { id: 18 },
+    { name: "Renamed ride" },
+    { start_date_local: "1998-09-12T10:00:00" },
+    { category: "RACE_A" },
+  ])("detects a change in a fingerprint field: %j", async (change) => {
+    const [before] = await reader([event]).read();
+    const [after] = await reader([{ ...event, ...change }]).read();
+    expect(after?.sourceRevision).not.toBe(before?.sourceRevision);
+  });
+
+  it("does not expose events without a valid name or exact civil date", async () => {
+    expect(
+      await reader([
+        { ...event, name: null },
+        { ...event, name: " " },
+        { ...event, start_date_local: "1998-02-30T09:00:00" },
+        { ...event, start_date_local: "not-a-date" },
+      ]).read(),
+    ).toEqual([]);
+  });
+
+  it("returns no sources when disconnected without reading the reference", async () => {
+    const readLatest = vi.fn(() => ({ planned_workouts: [event] }));
+    const disconnected = createPlanChangeEventSourceReader({
+      calendarConnected: async () => false,
+      readLatest,
+    });
+    expect(await disconnected.read()).toEqual([]);
+    expect(readLatest).not.toHaveBeenCalled();
+  });
+
+  it("returns no sources when no validated reference exists", async () => {
+    expect(
+      await createPlanChangeEventSourceReader({
+        calendarConnected: () => true,
+        readLatest: () => null,
+      }).read(),
+    ).toEqual([]);
+  });
+
+  it("reads current provider values on every call", async () => {
+    let current = event;
+    const source = createPlanChangeEventSourceReader({
+      calendarConnected: () => true,
+      readLatest: () => ({ planned_workouts: [current] }),
+    });
+    const before = await source.read();
+    current = { ...event, name: "Updated ride" };
+    const after = await source.read();
+    expect(after[0]?.name).toBe("Updated ride");
+    expect(after[0]?.sourceRevision).not.toBe(before[0]?.sourceRevision);
+  });
+});

--- a/packages/coach/tests/plan-change-operations.test.ts
+++ b/packages/coach/tests/plan-change-operations.test.ts
@@ -5,6 +5,7 @@ import {
   PlanCreationDraftSchema,
   type PlanCreationAnswerInput,
   type PlanChangeIntent,
+  type PlanChangeEventSource,
 } from "@enduragent/coach-contract";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import {
@@ -24,6 +25,7 @@ async function activatedPlan(
     lastSuccessfulSyncAtMs: null,
   },
   eventDate: string | null = null,
+  mode: "fixed" | "flexible" = "fixed",
 ) {
   const store = openSqliteStorage(":memory:");
   onTestFinished(() => store.close());
@@ -75,7 +77,9 @@ async function activatedPlan(
     refreshIntervals: async () => {},
   });
   const logger = { warn: vi.fn() };
-  const changes = createPlanChangeOperations({ ...dependencies, ftp, logger });
+  let candidates: PlanChangeEventSource[] = [];
+  const eventSources = { read: vi.fn(async () => structuredClone(candidates)) };
+  const changes = createPlanChangeOperations({ ...dependencies, ftp, logger, eventSources });
   const start = await creation["plan_creation.start"]({ commandId: "start" });
   if (start.status !== "started") throw new Error("Expected creation");
   let card = start.planCreation;
@@ -88,14 +92,16 @@ async function activatedPlan(
       : ([
           { kind: "goal", goal: { kind: "event-manual", name: "Autumn ride", date: eventDate } },
         ] satisfies PlanCreationAnswerInput[])),
-    { kind: "schedule-mode", mode: "fixed" },
-    {
-      kind: "availability",
-      mode: "fixed",
-      weeklyHoursLimit: 8,
-      longestWorkoutHours: 3,
-      usableWeekdays: [6, 2, 4],
-    },
+    { kind: "schedule-mode", mode },
+    mode === "fixed"
+      ? {
+          kind: "availability",
+          mode,
+          weeklyHoursLimit: 8,
+          longestWorkoutHours: 3,
+          usableWeekdays: [6, 2, 4],
+        }
+      : { kind: "availability", mode, weeklyHoursLimit: 8, longestWorkoutHours: 3 },
     { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
     { kind: "commitments", commitments: { kind: "none" } },
     { kind: "baseline", baseline: "regular" },
@@ -156,6 +162,10 @@ async function activatedPlan(
     ftp,
     saveManual,
     logger,
+    eventSources,
+    setEventSources: (sources: PlanChangeEventSource[]) => {
+      candidates = structuredClone(sources);
+    },
     setFtpSources: (sources: {
       manual?: PlanFtpSourceValue | null;
       intervalsFtp?: PlanFtpSourceValue | null;
@@ -1759,4 +1769,446 @@ it("does not read FTP evidence for other Changes or their inverse", async () => 
   );
   await applyChange(test, inverse.change.changeId, 2, "limit-restore");
   expect(read).not.toHaveBeenCalled();
+});
+
+describe("Supporting Event Plan Changes", () => {
+  const manualIntent = {
+    kind: "supporting-event",
+    operation: "add",
+    name: "Local autumn ride",
+    date: "1998-09-05",
+    role: "Training",
+  } satisfies PlanChangeIntent;
+  const source: PlanChangeEventSource = {
+    providerId: "fixture-race",
+    name: "Synchronized autumn ride",
+    date: "1998-09-05",
+    category: "RACE_B",
+    sourceRevision: "a".repeat(64),
+  };
+
+  it("never persists an invalid Draft as a preview when a week would exceed six Workouts", async () => {
+    const test = await activatedPlan();
+    let version = 1;
+    while ((await revisionSnapshot(test, version)).weeks[0].workouts.length < 6) {
+      const index = version - 1;
+      const preview = await test.preview(
+        { ...manualIntent, date: "1998-09-03", name: `Local ride ${index + 1}` },
+        `event-preview-${index}`,
+        index + 1,
+      );
+      await applyChange(test, preview.change.changeId, index + 1, `event-apply-${index}`);
+      version++;
+    }
+    const draft = await revisionSnapshot(test, version);
+    expect(draft.weeks[0].workouts).toHaveLength(6);
+    expect(PlanCreationDraftSchema.safeParse(draft).success).toBe(true);
+    const before = await dumpStore(test.store);
+    const changes = await test.store.all("SELECT * FROM plan_change ORDER BY id");
+    expect(
+      await test.changes["plan_change.preview"]({
+        commandId: "seventh-workout-preview",
+        planId: test.planId,
+        expectedVersion: version,
+        intent: { ...manualIntent, date: "1998-09-03" },
+      }),
+    ).toEqual({
+      status: "rejected",
+      reason: "invalid-intent",
+      explanation:
+        "A week can hold at most six Workouts. Remove or move one before adding this event.",
+    });
+    expect(await dumpStore(test.store)).toBe(before);
+    expect(await test.store.all("SELECT * FROM plan_change ORDER BY id")).toEqual(changes);
+    expect(await test.store.all("SELECT * FROM plan_change WHERE status = 'preview'")).toEqual([]);
+  });
+
+  it("adds a manual event without source evidence and undoes its pinned Workout and displacement", async () => {
+    const test = await activatedPlan();
+    const before = await test.workouts();
+    test.eventSources.read.mockRejectedValue(new Error("Source reader unavailable"));
+    const preview = await test.preview(manualIntent);
+    expect(preview.change.title).toBe("Add a Supporting Event");
+    expect(preview.change.premises.some((premise) => premise.id === "event-source")).toBe(false);
+    expect(await test.workouts()).toEqual(before);
+    const eventWorkout = preview.change.diff.find(
+      (row) => row.after?.supportingEventId !== undefined,
+    );
+    if (eventWorkout?.after === null || eventWorkout?.after === undefined)
+      throw new Error("Expected event Workout");
+    expect(eventWorkout.after).toMatchObject({
+      date: manualIntent.date,
+      kind: "event",
+      pinned: true,
+      minutes: 45,
+      guidance: "Use the accepted event limit",
+    });
+    expect(
+      preview.change.diff.some(
+        (row) => row.before?.date === manualIntent.date && row.after === null,
+      ),
+    ).toBe(true);
+    await applyChange(test, preview.change.changeId, 1, "manual-add");
+    expect((await revisionSnapshot(test, 2)).supportingEvents).toMatchObject([
+      {
+        name: manualIntent.name,
+        date: manualIntent.date,
+        role: "Training",
+        source: { kind: "manual" },
+      },
+    ]);
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: preview.change.changeId },
+      "manual-undo",
+      2,
+    );
+    expect(inverse.change.diff).toContainEqual({
+      workoutId: eventWorkout.workoutId,
+      before: eventWorkout.after,
+      after: null,
+    });
+    await applyChange(test, inverse.change.changeId, 2, "manual-restore");
+    expect((await revisionSnapshot(test, 3)).supportingEvents).toEqual([]);
+    expect(test.eventSources.read).not.toHaveBeenCalled();
+    expect((await revisionSnapshot(test, 3)).weeks).toEqual(test.draft.weeks);
+    expect((await test.workouts()).map((row) => row.structure_json).sort()).toEqual(
+      before.map((row) => row.structure_json).sort(),
+    );
+  });
+
+  it("retains the event Workout database id through role and date changes", async () => {
+    const test = await activatedPlan();
+    const added = await test.preview(manualIntent);
+    await applyChange(test, added.change.changeId, 1, "add-event");
+    const event = (await revisionSnapshot(test, 2)).supportingEvents[0];
+    if (event === undefined) throw new Error("Expected Supporting Event");
+    const stored = await test.store.get(
+      "SELECT id FROM plan_workout WHERE plan_id=? AND json_extract(structure_json,'$.supportingEventId')=?",
+      [test.planId, event.id],
+    );
+    const important = await test.preview(
+      { kind: "supporting-event", operation: "role", eventId: event.id, role: "Important" },
+      "important-preview",
+      2,
+    );
+    await applyChange(test, important.change.changeId, 2, "important-apply");
+    const corrected = await test.preview(
+      {
+        kind: "supporting-event",
+        operation: "manual",
+        eventId: event.id,
+        name: event.name,
+        date: "1998-09-08",
+      },
+      "correct-preview",
+      3,
+    );
+    await applyChange(test, corrected.change.changeId, 3, "correct-apply");
+    expect(
+      await test.store.get(
+        "SELECT id FROM plan_workout WHERE plan_id=? AND json_extract(structure_json,'$.supportingEventId')=?",
+        [test.planId, event.id],
+      ),
+    ).toEqual(stored);
+    const snapshot = await revisionSnapshot(test, 4);
+    expect(snapshot.supportingEvents[0]).toMatchObject({
+      id: event.id,
+      role: "Important",
+      date: "1998-09-08",
+    });
+    expect(
+      snapshot.weeks
+        .flatMap((week) => week.workouts)
+        .filter((workout) => workout.supportingEventId === event.id),
+    ).toMatchObject([{ date: "1998-09-08", pinned: true }]);
+  });
+
+  it("renames event metadata and undoes the name without rewriting Workouts", async () => {
+    const test = await activatedPlan();
+    const added = await test.preview(manualIntent);
+    await applyChange(test, added.change.changeId, 1, "add-event");
+    const event = (await revisionSnapshot(test, 2)).supportingEvents[0];
+    if (event === undefined) throw new Error("Expected Supporting Event");
+    const workouts = await test.workouts();
+    const renamed = await test.preview(
+      { kind: "supporting-event", operation: "name", eventId: event.id, name: "A new name" },
+      "rename-preview",
+      2,
+    );
+    expect(renamed.change.diff).toEqual([]);
+    await applyChange(test, renamed.change.changeId, 2, "rename-apply");
+    expect((await revisionSnapshot(test, 3)).supportingEvents[0]?.name).toBe("A new name");
+    expect(await test.workouts()).toEqual(workouts);
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: renamed.change.changeId },
+      "rename-undo",
+      3,
+    );
+    expect(inverse.change.diff).toEqual([]);
+    await applyChange(test, inverse.change.changeId, 3, "rename-restore");
+    expect((await revisionSnapshot(test, 4)).supportingEvents[0]?.name).toBe(event.name);
+    expect(await test.workouts()).toEqual(workouts);
+  });
+
+  it("captures synchronized event evidence and refuses changed or removed sources without mutation", async () => {
+    const test = await activatedPlan();
+    test.setEventSources([source]);
+    const preview = await test.preview({ ...manualIntent, providerId: source.providerId });
+    expect(preview.change.premises.find((premise) => premise.id === "event-source")).toMatchObject({
+      source: "Intervals.icu event",
+      value: source,
+    });
+    const before = await dumpStore(test.store);
+    const request = {
+      commandId: "synced-apply",
+      planId: test.planId,
+      expectedVersion: 1,
+      changeId: preview.change.changeId,
+      decision: "apply" as const,
+    };
+    for (const candidates of [[{ ...source, sourceRevision: "b".repeat(64) }], []]) {
+      test.setEventSources(candidates);
+      expect(await test.changes["plan_change.apply"](request)).toEqual({
+        status: "rejected",
+        reason: "event-source-changed",
+      });
+      expect(await dumpStore(test.store)).toBe(before);
+      expect((await test.creation["plan.list"]({})).changes).toContainEqual(preview.change);
+    }
+    test.setEventSources([source]);
+    const applied = await test.changes["plan_change.apply"](request);
+    expect(applied.status).toBe("applied");
+    const snapshot = await revisionSnapshot(test, 2);
+    expect(snapshot.supportingEvents[0]).toMatchObject({
+      name: source.name,
+      date: source.date,
+      source: {
+        kind: "synced",
+        providerId: source.providerId,
+        sourceRevision: source.sourceRevision,
+      },
+    });
+    test.eventSources.read.mockRejectedValue(new Error("Source reader unavailable"));
+    const after = await dumpStore(test.store);
+    expect(await test.changes["plan_change.apply"](request)).toEqual(applied);
+    expect(await test.preview({ ...manualIntent, providerId: source.providerId })).toEqual(preview);
+    expect(await dumpStore(test.store)).toBe(after);
+  });
+
+  it("rechecks source revision after entering the apply transaction", async () => {
+    const test = await activatedPlan();
+    test.setEventSources([source]);
+    const preview = await test.preview({ ...manualIntent, providerId: source.providerId });
+    const before = await dumpStore(test.store);
+    const transaction = test.store.transaction.bind(test.store);
+    const hook = vi.spyOn(test.store, "transaction").mockImplementationOnce((fn) => {
+      test.setEventSources([{ ...source, sourceRevision: "c".repeat(64) }]);
+      return transaction(fn);
+    });
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "source-race",
+        planId: test.planId,
+        expectedVersion: 1,
+        changeId: preview.change.changeId,
+        decision: "apply",
+      }),
+    ).toEqual({ status: "rejected", reason: "event-source-changed" });
+    expect(hook).toHaveBeenCalledOnce();
+    hook.mockRestore();
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it.each([
+    {
+      intent: { kind: "supporting-event", operation: "remove", eventId: "missing" },
+      explanation: "Choose a Supporting Event already accepted in this Plan.",
+    },
+    {
+      intent: { ...manualIntent, date: "1998-10-01" },
+      explanation: "Choose a Supporting Event inside this Plan span.",
+    },
+    {
+      intent: { ...manualIntent, date: "1998-09-06" },
+      explanation: "The event date conflicts with a confirmed training limit.",
+    },
+  ] satisfies { intent: PlanChangeIntent; explanation: string }[])(
+    "returns event validation without writing a preview: $explanation",
+    async ({ intent, explanation }) => {
+      const test = await activatedPlan();
+      const before = await dumpStore(test.store);
+      expect(
+        await test.changes["plan_change.preview"]({
+          commandId: "invalid-event",
+          planId: test.planId,
+          expectedVersion: 1,
+          intent,
+        }),
+      ).toEqual({ status: "rejected", reason: "invalid-intent", explanation });
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+
+  it.each([
+    { intent: { ...manualIntent, name: " " }, explanation: "Enter the event name and exact date." },
+    {
+      intent: { ...manualIntent, date: "1998-02-30" },
+      explanation: "Enter the event name and exact date.",
+    },
+    { intent: { ...manualIntent, role: "Ignored" }, explanation: "Choose Important or Training." },
+    {
+      intent: { kind: "supporting-event", operation: "remove", eventId: "" },
+      explanation: "Choose a Supporting Event already accepted in this Plan.",
+    },
+  ])(
+    "explains malformed event fields at the RPC boundary: $explanation",
+    async ({ intent, explanation }) => {
+      const test = await activatedPlan();
+      const before = await dumpStore(test.store);
+      const result = await Reflect.apply(test.changes["plan_change.preview"], undefined, [
+        {
+          commandId: "malformed-event",
+          planId: test.planId,
+          expectedVersion: 1,
+          intent,
+        },
+      ]);
+      expect(result).toEqual({ status: "rejected", reason: "invalid-intent", explanation });
+      expect(await dumpStore(test.store)).toBe(before);
+    },
+  );
+
+  it("refuses a date correction whose target day elapsed after preview", async () => {
+    let today = 19980902;
+    const test = await activatedPlan(() => today);
+    const added = await test.preview({ ...manualIntent, date: "1998-09-12" });
+    await applyChange(test, added.change.changeId, 1, "add-event");
+    const event = (await revisionSnapshot(test, 2)).supportingEvents[0];
+    if (event === undefined) throw new Error("Expected Supporting Event");
+    const correction = await test.preview(
+      {
+        kind: "supporting-event",
+        operation: "manual",
+        eventId: event.id,
+        name: event.name,
+        date: "1998-09-05",
+      },
+      "correct-date",
+      2,
+    );
+    today = 19980906;
+    const before = await dumpStore(test.store);
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "apply-elapsed-date",
+        planId: test.planId,
+        expectedVersion: 2,
+        changeId: correction.change.changeId,
+        decision: "apply",
+      }),
+    ).toEqual({ status: "rejected", reason: "stale-version" });
+    expect(await dumpStore(test.store)).toBe(before);
+  });
+
+  it("captures synchronized evidence for Undo and refuses source drift", async () => {
+    const test = await activatedPlan();
+    test.setEventSources([source]);
+    const added = await test.preview({ ...manualIntent, providerId: source.providerId });
+    await applyChange(test, added.change.changeId, 1, "synced-add");
+    const inverse = await test.preview(
+      { kind: "inverse", changeId: added.change.changeId },
+      "synced-undo",
+      2,
+    );
+    expect(inverse.change.premises.find((premise) => premise.id === "event-source")).toMatchObject({
+      source: "Intervals.icu event",
+      value: source,
+    });
+    test.setEventSources([{ ...source, sourceRevision: "d".repeat(64) }]);
+    const before = await dumpStore(test.store);
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "synced-restore",
+        planId: test.planId,
+        expectedVersion: 2,
+        changeId: inverse.change.changeId,
+        decision: "apply",
+      }),
+    ).toEqual({ status: "rejected", reason: "event-source-changed" });
+    expect(await dumpStore(test.store)).toBe(before);
+    test.setEventSources([source]);
+    await applyChange(test, inverse.change.changeId, 2, "synced-restore");
+    expect((await revisionSnapshot(test, 3)).supportingEvents).toEqual([]);
+  });
+
+  it("cancels synchronized Changes without rereading their source", async () => {
+    const test = await activatedPlan();
+    test.setEventSources([source]);
+    const preview = await test.preview({ ...manualIntent, providerId: source.providerId });
+    const workouts = await test.workouts();
+    test.eventSources.read.mockClear().mockRejectedValue(new Error("Source reader unavailable"));
+    expect(
+      await test.changes["plan_change.apply"]({
+        commandId: "synced-cancel",
+        planId: test.planId,
+        expectedVersion: 1,
+        changeId: preview.change.changeId,
+        decision: "cancel",
+      }),
+    ).toMatchObject({ status: "cancelled" });
+    expect(test.eventSources.read).not.toHaveBeenCalled();
+    expect(await test.workouts()).toEqual(workouts);
+  });
+});
+
+it("restores flexible Plan Workouts and the revision fingerprint after an Important event undo", async () => {
+  const test = await activatedPlan(undefined, undefined, null, "flexible");
+  const baseline = await test.preview({ kind: "ftp", watts: 220 });
+  await applyChange(test, baseline.change.changeId, 1, "baseline-ftp");
+  const before = await revisionSnapshot(test, 2);
+  const undated = before.weeks.flatMap((week) => week.workouts);
+  expect(undated.length).toBeGreaterThan(0);
+  expect(undated.every((workout) => workout.date === null)).toBe(true);
+  expect(await test.workouts()).toEqual([]);
+  const preview = await test.preview(
+    {
+      kind: "supporting-event",
+      operation: "add",
+      name: "Local ride",
+      date: "1998-09-03",
+      role: "Important",
+    },
+    "important-preview",
+    2,
+  );
+  expect(
+    preview.change.diff.some(
+      (row) => row.before?.date === null && row.before.minutes !== row.after?.minutes,
+    ),
+  ).toBe(true);
+  expect(
+    preview.change.diff.some(
+      (row) => row.before?.date === null && row.before.kind !== row.after?.kind,
+    ),
+  ).toBe(true);
+  expect(await revisionSnapshot(test, 2)).toEqual(before);
+  await applyChange(test, preview.change.changeId, 2, "important-add");
+  expect(await test.workouts()).toHaveLength(1);
+  const inverse = await test.preview(
+    { kind: "inverse", changeId: preview.change.changeId },
+    "important-undo",
+    3,
+  );
+  await applyChange(test, inverse.change.changeId, 3, "important-restore");
+  const restored = await revisionSnapshot(test, 4);
+  expect(restored.weeks.flatMap((week) => week.workouts)).toEqual(undated);
+  expect(restored).toEqual(before);
+  expect(restored.outputFingerprint).toBe(before.outputFingerprint);
+  expect(await test.workouts()).toEqual([]);
+  const revisions = await test.store.all(
+    "SELECT fingerprint FROM plan_revision WHERE plan_id=? AND revision_number IN (2,4) ORDER BY revision_number",
+    [test.planId],
+  );
+  expect(revisions).toHaveLength(2);
+  expect(revisions[1]).toEqual(revisions[0]);
 });

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1595,6 +1595,7 @@ describe("Plan Creation activation", () => {
     const activated = await test.host["plan_creation.activate"](test.request);
     let sequence = 1000;
     const changes = createPlanChangeOperations({
+      eventSources: { read: async () => [] },
       ftp: createCyclingPlanFtpAdapter({
         readManual: async () => null,
         readIntervalsFtp: async () => null,

--- a/packages/kernel-node/tests/plan-change-repository.test.ts
+++ b/packages/kernel-node/tests/plan-change-repository.test.ts
@@ -398,6 +398,74 @@ describe("Plan Change repository", () => {
     expect(await dumpStore(store)).toBe(before);
   });
 
+  it("applies undated Workout changes only to the revision and Plan version", async () => {
+    await activate();
+    const changed = { ...poolWorkout, minutes: 20, kind: "endurance" };
+    const next = {
+      ...draft,
+      weeks: [{ ...draft.weeks[0], workouts: [keptWorkout, removedWorkout, changed] }],
+    };
+    await repository.preview({
+      ...previewInput(),
+      build: () => ({
+        afterSnapshotJson: JSON.stringify(next),
+        envelope: {
+          ...envelope,
+          diff: [{ workoutId: poolWorkout.id, before: poolWorkout, after: changed }],
+        },
+      }),
+    });
+    const rows = await store.all("SELECT * FROM plan_workout ORDER BY id");
+    for (const operation of ["INSERT", "UPDATE", "DELETE"]) {
+      await store.exec(`CREATE TRIGGER reject_workout_${operation.toLowerCase()}
+        BEFORE ${operation} ON plan_workout
+        BEGIN SELECT RAISE(ABORT, 'Unexpected Workout row write'); END`);
+    }
+    const materialize = vi.fn(() => ({ insert: [], update: [], delete: [] }));
+    await expect(repository.apply({ ...applyInput(), materialize })).resolves.toMatchObject({
+      status: "applied",
+      revisionNumber: 2,
+      version: 2,
+    });
+    expect(materialize).toHaveBeenCalledWith(expect.any(String), expect.any(Array), new Set());
+    expect(await store.all("SELECT * FROM plan_workout ORDER BY id")).toEqual(rows);
+    expect(await store.get("SELECT version,current_revision_number FROM planning_plan")).toEqual({
+      version: 2,
+      current_revision_number: 2,
+    });
+    expect(
+      await store.get("SELECT snapshot_json FROM plan_revision WHERE revision_number=2"),
+    ).toEqual({ snapshot_json: canonicalJson(next) });
+  });
+
+  it.each(["undated-to-dated", "dated-to-undated"])(
+    "refuses %s Workout changes without writes",
+    async (direction) => {
+      await activate();
+      const next = structuredClone(draft);
+      const workout = next.weeks[0].workouts.find((candidate) =>
+        direction === "undated-to-dated" ? candidate.id === "pool" : candidate.id === "removed",
+      );
+      if (workout === undefined) throw new Error("Expected Workout");
+      workout.date = direction === "undated-to-dated" ? "1998-01-03" : null;
+      await repository.preview({
+        ...previewInput(),
+        build: () => ({
+          afterSnapshotJson: JSON.stringify(next),
+          envelope: { ...envelope, diff: [] },
+        }),
+      });
+      const before = await dumpStore(store);
+      const materialize = vi.fn(() => ({ insert: [], update: [], delete: [] }));
+      await expect(repository.apply({ ...applyInput(), materialize })).resolves.toEqual({
+        status: "rejected",
+        reason: "stale-version",
+      });
+      expect(materialize).not.toHaveBeenCalled();
+      expect(await dumpStore(store)).toBe(before);
+    },
+  );
+
   it("applies one new revision and atomically preserves, adds and removes Workout rows", async () => {
     await activate();
     await repository.preview(previewInput());

--- a/packages/kernel/src/planning/change-repository.ts
+++ b/packages/kernel/src/planning/change-repository.ts
@@ -49,13 +49,14 @@ export const PlanChangePreviewStoreResultSchema = z.discriminatedUnion("status",
     z
       .object({
         status: z.literal("rejected"),
-        reason: z.enum([
-          "stale-version",
-          "no-active-plan",
-          "command-conflict",
-          "invalid-intent",
-          "sync-stale",
-        ]),
+        reason: z.literal("invalid-intent"),
+        explanation: z.string().min(1).optional(),
+      })
+      .strict(),
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum(["stale-version", "no-active-plan", "command-conflict", "sync-stale"]),
       })
       .strict(),
     z
@@ -90,6 +91,7 @@ export const PlanChangeApplyStoreResultSchema = z.discriminatedUnion("status", [
         "sync-stale",
         "race-window",
         "ftp-sources-changed",
+        "event-source-changed",
       ]),
     })
     .strict(),
@@ -118,7 +120,11 @@ export interface PreviewPlanChangeInput {
     context: PlanChangeUndoContext & { readonly completedWorkoutIds: ReadonlySet<string> },
   ) =>
     | { readonly afterSnapshotJson: string; readonly envelope: PlanChangeEnvelope }
-    | { readonly status: "rejected"; readonly reason: "invalid-intent" }
+    | {
+        readonly status: "rejected";
+        readonly reason: "invalid-intent";
+        readonly explanation?: string;
+      }
     | Extract<PlanChangePreviewStoreResult, { reason: "race-window" }>;
 }
 export interface PlanChangeWorkoutMutations {
@@ -142,7 +148,11 @@ export interface ApplyPlanChangeInput {
       readonly premises: PlanChangeEnvelope["premises"];
       readonly todayDateKey: number;
     },
-  ) => Promise<Extract<PlanChangeApplyStoreResult, { status: "rejected" }>["reason"] | null>;
+  ) => Promise<
+    | Extract<PlanChangeApplyStoreResult, { status: "rejected" }>["reason"]
+    | { readonly mutablePinnedWorkoutIds: readonly string[] }
+    | null
+  >;
   readonly command: PlanCreationCommandStamp;
   readonly planId: string;
   readonly changeId: string;
@@ -307,6 +317,7 @@ export function createPlanChangeRepository(
     change: ChangeRow,
     afterSnapshotJson: string,
     todayDateKey: number,
+    mutablePinnedWorkoutIds: ReadonlySet<string>,
   ) => {
     const plan = await plans.read(input.planId);
     if (plan === undefined) return fail();
@@ -354,12 +365,15 @@ export function createPlanChangeRepository(
     for (const workout of changedWorkouts) {
       const row = currentByDraftId.get(workout.id);
       if (
-        workout.pinned ||
-        workout.date === null ||
-        dateKeyFromText(workout.date) < todayDateKey ||
+        (workout.pinned && !mutablePinnedWorkoutIds.has(workout.id)) ||
+        (workout.date === null
+          ? afterById.get(workout.id)?.date !== null
+          : afterById.get(workout.id)?.date === null ||
+            dateKeyFromText(workout.date) < todayDateKey) ||
         (row !== undefined && completedWorkoutIds.has(row.id))
       )
         return false;
+      if (workout.date === null) diffIds.delete(workout.id);
     }
     for (const workout of baseWorkouts) {
       if (!diffIds.has(workout.id)) continue;
@@ -567,15 +581,24 @@ export function createPlanChangeRepository(
             .object({ afterSnapshotJson: z.string() })
             .parse(JSON.parse(change.reconciliation_effect_json));
           const envelope = PlanChangeEnvelopeSchema.parse(JSON.parse(change.diff_json));
-          const rejection = await input.admitChange?.(store, {
+          const admission = await input.admitChange?.(store, {
             afterSnapshotJson,
             diff: envelope.diff,
             intent: envelope.intent,
             premises: envelope.premises,
             todayDateKey,
           });
-          if (rejection != null) return { status: "rejected", reason: rejection };
-          if (!(await writeWorkouts(input, change, afterSnapshotJson, todayDateKey)))
+          if (typeof admission === "string") return { status: "rejected", reason: admission };
+          const mutablePinnedWorkoutIds = new Set(admission?.mutablePinnedWorkoutIds ?? []);
+          if (
+            !(await writeWorkouts(
+              input,
+              change,
+              afterSnapshotJson,
+              todayDateKey,
+              mutablePinnedWorkoutIds,
+            ))
+          )
             return { status: "rejected", reason: "stale-version" };
           const revisionNumber = active.current_revision_number + 1;
           await store.run(

--- a/packages/sport-cycling/src/creation-draft-builder.ts
+++ b/packages/sport-cycling/src/creation-draft-builder.ts
@@ -36,6 +36,14 @@ export interface CreationDraftInput {
   ftp: number | null;
 }
 
+export interface SupportingEvent {
+  id: string;
+  name: string;
+  date: string;
+  role: "Important" | "Training";
+  source: { kind: "manual" } | { kind: "synced"; providerId: string; sourceRevision: string };
+}
+
 interface DraftWorkout {
   id: string;
   name: string;
@@ -43,6 +51,7 @@ interface DraftWorkout {
   date: string | null;
   minutes: number;
   pinned: boolean;
+  supportingEventId?: string;
   guidance: string;
   power: number | null;
 }
@@ -57,6 +66,7 @@ interface DraftWeek {
 
 export interface CreationDraft {
   kind: "draft";
+  supportingEvents?: SupportingEvent[];
   goal: CreationDraftInput["answers"]["goal"];
   mode: "fixed" | "flexible";
   start: string;

--- a/packages/sport-cycling/src/index.ts
+++ b/packages/sport-cycling/src/index.ts
@@ -64,11 +64,21 @@ export {
 export { buildCreationDraft } from "./creation-draft-builder.js";
 export {
   applyScheduleIntent,
+  applySupportingEventIntent,
+  supportingEventWorkoutLimitExplanation,
   planChangeRaceWindow,
   PLAN_CHANGE_RACE_WINDOW_DAYS,
 } from "./plan-change.js";
-export type { ScheduleIntent, ScheduleChangeDiff, ScheduleChangeTotals } from "./plan-change.js";
 export type {
+  ScheduleIntent,
+  ScheduleChangeDiff,
+  ScheduleChangeTotals,
+  SupportingEventIntent,
+  SupportingEventRules,
+  SupportingEventSourceCandidate,
+} from "./plan-change.js";
+export type {
+  SupportingEvent,
   CreationDraftInput,
   CreationDraft,
   CreationDraftResult,

--- a/packages/sport-cycling/src/plan-change.ts
+++ b/packages/sport-cycling/src/plan-change.ts
@@ -1,5 +1,10 @@
 import { addCivilDays, dateKeyFromText, weekdayForDateKey } from "@enduragent/kernel/planning";
-import { type CreationDraft, digest } from "./creation-draft-builder.js";
+import {
+  type CreationDraft,
+  type CreationDraftInput,
+  type SupportingEvent,
+  digest,
+} from "./creation-draft-builder.js";
 import { validateManualPlanFtp } from "./plan-ftp.js";
 
 export type ScheduleIntent =
@@ -55,7 +60,9 @@ function changed(before: Workout, after: Workout): boolean {
     before.date !== after.date ||
     before.minutes !== after.minutes ||
     before.guidance !== after.guidance ||
-    before.power !== after.power
+    before.power !== after.power ||
+    before.pinned !== after.pinned ||
+    before.supportingEventId !== after.supportingEventId
   );
 }
 
@@ -91,27 +98,86 @@ export function applyScheduleIntent<Draft extends CreationDraft>(
   if ("previousDraft" in input) {
     const after = structuredClone(input.previousDraft);
     const current = new Map(draft.weeks.flatMap((week) => week.workouts).map((w) => [w.id, w]));
+    const restorable = (workout: Workout) =>
+      (!workout.pinned || (workout.kind === "event" && workout.supportingEventId !== undefined)) &&
+      !completedWorkoutIds.has(workout.id) &&
+      (workout.date === null || dateKeyFromText(workout.date) >= todayDateKey);
     for (const week of after.weeks) {
+      const currentWeek = draft.weeks.find((candidate) => candidate.number === week.number);
+      const currentWeekIds = new Set(currentWeek?.workouts.map((workout) => workout.id));
       week.workouts = week.workouts
-        .filter(
-          (workout) =>
-            current.has(workout.id) || mutable(workout, todayDateKey, completedWorkoutIds),
-        )
+        .filter((workout) => {
+          const present = current.get(workout.id);
+          return present
+            ? restorable(present) || currentWeekIds.has(present.id)
+            : restorable(workout);
+        })
         .map((workout) => {
           const present = current.get(workout.id);
-          return present && !mutable(present, todayDateKey, completedWorkoutIds)
+          return present && !(restorable(present) && restorable(workout))
             ? structuredClone(present)
             : workout;
         });
       const restoredIds = new Set(week.workouts.map((workout) => workout.id));
-      const currentWeek = draft.weeks.find((candidate) => candidate.number === week.number);
       for (const workout of currentWeek?.workouts ?? []) {
-        if (!mutable(workout, todayDateKey, completedWorkoutIds) && !restoredIds.has(workout.id)) {
+        if (!restorable(workout) && !restoredIds.has(workout.id)) {
           week.workouts.push(structuredClone(workout));
         }
       }
     }
-    return changeResult(draft, after);
+    if (after.supportingEvents !== undefined || draft.supportingEvents !== undefined) {
+      const restoredEventIds = new Set(
+        after.weeks
+          .flatMap((week) => week.workouts)
+          .flatMap((workout) =>
+            workout.supportingEventId === undefined ? [] : [workout.supportingEventId],
+          ),
+      );
+      const protectedEventIds = new Set(
+        [...current.values()]
+          .filter((workout) => !restorable(workout))
+          .flatMap((workout) =>
+            workout.supportingEventId === undefined ? [] : [workout.supportingEventId],
+          ),
+      );
+      const previousWorkoutEventIds = new Set(
+        input.previousDraft.weeks
+          .flatMap((week) => week.workouts)
+          .flatMap((workout) =>
+            workout.supportingEventId === undefined ? [] : [workout.supportingEventId],
+          ),
+      );
+      const restoredEvents = (after.supportingEvents ?? []).filter(
+        (event) =>
+          !protectedEventIds.has(event.id) &&
+          (!previousWorkoutEventIds.has(event.id) || restoredEventIds.has(event.id)),
+      );
+      for (const event of draft.supportingEvents ?? []) {
+        if (!protectedEventIds.has(event.id)) continue;
+        const previous = input.previousDraft.supportingEvents?.find(
+          (candidate) => candidate.id === event.id,
+        );
+        restoredEvents.push(structuredClone(previous?.date === event.date ? previous : event));
+      }
+      if (input.previousDraft.supportingEvents !== undefined || restoredEvents.length > 0) {
+        after.supportingEvents = restoredEvents;
+      }
+    }
+    const {
+      inputFingerprint: _previousInput,
+      outputFingerprint: previousOutput,
+      ...previousContent
+    } = input.previousDraft;
+    const {
+      inputFingerprint: _restoredInput,
+      outputFingerprint: _restoredOutput,
+      ...restoredContent
+    } = after;
+    const result = changeResult(draft, after);
+    if (digest(previousContent) === digest(restoredContent)) {
+      result.after.outputFingerprint = previousOutput;
+    }
+    return result;
   }
   const { intent } = input;
   const after = structuredClone(draft);
@@ -202,4 +268,258 @@ export function planChangeRaceWindow(input: {
         end: input.goal.date,
       }
     : null;
+}
+
+export type SupportingEventIntent = { kind: "supporting-event" } & (
+  | {
+      operation: "add";
+      name: string;
+      date: string;
+      role: SupportingEvent["role"];
+      providerId?: string;
+    }
+  | { operation: "remove"; eventId: string }
+  | { operation: "role"; eventId: string; role: SupportingEvent["role"] }
+  | { operation: "manual"; eventId: string; name: string; date: string }
+  | { operation: "source-update"; eventId: string }
+  | { operation: "name"; eventId: string; name: string }
+);
+
+export type SupportingEventRules = Pick<
+  CreationDraftInput["answers"],
+  "availability" | "restriction"
+>;
+
+export interface SupportingEventSourceCandidate {
+  providerId: string;
+  name: string;
+  date: string;
+  category: "RACE_A" | "RACE_B" | "RACE_C";
+  sourceRevision: string;
+}
+
+function supportingEventDateValid(date: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(date)) return false;
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
+}
+
+function eventDayRules(rules: SupportingEventRules, date: string) {
+  const restriction = rules.restriction;
+  const active =
+    restriction.kind !== "none" && (!restriction.endDate || date <= restriction.endDate);
+  return {
+    unavailable:
+      (rules.availability.mode === "fixed" &&
+        !rules.availability.usableWeekdays.includes(
+          weekdayForDateKey(dateKeyFromText(date)) || 7,
+        )) ||
+      (active && restriction.kind === "no-training"),
+    minutes: Math.floor(
+      Math.min(
+        rules.availability.longestWorkoutHours,
+        active && restriction.kind === "max-duration" ? restriction.hours : Infinity,
+      ) * 60,
+    ),
+  };
+}
+
+export function supportingEventWorkoutLimitExplanation(draft: CreationDraft): string | null {
+  const civilWeeks = new Map<number, number>();
+  let exceeded = draft.weeks.some((week) => week.workouts.length > 6);
+  for (const week of draft.weeks) {
+    for (const workout of week.workouts) {
+      if (workout.date === null) continue;
+      const date = dateKeyFromText(workout.date);
+      const start = addCivilDays(date, 1 - (weekdayForDateKey(date) || 7));
+      const count = (civilWeeks.get(start) ?? 0) + 1;
+      civilWeeks.set(start, count);
+      if (count > 6) exceeded = true;
+    }
+  }
+  return exceeded
+    ? "A week can hold at most six Workouts. Remove or move one before adding this event."
+    : null;
+}
+
+export function applySupportingEventIntent<Draft extends CreationDraft>(input: {
+  draft: Draft;
+  intent: SupportingEventIntent;
+  todayDateKey: number;
+  completedWorkoutIds?: ReadonlySet<string>;
+  eventId?: string;
+  source?: SupportingEventSourceCandidate;
+  rules: SupportingEventRules;
+}):
+  | { status: "changed"; after: Draft; diff: ScheduleChangeDiff[]; totals: ScheduleChangeTotals }
+  | { status: "invalid"; explanation: string } {
+  const { draft, intent, todayDateKey, completedWorkoutIds = new Set<string>(), source } = input;
+  const invalid = (explanation: string) => ({ status: "invalid" as const, explanation });
+  const after = structuredClone(draft);
+  after.supportingEvents ??= [];
+  const result = () => {
+    const explanation = supportingEventWorkoutLimitExplanation(after);
+    return explanation === null
+      ? { status: "changed" as const, ...changeResult(draft, after) }
+      : invalid(explanation);
+  };
+  const existing =
+    "eventId" in intent
+      ? after.supportingEvents.find((event) => event.id === intent.eventId)
+      : undefined;
+  if (intent.operation !== "add" && !existing) {
+    return invalid("Choose a Supporting Event already accepted in this Plan.");
+  }
+  if (intent.operation === "manual" && existing?.source.kind === "synced") {
+    return invalid("Accept synchronized event updates through a fresh source-update preview.");
+  }
+  if (intent.operation === "source-update" && existing?.source.kind !== "synced") {
+    return invalid("Choose a synchronized Supporting Event already accepted in this Plan.");
+  }
+  const providerId =
+    intent.operation === "add"
+      ? intent.providerId
+      : intent.operation === "source-update" && existing?.source.kind === "synced"
+        ? existing.source.providerId
+        : undefined;
+  if (providerId !== undefined && (!source || source.providerId !== providerId)) {
+    return invalid("Choose an available synchronized event.");
+  }
+  let event: SupportingEvent;
+  if (intent.operation === "add") {
+    if (
+      !input.eventId ||
+      after.supportingEvents.some((candidate) => candidate.id === input.eventId)
+    ) {
+      return invalid("Choose a Supporting Event already accepted in this Plan.");
+    }
+    event = {
+      id: input.eventId,
+      name: providerId === undefined ? intent.name : (source?.name ?? intent.name),
+      date: providerId === undefined ? intent.date : (source?.date ?? intent.date),
+      role: intent.role,
+      source:
+        providerId !== undefined && source
+          ? { kind: "synced", providerId, sourceRevision: source.sourceRevision }
+          : { kind: "manual" },
+    };
+  } else {
+    if (!existing) return invalid("Choose a Supporting Event already accepted in this Plan.");
+    event = existing;
+    switch (intent.operation) {
+      case "remove":
+        break;
+      case "role":
+        event.role = intent.role;
+        break;
+      case "manual":
+        event.name = intent.name;
+        event.date = intent.date;
+        break;
+      case "source-update":
+        if (source) {
+          event.name = source.name;
+          event.date = source.date;
+          event.source = {
+            kind: "synced",
+            providerId: source.providerId,
+            sourceRevision: source.sourceRevision,
+          };
+        }
+        break;
+      case "name":
+        event.name = intent.name;
+        break;
+      default: {
+        const exhaustive: never = intent;
+        throw new Error(`Unsupported Supporting Event intent: ${exhaustive}`);
+      }
+    }
+  }
+  if (intent.operation !== "remove") {
+    if (!event.name.trim() || !supportingEventDateValid(event.date)) {
+      return invalid("Enter the event name and exact date.");
+    }
+    if (event.role !== "Important" && event.role !== "Training") {
+      return invalid("Choose Important or Training.");
+    }
+  }
+  if (intent.operation === "name") return result();
+  const eventWorkouts = draft.weeks
+    .flatMap((week) => week.workouts)
+    .filter((workout) => workout.supportingEventId === event.id);
+  const canEditEventWorkout = (workout: Workout) =>
+    workout.date !== null &&
+    dateKeyFromText(workout.date) >= todayDateKey &&
+    !completedWorkoutIds.has(workout.id);
+  if (eventWorkouts.some((workout) => !canEditEventWorkout(workout))) {
+    return invalid("Past or completed event Workouts cannot be changed.");
+  }
+  if (intent.operation === "remove") {
+    after.supportingEvents = after.supportingEvents.filter(
+      (candidate) => candidate.id !== event.id,
+    );
+    for (const week of after.weeks) {
+      week.workouts = week.workouts.filter((workout) => workout.supportingEventId !== event.id);
+    }
+    return result();
+  }
+  const targetWeek = after.weeks.find((week) => event.date >= week.start && event.date <= week.end);
+  if (
+    !targetWeek ||
+    event.date < draft.start ||
+    event.date > draft.end ||
+    (draft.goal.kind === "event" && event.date === draft.goal.date)
+  ) {
+    return invalid("Choose a Supporting Event inside this Plan span.");
+  }
+  const rules = eventDayRules(input.rules, event.date);
+  if (rules.unavailable || rules.minutes <= 0) {
+    return invalid("The event date conflicts with a confirmed training limit.");
+  }
+  if (dateKeyFromText(event.date) < todayDateKey) {
+    return invalid("Past or completed event Workouts cannot be changed.");
+  }
+  if (intent.operation === "add") after.supportingEvents.push(event);
+  for (const week of after.weeks) {
+    week.workouts = week.workouts.filter(
+      (workout) =>
+        workout.supportingEventId !== event.id &&
+        !(workout.date === event.date && mutable(workout, todayDateKey, completedWorkoutIds)),
+    );
+  }
+  const previousWorkout = eventWorkouts[0];
+  targetWeek.workouts.push({
+    id: previousWorkout?.id ?? `supporting-event-${event.id}`,
+    name: event.name,
+    kind: "event",
+    date: event.date,
+    minutes: Math.min(45, rules.minutes),
+    pinned: true,
+    power: previousWorkout?.power ?? null,
+    guidance: "Use the accepted event limit",
+    supportingEventId: event.id,
+  });
+  if (event.role === "Important") {
+    const eventDateKey = dateKeyFromText(event.date);
+    const weekStart = addCivilDays(eventDateKey, 1 - (weekdayForDateKey(eventDateKey) || 7));
+    const weekEnd = addCivilDays(weekStart, 6);
+    for (const week of after.weeks) {
+      for (const workout of week.workouts) {
+        if (workout.pinned || completedWorkoutIds.has(workout.id)) continue;
+        if (workout.date === null) {
+          if (week !== targetWeek) continue;
+        } else {
+          const date = dateKeyFromText(workout.date);
+          if (date < todayDateKey || date < weekStart || date > weekEnd) continue;
+        }
+        workout.minutes = Math.min(workout.minutes, 30);
+        if (workout.kind === "hard") {
+          workout.kind = "endurance";
+          workout.name = "Endurance ride";
+        }
+      }
+    }
+  }
+  return result();
 }

--- a/packages/sport-cycling/tests/plan-change.test.ts
+++ b/packages/sport-cycling/tests/plan-change.test.ts
@@ -4,6 +4,9 @@ import { describe, expect, it } from "vitest";
 import { type CreationDraft } from "../src/creation-draft-builder.js";
 import {
   applyScheduleIntent,
+  applySupportingEventIntent,
+  type SupportingEventIntent,
+  type SupportingEventRules,
   planChangeRaceWindow,
   type ScheduleIntent,
 } from "../src/plan-change.js";
@@ -316,7 +319,22 @@ describe("Inverse Plan Changes", () => {
     expect(previousDraft).toEqual(fixture());
   });
 
-  it("keeps current copies of completed, past, pinned and undated Workouts", () => {
+  it("keeps the current copy when the restored Workout would land before today", () => {
+    const previousDraft = fixture();
+    const draft = structuredClone(previousDraft);
+    const moved = draft.weeks[3].workouts[0];
+    moved.date = "1998-09-12";
+    const result = applyScheduleIntent({
+      draft,
+      previousDraft,
+      intent: { kind: "inverse", changeId: "applied-change" },
+      todayDateKey: 19980908,
+    });
+    expect(workouts(result.after).find((workout) => workout.id === moved.id)).toEqual(moved);
+    expect(result.diff.some((row) => row.workoutId === moved.id)).toBe(false);
+  });
+
+  it("keeps current copies of completed, past and pinned Workouts", () => {
     const previousDraft = fixture();
     const { after: draft } = applyScheduleIntent({
       draft: previousDraft,
@@ -324,7 +342,6 @@ describe("Inverse Plan Changes", () => {
       todayDateKey,
     });
     draft.weeks[2].workouts[0].pinned = true;
-    draft.weeks[2].workouts[1].date = null;
     const completedWorkoutIds = new Set(["w3-long"]);
     const result = applyScheduleIntent({
       draft,
@@ -333,24 +350,17 @@ describe("Inverse Plan Changes", () => {
       todayDateKey: 19980831,
       completedWorkoutIds,
     });
-    const protectedIds = [
-      "w2-hard",
-      "w2-endurance",
-      "w2-long",
-      "w3-hard",
-      "w3-endurance",
-      "w3-long",
-    ];
+    const protectedIds = ["w2-hard", "w2-endurance", "w2-long", "w3-hard", "w3-long"];
     for (const id of protectedIds) {
       expect(workouts(result.after).find((workout) => workout.id === id)).toEqual(
         workouts(draft).find((workout) => workout.id === id),
       );
       expect(result.diff.some((row) => row.workoutId === id)).toBe(false);
     }
-    expect(result.diff).toHaveLength(9);
+    expect(result.diff).toHaveLength(10);
   });
 
-  it("restores removed Workouts dated today and skips removed Workouts that are no longer mutable", () => {
+  it("restores removed Workouts dated today or undated and skips protected Workouts", () => {
     const previousDraft = fixture();
     const { after: draft } = applyScheduleIntent({
       draft: previousDraft,
@@ -368,12 +378,13 @@ describe("Inverse Plan Changes", () => {
     });
     expect(result.diff).toEqual([
       { workoutId: "w3-hard", before: null, after: previousDraft.weeks[2].workouts[0] },
+      { workoutId: "w5-hard", before: null, after: previousDraft.weeks[4].workouts[0] },
     ]);
     expect(
       workouts(result.after)
         .filter((workout) => workout.kind === "hard")
         .map((workout) => workout.id),
-    ).toEqual(["w1-hard", "w3-hard"]);
+    ).toEqual(["w1-hard", "w3-hard", "w5-hard"]);
   });
 
   it("preserves non-mutable Workouts present only in the current snapshot", () => {
@@ -396,10 +407,11 @@ describe("Inverse Plan Changes", () => {
     });
     expect(result.after.weeks[1].workouts.map((workout) => workout.id)).toEqual(
       draft.weeks[1].workouts
-        .filter((workout) => workout.id !== "new-mutable")
+        .filter((workout) => workout.id !== "new-mutable" && workout.id !== "new-undated")
         .map((workout) => workout.id),
     );
     expect(result.diff).toEqual([
+      { workoutId: "new-undated", before: { ...base, id: "new-undated", date: null }, after: null },
       { workoutId: "new-mutable", before: { ...base, id: "new-mutable" }, after: null },
     ]);
   });
@@ -620,3 +632,648 @@ describe("FTP Plan Changes", () => {
     ]);
   });
 });
+
+const eventRules: SupportingEventRules = {
+  availability: {
+    mode: "fixed",
+    usableWeekdays: [1, 2, 3, 4, 5, 6, 7],
+    longestWorkoutHours: 2,
+    weeklyHoursLimit: 8,
+  },
+  restriction: { kind: "none" },
+};
+const sourceEvent = {
+  providerId: "race-fixture",
+  name: "River ride",
+  date: "1998-09-02",
+  category: "RACE_B" as const,
+  sourceRevision: "a".repeat(64),
+};
+function eventChange(
+  intent: SupportingEventIntent,
+  draft: CreationDraft = fixture(),
+  rules = eventRules,
+) {
+  return applySupportingEventIntent({
+    draft,
+    intent,
+    rules,
+    todayDateKey,
+    eventId: "river",
+    source: sourceEvent,
+  });
+}
+function eventAdded(role: "Important" | "Training" = "Training") {
+  const result = eventChange({
+    kind: "supporting-event",
+    operation: "add",
+    name: "River ride",
+    date: "1998-09-02",
+    role,
+  });
+  if (result.status !== "changed") throw new Error(result.explanation);
+  return result;
+}
+
+describe("Supporting Event Plan Changes", () => {
+  it.each(["add", "manual", "source-update"] as const)(
+    "rejects %s when the resulting week would contain seven Workouts",
+    (operation) => {
+      const draft = eventAdded().after;
+      const week = draft.weeks[3];
+      const template = week.workouts[0];
+      while (week.workouts.length < 6) {
+        week.workouts.push({ ...template, id: `extra-${week.workouts.length}`, pinned: true });
+      }
+      const before = structuredClone(draft);
+      if (operation === "source-update" && draft.supportingEvents?.[0]) {
+        draft.supportingEvents[0].source = {
+          kind: "synced",
+          providerId: sourceEvent.providerId,
+          sourceRevision: sourceEvent.sourceRevision,
+        };
+      }
+      const result = applySupportingEventIntent({
+        draft,
+        intent:
+          operation === "add"
+            ? {
+                kind: "supporting-event",
+                operation,
+                name: "Hill ride",
+                date: "1998-09-10",
+                role: "Training",
+              }
+            : operation === "manual"
+              ? {
+                  kind: "supporting-event",
+                  operation,
+                  eventId: "river",
+                  name: "Hill ride",
+                  date: "1998-09-10",
+                }
+              : { kind: "supporting-event", operation, eventId: "river" },
+        eventId: "hill",
+        source: { ...sourceEvent, date: "1998-09-10" },
+        rules: eventRules,
+        todayDateKey,
+      });
+      expect(result).toEqual({
+        status: "invalid",
+        explanation:
+          "A week can hold at most six Workouts. Remove or move one before adding this event.",
+      });
+      expect(draft.weeks).toEqual(before.weeks);
+    },
+  );
+
+  it("adds a manual event, drops same-day training, and fingerprints its pinned Workout", () => {
+    const before = fixture();
+    const result = eventAdded();
+    expect(result.after.supportingEvents).toEqual([
+      {
+        id: "river",
+        name: "River ride",
+        date: "1998-09-02",
+        role: "Training",
+        source: { kind: "manual" },
+      },
+    ]);
+    expect(workouts(result.after).find((workout) => workout.supportingEventId === "river")).toEqual(
+      {
+        id: "supporting-event-river",
+        name: "River ride",
+        date: "1998-09-02",
+        kind: "event",
+        minutes: 45,
+        pinned: true,
+        power: null,
+        guidance: "Use the accepted event limit",
+        supportingEventId: "river",
+      },
+    );
+    expect(result.diff.map((row) => row.workoutId)).toEqual([
+      "w3-endurance",
+      "supporting-event-river",
+    ]);
+    expect(result.diff[0].after).toBeNull();
+    expect(result.diff[1].before).toBeNull();
+    expect(result.after.outputFingerprint).not.toBe(before.outputFingerprint);
+    expect(before).toEqual(fixture());
+  });
+
+  it("accepts source values on synced add and source-update while preserving the Workout id", () => {
+    const added = eventChange({
+      kind: "supporting-event",
+      operation: "add",
+      name: "Old name",
+      date: "1998-09-03",
+      role: "Training",
+      providerId: sourceEvent.providerId,
+    });
+    if (added.status !== "changed") throw new Error(added.explanation);
+    expect(added.after.supportingEvents?.[0]).toEqual({
+      id: "river",
+      name: sourceEvent.name,
+      date: sourceEvent.date,
+      role: "Training",
+      source: {
+        kind: "synced",
+        providerId: sourceEvent.providerId,
+        sourceRevision: sourceEvent.sourceRevision,
+      },
+    });
+    const updated = applySupportingEventIntent({
+      draft: added.after,
+      intent: { kind: "supporting-event", operation: "source-update", eventId: "river" },
+      todayDateKey,
+      rules: eventRules,
+      source: {
+        ...sourceEvent,
+        name: "New river ride",
+        date: "1998-09-10",
+        sourceRevision: "b".repeat(64),
+      },
+    });
+    if (updated.status !== "changed") throw new Error(updated.explanation);
+    expect(updated.after.supportingEvents?.[0]).toMatchObject({
+      name: "New river ride",
+      date: "1998-09-10",
+      source: { sourceRevision: "b".repeat(64) },
+    });
+    expect(updated.diff.find((row) => row.workoutId === "supporting-event-river")).toMatchObject({
+      before: { date: "1998-09-02" },
+      after: { id: "supporting-event-river", date: "1998-09-10", name: "New river ride" },
+    });
+    expect(
+      workouts(updated.after).filter((workout) => workout.supportingEventId === "river"),
+    ).toHaveLength(1);
+  });
+
+  it("corrects manual name and date in place, then removes the event and its Workout", () => {
+    const corrected = eventChange(
+      {
+        kind: "supporting-event",
+        operation: "manual",
+        eventId: "river",
+        name: "Hill ride",
+        date: "1998-09-10",
+      },
+      eventAdded().after,
+    );
+    if (corrected.status !== "changed") throw new Error(corrected.explanation);
+    expect(
+      workouts(corrected.after).find((workout) => workout.supportingEventId === "river"),
+    ).toMatchObject({ id: "supporting-event-river", name: "Hill ride", date: "1998-09-10" });
+    const removed = eventChange(
+      { kind: "supporting-event", operation: "remove", eventId: "river" },
+      corrected.after,
+    );
+    if (removed.status !== "changed") throw new Error(removed.explanation);
+    expect(removed.after.supportingEvents).toEqual([]);
+    expect(removed.diff).toEqual([
+      {
+        workoutId: "supporting-event-river",
+        before: workouts(corrected.after).find((workout) => workout.supportingEventId === "river"),
+        after: null,
+      },
+    ]);
+  });
+
+  it("renames metadata only, including synced events", () => {
+    const draft = eventAdded().after;
+    if (draft.supportingEvents?.[0])
+      draft.supportingEvents[0].source = {
+        kind: "synced",
+        providerId: sourceEvent.providerId,
+        sourceRevision: sourceEvent.sourceRevision,
+      };
+    const result = eventChange(
+      { kind: "supporting-event", operation: "name", eventId: "river", name: "My river ride" },
+      draft,
+    );
+    if (result.status !== "changed") throw new Error(result.explanation);
+    expect(result.after.supportingEvents?.[0].name).toBe("My river ride");
+    expect(result.after.weeks).toEqual(draft.weeks);
+    expect(result.diff).toEqual([]);
+    expect(result.totals.before).toEqual(result.totals.after);
+  });
+
+  it("caps Important event civil weeks across Draft week boundaries, then restores nothing for Training", () => {
+    const draft = eventAdded().after;
+    for (const workout of workouts(draft)) {
+      if (workout.id === "w3-hard") workout.date = "1998-09-03";
+      if (workout.id === "w4-hard") workout.date = "1998-09-06";
+    }
+    const result = eventChange(
+      { kind: "supporting-event", operation: "role", eventId: "river", role: "Important" },
+      draft,
+    );
+    if (result.status !== "changed") throw new Error(result.explanation);
+    for (const id of ["w3-hard", "w4-hard"])
+      expect(workouts(result.after).find((workout) => workout.id === id)).toMatchObject({
+        kind: "endurance",
+        name: "Endurance ride",
+        minutes: 30,
+      });
+    expect(workouts(result.after).find((workout) => workout.id === "w3-long")?.minutes).toBe(30);
+    expect(workouts(result.after).find((workout) => workout.id === "w4-long")?.minutes).toBe(100);
+    const training = eventChange(
+      { kind: "supporting-event", operation: "role", eventId: "river", role: "Training" },
+      result.after,
+    );
+    if (training.status !== "changed") throw new Error(training.explanation);
+    expect(training.after.weeks).toEqual(result.after.weeks);
+    expect(training.diff).toEqual([]);
+  });
+
+  it("caps event duration to the answered day limit and active restriction", () => {
+    const intent = {
+      kind: "supporting-event",
+      operation: "add",
+      name: "River ride",
+      date: "1998-09-02",
+      role: "Training",
+    } as const;
+    for (const rules of [
+      { ...eventRules, availability: { ...eventRules.availability, longestWorkoutHours: 0.5 } },
+      {
+        ...eventRules,
+        restriction: { kind: "max-duration", hours: 0.5, endDate: "1998-09-02" } as const,
+      },
+    ]) {
+      const result = eventChange(intent, fixture(), rules);
+      if (result.status !== "changed") throw new Error(result.explanation);
+      expect(
+        workouts(result.after).find((workout) => workout.supportingEventId === "river")?.minutes,
+      ).toBe(30);
+    }
+  });
+
+  it("restores the prior Draft through inverse add, remove and date correction", () => {
+    for (const [draft, intent] of [
+      [
+        fixture(),
+        {
+          kind: "supporting-event",
+          operation: "add",
+          name: "River ride",
+          date: "1998-09-02",
+          role: "Training",
+        },
+      ],
+      [eventAdded().after, { kind: "supporting-event", operation: "remove", eventId: "river" }],
+      [
+        eventAdded().after,
+        {
+          kind: "supporting-event",
+          operation: "manual",
+          eventId: "river",
+          name: "New name",
+          date: "1998-09-10",
+        },
+      ],
+    ] satisfies [CreationDraft, SupportingEventIntent][]) {
+      const result = eventChange(intent, draft);
+      if (result.status !== "changed") throw new Error(result.explanation);
+      const inverse = applyScheduleIntent({
+        draft: result.after,
+        previousDraft: draft,
+        intent: { kind: "inverse", changeId: "change" },
+        todayDateKey,
+      });
+      expect(inverse.after).toEqual(draft);
+    }
+  });
+
+  it("counts an event added during the race window as an increase", () => {
+    const draft = fixture();
+    const result = applySupportingEventIntent({
+      draft,
+      intent: {
+        kind: "supporting-event",
+        operation: "add",
+        name: "Local ride",
+        date: "1998-09-24",
+        role: "Training",
+      },
+      eventId: "local",
+      rules: eventRules,
+      todayDateKey: 19980921,
+    });
+    if (result.status !== "changed") throw new Error(result.explanation);
+    expect(
+      planChangeRaceWindow({ goal: draft.goal, todayDateKey: 19980921, diff: result.diff }),
+    ).toEqual({ start: "1998-09-21", end: "1998-09-27" });
+  });
+
+  it("rejects unknown events, malformed details, invalid roles, outside dates, and Main Goal dates", () => {
+    const add = {
+      kind: "supporting-event",
+      operation: "add",
+      name: "River ride",
+      date: "1998-09-02",
+      role: "Training",
+    } as const;
+    expect(
+      eventChange({ kind: "supporting-event", operation: "remove", eventId: "missing" }),
+    ).toEqual({
+      status: "invalid",
+      explanation: "Choose a Supporting Event already accepted in this Plan.",
+    });
+    for (const intent of [
+      { ...add, name: " " },
+      { ...add, date: "1998-02-30" },
+    ])
+      expect(eventChange(intent)).toEqual({
+        status: "invalid",
+        explanation: "Enter the event name and exact date.",
+      });
+    for (const date of ["1998-08-16", "1998-09-28", "1998-09-27"])
+      expect(eventChange({ ...add, date })).toEqual({
+        status: "invalid",
+        explanation: "Choose a Supporting Event inside this Plan span.",
+      });
+  });
+
+  it("refuses an unavailable weekday or an active no-training restriction", () => {
+    const intent = {
+      kind: "supporting-event",
+      operation: "add",
+      name: "River ride",
+      date: "1998-09-02",
+      role: "Training",
+    } as const;
+    for (const rules of [
+      {
+        ...eventRules,
+        availability: {
+          mode: "fixed",
+          longestWorkoutHours: 2,
+          weeklyHoursLimit: 8,
+          usableWeekdays: [1],
+        } as const,
+      },
+      { ...eventRules, restriction: { kind: "no-training", endDate: "1998-09-02" } as const },
+    ])
+      expect(eventChange(intent, fixture(), rules)).toEqual({
+        status: "invalid",
+        explanation: "The event date conflicts with a confirmed training limit.",
+      });
+  });
+
+  it("refuses manual correction of synced events and source-update of manual events", () => {
+    const draft = eventAdded().after;
+    expect(
+      eventChange(
+        { kind: "supporting-event", operation: "source-update", eventId: "river" },
+        draft,
+      ),
+    ).toEqual({
+      status: "invalid",
+      explanation: "Choose a synchronized Supporting Event already accepted in this Plan.",
+    });
+    if (draft.supportingEvents?.[0])
+      draft.supportingEvents[0].source = {
+        kind: "synced",
+        providerId: sourceEvent.providerId,
+        sourceRevision: sourceEvent.sourceRevision,
+      };
+    expect(
+      eventChange(
+        {
+          kind: "supporting-event",
+          operation: "manual",
+          eventId: "river",
+          name: "Correction",
+          date: "1998-09-03",
+        },
+        draft,
+      ),
+    ).toEqual({
+      status: "invalid",
+      explanation: "Accept synchronized event updates through a fresh source-update preview.",
+    });
+  });
+
+  it("preserves completed event Workouts through inverse and refuses direct edits", () => {
+    const draft = eventAdded().after;
+    const completedWorkoutIds = new Set(["supporting-event-river"]);
+    const result = applySupportingEventIntent({
+      draft,
+      intent: { kind: "supporting-event", operation: "remove", eventId: "river" },
+      rules: eventRules,
+      todayDateKey,
+      completedWorkoutIds,
+    });
+    expect(result).toEqual({
+      status: "invalid",
+      explanation: "Past or completed event Workouts cannot be changed.",
+    });
+    const inverse = applyScheduleIntent({
+      draft,
+      previousDraft: fixture(),
+      intent: { kind: "inverse", changeId: "change" },
+      todayDateKey,
+      completedWorkoutIds,
+    });
+    expect(
+      workouts(inverse.after).find((workout) => workout.supportingEventId === "river"),
+    ).toEqual(workouts(draft).find((workout) => workout.supportingEventId === "river"));
+    expect(inverse.after.supportingEvents).toEqual(draft.supportingEvents);
+  });
+});
+
+it("keeps a past moved event in its current week with its accepted metadata during inverse", () => {
+  const previousDraft = eventAdded().after;
+  const moved = eventChange(
+    {
+      kind: "supporting-event",
+      operation: "manual",
+      eventId: "river",
+      name: "Early river ride",
+      date: "1998-08-27",
+    },
+    previousDraft,
+  );
+  if (moved.status !== "changed") throw new Error(moved.explanation);
+  const inverse = applyScheduleIntent({
+    draft: moved.after,
+    previousDraft,
+    intent: { kind: "inverse", changeId: "move" },
+    todayDateKey: 19980828,
+  });
+  const linked = workouts(inverse.after).filter((workout) => workout.supportingEventId === "river");
+  expect(linked).toHaveLength(1);
+  expect(linked[0]).toMatchObject({ date: "1998-08-27", name: "Early river ride" });
+  expect(inverse.after.weeks[1].workouts).toContainEqual(linked[0]);
+  expect(inverse.after.supportingEvents).toEqual(moved.after.supportingEvents);
+});
+
+it("does not restore a removed event whose Workout date has passed", () => {
+  const previousDraft = eventAdded().after;
+  const removed = eventChange(
+    { kind: "supporting-event", operation: "remove", eventId: "river" },
+    previousDraft,
+  );
+  if (removed.status !== "changed") throw new Error(removed.explanation);
+  const inverse = applyScheduleIntent({
+    draft: removed.after,
+    previousDraft,
+    intent: { kind: "inverse", changeId: "remove" },
+    todayDateKey: 19980903,
+  });
+  expect(inverse.after.supportingEvents).toEqual([]);
+  expect(workouts(inverse.after).some((workout) => workout.supportingEventId === "river")).toBe(
+    false,
+  );
+  expect(inverse.diff).toEqual([]);
+});
+
+it("leaves past, completed and pinned training unchanged and caps undated training in the event week when an Important event caps the week", () => {
+  const draft = fixture();
+  draft.weeks[2].workouts.push({
+    id: "pinned-training",
+    name: "Pinned ride",
+    kind: "endurance",
+    date: "1998-09-04",
+    minutes: 60,
+    pinned: true,
+    power: null,
+    guidance: "Ride comfortably",
+  });
+  draft.weeks[2].workouts.push({
+    id: "undated-training",
+    name: "Optional ride",
+    kind: "endurance",
+    date: null,
+    minutes: 60,
+    pinned: false,
+    power: null,
+    guidance: "Ride comfortably",
+  });
+  const result = applySupportingEventIntent({
+    draft,
+    intent: {
+      kind: "supporting-event",
+      operation: "add",
+      name: "River ride",
+      date: "1998-09-03",
+      role: "Important",
+    },
+    eventId: "river",
+    rules: eventRules,
+    todayDateKey: 19980901,
+    completedWorkoutIds: new Set(["w3-endurance"]),
+  });
+  if (result.status !== "changed") throw new Error(result.explanation);
+  for (const id of ["w3-hard", "w3-endurance", "pinned-training", "event"]) {
+    expect(workouts(result.after).find((workout) => workout.id === id)).toEqual(
+      workouts(draft).find((workout) => workout.id === id),
+    );
+  }
+  expect(workouts(result.after).find((workout) => workout.id === "w3-long")?.minutes).toBe(30);
+  expect(workouts(result.after).find((workout) => workout.id === "undated-training")).toMatchObject(
+    { minutes: 30, kind: "endurance", date: null },
+  );
+});
+
+it("preserves a legacy revision fingerprint when inverse restores its defaulted snapshot", () => {
+  const previousDraft = fixture();
+  const legacyFingerprint = previousDraft.outputFingerprint;
+  previousDraft.supportingEvents = [];
+  const changed = applyScheduleIntent({
+    draft: previousDraft,
+    intent: { kind: "longest-workout", minutes: 20 },
+    todayDateKey,
+  });
+  const inverse = applyScheduleIntent({
+    draft: changed.after,
+    previousDraft,
+    intent: { kind: "inverse", changeId: "legacy-change" },
+    todayDateKey,
+  });
+  expect(inverse.after).toEqual(previousDraft);
+  expect(inverse.after.outputFingerprint).toBe(legacyFingerprint);
+});
+
+it("undoes a metadata-only rename after the event Workout is completed", () => {
+  const previousDraft = eventAdded().after;
+  const renamed = eventChange(
+    { kind: "supporting-event", operation: "name", eventId: "river", name: "A corrected name" },
+    previousDraft,
+  );
+  if (renamed.status !== "changed") throw new Error(renamed.explanation);
+  const linked = workouts(renamed.after).find((workout) => workout.supportingEventId === "river");
+  if (linked === undefined) throw new Error("Expected an event Workout");
+  const inverse = applyScheduleIntent({
+    draft: renamed.after,
+    previousDraft,
+    intent: { kind: "inverse", changeId: "rename" },
+    todayDateKey: 19980903,
+    completedWorkoutIds: new Set([linked.id]),
+  });
+  expect(inverse.diff).toEqual([]);
+  expect(inverse.after.supportingEvents).toEqual(previousDraft.supportingEvents);
+  expect(workouts(inverse.after).find((workout) => workout.id === linked.id)).toEqual(linked);
+});
+
+it("restores undated Workout minutes and kinds after an Important event inverse", () => {
+  const draft = fixture();
+  draft.mode = "flexible";
+  for (const workout of draft.weeks[2].workouts) workout.date = null;
+  const result = eventChange(
+    {
+      kind: "supporting-event",
+      operation: "add",
+      name: "River ride",
+      date: "1998-09-02",
+      role: "Important",
+    },
+    draft,
+  );
+  if (result.status !== "changed") throw new Error(result.explanation);
+  expect(result.after.weeks[2].workouts[0]).toMatchObject({
+    date: null,
+    minutes: 30,
+    kind: "endurance",
+  });
+  const inverse = applyScheduleIntent({
+    draft: result.after,
+    previousDraft: draft,
+    intent: { kind: "inverse", changeId: "important-add" },
+    todayDateKey,
+  });
+  expect(inverse.after.weeks[2].workouts).toEqual(draft.weeks[2].workouts);
+  expect(inverse.after).toEqual(draft);
+});
+
+it.each(["mutable", "pinned", "completed"])(
+  "restores all undated Workout fields only when %s allows it",
+  (state) => {
+    const previousDraft = fixture();
+    const previous = previousDraft.weeks[1].workouts.find((workout) => workout.id === "undated");
+    if (previous === undefined) throw new Error("Expected undated Workout");
+    previous.pinned = state === "pinned";
+    const draft = structuredClone(previousDraft);
+    const present = draft.weeks[1].workouts.find((workout) => workout.id === "undated");
+    if (present === undefined) throw new Error("Expected undated Workout");
+    Object.assign(present, {
+      minutes: 20,
+      kind: "endurance",
+      name: "Changed ride",
+      guidance: "Use power",
+      power: 200,
+    });
+    const inverse = applyScheduleIntent({
+      draft,
+      previousDraft,
+      intent: { kind: "inverse", changeId: "undated-change" },
+      todayDateKey,
+      completedWorkoutIds: new Set(state === "completed" ? [present.id] : []),
+    });
+    expect(workouts(inverse.after).find((workout) => workout.id === present.id)).toEqual(
+      state === "mutable" ? previous : present,
+    );
+  },
+);


### PR DESCRIPTION
## Summary
- Draft shape: `supportingEvents[]` (default empty; every existing revision and creation parses unchanged and keeps its fingerprint) and Workout `supportingEventId`.
- Intent `supporting-event` with six operations: add (manual or synced candidate), remove, role, manual (name/date of manual events), source-update, name. Event Workouts keep their id, are pinned `event` Workouts of 45 min capped by the day limit; `Important` caps the week's unpinned Workouts to 30 min and turns hard into endurance, including undated Workouts of flexible Plans; name is metadata only.
- Validation copy per the prototype; the Main Goal date is never accepted; a week can hold at most six Workouts, rejected at preview with nothing stored.
- Synced events: a reader over the synchronized race events with `sourceRevision` = sha256 of `{ id, name, start_date_local, category }`; premise `event-source` by value; apply rechecks in the change-phase admission and refuses `event-source-changed`. Manual events skip the recheck.
- Kernel: changed undated Workouts are accepted as snapshot-only changes without row writes; undated to dated and dated to undated still refuse. The inverse restores undated Workouts and keeps the current copy when a restore would land before today.

## Verification
astra high read-only: three rounds (Important cap on undated Workouts, kernel refusing undated changes and Undo not restoring them, Undo restoring to an elapsed date); all fixed, the last inline with a sport test.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project workspace` contract, sport-cycling, coach, kernel, kernel-node change repo, renderer | all pass except the known package-exports 5 s load timeout |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn