### PR TITLE
feat(desktop): choose today's Workout from the Plan Change surface

### DIFF
--- a/.changeset/plan-change-daily-card.md
+++ b/.changeset/plan-change-daily-card.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Choose an eligible Workout for today from your flexible Plan, review its date, and confirm when ready. Undo returns the Workout to its undated state.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -1780,7 +1780,7 @@ export function createChatController(input: {
   });
 
   render();
-  return {
+  const controller: ChatController = {
     requestPlanLibraryFocus(target) {
       if (disposed) return;
       planCreationFocusRequest = {
@@ -1810,24 +1810,26 @@ export function createChatController(input: {
       const active = library?.active;
       if (disposed || readChange().busy || !active || changesPaused()) return;
       const parameterCopy =
-        intent.kind === "ftp"
-          ? "Enter FTP above zero."
-          : intent.kind === "supporting-event"
-            ? "eventId" in intent && !intent.eventId.trim()
-              ? "Choose a Supporting Event already accepted in this Plan."
-              : "Enter the event name and exact date."
-            : intent.kind === "weekly-duration"
-              ? Number.isFinite(intent.hours) &&
-                intent.hours > 0 &&
-                !Number.isInteger(intent.hours * 4)
-                ? "Enter weekly hours in quarter-hour steps, like 2.25."
-                : "Enter a weekly duration above zero."
-              : "day" in intent &&
-                  (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
-                ? "Choose the weekday to change."
-                : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
+        intent.kind === "choose-workout"
+          ? "This Workout is no longer eligible."
+          : intent.kind === "ftp"
+            ? "Enter FTP above zero."
+            : intent.kind === "supporting-event"
+              ? "eventId" in intent && !intent.eventId.trim()
+                ? "Choose a Supporting Event already accepted in this Plan."
+                : "Enter the event name and exact date."
+              : intent.kind === "weekly-duration"
+                ? Number.isFinite(intent.hours) &&
+                  intent.hours > 0 &&
+                  !Number.isInteger(intent.hours * 4)
+                  ? "Enter weekly hours in quarter-hour steps, like 2.25."
+                  : "Enter a weekly duration above zero."
+                : "day" in intent &&
+                    (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
                   ? "Choose the weekday to change."
-                  : "Enter a duration above zero.";
+                  : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
+                    ? "Choose the weekday to change."
+                    : "Enter a duration above zero.";
       const parsedIntent = PlanChangeIntentSchema.safeParse(intent);
       if (!parsedIntent.success) {
         publishChange({ error: parameterCopy });
@@ -1873,7 +1875,7 @@ export function createChatController(input: {
               result.reason === "stale-version"
                 ? "This request used an older Plan revision. Request a fresh preview."
                 : result.reason === "invalid-intent"
-                  ? (result.explanation ?? parameterCopy)
+                  ? (result.explanation ?? result.message ?? parameterCopy)
                   : "This Change could not be previewed. Training is unchanged.",
           });
           if (result.reason === "stale-version") {
@@ -1946,24 +1948,30 @@ export function createChatController(input: {
           }
           publishChange({
             notice:
-              result.reason === "event-source-changed"
-                ? "The synchronized event changed. Request a fresh preview before applying."
-                : result.reason === "race-window"
-                  ? "Only training reductions are allowed in the current race window. This Change was not applied."
-                  : result.reason === "ftp-sources-changed"
-                    ? "The FTP sources changed. Request a fresh preview before applying this correction."
-                    : result.reason === "stale-version"
-                      ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
-                      : result.reason === "not-pending"
-                        ? "This preview is no longer pending. Training is unchanged."
-                        : "This Change could not be applied. Training and the pending preview are unchanged.",
+              result.reason === "day-changed"
+                ? "The day changed while this choice was open. Request a fresh choice for today; no date was assigned."
+                : result.reason === "not-eligible"
+                  ? "This Workout is no longer eligible."
+                  : result.reason === "event-source-changed"
+                    ? "The synchronized event changed. Request a fresh preview before applying."
+                    : result.reason === "race-window"
+                      ? "Only training reductions are allowed in the current race window. This Change was not applied."
+                      : result.reason === "ftp-sources-changed"
+                        ? "The FTP sources changed. Request a fresh preview before applying this correction."
+                        : result.reason === "stale-version"
+                          ? "This preview is stale because the Plan or its sources changed. Request a fresh preview; no training changed."
+                          : result.reason === "not-pending"
+                            ? "This preview is no longer pending. Training is unchanged."
+                            : "This Change could not be applied. Training and the pending preview are unchanged.",
           });
           if (
             result.reason === "stale-version" ||
             result.reason === "not-pending" ||
             result.reason === "race-window" ||
             result.reason === "ftp-sources-changed" ||
-            result.reason === "event-source-changed"
+            result.reason === "event-source-changed" ||
+            result.reason === "day-changed" ||
+            result.reason === "not-eligible"
           ) {
             await input.refreshPlanLibrary?.().catch(() => {});
           }
@@ -2032,6 +2040,33 @@ export function createChatController(input: {
         planCreationBlocksWork()
       ) {
         return Promise.resolve(false);
+      }
+      const library = input.readPlanLibrary?.();
+      const changeSurface = readChange();
+      const changeOpen =
+        library?.active &&
+        ((changeSurface.open && changeSurface.planId === library.active.planId) ||
+          library.changes.some((change) => change.status === "pending"));
+      if (
+        changeOpen &&
+        attachmentIds.length === 0 &&
+        /^what should i ride today[\p{P}\s]*$/iu.test(message.trim())
+      ) {
+        if (changeSurface.busy) return false;
+        controller.saveAttachmentDraftText("");
+        await attachmentTextSaveTask;
+        if (!changesPaused()) {
+          const workout = library.active?.todayChoice?.eligible[0];
+          if (workout) {
+            await controller.previewPlanChange({
+              kind: "choose-workout",
+              workoutId: workout.workoutId,
+            });
+          } else {
+            publishChange({ error: null, notice: "No eligible Workout can be selected today." });
+          }
+        }
+        return true;
       }
       const ownership = beginAttachmentWrite(false);
       if (ownership === null) return Promise.resolve(false);
@@ -3069,4 +3104,5 @@ export function createChatController(input: {
       sequence += 1;
     },
   };
+  return controller;
 }

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -231,6 +231,7 @@ function premiseValue(premise: PlanChangeModel["premises"][number]): ReactNode {
       return `${intent.hours} hours each week`;
     case "longest-workout":
       return `${intent.minutes} min`;
+    case "choose-workout":
     case "inverse":
     case "supporting-event":
       return premise.label;
@@ -513,6 +514,47 @@ export function PlanChangeCards(): ReactElement | null {
         </div>
       </ChangeCard>
       {state.editorOpen && !paused ? <ChangeEditor /> : null}
+      {library.active.todayChoice ? (
+        <ChangeCard eyebrow="Today" title="Choose one eligible Workout">
+          <ul className="m-0 grid list-none p-0">
+            {library.active.todayChoice.eligible.map((workout) => (
+              <li
+                key={workout.workoutId}
+                className="flex flex-wrap items-center justify-between gap-inset border-t border-line py-3 first:border-t-0"
+              >
+                <span className="text-sm leading-5">
+                  {workout.name} · {workout.minutes} min
+                </span>
+                <Button
+                  variant="outline"
+                  disabled={paused || state.busy || actions === null}
+                  aria-describedby={pausedReason}
+                  onClick={() =>
+                    actions?.previewPlanChange({
+                      kind: "choose-workout",
+                      workoutId: workout.workoutId,
+                    })
+                  }
+                >
+                  Review {workout.name}
+                </Button>
+              </li>
+            ))}
+            {library.active.todayChoice.blocked.map((workout) => (
+              <li
+                key={workout.workoutId}
+                className="flex flex-wrap items-center justify-between gap-inset border-t border-line py-3 first:border-t-0"
+              >
+                <span className="text-sm leading-5">{workout.name}</span>
+                <span className="text-sm leading-5 text-ink-2">{workout.reason}</span>
+              </li>
+            ))}
+          </ul>
+          {library.active.todayChoice.eligible.length === 0 && library.active.todayChoice.reason ? (
+            <p className="m-0 text-sm leading-5 text-ink-2">{library.active.todayChoice.reason}</p>
+          ) : null}
+        </ChangeCard>
+      ) : null}
       {pending ? (
         <ChangeCard
           eyebrow="Plan Change"
@@ -525,6 +567,9 @@ export function PlanChangeCards(): ReactElement | null {
               : "Review this exact difference. Training stays unchanged until you confirm."
           }
         >
+          {pending.details ? (
+            <p className="m-0 text-sm leading-5 text-ink-2">{pending.details}</p>
+          ) : null}
           <Difference change={pending} library={library} />
           <div role="table" aria-label="Facts">
             <Fact label="Main Goal">{library.active.name}</Fact>

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -205,6 +205,117 @@ beforeEach(() => {
 });
 
 describe("Plan Change cards", () => {
+  function setTodayChoice(
+    todayChoice: NonNullable<ListPlansResult["active"]>["todayChoice"],
+  ): void {
+    const value = useEnduragentStore.getState().planLibrary.value;
+    if (!value?.active) throw new Error("Missing active Plan");
+    const activePlan = value.active;
+    act(() =>
+      useEnduragentStore.setState({
+        planLibrary: {
+          status: "ready",
+          value: { ...value, active: { ...activePlan, todayChoice } },
+        },
+      }),
+    );
+  }
+
+  it("shows host-eligible Workouts and previews the selected row", async () => {
+    setTodayChoice({
+      date: "1998-09-07",
+      eligible: [
+        { workoutId: "easy", name: "Easy ride", minutes: 30, kind: "endurance" },
+        { workoutId: "steady", name: "Steady ride", minutes: 45, kind: "endurance" },
+      ],
+      blocked: [
+        { workoutId: "hard", name: "Hill repeats", reason: "No hard training today." },
+        { workoutId: "long", name: "Long ride", reason: "Today is limited to 45 minutes." },
+      ],
+      reason: null,
+    });
+    render(<PlanChangeCards />);
+    const card = screen.getByRole("region", { name: "Choose one eligible Workout" });
+    expect(within(card).getByText("Today")).toBeVisible();
+    expect(within(card).getByText("Easy ride · 30 min")).toBeVisible();
+    expect(within(card).getByText("Steady ride · 45 min")).toBeVisible();
+    expect(within(card).getByText("No hard training today.")).toBeVisible();
+    expect(within(card).getByText("Today is limited to 45 minutes.")).toBeVisible();
+    expect(within(card).queryByRole("button", { name: "Review Hill repeats" })).toBeNull();
+    await userEvent.click(within(card).getByRole("button", { name: "Review Steady ride" }));
+    expect(
+      useEnduragentStore.getState().chatActions?.previewPlanChange,
+    ).toHaveBeenCalledExactlyOnceWith({
+      kind: "choose-workout",
+      workoutId: "steady",
+    });
+  });
+
+  it("shows the Plan-level blocker when no Workout is eligible", () => {
+    setTodayChoice({
+      date: "1998-09-07",
+      eligible: [],
+      blocked: [],
+      reason: "Today already belongs to a dated Workout.",
+    });
+    render(<PlanChangeCards />);
+    const card = screen.getByRole("region", { name: "Choose one eligible Workout" });
+    expect(within(card).getByText("Today already belongs to a dated Workout.")).toBeVisible();
+    expect(within(card).queryByRole("button")).toBeNull();
+  });
+
+  it("omits the Today card when the host exposes no choice", () => {
+    render(<PlanChangeCards />);
+    expect(screen.queryByRole("region", { name: "Choose one eligible Workout" })).toBeNull();
+  });
+
+  it.each(["busy", "paused", "disconnected"])("disables daily review while %s", (state) => {
+    setTodayChoice({
+      date: "1998-09-07",
+      eligible: [{ workoutId: "easy", name: "Easy ride", minutes: 30, kind: "endurance" }],
+      blocked: [],
+      reason: null,
+    });
+    if (state === "busy") patchChange({ busy: true });
+    if (state === "disconnected") useEnduragentStore.setState({ chatActions: null });
+    if (state === "paused") {
+      const value = useEnduragentStore.getState().planLibrary.value;
+      if (!value) throw new Error("Missing library");
+      useEnduragentStore.setState({
+        planLibrary: {
+          status: "ready",
+          value: { ...value, changesPaused: { reason: "sync-stale", lastSuccessfulSyncAtMs: 0 } },
+        },
+      });
+    }
+    render(<PlanChangeCards />);
+    expect(screen.getByRole("button", { name: "Review Easy ride" })).toBeDisabled();
+  });
+
+  it("shows the daily choice guarantee beside the exact date difference", () => {
+    setChanges([
+      change({
+        title: "Choose a Workout for today",
+        intent: { kind: "choose-workout", workoutId: workout.id },
+        details: "Only this Workout will receive today’s date after confirmation.",
+        diff: [
+          {
+            workoutId: workout.id,
+            before: { ...workout, date: null },
+            after: { ...workout, date: "1998-09-07" },
+          },
+        ],
+      }),
+    ]);
+    render(<PlanChangeCards />);
+    const card = screen.getByRole("region", { name: "Choose a Workout for today" });
+    expect(
+      within(card).getByText("Only this Workout will receive today’s date after confirmation."),
+    ).toBeVisible();
+    expect(within(card).getByText("Undated · 60 min → 7 Sept 1998 · 60 min")).toBeVisible();
+    expect(within(card).getByRole("button", { name: "Apply to Plan" })).toBeEnabled();
+  });
+
   it("announces recovery when a paused library loaded before the surface opened turns fresh", () => {
     setChanges([]);
     patchChange({ open: false, notice: null });

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -1,7 +1,9 @@
 import { CoachRpcRemoteError } from "@enduragent/coach-client";
 import type { CoachClient } from "@enduragent/coach-client";
 import type {
+  ChatAttachmentComposerReadModel,
   ListPlansResult,
+  PlanTodayChoice,
   PlanChangeModel,
   PlanChangeIntent,
 } from "@enduragent/coach-contract";
@@ -33,6 +35,35 @@ const change: PlanChangeModel = {
   premises: [],
 };
 
+const todayChoice: PlanTodayChoice = {
+  date: "1998-09-07",
+  eligible: [
+    { workoutId: "workout-first", name: "Easy spin", minutes: 30, kind: "easy" },
+    { workoutId: "workout-second", name: "Endurance ride", minutes: 60, kind: "endurance" },
+  ],
+  blocked: [{ workoutId: "workout-hard", name: "Hard intervals", reason: "Recovery is required." }],
+  reason: null,
+};
+
+const emptyComposer: ChatAttachmentComposerReadModel = {
+  schemaVersion: 1,
+  capabilities: {
+    schemaVersion: 1,
+    active: { provider: "test", model: "text-only", transport: "test" },
+    documents: { enabled: true, extensions: ["pdf", "txt", "csv", "docx"] },
+    completedActivities: { enabled: true, extensions: ["fit", "tcx", "gpx"] },
+    plannedWorkouts: { enabled: true, extensions: ["zwo", "erg", "mrc"] },
+    images: {
+      enabled: false,
+      mediaTypes: [],
+      reason: "model_incompatible",
+      source: "maintained_catalogue",
+      checkedAt: "1998-09-07T00:00:00.000Z",
+    },
+  },
+  draft: null,
+};
+
 function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
   let surface: PlanChangeSurfaceState = EMPTY_PLAN_CHANGE_SURFACE;
   let library: ListPlansResult = {
@@ -60,8 +91,14 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
     changes,
   };
   const call = vi.fn(async (_method: string, _request: unknown): Promise<never> => {
-    if (result instanceof Error) throw result;
-    return result as never;
+    const response =
+      _method === "saveChatAttachmentDraftText" || _method === "getChatAttachmentComposer"
+        ? emptyComposer
+        : _method === "enqueueChatMessage"
+          ? { schemaVersion: 1, revision: 1, items: [] }
+          : result;
+    if (response instanceof Error) throw response;
+    return response as never;
   });
   const client: CoachClient = {
     handshake: {} as CoachClient["handshake"],
@@ -76,6 +113,7 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
       close: async () => {},
     },
     view: { render: vi.fn() },
+    initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
     refreshTrainingContext: async () => {},
     refreshSpend: async () => {},
     readPlanLibrary: () => library,
@@ -95,6 +133,13 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
         ...library,
         changesPaused: { reason: "sync-stale", lastSuccessfulSyncAtMs: 900000000000 },
       };
+    },
+    setTodayChoice(choice: PlanTodayChoice | null = todayChoice) {
+      if (library.active)
+        library = { ...library, active: { ...library.active, todayChoice: choice } };
+    },
+    setSurface(patch: Partial<PlanChangeSurfaceState>) {
+      surface = { ...surface, ...patch };
     },
     updateVersion(version: number) {
       if (library.active) library = { ...library, active: { ...library.active, version } };
@@ -279,6 +324,181 @@ describe("Plan Change controller", () => {
     expect(h.call).toHaveBeenCalledTimes(2);
     expect(h.call.mock.calls[1]).toEqual(h.call.mock.calls[0]);
   });
+
+  it("previews the selected Workout through the existing confirmation path", async () => {
+    const intent: PlanChangeIntent = { kind: "choose-workout", workoutId: "workout-second" };
+    const h = harness({ status: "previewed", change: { ...change, intent }, version: 8 }, []);
+    await h.controller.previewPlanChange(intent);
+    expect(h.call).toHaveBeenCalledExactlyOnceWith("plan_change.preview", {
+      planId: "plan-active",
+      expectedVersion: 7,
+      intent,
+      commandId: expect.any(String),
+    });
+    expect(h.refresh).toHaveBeenCalledOnce();
+    expect(h.surface()).toMatchObject({
+      busy: false,
+      error: null,
+      focusRequest: { target: "preview" },
+    });
+  });
+
+  it("preserves the host explanation when a Workout choice preview is refused", async () => {
+    const explanation = "This Workout needs a recovery day first.";
+    const h = harness({ status: "rejected", reason: "invalid-intent", message: explanation });
+    await h.controller.previewPlanChange({ kind: "choose-workout", workoutId: "workout-hard" });
+    expect(h.surface()).toMatchObject({ error: explanation, busy: false });
+  });
+
+  describe.each([
+    [
+      "day-changed",
+      "The day changed while this choice was open. Request a fresh choice for today; no date was assigned.",
+    ],
+    ["not-eligible", "This Workout is no longer eligible."],
+  ])("%s choice apply refusal", (reason, notice) => {
+    it.each([false, true])(
+      "retains the notice and refreshes when refresh fails: %s",
+      async (refreshFails) => {
+        const h = harness({ status: "rejected", reason }, [
+          { ...change, intent: { kind: "choose-workout", workoutId: "workout-first" } },
+        ]);
+        if (refreshFails) h.refresh.mockRejectedValue(new Error("unavailable"));
+        else h.refresh.mockImplementation(async () => h.updateVersion(8));
+        await h.controller.applyPlanChange("apply");
+        expect(h.surface()).toMatchObject({ busy: false, error: null, notice });
+        expect(h.refresh).toHaveBeenCalledOnce();
+        if (!refreshFails) {
+          await h.controller.previewPlanChange({
+            kind: "choose-workout",
+            workoutId: "workout-second",
+          });
+          expect(h.call).toHaveBeenNthCalledWith(
+            2,
+            "plan_change.preview",
+            expect.objectContaining({ expectedVersion: 8 }),
+          );
+        }
+      },
+    );
+  });
+
+  it.each([
+    "what should i ride today",
+    "WHAT SHOULD I RIDE TODAY?!",
+    " What Should I Ride Today...  ",
+  ])(
+    "routes %j to the first eligible Workout and clears the persisted composer draft",
+    async (message) => {
+      const h = harness({ status: "previewed", change, version: 8 }, []);
+      h.setTodayChoice();
+      h.controller.openPlanChangeEditor();
+      expect(await h.controller.submit(message)).toBe(true);
+      expect(h.call).toHaveBeenCalledWith(
+        "plan_change.preview",
+        expect.objectContaining({
+          intent: { kind: "choose-workout", workoutId: "workout-first" },
+        }),
+      );
+      expect(h.call).toHaveBeenCalledWith("saveChatAttachmentDraftText", {
+        chatId: "desktop",
+        text: "",
+      });
+      expect(h.call.mock.calls.some(([method]) => method === "enqueueChatMessage")).toBe(false);
+      h.controller.dispose();
+    },
+  );
+
+  it("clears the submitted draft before the preview returns so newer text survives", async () => {
+    const h = harness(null, []);
+    h.setTodayChoice(todayChoice);
+    h.controller.openPlanChangeEditor();
+    const order: string[] = [];
+    const original = h.call.getMockImplementation();
+    h.call.mockImplementation(async (method: string, request: unknown): Promise<never> => {
+      order.push(method);
+      if (method === "plan_change.preview") return new Promise<never>(() => {});
+      return original!(method, request);
+    });
+    void h.controller.submit("what should i ride today?");
+    await vi.waitFor(() => expect(order).toContain("plan_change.preview"));
+    expect(order.indexOf("saveChatAttachmentDraftText")).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf("saveChatAttachmentDraftText")).toBeLessThan(
+      order.indexOf("plan_change.preview"),
+    );
+    h.controller.dispose();
+  });
+
+  it.each([null, { ...todayChoice, eligible: [], reason: "Recovery is required." }])(
+    "announces that no Workout is eligible without sending chat when the choice is %j",
+    async (choice) => {
+      const h = harness(null, []);
+      h.setTodayChoice(choice);
+      h.controller.openPlanChangeEditor();
+      expect(await h.controller.submit("what should i ride today?")).toBe(true);
+      expect(h.surface().notice).toBe("No eligible Workout can be selected today.");
+      expect(h.call).toHaveBeenCalledExactlyOnceWith("saveChatAttachmentDraftText", {
+        chatId: "desktop",
+        text: "",
+      });
+      h.controller.dispose();
+    },
+  );
+
+  it.each([
+    "unrelated text",
+    "what should i ride today please",
+    "what should i ride today? And tomorrow?",
+  ])("sends %j through normal chat", async (message) => {
+    const h = harness(null, []);
+    h.setTodayChoice();
+    h.controller.openPlanChangeEditor();
+    expect(await h.controller.submit(message)).toBe(true);
+    expect(h.call).toHaveBeenCalledWith(
+      "enqueueChatMessage",
+      expect.objectContaining({ text: message }),
+    );
+    expect(h.call.mock.calls.some(([method]) => method === "plan_change.preview")).toBe(false);
+    h.controller.dispose();
+  });
+
+  it.each(["closed", "attachments"])(
+    "keeps the today question in normal chat with %s",
+    async (scope) => {
+      const h = harness(null, []);
+      h.setTodayChoice();
+      if (scope === "attachments") h.controller.openPlanChangeEditor();
+      const attachmentIds = scope === "attachments" ? ["attachment-workout"] : [];
+      expect(await h.controller.submit("what should i ride today?", attachmentIds)).toBe(true);
+      expect(h.call).toHaveBeenCalledWith(
+        "enqueueChatMessage",
+        expect.objectContaining({
+          text: "what should i ride today?",
+          ...(attachmentIds.length ? { attachmentIds } : {}),
+        }),
+      );
+      expect(h.call.mock.calls.some(([method]) => method === "plan_change.preview")).toBe(false);
+      h.controller.dispose();
+    },
+  );
+
+  it.each(["busy", "paused"])(
+    "does not preview or enqueue today's question while %s",
+    async (state) => {
+      const h = harness(null, []);
+      h.setTodayChoice();
+      h.controller.openPlanChangeEditor();
+      if (state === "busy") h.setSurface({ busy: true });
+      else h.pause();
+      expect(await h.controller.submit("what should i ride today?")).toBe(state === "paused");
+      expect(
+        h.call.mock.calls.some(
+          ([method]) => method === "plan_change.preview" || method === "enqueueChatMessage",
+        ),
+      ).toBe(false);
+      h.controller.dispose();
+    },
+  );
 
   it("sends the FTP intent and keeps daemon rejection copy", async () => {
     const h = harness({ status: "rejected", reason: "command-conflict" });

--- a/apps/desktop/tests/e2e/plan-change-daily-choice.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change-daily-choice.spec.ts
@@ -1,0 +1,342 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import {
+  PlanChangePreviewRpcParamsSchema,
+  PlanChangeWorkoutSchema,
+  PlanCreationDraftSchema,
+} from "@enduragent/coach-contract";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+const previews = fileURLToPath(new URL("./previews/plan-change-daily-choice/", import.meta.url));
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  readonly seed: Awaited<ReturnType<PlanCreationBackend["seedActiveTraining"]>>;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Change renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-change-daily-choice-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    const seed = await backend.seedActiveTraining({ mode: "flexible" });
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    return { backend, fixture, scratch, seed, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  await mkdir(previews, { recursive: true });
+  const screenshotPath = join(previews, `${name}-${scenario.width}-${scenario.colorScheme}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-plan-change", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        activation: await scenario.backend.inspectActivation(),
+        requests: scenario.backend.creationRequests,
+        seed: scenario.seed,
+        library: await scenario.backend.library(),
+        responses: scenario.backend.changeApplyResponses,
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+const appearances = [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const;
+const choiceTitle = "Choose a Workout for today";
+const inverseTitle = "Undo the latest Change";
+const occupiedReason = "Today already belongs to a dated Workout.";
+
+function changes(scenario: Scenario) {
+  return scenario.page.getByRole("region", { name: "Plan Changes", exact: true });
+}
+
+function todayCard(scenario: Scenario) {
+  return changes(scenario).getByRole("region", {
+    name: "Choose one eligible Workout",
+    exact: true,
+  });
+}
+
+function changeCard(scenario: Scenario, title: string, status: string) {
+  return changes(scenario)
+    .getByRole("region", { name: title, exact: true })
+    .filter({ has: scenario.page.getByText(status, { exact: true }) });
+}
+
+for (const appearance of appearances) {
+  test(`chooses today's Workout and restores its undated state at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      const initial = await scenario.backend.inspectActivation();
+      const library = await scenario.backend.library();
+      const choice = library.active?.todayChoice;
+      const selected = choice?.eligible[0];
+      if (!choice || !selected || !scenario.seed.planId)
+        throw new TypeError("Flexible Plan daily choice is unavailable");
+      expect(choice.eligible.length).toBeGreaterThan(1);
+      expect(initial.workouts).toHaveLength(0);
+      await scenario.page
+        .getByRole("navigation", { name: "Main navigation" })
+        .getByRole("button", { name: "Plan", exact: true })
+        .click();
+      await scenario.page
+        .getByRole("region", { name: "Plan library", exact: true })
+        .getByRole("button", { name: "Change in Chat", exact: true })
+        .click();
+      const today = todayCard(scenario);
+      await expect(today.getByText("Today", { exact: true })).toBeVisible();
+      for (const workout of choice.eligible) {
+        await expect(
+          today.getByText(`${workout.name} · ${workout.minutes} min`, { exact: true }),
+        ).toBeVisible();
+        await expect(
+          today.getByRole("button", { name: `Review ${workout.name}`, exact: true }),
+        ).toBeEnabled();
+      }
+      await capture(scenario, "eligible-workouts");
+      await today.getByRole("button", { name: `Review ${selected.name}`, exact: true }).click();
+      const pending = changeCard(scenario, choiceTitle, "Pending");
+      await expect(pending.getByRole("heading", { name: choiceTitle, exact: true })).toBeFocused();
+      await expect(
+        pending.getByText("Only this Workout will receive today’s date after confirmation.", {
+          exact: true,
+        }),
+      ).toBeVisible();
+      const previewRequests = scenario.backend.creationRequests.filter(
+        (request) => request.method === "plan_change.preview",
+      );
+      expect(previewRequests).toHaveLength(1);
+      expect(PlanChangePreviewRpcParamsSchema.parse(previewRequests[0]?.params)).toMatchObject({
+        planId: scenario.seed.planId,
+        expectedVersion: 1,
+        intent: { kind: "choose-workout", workoutId: selected.workoutId },
+      });
+      const preview = (await scenario.backend.library()).changes.find(
+        (change) => change.status === "pending",
+      );
+      expect(preview?.diff).toHaveLength(1);
+      expect(preview?.diff[0]).toMatchObject({
+        before: { id: selected.workoutId, date: null },
+        after: { id: selected.workoutId, date: choice.date },
+      });
+      expect((await scenario.backend.inspectActivation()).workouts).toEqual(initial.workouts);
+      await pending.scrollIntoViewIfNeeded();
+      await capture(scenario, "pending-choice");
+      await pending.getByRole("button", { name: "Apply to Plan", exact: true }).click();
+      await expect(changeCard(scenario, choiceTitle, "Applied")).toBeVisible();
+      await expect(changes(scenario).getByRole("status")).toHaveText(
+        "Change applied locally. Training now matches the confirmed preview.",
+      );
+      const applied = await scenario.backend.inspectActivation();
+      const afterDraft = PlanCreationDraftSchema.parse(
+        JSON.parse(String(applied.revisions[1]?.snapshot_json)),
+      );
+      expect(afterDraft.weeks).toEqual(
+        scenario.seed.draft.weeks.map((week) => ({
+          ...week,
+          workouts: week.workouts.map((workout) =>
+            workout.id === selected.workoutId ? { ...workout, date: choice.date } : workout,
+          ),
+        })),
+      );
+      expect(applied.workouts).toHaveLength(1);
+      expect(applied.workouts[0]).toMatchObject({
+        date_key: Number(choice.date.replaceAll("-", "")),
+      });
+      expect(
+        PlanChangeWorkoutSchema.parse(JSON.parse(String(applied.workouts[0]?.structure_json))),
+      ).toEqual(preview?.diff[0]?.after);
+      expect(applied.planningPlans[0]).toMatchObject({ version: 2, current_revision_number: 2 });
+      const blocked = (await scenario.backend.library()).active?.todayChoice;
+      expect(blocked?.eligible).toEqual([]);
+      expect(blocked?.reason).toBe(occupiedReason);
+      expect(blocked?.blocked).toHaveLength(choice.eligible.length - 1);
+      await expect(today.getByRole("button")).toHaveCount(0);
+      await expect(today.getByText(occupiedReason, { exact: true })).toHaveCount(
+        choice.eligible.length,
+      );
+      for (const workout of blocked?.blocked ?? []) {
+        await expect(today.getByText(workout.name, { exact: true })).toBeVisible();
+        expect(workout.reason).toBe(occupiedReason);
+      }
+      await today.getByRole("heading").scrollIntoViewIfNeeded();
+      await capture(scenario, "blocked-workouts");
+      await changeCard(scenario, choiceTitle, "Applied")
+        .getByRole("button", { name: "Undo", exact: true })
+        .click();
+      const inverse = changeCard(scenario, inverseTitle, "Pending");
+      await expect(inverse.getByRole("heading")).toBeFocused();
+      const inversePreview = (await scenario.backend.library()).changes.find(
+        (change) => change.status === "pending",
+      );
+      expect(inversePreview?.diff).toHaveLength(1);
+      expect(inversePreview?.diff[0]).toMatchObject({
+        before: { id: selected.workoutId, date: choice.date },
+        after: { id: selected.workoutId, date: null },
+      });
+      await inverse.scrollIntoViewIfNeeded();
+      await capture(scenario, "pending-undo");
+      await inverse.getByRole("button", { name: "Apply to Plan", exact: true }).click();
+      await expect(changeCard(scenario, inverseTitle, "Applied")).toBeVisible();
+      const restored = await scenario.backend.inspectActivation();
+      expect(restored.planningPlans[0]).toMatchObject({ version: 3, current_revision_number: 3 });
+      expect(restored.workouts).toEqual(initial.workouts);
+      expect(
+        PlanCreationDraftSchema.parse(JSON.parse(String(restored.revisions[2]?.snapshot_json)))
+          .weeks,
+      ).toEqual(scenario.seed.draft.weeks);
+      expect((await scenario.backend.library()).active?.todayChoice).toEqual(choice);
+      await expect(
+        today.getByRole("button", { name: `Review ${selected.name}`, exact: true }),
+      ).toBeEnabled();
+      await today.getByRole("heading").scrollIntoViewIfNeeded();
+      await capture(scenario, "restored-choice");
+      const requestsBeforeChat = scenario.backend.creationRequests.length;
+      const composer = scenario.page.getByRole("combobox", { name: "Message your coach" });
+      await composer.fill("WHAT SHOULD I RIDE TODAY?!");
+      await scenario.page.getByRole("button", { name: "Send message", exact: true }).click();
+      const chatPending = changeCard(scenario, choiceTitle, "Pending");
+      await expect(chatPending.getByRole("heading")).toBeFocused();
+      await expect(composer).toHaveValue("");
+      const chatRequests = scenario.backend.creationRequests
+        .slice(requestsBeforeChat)
+        .filter((request) => request.method === "plan_change.preview");
+      expect(chatRequests).toHaveLength(1);
+      expect(PlanChangePreviewRpcParamsSchema.parse(chatRequests[0]?.params)).toMatchObject({
+        planId: scenario.seed.planId,
+        expectedVersion: 3,
+        intent: { kind: "choose-workout", workoutId: selected.workoutId },
+      });
+      await chatPending.scrollIntoViewIfNeeded();
+      await capture(scenario, "chat-choice");
+      await chatPending.getByRole("button", { name: "Cancel", exact: true }).click();
+      await expect(changeCard(scenario, choiceTitle, "Cancelled")).toBeVisible();
+      await expect(changes(scenario).getByRole("status")).toHaveText(
+        "Change cancelled. Training is unchanged; the preview remains in history.",
+      );
+      const cancelled = await scenario.backend.inspectActivation();
+      expect(cancelled.workouts).toEqual(restored.workouts);
+      expect(cancelled.revisions).toEqual(restored.revisions);
+      expect(cancelled.planningPlans).toEqual(restored.planningPlans);
+      expect((await scenario.backend.library()).active?.todayChoice).toEqual(choice);
+    } finally {
+      await close(scenario);
+    }
+  });
+}

--- a/apps/desktop/tests/e2e/plan-change.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change.spec.ts
@@ -173,6 +173,8 @@ const options = [
   "No hard training on a weekday",
   "Weekly duration cap",
   "Longest-Workout cap",
+  "Correct FTP",
+  "Supporting Event",
 ];
 const confidence =
   "Moderate confidence. Based on your confirmed limits and the available training record.";


### PR DESCRIPTION
## Summary
- `Today` card on the Plan Change surface for a flexible Plan: title `Choose one eligible Workout`, rows `name · N min` with `Review {name}` buttons, blocked rows with their reason, or the Plan-level reason when nothing is eligible. Review previews `choose-workout`; the pending card shows `Only this Workout will receive today’s date after confirmation.`
- Chat text `what should i ride today` while the surface is open previews the first eligible Workout or shows `No eligible Workout can be selected today.`; other messages still reach the coach. The submitted draft is cleared before the preview so newer text is never overwritten.
- Apply refusal notices for `day-changed` and `not-eligible`, both re-reading the library.
- New Playwright spec plan-change-daily-choice.spec.ts: choose, apply dates today, Undo restores, blocked reasons, at 1180/720 light and dark.

## Verification
astra high read-only: one finding (draft cleared after the preview returned), fixed inline with an ordering test.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project renderer-dom --maxWorkers 2` | 735 passed |
| playwright daily-choice + undo | 8 passed |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn