### PR TITLE
feat(plan): choose today's Workout in a flexible Plan

### DIFF
--- a/.changeset/plan-change-daily-choice.md
+++ b/.changeset/plan-change-daily-choice.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Choose an eligible workout for today in a flexible Plan after reviewing the change. Undo returns it to the undated choices.

--- a/apps/desktop-renderer/tests/boot-plan-change.test.ts
+++ b/apps/desktop-renderer/tests/boot-plan-change.test.ts
@@ -163,6 +163,7 @@ function library(planId: string, pending = false): ListPlansResult {
       closeReason: null,
       closedAt: null,
       activatedAt: "1998-09-07",
+      todayChoice: null,
       calendar: { status: "pending", window: null, currentThrough: null, error: null },
       creationId: null,
     },

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -3189,6 +3189,7 @@ describe("chat surface", () => {
                     closeReason: null,
                     closedAt: null,
                     activatedAt: "1998-07-06",
+                    todayChoice: null,
                     creationId: null,
                     calendar: {
                       status: "pending",

--- a/apps/desktop-renderer/tests/plan-calendar-dialog.test.tsx
+++ b/apps/desktop-renderer/tests/plan-calendar-dialog.test.tsx
@@ -16,6 +16,7 @@ const summary: NonNullable<ListPlansResult["active"]> = {
   closeReason: null,
   closedAt: null,
   activatedAt: "1998-09-07",
+  todayChoice: null,
   calendar: { status: "pending", window: null, currentThrough: null, error: null },
   creationId: null,
 };

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -80,6 +80,7 @@ const active: NonNullable<ListPlansResult["active"]> = {
   closeReason: null,
   closedAt: null,
   activatedAt: "1998-09-07",
+  todayChoice: null,
   calendar: { status: "pending", window: null, currentThrough: null, error: null },
   creationId: null,
 };

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -49,6 +49,7 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
       closeReason: null,
       closedAt: null,
       activatedAt: "1998-09-07",
+      todayChoice: null,
       calendar: { status: "pending", window: null, currentThrough: null, error: null },
       creationId: null,
     },

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -189,6 +189,7 @@ const active: NonNullable<ListPlansResult["active"]> = {
   closeReason: null,
   closedAt: null,
   activatedAt: "1998-09-07",
+  todayChoice: null,
   calendar: { status: "pending", window: null, currentThrough: null, error: null },
   creationId: null,
 };

--- a/apps/desktop/tests/helpers/plan-creation-backend.ts
+++ b/apps/desktop/tests/helpers/plan-creation-backend.ts
@@ -554,6 +554,7 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
       kind: "none",
     },
     goal: Extract<PlanCreationAnswerInput, { kind: "goal" }>["goal"] = { kind: "fitness" },
+    mode: Extract<PlanCreationAnswerInput, { kind: "schedule-mode" }>["mode"] = "fixed",
   ): Promise<PlanCreationCardModel> {
     const host = this.requireHost();
     const started = await host["plan_creation.start"]({ commandId: "seed-training-start" });
@@ -564,14 +565,21 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
       ...(goal.kind === "fitness"
         ? [{ kind: "plan-length", weeks: 4 } satisfies PlanCreationAnswerInput]
         : []),
-      { kind: "schedule-mode", mode: "fixed" },
-      {
-        kind: "availability",
-        mode: "fixed",
-        weeklyHoursLimit: 6,
-        longestWorkoutHours: 2,
-        usableWeekdays: [1, 3, 6],
-      },
+      { kind: "schedule-mode", mode },
+      mode === "fixed"
+        ? {
+            kind: "availability",
+            mode,
+            weeklyHoursLimit: 6,
+            longestWorkoutHours: 2,
+            usableWeekdays: [1, 3, 6],
+          }
+        : {
+            kind: "availability",
+            mode,
+            weeklyHoursLimit: 6,
+            longestWorkoutHours: 2,
+          },
       { kind: "start-timing", timing: { kind: "as-soon-as-possible" } },
       { kind: "commitments", commitments },
       { kind: "baseline", baseline: "regular" },
@@ -591,7 +599,12 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
     return card;
   }
 
-  async seedActiveTraining(options: { readonly goal?: "fitness" | "event" } = {}) {
+  async seedActiveTraining(
+    options: {
+      readonly goal?: "fitness" | "event";
+      readonly mode?: Extract<PlanCreationAnswerInput, { kind: "schedule-mode" }>["mode"];
+    } = {},
+  ) {
     const host = this.requireHost();
     await this.requireStore().run(
       "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?, 'cycling', 'ftp', 210, 'W', 883612800, 'intervals-icu', 'platform', NULL, 'sync', 'fixture-device', 883612800000, 0)",
@@ -608,6 +621,7 @@ BEGIN SELECT RAISE(ABORT, 'Synthetic close ledger failure'); END`);
               .slice(0, 10),
           }
         : { kind: "fitness" },
+      options.mode,
     );
     const previewed = await host["plan_creation.preview"]({
       commandId: "seed-training-preview",

--- a/packages/coach-contract/src/plan-change.ts
+++ b/packages/coach-contract/src/plan-change.ts
@@ -93,6 +93,7 @@ const WeekdaySchema = z.number().int().min(1).max(7);
 export const PlanChangeIntentSchema = z.discriminatedUnion("kind", [
   SupportingEventIntentSchema,
   z.object({ kind: z.literal("ftp"), watts: FtpWattsSchema }).strict(),
+  z.object({ kind: z.literal("choose-workout"), workoutId: z.string().min(1).max(128) }).strict(),
   z
     .object({
       kind: z.literal("weekday-duration"),
@@ -141,6 +142,7 @@ export const PlanChangeModelSchema = z
     baseRevisionNumber: z.number().int().positive(),
     status: z.enum(["pending", "applied", "cancelled", "superseded", "stale"]),
     title: z.string().min(1),
+    details: z.string().min(1).optional(),
     intent: PlanChangeIntentSchema,
     diff: z.array(
       z
@@ -209,6 +211,7 @@ export const PlanChangePreviewResultSchema = z.discriminatedUnion("status", [
       .object({
         status: z.literal("rejected"),
         reason: z.literal("invalid-intent"),
+        message: z.string().min(1).optional(),
         explanation: z.string().min(1).optional(),
       })
       .strict(),
@@ -247,21 +250,30 @@ export const PlanChangeApplyResultSchema = z.discriminatedUnion("status", [
       version: z.number().int().positive(),
     })
     .strict(),
-  z
-    .object({
-      status: z.literal("rejected"),
-      reason: z.enum([
-        "stale-version",
-        "not-pending",
-        "no-active-plan",
-        "command-conflict",
-        "sync-stale",
-        "race-window",
-        "ftp-sources-changed",
-        "event-source-changed",
-      ]),
-    })
-    .strict(),
+  z.discriminatedUnion("reason", [
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum(["day-changed", "not-eligible"]),
+        message: z.string().min(1).optional(),
+      })
+      .strict(),
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum([
+          "stale-version",
+          "not-pending",
+          "no-active-plan",
+          "command-conflict",
+          "sync-stale",
+          "race-window",
+          "ftp-sources-changed",
+          "event-source-changed",
+        ]),
+      })
+      .strict(),
+  ]),
 ]);
 export type PlanChangeApplyResult = z.infer<typeof PlanChangeApplyResultSchema>;
 

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -186,6 +186,33 @@ export const LegacyPlanSummarySchema = z
   .strict();
 export type LegacyPlanSummary = z.infer<typeof LegacyPlanSummarySchema>;
 
+export const PlanTodayChoiceSchema = z
+  .object({
+    date: z.iso.date(),
+    eligible: z.array(
+      z
+        .object({
+          workoutId: PlanCreationDraftSchema.shape.weeks.element.shape.workouts.element.shape.id,
+          name: PlanCreationDraftSchema.shape.weeks.element.shape.workouts.element.shape.name,
+          minutes: PlanCreationDraftSchema.shape.weeks.element.shape.workouts.element.shape.minutes,
+          kind: PlanCreationDraftSchema.shape.weeks.element.shape.workouts.element.shape.kind,
+        })
+        .strict(),
+    ),
+    blocked: z.array(
+      z
+        .object({
+          workoutId: z.string().min(1),
+          name: z.string().min(1),
+          reason: z.string().min(1),
+        })
+        .strict(),
+    ),
+    reason: z.string().min(1).nullable(),
+  })
+  .strict();
+export type PlanTodayChoice = z.infer<typeof PlanTodayChoiceSchema>;
+
 export const ListPlansParamsSchema = z.object({}).strict();
 export type ListPlansParams = z.infer<typeof ListPlansParamsSchema>;
 export const ListPlansResultSchema = z
@@ -193,7 +220,10 @@ export const ListPlansResultSchema = z
     calendarConnected: z.boolean(),
     legacy: LegacyPlanSummarySchema.nullable(),
     creation: PlanCreationCardModelSchema.nullable(),
-    active: PlanSummarySchema.extend({ status: z.literal("active") }).nullable(),
+    active: PlanSummarySchema.extend({
+      status: z.literal("active"),
+      todayChoice: PlanTodayChoiceSchema.nullable(),
+    }).nullable(),
     closed: z.array(PlanSummarySchema.extend({ status: z.literal("closed") })),
     changes: z.array(PlanChangeModelSchema),
     changesPaused: PlanChangesPausedSchema,

--- a/packages/coach-contract/tests/plan-change-contract.test.ts
+++ b/packages/coach-contract/tests/plan-change-contract.test.ts
@@ -13,6 +13,7 @@ import {
   PlanChangePreviewResultSchema,
   PlanChangePreviewRpcParamsSchema,
   PlanChangeWorkoutSchema,
+  PlanTodayChoiceSchema,
   PlanCreationDraftSchema,
 } from "../src/index.js";
 
@@ -68,6 +69,7 @@ describe("Plan Change contract", () => {
     { kind: "weekly-duration", hours: 2.5 },
     { kind: "weekly-duration", hours: 2.75 },
     { kind: "longest-workout", minutes: 45 },
+    { kind: "choose-workout", workoutId: "w1-template-1" },
     { kind: "inverse", changeId },
     { kind: "ftp", watts: 1 },
     { kind: "ftp", watts: 9_999 },
@@ -90,6 +92,9 @@ describe("Plan Change contract", () => {
     { kind: "longest-workout", minutes: 45.5 },
     { kind: "longest-workout", minutes: Infinity },
     { kind: "hard-weekday", day: 3, minutes: 30 },
+    { kind: "choose-workout" },
+    { kind: "choose-workout", workoutId: "" },
+    { kind: "choose-workout", workoutId: "workout", date: "1998-09-02" },
     { kind: "inverse" },
     { kind: "inverse", changeId: "invalid" },
     { kind: "inverse", changeId, extra: true },
@@ -466,4 +471,60 @@ describe("Supporting Event contracts", () => {
     const drift = { status: "rejected", reason: "event-source-changed" };
     expect(PlanChangeApplyResultSchema.parse(drift)).toEqual(drift);
   });
+});
+
+it("validates daily choice candidates and preserves the day premise and rejection copy", () => {
+  const todayChoice = {
+    date: "1998-09-02",
+    eligible: [{ workoutId: workout.id, name: workout.name, kind: "endurance", minutes: 60 }],
+    blocked: [
+      { workoutId: "hard-ride", name: "Controlled effort", reason: "No hard training today." },
+    ],
+    reason: null,
+  };
+  expect(PlanTodayChoiceSchema.parse(todayChoice)).toEqual(todayChoice);
+  expect(PlanTodayChoiceSchema.safeParse({ ...todayChoice, date: "1998-02-30" }).success).toBe(
+    false,
+  );
+  expect(
+    PlanTodayChoiceSchema.safeParse({
+      ...todayChoice,
+      eligible: [{ ...todayChoice.eligible[0], extra: true }],
+    }).success,
+  ).toBe(false);
+  const premise = {
+    id: "today",
+    label: "Today",
+    source: "Your local day",
+    value: { date: todayChoice.date },
+  };
+  expect(
+    PlanChangeModelSchema.parse({
+      ...change,
+      intent: { kind: "choose-workout", workoutId: workout.id },
+      details: "Only this Workout will receive today’s date after confirmation.",
+      premises: [premise],
+    }).premises,
+  ).toEqual([premise]);
+  const preview = {
+    status: "rejected",
+    reason: "invalid-intent",
+    message: "This Workout is no longer eligible.",
+  };
+  expect(PlanChangePreviewResultSchema.parse(preview)).toEqual(preview);
+  for (const reason of ["day-changed", "not-eligible"]) {
+    const rejection = {
+      status: "rejected",
+      reason,
+      message: "This Workout is no longer eligible.",
+    };
+    expect(PlanChangeApplyResultSchema.parse(rejection)).toEqual(rejection);
+  }
+  expect(
+    PlanChangeApplyResultSchema.safeParse({
+      status: "rejected",
+      reason: "stale-version",
+      message: "Extra",
+    }).success,
+  ).toBe(false);
 });

--- a/packages/coach-contract/tests/planning-read-contract.test.ts
+++ b/packages/coach-contract/tests/planning-read-contract.test.ts
@@ -132,7 +132,7 @@ describe("Plan library contract", () => {
       calendarConnected: true,
       legacy: null,
       creation: null,
-      active,
+      active: { ...active, todayChoice: null },
       closed: [],
       changes: [],
     };
@@ -195,7 +195,7 @@ describe("Plan library contract", () => {
         calendarConnected: false,
         legacy: null,
         creation: null,
-        active,
+        active: { ...active, todayChoice: null },
         closed: [closed],
         changes: [],
         changesPaused: null,

--- a/packages/coach/src/plan-change-operations.ts
+++ b/packages/coach/src/plan-change-operations.ts
@@ -31,6 +31,7 @@ import {
   supportingEventWorkoutLimitExplanation,
   planChangeRaceWindow,
   readCyclingPlanFtpCandidates,
+  readTodayChoice,
 } from "@enduragent/sport-cycling";
 import type { PlanFtpAdapter } from "@enduragent/engine/sport";
 import { z } from "zod";
@@ -60,6 +61,7 @@ const titles = {
   "longest-workout": "Limit the longest Workout",
   inverse: "Undo the latest Change",
   ftp: "Correct FTP",
+  "choose-workout": "Choose a Workout for today",
 } satisfies Record<Exclude<PlanChangeIntent["kind"], "supporting-event">, string>;
 
 const eventTitles = {
@@ -114,6 +116,60 @@ async function readCompletedWorkoutIds(
   return new Set(
     rows.map((row) => DraftIdSchema.parse(JSON.parse(z.string().parse(row.structure_json))).id),
   );
+}
+
+export async function readClosedPlanOccupiesToday(
+  store: SqlStore,
+  todayDateKey: number,
+): Promise<boolean> {
+  return (
+    (await store.get(
+      `SELECT 1 FROM plan_workout workout
+    JOIN planning_plan plan ON plan.plan_id=workout.plan_id
+    JOIN plan_reconciliation_item item ON item.plan_workout_id=workout.id
+    JOIN plan_reconciliation_job job ON job.id=item.job_id
+    WHERE plan.status='closed' AND workout.date_key=? AND item.date_key=?
+      AND job.kind='mirror' AND item.operation='create' AND item.status IN ('created','verified')
+    LIMIT 1`,
+      [todayDateKey, todayDateKey],
+    )) !== undefined
+  );
+}
+
+export function projectTodayChoice(
+  draft: z.infer<typeof PlanCreationDraftSchema>,
+  todayDateKey: number,
+  occupiedByClosedPlan: boolean,
+  completedWorkoutIds: ReadonlySet<string> = new Set(),
+) {
+  if (draft.mode !== "flexible") return null;
+  const answers = draft.answeredSummaries.map((summary) => summary.answer);
+  const availability = answers.find((answer) => answer.kind === "availability");
+  const restriction = answers.find((answer) => answer.kind === "restriction");
+  if (availability === undefined || restriction === undefined) return null;
+  return readTodayChoice({
+    draft,
+    todayDateKey,
+    occupiedByClosedPlan,
+    completedWorkoutIds,
+    answers: { availability, restriction: restriction.restriction },
+  });
+}
+
+function choiceRejection(
+  choice: ReturnType<typeof projectTodayChoice>,
+  workoutId: string,
+): string | null {
+  if (choice?.eligible.some((workout) => workout.workoutId === workoutId)) return null;
+  return (
+    choice?.blocked.find((workout) => workout.workoutId === workoutId)?.reason ??
+    "This Workout is no longer eligible."
+  );
+}
+
+function civilDate(todayDateKey: number): string {
+  const text = String(todayDateKey);
+  return `${text.slice(0, 4)}-${text.slice(4, 6)}-${text.slice(6, 8)}`;
 }
 
 async function readAppliedIntent(
@@ -248,12 +304,17 @@ export function createPlanChangeOperations(input: {
         throw parsed.error;
       }
       const { intent, planId, expectedVersion } = parsed.data;
+      let occupiedByClosedPlan = false;
+      let previewTodayDateKey: number;
       let ftpCandidates: Awaited<ReturnType<typeof readCyclingPlanFtpCandidates>> = [];
       let eventSources: PlanChangeEventSource[] = [];
       const result = await repository.preview({
         async admit(store) {
           const rejection = await admit(store);
           if (rejection !== null) return rejection;
+          previewTodayDateKey = input.todayDateKey();
+          if (intent.kind === "choose-workout")
+            occupiedByClosedPlan = await readClosedPlanOccupiesToday(store, previewTodayDateKey);
           const original =
             intent.kind === "inverse"
               ? await readAppliedIntent(store, planId, intent.changeId)
@@ -294,10 +355,22 @@ export function createPlanChangeOperations(input: {
               PlanChangeModelSchema.shape.intent.parse(newestApplied.intent).kind === "inverse")
           )
             return { status: "rejected", reason: "invalid-intent" };
+          if (intent.kind === "choose-workout") {
+            const message = choiceRejection(
+              projectTodayChoice(
+                draft,
+                previewTodayDateKey,
+                occupiedByClosedPlan,
+                completedWorkoutIds,
+              ),
+              intent.workoutId,
+            );
+            if (message !== null) return { status: "rejected", reason: "invalid-intent", message };
+          }
           const transformation = {
             draft,
             completedWorkoutIds,
-            todayDateKey: input.todayDateKey(),
+            todayDateKey: previewTodayDateKey,
           };
           const originalIntent =
             intent.kind === "inverse" && newestApplied !== null
@@ -385,6 +458,9 @@ export function createPlanChangeOperations(input: {
                 intent.kind === "supporting-event"
                   ? eventTitles[intent.operation]
                   : titles[intent.kind],
+              ...(intent.kind === "choose-workout"
+                ? { details: "Only this Workout will receive today’s date after confirmation." }
+                : {}),
               intent,
               diff,
               totals,
@@ -400,6 +476,16 @@ export function createPlanChangeOperations(input: {
                         value: eventSource,
                       },
                     ]),
+                ...(intent.kind === "choose-workout"
+                  ? [
+                      {
+                        id: "today",
+                        label: "Today",
+                        source: "Your local day",
+                        value: { date: civilDate(previewTodayDateKey) },
+                      },
+                    ]
+                  : []),
                 ...(correctsFtp
                   ? [
                       {
@@ -451,7 +537,7 @@ export function createPlanChangeOperations(input: {
         admit,
         async admitChange(
           store,
-          { afterSnapshotJson, diff, todayDateKey, intent: rawIntent, premises },
+          { snapshotJson, afterSnapshotJson, diff, todayDateKey, intent: rawIntent, premises },
         ) {
           const draft = PlanCreationDraftSchema.parse(JSON.parse(afterSnapshotJson));
           const parsedIntent = PlanChangeModelSchema.shape.intent.safeParse(rawIntent);
@@ -463,6 +549,29 @@ export function createPlanChangeOperations(input: {
               (candidate) => candidate.providerId === source.providerId,
             );
             if (current?.sourceRevision !== source.sourceRevision) return "event-source-changed";
+          }
+          if (intent?.kind === "choose-workout") {
+            const today = z
+              .object({ date: z.iso.date() })
+              .strict()
+              .safeParse(premises.find((premise) => premise.id === "today")?.value);
+            if (!today.success || today.data.date !== civilDate(todayDateKey))
+              return {
+                status: "rejected",
+                reason: "day-changed",
+                message:
+                  "The day changed while this choice was open. Request a fresh choice for today; no date was assigned.",
+              };
+            const message = choiceRejection(
+              projectTodayChoice(
+                PlanCreationDraftSchema.parse(JSON.parse(snapshotJson)),
+                todayDateKey,
+                await readClosedPlanOccupiesToday(store, todayDateKey),
+                await readCompletedWorkoutIds(store, parsed.planId),
+              ),
+              intent.workoutId,
+            );
+            if (message !== null) return { status: "rejected", reason: "not-eligible", message };
           }
           const ftpPremise = premises.find((premise) => premise.id === "ftp-sources");
           if (ftpPremise !== undefined) {

--- a/packages/coach/src/plan-creation-operations.ts
+++ b/packages/coach/src/plan-creation-operations.ts
@@ -61,7 +61,12 @@ import {
   type PlanCreationBaselineEvidence,
 } from "./plan-creation-answers.js";
 
-import { projectPlanChanges, readPlanChangesPaused } from "./plan-change-operations.js";
+import {
+  projectPlanChanges,
+  readPlanChangesPaused,
+  projectTodayChoice,
+  readClosedPlanOccupiesToday,
+} from "./plan-change-operations.js";
 
 export { projectPlanCreationCard } from "./plan-creation-answers.js";
 
@@ -338,12 +343,41 @@ export function createPlanCreationOperations(input: {
           ),
         }));
         const active = summaries.find((plan) => plan.status === "active") ?? null;
+        const choiceDateKey = todayDateKey();
+        const activeRevision =
+          active === null
+            ? undefined
+            : await transactionStore.get(
+                `SELECT revision.snapshot_json FROM planning_plan plan
+          JOIN plan_revision revision ON revision.plan_id=plan.plan_id AND revision.revision_number=plan.current_revision_number
+          WHERE plan.plan_id=?`,
+                [active.planId],
+              );
+        const activeDraft =
+          activeRevision === undefined
+            ? null
+            : PlanCreationDraftSchema.safeParse(
+                JSON.parse(z.string().parse(activeRevision.snapshot_json)),
+              );
+        const todayChoice = !activeDraft?.success
+          ? null
+          : projectTodayChoice(
+              activeDraft.data,
+              choiceDateKey,
+              await readClosedPlanOccupiesToday(transactionStore, choiceDateKey),
+            );
         return ListPlansResultSchema.parse({
           calendarConnected: calendarConnected(),
           legacy,
           creation:
             creation === undefined ? null : projectPlanCreationCard(creation, { today: today() }),
-          active,
+          active:
+            active === null
+              ? null
+              : {
+                  ...active,
+                  todayChoice,
+                },
           changesPaused:
             active === null
               ? null

--- a/packages/coach/tests/plan-change-operations.test.ts
+++ b/packages/coach/tests/plan-change-operations.test.ts
@@ -158,6 +158,36 @@ async function activatedPlan(
   const workouts = () =>
     store.all("SELECT * FROM plan_workout WHERE plan_id = ? ORDER BY id", [planId]);
   return {
+    async activateNext() {
+      const started = await creation["plan_creation.start"]({
+        commandId: `next-start-${++sequence}`,
+      });
+      if (started.status !== "started") throw new Error("Expected next creation");
+      let next = started.planCreation;
+      for (const answer of answers) {
+        const result = await creation["plan_creation.answer"]({
+          commandId: `next-answer-${++sequence}`,
+          creationId: next.creationId,
+          expectedVersion: next.version,
+          answer,
+        });
+        if (result.status !== "answered") throw new Error("Expected next answer");
+        next = result.planCreation;
+      }
+      const preview = await creation["plan_creation.preview"]({
+        commandId: `next-preview-${++sequence}`,
+        creationId: next.creationId,
+        expectedVersion: next.version,
+      });
+      if (preview.status !== "previewed") throw new Error("Expected next Draft");
+      const result = await creation["plan_creation.activate"]({
+        commandId: `next-activate-${++sequence}`,
+        creationId: next.creationId,
+        expectedVersion: preview.planCreation.version,
+        incumbent: { planId, version: 2 },
+      });
+      return result.planId;
+    },
     store,
     ftp,
     saveManual,
@@ -2211,4 +2241,220 @@ it("restores flexible Plan Workouts and the revision fingerprint after an Import
   );
   expect(revisions).toHaveLength(2);
   expect(revisions[1]).toEqual(revisions[0]);
+});
+
+describe("Flexible daily choice", () => {
+  const flexiblePlan = (todayDateKey = () => 19980902, eventDate: string | null = null) =>
+    activatedPlan(
+      todayDateKey,
+      { connected: false, lastSuccessfulSyncAtMs: null },
+      eventDate,
+      "flexible",
+    );
+
+  it("projects current choices, dates only the selected Draft Workout and undoes its row", async () => {
+    const test = await flexiblePlan();
+    const list = await test.creation["plan.list"]({});
+    const choice = list.active?.todayChoice;
+    expect(choice?.date).toBe("1998-09-02");
+    const selected = choice?.eligible[0];
+    if (!selected) throw new Error("Expected eligible Workout");
+    expect(await test.workouts()).toEqual([]);
+    const preview = await test.preview({ kind: "choose-workout", workoutId: selected.workoutId });
+    expect(preview.change.title).toBe("Choose a Workout for today");
+    expect(preview.change.details).toBe(
+      "Only this Workout will receive today’s date after confirmation.",
+    );
+    expect(preview.change.premises).toContainEqual({
+      id: "today",
+      label: "Today",
+      source: "Your local day",
+      value: { date: "1998-09-02" },
+    });
+    expect(preview.change.diff).toHaveLength(1);
+    expect(preview.change.diff[0]).toMatchObject({
+      workoutId: selected.workoutId,
+      before: { date: null },
+      after: { date: "1998-09-02", id: selected.workoutId },
+    });
+    const apply = {
+      commandId: "choose-apply",
+      planId: test.planId,
+      expectedVersion: 1,
+      changeId: preview.change.changeId,
+      decision: "apply" as const,
+    };
+    expect(await test.changes["plan_change.apply"](apply)).toMatchObject({
+      status: "applied",
+      revisionNumber: 2,
+      version: 2,
+    });
+    const rows = await test.workouts();
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(String(rows[0]?.structure_json))).toMatchObject({
+      id: selected.workoutId,
+      date: "1998-09-02",
+    });
+    expect(rows[0]?.date_key).toBe(19980902);
+    expect((await test.creation["plan.list"]({})).active?.todayChoice).toMatchObject({
+      eligible: [],
+      reason: "Today already belongs to a dated Workout.",
+    });
+    const undo = await test.preview(
+      { kind: "inverse", changeId: preview.change.changeId },
+      "undo-choice",
+      2,
+    );
+    expect(undo.change.diff[0]?.after?.date).toBeNull();
+    expect(
+      await test.changes["plan_change.apply"]({
+        ...apply,
+        commandId: "undo-apply",
+        changeId: undo.change.changeId,
+        expectedVersion: 2,
+      }),
+    ).toMatchObject({ status: "applied", revisionNumber: 3 });
+    expect(await test.workouts()).toEqual([]);
+    expect((await test.creation["plan.list"]({})).active?.todayChoice?.eligible).toContainEqual(
+      selected,
+    );
+  });
+
+  it("returns null for fixed Plans and rejects ids outside eligible choices", async () => {
+    const fixed = await activatedPlan();
+    expect((await fixed.creation["plan.list"]({})).active?.todayChoice).toBeNull();
+    const test = await flexiblePlan();
+    for (const host of [fixed, test]) {
+      expect(
+        await host.changes["plan_change.preview"]({
+          commandId: "invalid-choice",
+          planId: host.planId,
+          expectedVersion: 1,
+          intent: { kind: "choose-workout", workoutId: "missing" },
+        }),
+      ).toEqual({
+        status: "rejected",
+        reason: "invalid-intent",
+        message: "This Workout is no longer eligible.",
+      });
+    }
+  });
+
+  it("refuses a changed day without mutation and leaves cancellation available", async () => {
+    let today = 19980902;
+    const test = await flexiblePlan(() => today);
+    const workoutId = test.draft.weeks[0]?.workouts[0]?.id;
+    if (!workoutId) throw new Error("Expected Workout");
+    const preview = await test.preview({ kind: "choose-workout", workoutId });
+    const before = await dumpStore(test.store);
+    today = 19980903;
+    const request = {
+      commandId: "midnight-choice",
+      planId: test.planId,
+      expectedVersion: 1,
+      changeId: preview.change.changeId,
+      decision: "apply" as const,
+    };
+    expect(await test.changes["plan_change.apply"](request)).toEqual({
+      status: "rejected",
+      reason: "day-changed",
+      message:
+        "The day changed while this choice was open. Request a fresh choice for today; no date was assigned.",
+    });
+    expect(await dumpStore(test.store)).toEqual(before);
+    expect(
+      await test.changes["plan_change.apply"]({
+        ...request,
+        commandId: "cancel-midnight",
+        decision: "cancel",
+      }),
+    ).toMatchObject({ status: "cancelled" });
+  });
+
+  it("rejects dating an undated Workout in the race window", async () => {
+    const test = await flexiblePlan(() => 19980902, "1998-09-07");
+    const workoutId = test.draft.weeks[0]?.workouts.find((workout) => !workout.pinned)?.id;
+    if (!workoutId) throw new Error("Expected Workout");
+    expect(
+      await test.changes["plan_change.preview"]({
+        commandId: "race-choice",
+        planId: test.planId,
+        expectedVersion: 1,
+        intent: { kind: "choose-workout", workoutId },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "race-window" });
+  });
+});
+
+it("blocks mirrored closed-Plan Workouts at preview and rechecks mirror completion at apply", async () => {
+  const test = await activatedPlan(
+    () => 19980902,
+    { connected: false, lastSuccessfulSyncAtMs: null },
+    null,
+    "flexible",
+  );
+  const workoutId = test.draft.weeks[0]?.workouts[0]?.id;
+  if (!workoutId) throw new Error("Expected Workout");
+  const first = await test.preview({ kind: "choose-workout", workoutId });
+  expect(
+    await test.changes["plan_change.apply"]({
+      commandId: "first-choice",
+      planId: test.planId,
+      expectedVersion: 1,
+      changeId: first.change.changeId,
+      decision: "apply",
+    }),
+  ).toMatchObject({ status: "applied" });
+  const row = (await test.workouts())[0];
+  if (typeof row?.id !== "string") throw new Error("Expected dated row");
+  const job = await test.store.get(
+    "SELECT id FROM plan_reconciliation_job WHERE plan_id=? AND kind='mirror' ORDER BY created_at_ms DESC LIMIT 1",
+    [test.planId],
+  );
+  const itemId = "00000000000000000000000999";
+  await test.store.run(
+    `INSERT INTO plan_reconciliation_item (id,job_id,plan_workout_id,operation,status,date_key,external_id,expected_json,created_at_ms,updated_at_ms) VALUES (?,?,?,'create','pending',19980902,'synthetic-choice','{}',904694400000,904694400000)`,
+    [itemId, String(job?.id), row.id],
+  );
+  const planId = await test.activateNext();
+  const choice = (await test.creation["plan.list"]({})).active?.todayChoice;
+  const selected = choice?.eligible[0];
+  if (!selected) throw new Error("Expected eligible choice before mirror completion");
+  const request = {
+    commandId: "next-choice",
+    planId,
+    expectedVersion: 1,
+    intent: { kind: "choose-workout" as const, workoutId: selected.workoutId },
+  };
+  const preview = await test.changes["plan_change.preview"](request);
+  if (preview.status !== "previewed") throw new Error("Expected choice preview");
+  await test.store.run("UPDATE plan_reconciliation_item SET status='created' WHERE id=?", [itemId]);
+  const blocked = (await test.creation["plan.list"]({})).active?.todayChoice;
+  expect(blocked).toMatchObject({
+    eligible: [],
+    reason: "Today already belongs to a dated Workout.",
+  });
+  expect(blocked?.blocked[0]?.reason).toBe("Today already belongs to a dated Workout.");
+  expect(
+    await test.changes["plan_change.preview"]({ ...request, commandId: "blocked-preview" }),
+  ).toEqual({
+    status: "rejected",
+    reason: "invalid-intent",
+    message: "Today already belongs to a dated Workout.",
+  });
+  const before = await dumpStore(test.store);
+  expect(
+    await test.changes["plan_change.apply"]({
+      commandId: "blocked-apply",
+      planId,
+      expectedVersion: 1,
+      changeId: preview.change.changeId,
+      decision: "apply",
+    }),
+  ).toEqual({
+    status: "rejected",
+    reason: "not-eligible",
+    message: "Today already belongs to a dated Workout.",
+  });
+  expect(await dumpStore(test.store)).toEqual(before);
 });

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -1722,6 +1722,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
       changes: [],
       changesPaused: null,
       active: {
+        todayChoice: null,
         planId: activated.planId,
         version: 1,
         name: "Improve fitness",

--- a/packages/kernel-node/tests/plan-change-repository.test.ts
+++ b/packages/kernel-node/tests/plan-change-repository.test.ts
@@ -7,6 +7,7 @@ import {
   createPlanLifecycleRepository,
   createPlanReconciliationRepository,
   type PlanCreationCommandStamp,
+  type PlanChangeEnvelope,
   type PreviewPlanChangeInput,
 } from "@enduragent/kernel/planning";
 import {
@@ -52,7 +53,7 @@ const addedWorkout = {
   date: "1998-01-03",
   minutes: 30,
 };
-const poolWorkout = { id: "pool", name: "Flexible ride", kind: "easy", date: null, minutes: 30 };
+const poolWorkout = { id: id("35"), name: "Flexible ride", kind: "easy", date: null, minutes: 30 };
 const draft = {
   outputFingerprint: fingerprint,
   weeks: [{ number: 1, minutes: 180, workouts: [keptWorkout, removedWorkout, poolWorkout] }],
@@ -101,11 +102,20 @@ describe("Plan Change repository", () => {
   });
   afterEach(async () => store.close());
 
-  const activate = async (pinned = false) => {
+  const activate = async (pinned = false, poolPinned = false) => {
     const removed = pinned ? { ...removedWorkout, pinned: true } : removedWorkout;
     const snapshot = {
       ...draft,
-      weeks: [{ ...draft.weeks[0], workouts: [keptWorkout, removed, poolWorkout] }],
+      weeks: [
+        {
+          ...draft.weeks[0],
+          workouts: [
+            keptWorkout,
+            removed,
+            poolPinned ? { ...poolWorkout, pinned: true } : poolWorkout,
+          ],
+        },
+      ],
     };
     const creation = createPlanCreationRepository(store);
     await creation.start({
@@ -262,6 +272,309 @@ describe("Plan Change repository", () => {
     expect(await dumpStore(store)).toBe(before);
     await expect(repository.listChanges(planId)).resolves.toMatchObject([{ status: "pending" }]);
   });
+
+  const choiceSnapshot = (workout: { date: string | null; minutes: number }) => ({
+    ...draft,
+    weeks: [
+      {
+        ...draft.weeks[0],
+        workouts: [keptWorkout, removedWorkout, { ...poolWorkout, ...workout }],
+      },
+    ],
+  });
+  const chooseToday = async () => {
+    const chosen = { ...poolWorkout, date: "1998-01-03" };
+    await repository.preview({
+      ...previewInput(),
+      build: () => ({
+        afterSnapshotJson: JSON.stringify(choiceSnapshot(chosen)),
+        envelope: {
+          ...envelope,
+          title: "Choose a Workout for today",
+          details: "Only this Workout will receive today’s date after confirmation.",
+          intent: { kind: "choose-workout", workoutId: poolWorkout.id },
+          diff: [{ workoutId: poolWorkout.id, before: poolWorkout, after: chosen }],
+          premises: [
+            { id: "today", label: "Today", source: "Current day", value: { date: chosen.date } },
+          ],
+        },
+      }),
+    });
+    const materialize: Parameters<typeof repository.apply>[0]["materialize"] = (
+      _snapshot,
+      current,
+      diffIds,
+    ) => {
+      expect(diffIds).toEqual(new Set([poolWorkout.id]));
+      const template = current[0];
+      if (template === undefined) throw new Error("Expected existing Workout");
+      return {
+        insert: [
+          {
+            ...template,
+            id: poolWorkout.id,
+            dateKey: 19980103,
+            name: chosen.name,
+            durationS: chosen.minutes * 60,
+            structureJson: JSON.stringify(chosen),
+          },
+        ],
+        update: [],
+        delete: [],
+      };
+    };
+    return { ...applyInput(), todayDateKey: () => 19980103, materialize };
+  };
+
+  it.each([
+    { date: null, minutes: 20 },
+    { date: "1998-01-02", minutes: 30 },
+    { date: "1998-01-04", minutes: 30 },
+  ])("handles an undated mutation to $date with $minutes minutes", async (workout) => {
+    await activate();
+    await repository.preview({
+      ...previewInput(),
+      build: () => ({ afterSnapshotJson: JSON.stringify(choiceSnapshot(workout)), envelope }),
+    });
+    const before = await dumpStore(store);
+    if (workout.date === null) {
+      const rows = await store.all("SELECT * FROM plan_workout ORDER BY id");
+      const materialize = vi.fn(() => ({ insert: [], update: [], delete: [] }));
+      await expect(
+        repository.apply({ ...applyInput(), todayDateKey: () => 19980103, materialize }),
+      ).resolves.toMatchObject({ status: "applied", revisionNumber: 2, version: 2 });
+      expect(materialize).toHaveBeenCalledWith(expect.any(String), expect.any(Array), new Set());
+      expect(await store.all("SELECT * FROM plan_workout ORDER BY id")).toEqual(rows);
+      expect(
+        await store.get("SELECT snapshot_json FROM plan_revision WHERE revision_number=2"),
+      ).toEqual({ snapshot_json: canonicalJson(choiceSnapshot(workout)) });
+      return;
+    }
+    const materialize = vi.fn(applyInput().materialize);
+    await expect(
+      repository.apply({ ...applyInput(), todayDateKey: () => 19980103, materialize }),
+    ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+    expect(materialize).not.toHaveBeenCalled();
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it.each<PlanChangeEnvelope["intent"]>([
+    { kind: "weekly-duration", hours: 1.5 },
+    { kind: "choose-workout", workoutId: "another-workout" },
+  ])("refuses dating an undated Workout outside its own choice intent: %j", async (intent) => {
+    await activate();
+    await repository.preview({
+      ...previewInput(),
+      build: () => ({
+        afterSnapshotJson: JSON.stringify(choiceSnapshot({ date: "1998-01-03", minutes: 30 })),
+        envelope: { ...envelope, intent },
+      }),
+    });
+    const before = await dumpStore(store);
+    const materialize = vi.fn(() => ({ insert: [], update: [], delete: [] }));
+    await expect(
+      repository.apply({ ...applyInput(), todayDateKey: () => 19980103, materialize }),
+    ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+    expect(materialize).not.toHaveBeenCalled();
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it("keeps the pinned guard when an undated Workout receives today's date", async () => {
+    await activate(false, true);
+    const input = await chooseToday();
+    const before = await dumpStore(store);
+    await expect(repository.apply(input)).resolves.toEqual({
+      status: "rejected",
+      reason: "stale-version",
+    });
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it.each(["day-changed", "not-eligible"] as const)(
+    "preserves %s admission copy without writes",
+    async (reason) => {
+      await activate();
+      const input = await chooseToday();
+      const before = await dumpStore(store);
+      const rejection = {
+        status: "rejected" as const,
+        reason,
+        message: "Request a fresh choice for today.",
+      };
+      const admitChange = vi.fn<NonNullable<Parameters<typeof repository.apply>[0]["admitChange"]>>(
+        async (_store, context) => {
+          expect(context.snapshotJson).toBe(JSON.stringify(draft));
+          expect(context.todayDateKey).toBe(19980103);
+          expect(context.premises).toEqual([
+            { id: "today", label: "Today", source: "Current day", value: { date: "1998-01-03" } },
+          ]);
+          return rejection;
+        },
+      );
+      await expect(repository.apply({ ...input, admitChange })).resolves.toEqual(rejection);
+      expect(admitChange).toHaveBeenCalledTimes(1);
+      expect(await dumpStore(store)).toBe(before);
+    },
+  );
+
+  it.each([
+    { completed: false, todayDateKey: 19980103 },
+    { completed: true, todayDateKey: 19980103 },
+    { completed: false, todayDateKey: 19980104 },
+    { completed: false, todayDateKey: 19980102 },
+  ])(
+    "inserts today's choice and handles inverse with completed=$completed on $todayDateKey",
+    async ({ completed, todayDateKey }) => {
+      await activate();
+      const input = await chooseToday();
+      await expect(repository.apply(input)).resolves.toMatchObject({
+        status: "applied",
+        revisionNumber: 2,
+        version: 2,
+      });
+      expect(
+        await store.get("SELECT id,date_key FROM plan_workout WHERE id=?", [poolWorkout.id]),
+      ).toEqual({ id: poolWorkout.id, date_key: 19980103 });
+      expect(
+        await store.get(
+          "SELECT status FROM plan_reconciliation_job WHERE window_start_date_key=19980103",
+        ),
+      ).toEqual({ status: "pending" });
+      if (completed)
+        await store.run(
+          "INSERT INTO plan_workout_match (id,plan_id,plan_workout_id,activity_id,source,decision,activity_date_key,activity_sport,observed_at_ms,decided_at_ms,device_id,hlc_physical_ms,hlc_counter) VALUES (?,?,?,?,'heuristic','confirmed',19980103,'Ride',?,?,'test-device-1998',?,0)",
+          [id("70"), planId, poolWorkout.id, "c".repeat(64), nowMs, nowMs, nowMs],
+        );
+      await repository.preview({
+        ...previewInput(40),
+        expectedVersion: 2,
+        build: () => ({
+          afterSnapshotJson: JSON.stringify(draft),
+          envelope: { ...envelope, intent: { kind: "inverse", changeId: id("90") } },
+        }),
+      });
+      const before = await dumpStore(store);
+      const inverseInput = {
+        ...input,
+        command: stamp("undo-choice", 50),
+        nowMs: nowMs + 50,
+        changeId: id("120"),
+        expectedVersion: 2,
+        todayDateKey: () => todayDateKey,
+        materialize: () => ({ insert: [], update: [], delete: [poolWorkout.id] }),
+      };
+      const result = await repository.apply(inverseInput);
+      if (completed || todayDateKey !== 19980103) {
+        expect(result).toEqual({ status: "rejected", reason: "stale-version" });
+        expect(await dumpStore(store)).toBe(before);
+      } else {
+        expect(result).toMatchObject({ status: "applied", revisionNumber: 3 });
+        expect(
+          await store.get("SELECT id FROM plan_workout WHERE id=?", [poolWorkout.id]),
+        ).toBeUndefined();
+        expect(
+          await store.get("SELECT snapshot_json FROM plan_revision WHERE revision_number=3"),
+        ).toEqual({ snapshot_json: canonicalJson(draft) });
+        const applied = await dumpStore(store);
+        await expect(repository.apply(inverseInput)).resolves.toEqual(result);
+        expect(await dumpStore(store)).toBe(applied);
+      }
+    },
+  );
+
+  it("refuses an inverse of another applied intent that undates a Workout", async () => {
+    await activate();
+    await repository.preview(previewInput());
+    await expect(repository.apply(applyInput())).resolves.toMatchObject({ status: "applied" });
+    const undated = {
+      ...after,
+      weeks: [
+        {
+          ...after.weeks[0],
+          workouts: [keptWorkout, { ...addedWorkout, date: null }, poolWorkout],
+        },
+      ],
+    };
+    await repository.preview({
+      ...previewInput(40),
+      expectedVersion: 2,
+      build: () => ({
+        afterSnapshotJson: JSON.stringify(undated),
+        envelope: { ...envelope, intent: { kind: "inverse", changeId: id("90") } },
+      }),
+    });
+    const before = await dumpStore(store);
+    const materialize = vi.fn(() => ({ insert: [], update: [], delete: [id("33")] }));
+    await expect(
+      repository.apply({
+        ...applyInput(),
+        command: stamp("undo-duration", 50),
+        nowMs: nowMs + 50,
+        changeId: id("120"),
+        expectedVersion: 2,
+        todayDateKey: () => 19980103,
+        materialize,
+      }),
+    ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+    expect(materialize).not.toHaveBeenCalled();
+    expect(await dumpStore(store)).toBe(before);
+  });
+
+  it.each(["another-workout", "pending-change", "missing-change"])(
+    "refuses undating through a choice inverse with %s",
+    async (reason) => {
+      await activate();
+      const input = await chooseToday();
+      await expect(repository.apply(input)).resolves.toMatchObject({ status: "applied" });
+      const inverseSnapshot =
+        reason === "another-workout"
+          ? {
+              ...draft,
+              weeks: [
+                {
+                  ...draft.weeks[0],
+                  workouts: [
+                    keptWorkout,
+                    { ...removedWorkout, date: null },
+                    { ...poolWorkout, date: "1998-01-03" },
+                  ],
+                },
+              ],
+            }
+          : draft;
+      await repository.preview({
+        ...previewInput(40),
+        expectedVersion: 2,
+        build: () => ({
+          afterSnapshotJson: JSON.stringify(inverseSnapshot),
+          envelope: {
+            ...envelope,
+            intent: {
+              kind: "inverse",
+              changeId: id(
+                reason === "another-workout" ? "90" : reason === "pending-change" ? "120" : "999",
+              ),
+            },
+          },
+        }),
+      });
+      const before = await dumpStore(store);
+      const materialize = vi.fn(() => ({ insert: [], update: [], delete: [] }));
+      await expect(
+        repository.apply({
+          ...input,
+          command: stamp("undo-choice", 50),
+          nowMs: nowMs + 50,
+          changeId: id("120"),
+          expectedVersion: 2,
+          todayDateKey: () => (reason === "another-workout" ? 19980102 : 19980103),
+          materialize,
+        }),
+      ).resolves.toEqual({ status: "rejected", reason: "stale-version" });
+      expect(materialize).not.toHaveBeenCalled();
+      expect(await dumpStore(store)).toBe(before);
+    },
+  );
 
   it("previews the current revision without changing training or Plan version", async () => {
     await activate();
@@ -444,7 +757,9 @@ describe("Plan Change repository", () => {
       await activate();
       const next = structuredClone(draft);
       const workout = next.weeks[0].workouts.find((candidate) =>
-        direction === "undated-to-dated" ? candidate.id === "pool" : candidate.id === "removed",
+        direction === "undated-to-dated"
+          ? candidate.id === poolWorkout.id
+          : candidate.id === removedWorkout.id,
       );
       if (workout === undefined) throw new Error("Expected Workout");
       workout.date = direction === "undated-to-dated" ? "1998-01-03" : null;

--- a/packages/kernel/src/planning/change-repository.ts
+++ b/packages/kernel/src/planning/change-repository.ts
@@ -17,6 +17,7 @@ const TotalsSchema = z.object({
 export const PlanChangeEnvelopeSchema = z
   .object({
     title: z.string().min(1).max(20000),
+    details: z.string().min(1).max(20000).optional(),
     intent: z.json(),
     diff: z.array(z.object({ workoutId: z.string(), before: z.json(), after: z.json() })),
     totals: z.object({ before: TotalsSchema, after: TotalsSchema }),
@@ -51,6 +52,7 @@ export const PlanChangePreviewStoreResultSchema = z.discriminatedUnion("status",
         status: z.literal("rejected"),
         reason: z.literal("invalid-intent"),
         explanation: z.string().min(1).optional(),
+        message: z.string().optional(),
       })
       .strict(),
     z
@@ -80,21 +82,30 @@ export const PlanChangeApplyStoreResultSchema = z.discriminatedUnion("status", [
   z
     .object({ status: z.literal("cancelled"), changeId: UlidSchema, version: RevisionNumberSchema })
     .strict(),
-  z
-    .object({
-      status: z.literal("rejected"),
-      reason: z.enum([
-        "stale-version",
-        "not-pending",
-        "no-active-plan",
-        "command-conflict",
-        "sync-stale",
-        "race-window",
-        "ftp-sources-changed",
-        "event-source-changed",
-      ]),
-    })
-    .strict(),
+  z.discriminatedUnion("reason", [
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum(["day-changed", "not-eligible"]),
+        message: z.string().optional(),
+      })
+      .strict(),
+    z
+      .object({
+        status: z.literal("rejected"),
+        reason: z.enum([
+          "stale-version",
+          "not-pending",
+          "no-active-plan",
+          "command-conflict",
+          "sync-stale",
+          "race-window",
+          "ftp-sources-changed",
+          "event-source-changed",
+        ]),
+      })
+      .strict(),
+  ]),
 ]);
 export type PlanChangePreviewStoreResult = z.infer<typeof PlanChangePreviewStoreResultSchema>;
 export type PlanChangeApplyStoreResult = z.infer<typeof PlanChangeApplyStoreResultSchema>;
@@ -120,11 +131,7 @@ export interface PreviewPlanChangeInput {
     context: PlanChangeUndoContext & { readonly completedWorkoutIds: ReadonlySet<string> },
   ) =>
     | { readonly afterSnapshotJson: string; readonly envelope: PlanChangeEnvelope }
-    | {
-        readonly status: "rejected";
-        readonly reason: "invalid-intent";
-        readonly explanation?: string;
-      }
+    | Extract<PlanChangePreviewStoreResult, { reason: "invalid-intent" }>
     | Extract<PlanChangePreviewStoreResult, { reason: "race-window" }>;
 }
 export interface PlanChangeWorkoutMutations {
@@ -142,6 +149,7 @@ export interface ApplyPlanChangeInput {
   readonly admitChange?: (
     store: SqlStore,
     context: {
+      readonly snapshotJson: string;
       readonly afterSnapshotJson: string;
       readonly diff: PlanChangeEnvelope["diff"];
       readonly intent: PlanChangeEnvelope["intent"];
@@ -151,6 +159,7 @@ export interface ApplyPlanChangeInput {
   ) => Promise<
     | Extract<PlanChangeApplyStoreResult, { status: "rejected" }>["reason"]
     | { readonly mutablePinnedWorkoutIds: readonly string[] }
+    | Extract<PlanChangeApplyStoreResult, { status: "rejected" }>
     | null
   >;
   readonly command: PlanCreationCommandStamp;
@@ -214,6 +223,7 @@ const SnapshotSchema = z.object({
   ),
 });
 const DraftIdSchema = z.object({ id: z.string() }).passthrough();
+const ChoiceIntentSchema = z.object({ kind: z.literal("choose-workout"), workoutId: z.string() });
 const draftId = (workout: PlanWorkoutRecord) =>
   DraftIdSchema.parse(JSON.parse(workout.structureJson)).id;
 
@@ -314,23 +324,17 @@ export function createPlanChangeRepository(
   };
   const writeWorkouts = async (
     input: ApplyPlanChangeInput,
-    change: ChangeRow,
+    snapshotJson: string,
     afterSnapshotJson: string,
     todayDateKey: number,
     mutablePinnedWorkoutIds: ReadonlySet<string>,
+    chosenWorkoutId: string | undefined,
+    undoneChoiceWorkoutId: string | undefined,
   ) => {
     const plan = await plans.read(input.planId);
     if (plan === undefined) return fail();
     const current = await plans.readWorkouts(input.planId);
-    const revision = z
-      .object({ snapshot_json: z.string() })
-      .parse(
-        await store.get(
-          "SELECT snapshot_json FROM plan_revision WHERE plan_id=? AND revision_number=?",
-          [input.planId, change.base_revision_number],
-        ),
-      );
-    const baseWorkouts = SnapshotSchema.parse(JSON.parse(revision.snapshot_json)).weeks.flatMap(
+    const baseWorkouts = SnapshotSchema.parse(JSON.parse(snapshotJson)).weeks.flatMap(
       (week) => week.workouts,
     );
     const afterWorkouts = SnapshotSchema.parse(JSON.parse(afterSnapshotJson)).weeks.flatMap(
@@ -363,17 +367,22 @@ export function createPlanChangeRepository(
         return false;
     }
     for (const workout of changedWorkouts) {
+      const afterDate = afterById.get(workout.id)?.date;
       const row = currentByDraftId.get(workout.id);
       if (
         (workout.pinned && !mutablePinnedWorkoutIds.has(workout.id)) ||
         (workout.date === null
-          ? afterById.get(workout.id)?.date !== null
-          : afterById.get(workout.id)?.date === null ||
+          ? afterDate === undefined ||
+            (afterDate !== null &&
+              (workout.id !== chosenWorkoutId || dateKeyFromText(afterDate) !== todayDateKey))
+          : (afterDate === null &&
+              (workout.id !== undoneChoiceWorkoutId ||
+                dateKeyFromText(workout.date) !== todayDateKey)) ||
             dateKeyFromText(workout.date) < todayDateKey) ||
         (row !== undefined && completedWorkoutIds.has(row.id))
       )
         return false;
-      if (workout.date === null) diffIds.delete(workout.id);
+      if (workout.date === null && afterDate === null) diffIds.delete(workout.id);
     }
     for (const workout of baseWorkouts) {
       if (!diffIds.has(workout.id)) continue;
@@ -581,7 +590,16 @@ export function createPlanChangeRepository(
             .object({ afterSnapshotJson: z.string() })
             .parse(JSON.parse(change.reconciliation_effect_json));
           const envelope = PlanChangeEnvelopeSchema.parse(JSON.parse(change.diff_json));
+          const { snapshot_json: snapshotJson } = z
+            .object({ snapshot_json: z.string() })
+            .parse(
+              await store.get(
+                "SELECT snapshot_json FROM plan_revision WHERE plan_id=? AND revision_number=?",
+                [input.planId, change.base_revision_number],
+              ),
+            );
           const admission = await input.admitChange?.(store, {
+            snapshotJson,
             afterSnapshotJson,
             diff: envelope.diff,
             intent: envelope.intent,
@@ -589,14 +607,35 @@ export function createPlanChangeRepository(
             todayDateKey,
           });
           if (typeof admission === "string") return { status: "rejected", reason: admission };
+          if (admission != null && "status" in admission) return admission;
           const mutablePinnedWorkoutIds = new Set(admission?.mutablePinnedWorkoutIds ?? []);
+          const choice = ChoiceIntentSchema.safeParse(envelope.intent);
+          const inverse = z
+            .object({ kind: z.literal("inverse"), changeId: UlidSchema })
+            .safeParse(envelope.intent);
+          let undoneChoiceWorkoutId: string | undefined;
+          if (inverse.success) {
+            const applied = await store.get(
+              "SELECT * FROM plan_change WHERE id=? AND plan_id=? AND status='applied'",
+              [inverse.data.changeId, input.planId],
+            );
+            if (applied !== undefined) {
+              const appliedEnvelope = PlanChangeEnvelopeSchema.parse(
+                JSON.parse(ChangeRowSchema.parse(applied).diff_json),
+              );
+              const undoneChoice = ChoiceIntentSchema.safeParse(appliedEnvelope.intent);
+              if (undoneChoice.success) undoneChoiceWorkoutId = undoneChoice.data.workoutId;
+            }
+          }
           if (
             !(await writeWorkouts(
               input,
-              change,
+              snapshotJson,
               afterSnapshotJson,
               todayDateKey,
               mutablePinnedWorkoutIds,
+              choice.success ? choice.data.workoutId : undefined,
+              undoneChoiceWorkoutId,
             ))
           )
             return { status: "rejected", reason: "stale-version" };

--- a/packages/sport-cycling/src/index.ts
+++ b/packages/sport-cycling/src/index.ts
@@ -83,3 +83,5 @@ export type {
   CreationDraft,
   CreationDraftResult,
 } from "./creation-draft-builder.js";
+
+export { readTodayChoice, type TodayChoice } from "./today-choice.js";

--- a/packages/sport-cycling/src/plan-change.ts
+++ b/packages/sport-cycling/src/plan-change.ts
@@ -13,7 +13,8 @@ export type ScheduleIntent =
   | { kind: "hard-weekday"; day: number }
   | { kind: "weekly-duration"; hours: number }
   | { kind: "longest-workout"; minutes: number }
-  | { kind: "ftp"; watts: number };
+  | { kind: "ftp"; watts: number }
+  | { kind: "choose-workout"; workoutId: string };
 
 type Workout = CreationDraft["weeks"][number]["workouts"][number];
 
@@ -181,6 +182,23 @@ export function applyScheduleIntent<Draft extends CreationDraft>(
   }
   const { intent } = input;
   const after = structuredClone(draft);
+  if (intent.kind === "choose-workout") {
+    const date = String(todayDateKey);
+    const today = `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+    const week = after.weeks.find((week) => week.start <= today && today <= week.end);
+    const workout = week?.workouts.find((workout) => workout.id === intent.workoutId);
+    if (
+      draft.mode !== "flexible" ||
+      !workout ||
+      workout.date !== null ||
+      workout.pinned ||
+      completedWorkoutIds.has(workout.id)
+    ) {
+      throw new Error("This Workout is no longer eligible.");
+    }
+    workout.date = today;
+    return changeResult(draft, after);
+  }
   if (intent.kind === "ftp") {
     const watts = validateManualPlanFtp(intent.watts);
     after.ftp = watts;
@@ -256,6 +274,7 @@ export function planChangeRaceWindow(input: {
       date >= start &&
       date <= end &&
       (before === null ||
+        before.date === null ||
         after.minutes > before.minutes ||
         (before.kind !== "hard" && after.kind === "hard") ||
         (after.power ?? 0) > (before.power ?? 0))

--- a/packages/sport-cycling/src/today-choice.ts
+++ b/packages/sport-cycling/src/today-choice.ts
@@ -1,0 +1,70 @@
+import { type CreationDraft, type CreationDraftInput } from "./creation-draft-builder.js";
+
+type Workout = CreationDraft["weeks"][number]["workouts"][number];
+
+export interface TodayChoice {
+  date: string;
+  eligible: { workoutId: string; name: string; minutes: number; kind: Workout["kind"] }[];
+  blocked: { workoutId: string; name: string; reason: string }[];
+  reason: string | null;
+}
+
+export function readTodayChoice(input: {
+  draft: CreationDraft;
+  todayDateKey: number;
+  answers: Pick<CreationDraftInput["answers"], "availability" | "restriction">;
+  completedWorkoutIds?: ReadonlySet<string>;
+  occupiedByClosedPlan?: boolean;
+}): TodayChoice | null {
+  const { draft, answers } = input;
+  if (draft.mode !== "flexible") return null;
+  const digits = String(input.todayDateKey).padStart(8, "0");
+  const date = `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+  const week = draft.weeks.find((week) => week.start <= date && date <= week.end);
+  const candidates = week?.workouts.filter(
+    (workout) =>
+      workout.date === null && !workout.pinned && !input.completedWorkoutIds?.has(workout.id),
+  );
+  if (!candidates?.length) return null;
+  const occupied =
+    input.occupiedByClosedPlan ||
+    draft.weeks.some((week) => week.workouts.some((workout) => workout.date === date));
+  const restriction = answers.restriction;
+  const active =
+    restriction.kind !== "none" && (!restriction.endDate || date <= restriction.endDate);
+  const unavailable = active && restriction.kind === "no-training";
+  const noHard = active && restriction.kind === "no-hard-training";
+  const minutes = Math.floor(
+    Math.min(
+      answers.availability.longestWorkoutHours,
+      active && restriction.kind === "max-duration" ? restriction.hours : Infinity,
+    ) * 60,
+  );
+  const planReason = occupied
+    ? "Today already belongs to a dated Workout."
+    : unavailable
+      ? "Today is unavailable under your confirmed limits."
+      : null;
+  const result: TodayChoice = { date, eligible: [], blocked: [], reason: null };
+  for (const workout of candidates) {
+    const reason =
+      planReason ??
+      (workout.minutes > minutes
+        ? `Today is limited to ${minutes} minutes.`
+        : workout.kind === "hard" && noHard
+          ? "No hard training today."
+          : null);
+    if (reason) {
+      result.blocked.push({ workoutId: workout.id, name: workout.name, reason });
+    } else {
+      result.eligible.push({
+        workoutId: workout.id,
+        name: workout.name,
+        minutes: workout.minutes,
+        kind: workout.kind,
+      });
+    }
+  }
+  if (result.eligible.length === 0) result.reason = planReason ?? result.blocked[0]?.reason ?? null;
+  return result;
+}

--- a/packages/sport-cycling/tests/plan-change.test.ts
+++ b/packages/sport-cycling/tests/plan-change.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { canonicalJson } from "@enduragent/kernel/archive";
 import { describe, expect, it } from "vitest";
-import { type CreationDraft } from "../src/creation-draft-builder.js";
+import { type CreationDraft, type CreationDraftInput } from "../src/creation-draft-builder.js";
 import {
   applyScheduleIntent,
   applySupportingEventIntent,
@@ -10,6 +10,8 @@ import {
   planChangeRaceWindow,
   type ScheduleIntent,
 } from "../src/plan-change.js";
+
+import { readTodayChoice } from "../src/today-choice.js";
 
 const todayDateKey = 19980824;
 
@@ -1277,3 +1279,184 @@ it.each(["mutable", "pinned", "completed"])(
     );
   },
 );
+
+describe("flexible daily choice", () => {
+  const answers: Pick<CreationDraftInput["answers"], "availability" | "restriction"> = {
+    availability: { mode: "flexible", weeklyHoursLimit: 6, longestWorkoutHours: 2 },
+    restriction: { kind: "none" },
+  };
+
+  function flexibleDraft() {
+    const draft = fixture();
+    draft.mode = "flexible";
+    for (const workout of workouts(draft)) {
+      if (!workout.pinned) workout.date = null;
+    }
+    return draft;
+  }
+
+  function choice(restriction: CreationDraftInput["answers"]["restriction"] = { kind: "none" }) {
+    return readTodayChoice({
+      draft: flexibleDraft(),
+      todayDateKey,
+      answers: { ...answers, restriction },
+    });
+  }
+
+  it("offers only undated unpinned and incomplete Workouts in today's week", () => {
+    const draft = flexibleDraft();
+    draft.weeks[1].workouts[2].pinned = true;
+    const result = readTodayChoice({
+      draft,
+      todayDateKey,
+      answers,
+      completedWorkoutIds: new Set(["w2-endurance"]),
+    });
+    expect(result).toEqual({
+      date: "1998-08-24",
+      eligible: [
+        { workoutId: "w2-hard", name: "Controlled effort", minutes: 45, kind: "hard" },
+        { workoutId: "undated", name: "Optional ride", minutes: 75, kind: "easy" },
+      ],
+      blocked: [],
+      reason: null,
+    });
+  });
+
+  it("returns null for fixed mode, another week and no remaining candidates", () => {
+    expect(readTodayChoice({ draft: fixture(), todayDateKey, answers })).toBeNull();
+    expect(readTodayChoice({ draft: flexibleDraft(), todayDateKey: 19981001, answers })).toBeNull();
+    const draft = flexibleDraft();
+    draft.weeks[1].workouts = [];
+    expect(readTodayChoice({ draft, todayDateKey, answers })).toBeNull();
+  });
+
+  it.each([false, true])("prioritizes today's occupied date with closed Plan = %s", (closed) => {
+    const draft = flexibleDraft();
+    if (!closed) draft.weeks[0].workouts[0].date = "1998-08-24";
+    const result = readTodayChoice({
+      draft,
+      todayDateKey,
+      answers: { ...answers, restriction: { kind: "no-training" } },
+      occupiedByClosedPlan: closed,
+    });
+    expect(result?.eligible).toEqual([]);
+    expect(result?.reason).toBe("Today already belongs to a dated Workout.");
+    expect(result?.blocked).toHaveLength(4);
+    expect(result?.blocked.every((item) => item.reason === result.reason)).toBe(true);
+  });
+
+  it("blocks every candidate under a current no-training restriction", () => {
+    const result = choice({ kind: "no-training", endDate: "1998-08-24" });
+    expect(result?.eligible).toEqual([]);
+    expect(result?.reason).toBe("Today is unavailable under your confirmed limits.");
+    expect(result?.blocked.every((item) => item.reason === result.reason)).toBe(true);
+  });
+
+  it.each([
+    { kind: "no-training", endDate: "1998-08-23" },
+    { kind: "no-hard-training", endDate: "1998-08-23" },
+    { kind: "max-duration", hours: 0.5, endDate: "1998-08-23" },
+  ] satisfies CreationDraftInput["answers"]["restriction"][])(
+    "ignores the expired restriction $kind",
+    (restriction) => {
+      const result = choice(restriction);
+      expect(result?.eligible).toHaveLength(4);
+      expect(result?.blocked).toEqual([]);
+      expect(result?.reason).toBeNull();
+    },
+  );
+
+  it("caps today's duration at the lower answered limit and includes the exact boundary", () => {
+    const result = choice({ kind: "max-duration", hours: 0.75 });
+    expect(result?.eligible.map((workout) => workout.workoutId)).toEqual(["w2-hard"]);
+    expect(result?.blocked.map((workout) => workout.reason)).toEqual(
+      Array<string>(3).fill("Today is limited to 45 minutes."),
+    );
+    expect(result?.reason).toBeNull();
+    const longest = readTodayChoice({
+      draft: flexibleDraft(),
+      todayDateKey,
+      answers: {
+        availability: { ...answers.availability, longestWorkoutHours: 0.5 },
+        restriction: { kind: "max-duration", hours: 1 },
+      },
+    });
+    expect(longest?.eligible).toEqual([]);
+    expect(longest?.reason).toBe("Today is limited to 30 minutes.");
+  });
+
+  it("blocks hard training after duration checks and permits other kinds", () => {
+    const result = choice({ kind: "no-hard-training" });
+    expect(result?.blocked).toEqual([
+      { workoutId: "w2-hard", name: "Controlled effort", reason: "No hard training today." },
+    ]);
+    expect(result?.eligible).toHaveLength(3);
+    const capped = readTodayChoice({
+      draft: flexibleDraft(),
+      todayDateKey,
+      answers: {
+        availability: { ...answers.availability, longestWorkoutHours: 0.5 },
+        restriction: { kind: "no-hard-training" },
+      },
+    });
+    expect(capped?.blocked[0].reason).toBe("Today is limited to 30 minutes.");
+    const draft = flexibleDraft();
+    draft.weeks[1].workouts = draft.weeks[1].workouts.filter((workout) => workout.kind === "hard");
+    expect(
+      readTodayChoice({
+        draft,
+        todayDateKey,
+        answers: { ...answers, restriction: { kind: "no-hard-training" } },
+      })?.reason,
+    ).toBe("No hard training today.");
+  });
+
+  it("dates only the selected Workout and restores its null date through the inverse", () => {
+    const draft = flexibleDraft();
+    const before = structuredClone(draft);
+    const result = applyScheduleIntent({
+      draft,
+      todayDateKey,
+      intent: { kind: "choose-workout", workoutId: "w2-hard" },
+    });
+    expect(result.diff).toEqual([
+      {
+        workoutId: "w2-hard",
+        before: draft.weeks[1].workouts[0],
+        after: { ...draft.weeks[1].workouts[0], date: "1998-08-24" },
+      },
+    ]);
+    expect(draft).toEqual(before);
+    expect(result.totals.after.plan - result.totals.before.plan).toBe(45);
+    const inverse = applyScheduleIntent({
+      draft: result.after,
+      previousDraft: before,
+      todayDateKey,
+      intent: { kind: "inverse", changeId: "chosen-workout" },
+    });
+    expect(inverse.after.weeks).toEqual(before.weeks);
+    expect(inverse.diff[0].after?.date).toBeNull();
+  });
+
+  it.each(["missing", "w1-hard", "event"])("refuses an unavailable selection %s", (workoutId) => {
+    expect(() =>
+      applyScheduleIntent({
+        draft: flexibleDraft(),
+        todayDateKey,
+        intent: { kind: "choose-workout", workoutId },
+      }),
+    ).toThrow("This Workout is no longer eligible.");
+  });
+
+  it("counts dating an undated Workout inside the race window as an increase", () => {
+    const workout = { date: null, minutes: 45, kind: "easy", power: null } as const;
+    expect(
+      planChangeRaceWindow({
+        goal: { kind: "event", name: "Autumn ride", date: "1998-09-27" },
+        todayDateKey: 19980921,
+        diff: [{ before: workout, after: { ...workout, date: "1998-09-21" } }],
+      }),
+    ).toEqual({ start: "1998-09-21", end: "1998-09-27" });
+  });
+});


### PR DESCRIPTION
## Summary
- Read model: `plan.list` active summary gains `todayChoice` for a flexible Plan with undated unpinned Workouts in the week containing today: eligible candidates and blocked ones with reasons in order (`Today already belongs to a dated Workout.` including a mirrored Workout of the just-closed Plan, `Today is unavailable under your confirmed limits.`, `Today is limited to {n} minutes.`, `No hard training today.`).
- Intent `{ kind: "choose-workout", workoutId }` dates exactly one eligible Workout to today; title `Choose a Workout for today`; premise `today` by value.
- Apply rechecks in the change-phase admission: `day-changed` when the transaction's today differs from the premise, `not-eligible` on recheck, both with no mutation and the preview left pending. The kernel accepts only base undated → dated today; every other undated transition still refuses. Apply inserts the Workout row (Draft id kept in the structure) and the mirror job covers it; the inverse restores null and deletes the row.
- The dated Workout counts as a race-window increase. Fixed-mode Plans expose null. Fixture backend gains a flexible-mode seed. Renderer is the next PR.

## Verification
astra high read-only: no correctness finding; one wording block (row id vs Draft id) resolved by spec: row ids are ULIDs by schema and the Draft id lives in the structure as in every earlier family.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project workspace` contract, sport-cycling, coach, kernel, kernel-node change repo, renderer | all pass |

Note: rebased onto the Supporting Events backend before merge; both touch the kernel undated guard.

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn