### PR TITLE
feat(desktop): type a Plan Change request in Chat

### DIFF
--- a/.changeset/plan-change-text-chat.md
+++ b/.changeset/plan-change-text-chat.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Type a change while reviewing your Plan changes to preview it before confirming. Requests that cannot be handled explain why, and separate changes must be requested one at a time.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -25,6 +25,8 @@ import {
   type PlanHandoffSuggestion,
   type ListPlansResult,
   type PlanChangeIntent,
+  PlanChangeRequestSchema,
+  type PlanChangeRequest,
   type PlanChangePreviewRpcParams,
   type PlanChangeApplyRpcParams,
   type PlanCreationActivateRpcParams,
@@ -231,7 +233,9 @@ export interface ChatView {
 export interface ChatController {
   openPlanChangeEditor(): void;
   backFromPlanChangeEditor(): void;
-  previewPlanChange(intent: PlanChangeIntent): Promise<void>;
+  previewPlanChange(
+    intent: PlanChangeIntent | Extract<PlanChangeRequest, { kind: "text" }>,
+  ): Promise<void>;
   applyPlanChange(decision: "apply" | "cancel"): Promise<void>;
   start(): Promise<void>;
   resume(): Promise<void>;
@@ -1921,40 +1925,49 @@ export function createChatController(input: {
       const active = library?.active;
       if (disposed || readChange().busy || !active || changesPaused()) return;
       const parameterCopy =
-        intent.kind === "choose-workout"
-          ? "This Workout is no longer eligible."
-          : intent.kind === "ftp"
-            ? "Enter FTP above zero."
-            : intent.kind === "supporting-event"
-              ? "eventId" in intent && !intent.eventId.trim()
-                ? "Choose a Supporting Event already accepted in this Plan."
-                : "Enter the event name and exact date."
-              : intent.kind === "weekly-duration"
-                ? Number.isFinite(intent.hours) &&
-                  intent.hours > 0 &&
-                  !Number.isInteger(intent.hours * 4)
-                  ? "Enter weekly hours in quarter-hour steps, like 2.25."
-                  : "Enter a weekly duration above zero."
-                : "day" in intent &&
-                    (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
-                  ? "Choose the weekday to change."
-                  : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
+        intent.kind === "text"
+          ? "Keep your change request to 500 characters or fewer."
+          : intent.kind === "choose-workout"
+            ? "This Workout is no longer eligible."
+            : intent.kind === "ftp"
+              ? "Enter FTP above zero."
+              : intent.kind === "supporting-event"
+                ? "eventId" in intent && !intent.eventId.trim()
+                  ? "Choose a Supporting Event already accepted in this Plan."
+                  : "Enter the event name and exact date."
+                : intent.kind === "weekly-duration"
+                  ? Number.isFinite(intent.hours) &&
+                    intent.hours > 0 &&
+                    !Number.isInteger(intent.hours * 4)
+                    ? "Enter weekly hours in quarter-hour steps, like 2.25."
+                    : "Enter a weekly duration above zero."
+                  : "day" in intent &&
+                      (!Number.isInteger(intent.day) || intent.day < 1 || intent.day > 7)
                     ? "Choose the weekday to change."
-                    : "Enter a duration above zero.";
-      const parsedIntent = PlanChangeIntentSchema.safeParse(intent);
+                    : intent.kind === "weekday-unavailable" || intent.kind === "hard-weekday"
+                      ? "Choose the weekday to change."
+                      : "Enter a duration above zero.";
+      const parsedIntent =
+        intent.kind === "text"
+          ? PlanChangeRequestSchema.options[1].safeParse(intent)
+          : PlanChangeIntentSchema.safeParse(intent);
       if (!parsedIntent.success) {
         publishChange({ error: parameterCopy });
         return;
       }
       if (
         previewAttempt?.planId !== active.planId ||
-        JSON.stringify(previewAttempt.intent) !== JSON.stringify(parsedIntent.data)
+        JSON.stringify(
+          "request" in previewAttempt ? previewAttempt.request : previewAttempt.intent,
+        ) !== JSON.stringify(parsedIntent.data)
       ) {
         previewAttempt = {
           commandId: globalThis.crypto.randomUUID(),
           planId: active.planId,
           expectedVersion: active.version,
-          intent: parsedIntent.data,
+          ...(parsedIntent.data.kind === "text"
+            ? { request: parsedIntent.data }
+            : { intent: parsedIntent.data }),
         };
       }
       publishChange({ busy: true, error: null, notice: null });
@@ -1963,6 +1976,10 @@ export function createChatController(input: {
         previewAttempt = null;
         if (disposed) return;
         if (result.status === "rejected") {
+          if (result.reason === "unsupported-request") {
+            publishChange({ editorOpen: false, error: null, notice: result.explanation });
+            return;
+          }
           if (result.reason === "sync-stale") {
             publishChange({ editorOpen: false, error: null, notice: PLAN_CHANGES_PAUSED_NOTICE });
             await input.refreshPlanLibrary?.().catch(() => {});
@@ -1981,14 +1998,17 @@ export function createChatController(input: {
             await input.refreshPlanLibrary?.().catch(() => {});
             return;
           }
-          publishChange({
-            error:
-              result.reason === "stale-version"
-                ? "This request used an older Plan revision. Request a fresh preview."
-                : result.reason === "invalid-intent"
-                  ? (result.explanation ?? result.message ?? parameterCopy)
-                  : "This Change could not be previewed. Training is unchanged.",
-          });
+          const rejectionCopy =
+            result.reason === "stale-version"
+              ? "This request used an older Plan revision. Request a fresh preview."
+              : result.reason === "invalid-intent"
+                ? (result.explanation ?? result.message ?? parameterCopy)
+                : "This Change could not be previewed. Training is unchanged.";
+          publishChange(
+            parsedIntent.data.kind === "text"
+              ? { editorOpen: false, error: null, notice: rejectionCopy }
+              : { error: rejectionCopy },
+          );
           if (result.reason === "stale-version") {
             await input.refreshPlanLibrary?.().catch(() => {});
           }
@@ -2159,26 +2179,23 @@ export function createChatController(input: {
       const changeOpen =
         library?.active &&
         ((changeSurface.open && changeSurface.planId === library.active.planId) ||
-          library.changes.some((change) => change.status === "pending"));
-      if (
-        changeOpen &&
-        attachmentIds.length === 0 &&
-        /^what should i ride today[\p{P}\s]*$/iu.test(message.trim())
-      ) {
+          library.changes.some(
+            (change) => change.status === "pending" && change.planId === library.active?.planId,
+          ));
+      if (changeOpen && attachmentIds.length === 0) {
         if (changeSurface.busy) return false;
-        controller.saveAttachmentDraftText("");
-        await attachmentTextSaveTask;
-        if (!changesPaused()) {
-          const workout = library.active?.todayChoice?.eligible[0];
-          if (workout) {
-            await controller.previewPlanChange({
-              kind: "choose-workout",
-              workoutId: workout.workoutId,
-            });
-          } else {
-            publishChange({ error: null, notice: "No eligible Workout can be selected today." });
-          }
+        if (changesPaused()) return true;
+        publishChange({ busy: true, error: null, notice: null });
+        reduce({ type: "append-athlete-message", id: nextId("message"), text: message });
+        if (
+          attachmentGenerationIsCurrent(submittedAttachmentGeneration) &&
+          submittedTextRevision === attachmentTextRevision
+        ) {
+          controller.saveAttachmentDraftText("");
+          await attachmentTextSaveTask;
         }
+        publishChange({ busy: false });
+        await controller.previewPlanChange({ kind: "text", text: message });
         return true;
       }
       if (

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -99,6 +99,7 @@ export const EMPTY_CHAT_STATE: ChatState = {
 };
 
 export type ChatAction =
+  | { readonly type: "append-athlete-message"; readonly id: string; readonly text: string }
   | {
       readonly type: "submit";
       readonly requestKey: number;
@@ -189,6 +190,14 @@ export function hasClearableConversation(state: ChatState): boolean {
 
 export function reduceChatState(state: ChatState, action: ChatAction): ChatState {
   switch (action.type) {
+    case "append-athlete-message":
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          { id: action.id, role: "athlete", text: action.text, delivery: "complete" },
+        ],
+      };
     case "submit": {
       if (state.status === "streaming") return state;
       const assistant: ChatTranscriptMessage = {

--- a/apps/desktop-renderer/src/ui/chat/Transcript.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Transcript.tsx
@@ -22,10 +22,7 @@ import { CoachMessage } from "./CoachMessage";
 import { HistoryControls } from "./HistoryControls";
 import { PlanReferenceCard } from "./PlanReferenceCard";
 import { StreamingMessage } from "./StreamingMessage";
-import {
-  PlanCreationConversation,
-  PlanCreationDiscardConsequence,
-} from "./PlanCreationCards";
+import { PlanCreationConversation, PlanCreationDiscardConsequence } from "./PlanCreationCards";
 
 function planHandoffSummary(suggestion: PlanHandoffSuggestion): string {
   if (suggestion.kind === "plan_creation") {
@@ -78,6 +75,7 @@ function MessageRow(props: {
         delivery.source?.messageId === sourceMessageId && delivery.state !== "cancelled",
     ),
   );
+  const hasActivePlan = useEnduragentStore((state) => state.planLibrary.value?.active != null);
   const streaming = message.role === "coach" && message.delivery === "streaming";
   const silent = message.historical || message.role === "athlete";
   const rowClassName = cn(
@@ -139,7 +137,9 @@ function MessageRow(props: {
           {message.planReference === undefined ? null : (
             <PlanReferenceCard selection={message.planReference} />
           )}
-          {message.planHandoff === undefined || handoffDelivery !== undefined ? null : (
+          {message.planHandoff === undefined ||
+          handoffDelivery !== undefined ||
+          (hasActivePlan && message.planHandoff.kind === "plan_change") ? null : (
             <PlanHandoffCard messageId={sourceMessageId} suggestion={message.planHandoff} />
           )}
         </div>

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -511,6 +511,7 @@ describe("chat surface", () => {
       firstSync: { status: "idle" },
       training: EMPTY_TRAINING_SURFACE,
       plan: EMPTY_PLAN_SURFACE,
+      planLibrary: { status: "loading", value: null },
       planSurface: { status: "loading", value: null },
       planFocus: null,
       planReturnToChat: false,
@@ -526,6 +527,7 @@ describe("chat surface", () => {
       firstSync: { status: "idle" },
       training: EMPTY_TRAINING_SURFACE,
       plan: EMPTY_PLAN_SURFACE,
+      planLibrary: { status: "loading", value: null },
       planSurface: { status: "loading", value: null },
       planFocus: null,
       planReturnToChat: false,
@@ -1450,6 +1452,170 @@ describe("chat surface", () => {
       await user.click(screen.getByRole("button", { name: "Continue in Plan" }));
       expect(actions.continueMessageInPlan).toHaveBeenCalledWith("turn-1", message.planHandoff);
     });
+
+    it.each(["plan_change", "plan_question", "plan_creation"] as const)(
+      "hides only the legacy change suggestion with an active Plan: %s",
+      (kind) => {
+        useEnduragentStore.setState({
+          planLibrary: {
+            status: "ready",
+            value: {
+              calendarConnected: false,
+              legacy: null,
+              creation: null,
+              closed: [],
+              changesPaused: null,
+              changes: [],
+              active: {
+                planId: "plan-active",
+                version: 1,
+                name: "Build fitness",
+                start: "1998-07-06",
+                end: "1998-10-04",
+                weeks: 12,
+                status: "active",
+                supportingEventCandidates: [],
+                closeReason: null,
+                closedAt: null,
+                activatedAt: "1998-07-06",
+                todayChoice: null,
+                creationId: null,
+                calendar: { status: "pending", window: null, currentThrough: null, error: null },
+              },
+            },
+          },
+        });
+        const message: ChatMessageView = {
+          id: "message-handoff",
+          role: "coach",
+          delivery: "complete",
+          historical: false,
+          text: "We can review your training.",
+          planHandoff: { kind, title: "Review training", intent: "Review my training." },
+        };
+        setChat({
+          messages: [message],
+          planningRequestsLoaded: true,
+          timeline: [{ kind: "message", message }],
+        });
+        render(<Harness />);
+        expect(screen.getByText(message.text)).toBeVisible();
+        if (kind === "plan_change") {
+          expect(screen.queryByText(/Review a structured Proposal/u)).toBeNull();
+          expect(screen.queryByRole("button", { name: "Continue in Plan" })).toBeNull();
+        } else {
+          expect(screen.getByRole("button", { name: "Continue in Plan" })).toBeVisible();
+        }
+      },
+    );
+
+    it("shows a retry action for a safely saved failed Plan handoff", async () => {
+      const user = userEvent.setup();
+      const delivered = planningDelivery("open");
+      const failed: PlanningRequestDelivery = {
+        ...delivered,
+        state: "failed",
+        failureCode: "planning_unavailable",
+        retryable: true,
+        deliveredAtMs: null,
+        planningRequest: null,
+      };
+      setChat({
+        planningRequests: [failed],
+        planningRequestsLoaded: true,
+        timeline: [{ kind: "planning-request", delivery: failed }],
+      });
+      render(<Harness />);
+
+      expect(screen.getByText("Couldn’t open")).toBeVisible();
+      expect(screen.getAllByText(/will not create a duplicate/u)).not.toHaveLength(0);
+      await user.click(screen.getByRole("button", { name: "Try again" }));
+      expect(actions.retryPlanningRequest).toHaveBeenCalledWith(failed.requestId);
+    });
+
+    it("renders one host-owned text handoff and keeps Plan unchanged until continued while the library is unavailable", async () => {
+      const user = userEvent.setup();
+      const message: ChatMessageView = {
+        id: "message-live-1",
+        turnId: "turn-1",
+        role: "coach",
+        delivery: "complete",
+        historical: false,
+        text: "This change should be reviewed in Plan.",
+        planHandoff: {
+          kind: "plan_change",
+          title: "Review a lighter Friday",
+          intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+        },
+      };
+      setChat({
+        messages: [message],
+        planningRequestsLoaded: true,
+        timeline: [{ kind: "message", message }],
+      });
+      render(<Harness />);
+
+      expect(screen.getByRole("heading", { name: "Review a lighter Friday" })).toBeVisible();
+      expect(screen.getByText(/Nothing changes until you approve it/u)).toBeVisible();
+      await user.click(screen.getByRole("button", { name: "Continue in Plan" }));
+      expect(actions.continueMessageInPlan).toHaveBeenCalledWith("turn-1", message.planHandoff);
+    });
+
+    it.each(["plan_change", "plan_question", "plan_creation"] as const)(
+      "hides only the legacy change suggestion with an active Plan: %s",
+      (kind) => {
+        useEnduragentStore.setState({
+          planLibrary: {
+            status: "unavailable",
+            value: {
+              calendarConnected: false,
+              legacy: null,
+              creation: null,
+              closed: [],
+              changesPaused: null,
+              changes: [],
+              active: {
+                planId: "plan-active",
+                version: 1,
+                name: "Build fitness",
+                start: "1998-07-06",
+                end: "1998-10-04",
+                weeks: 12,
+                status: "active",
+                supportingEventCandidates: [],
+                closeReason: null,
+                closedAt: null,
+                activatedAt: "1998-07-06",
+                todayChoice: null,
+                creationId: null,
+                calendar: { status: "pending", window: null, currentThrough: null, error: null },
+              },
+            },
+          },
+        });
+        const message: ChatMessageView = {
+          id: "message-handoff",
+          role: "coach",
+          delivery: "complete",
+          historical: false,
+          text: "We can review your training.",
+          planHandoff: { kind, title: "Review training", intent: "Review my training." },
+        };
+        setChat({
+          messages: [message],
+          planningRequestsLoaded: true,
+          timeline: [{ kind: "message", message }],
+        });
+        render(<Harness />);
+        expect(screen.getByText(message.text)).toBeVisible();
+        if (kind === "plan_change") {
+          expect(screen.queryByText(/Review a structured Proposal/u)).toBeNull();
+          expect(screen.queryByRole("button", { name: "Continue in Plan" })).toBeNull();
+        } else {
+          expect(screen.getByRole("button", { name: "Continue in Plan" })).toBeVisible();
+        }
+      },
+    );
 
     it("shows a retry action for a safely saved failed Plan handoff", async () => {
       const user = userEvent.setup();

--- a/apps/desktop-renderer/tests/plan-change-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-change-controller.test.ts
@@ -106,13 +106,14 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
     close: vi.fn(async () => {}),
   };
   const refresh = vi.fn(async () => {});
+  const render = vi.fn();
   const controller = createChatController({
     clients: {
       getClient: async () => client,
       reconnect: async () => client,
       close: async () => {},
     },
-    view: { render: vi.fn() },
+    view: { render },
     initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
     refreshTrainingContext: async () => {},
     refreshSpend: async () => {},
@@ -125,9 +126,13 @@ function harness(result: unknown, changes: PlanChangeModel[] = [change]) {
   });
   return {
     controller,
+    render,
     call,
     refresh,
     surface: () => surface,
+    clearActivePlan() {
+      library = { ...library, active: null };
+    },
     pause() {
       library = {
         ...library,
@@ -384,11 +389,13 @@ describe("Plan Change controller", () => {
   });
 
   it.each([
+    "wednesdays at most 30 minutes",
+    "my ftp is 220",
     "what should i ride today",
     "WHAT SHOULD I RIDE TODAY?!",
     " What Should I Ride Today...  ",
   ])(
-    "routes %j to the first eligible Workout and clears the persisted composer draft",
+    "routes %j through text preview, echoes it, and clears the persisted composer draft",
     async (message) => {
       const h = harness({ status: "previewed", change, version: 8 }, []);
       h.setTodayChoice();
@@ -397,9 +404,13 @@ describe("Plan Change controller", () => {
       expect(h.call).toHaveBeenCalledWith(
         "plan_change.preview",
         expect.objectContaining({
-          intent: { kind: "choose-workout", workoutId: "workout-first" },
+          request: { kind: "text", text: message },
         }),
       );
+      expect(h.render.mock.lastCall?.[0].messages).toContainEqual(
+        expect.objectContaining({ role: "athlete", text: message, delivery: "complete" }),
+      );
+      expect(h.surface()).toMatchObject({ busy: false, focusRequest: { target: "preview" } });
       expect(h.call).toHaveBeenCalledWith("saveChatAttachmentDraftText", {
         chatId: "desktop",
         text: "",
@@ -432,12 +443,23 @@ describe("Plan Change controller", () => {
   it.each([null, { ...todayChoice, eligible: [], reason: "Recovery is required." }])(
     "announces that no Workout is eligible without sending chat when the choice is %j",
     async (choice) => {
-      const h = harness(null, []);
+      const h = harness(
+        {
+          status: "rejected",
+          reason: "unsupported-request",
+          explanation: "No eligible Workout can be selected today.",
+        },
+        [],
+      );
       h.setTodayChoice(choice);
       h.controller.openPlanChangeEditor();
       expect(await h.controller.submit("what should i ride today?")).toBe(true);
       expect(h.surface().notice).toBe("No eligible Workout can be selected today.");
-      expect(h.call).toHaveBeenCalledExactlyOnceWith("saveChatAttachmentDraftText", {
+      expect(h.call).toHaveBeenCalledWith(
+        "plan_change.preview",
+        expect.objectContaining({ request: { kind: "text", text: "what should i ride today?" } }),
+      );
+      expect(h.call).toHaveBeenCalledWith("saveChatAttachmentDraftText", {
         chatId: "desktop",
         text: "",
       });
@@ -449,10 +471,9 @@ describe("Plan Change controller", () => {
     "unrelated text",
     "what should i ride today please",
     "what should i ride today? And tomorrow?",
-  ])("sends %j through normal chat", async (message) => {
+  ])("sends %j through normal chat when Change is closed", async (message) => {
     const h = harness(null, []);
     h.setTodayChoice();
-    h.controller.openPlanChangeEditor();
     expect(await h.controller.submit(message)).toBe(true);
     expect(h.call).toHaveBeenCalledWith(
       "enqueueChatMessage",
@@ -482,6 +503,32 @@ describe("Plan Change controller", () => {
     },
   );
 
+  it.each(["different-plan", "no-active-plan"])(
+    "keeps text in normal chat with %s",
+    async (scope) => {
+      const h = harness(null, []);
+      h.setSurface({ open: true, planId: "another-plan" });
+      if (scope === "no-active-plan") h.clearActivePlan();
+      await h.controller.submit("my ftp is 220");
+      expect(h.call).toHaveBeenCalledWith(
+        "enqueueChatMessage",
+        expect.objectContaining({ text: "my ftp is 220" }),
+      );
+      expect(h.call.mock.calls.some(([method]) => method === "plan_change.preview")).toBe(false);
+      h.controller.dispose();
+    },
+  );
+
+  it("routes text while the active Plan has a pending preview", async () => {
+    const h = harness({ status: "previewed", change, version: 8 });
+    await h.controller.submit("my ftp is 220");
+    expect(h.call).toHaveBeenCalledWith(
+      "plan_change.preview",
+      expect.objectContaining({ request: { kind: "text", text: "my ftp is 220" } }),
+    );
+    h.controller.dispose();
+  });
+
   it.each(["busy", "paused"])(
     "does not preview or enqueue today's question while %s",
     async (state) => {
@@ -499,6 +546,44 @@ describe("Plan Change controller", () => {
       h.controller.dispose();
     },
   );
+
+  it.each([
+    "This request is not supported yet. Choose one of the available actions.",
+    "Ask for one change at a time.",
+  ])("renders the backend rejection as a notice: %s", async (explanation) => {
+    const h = harness({ status: "rejected", reason: "unsupported-request", explanation }, []);
+    h.controller.openPlanChangeEditor();
+    await h.controller.submit("some request");
+    expect(h.surface()).toMatchObject({ busy: false, error: null, notice: explanation });
+    expect(h.render.mock.lastCall?.[0].messages).toContainEqual(
+      expect.objectContaining({ role: "athlete", text: "some request" }),
+    );
+    expect(h.call.mock.calls.some(([method]) => method === "enqueueChatMessage")).toBe(false);
+    h.controller.dispose();
+  });
+
+  it("keeps host validation explanations in a text request notice", async () => {
+    const explanation = "This Plan has no remaining Workouts on Wednesday.";
+    const h = harness({ status: "rejected", reason: "invalid-intent", explanation }, []);
+    h.controller.openPlanChangeEditor();
+    await h.controller.submit("no training on wednesdays");
+    expect(h.surface()).toMatchObject({ busy: false, error: null, notice: explanation });
+    h.controller.dispose();
+  });
+
+  it("reserves one attempt while saving the draft and uses a new command for the next submission", async () => {
+    const h = harness({ status: "previewed", change, version: 8 }, []);
+    h.controller.openPlanChangeEditor();
+    const first = h.controller.submit("my ftp is 220");
+    expect(await h.controller.submit("my ftp is 230")).toBe(false);
+    await first;
+    await h.controller.submit("my ftp is 220");
+    const previews = h.call.mock.calls.filter(([method]) => method === "plan_change.preview");
+    expect(previews).toHaveLength(2);
+    expect(previews[0]?.[1]).not.toEqual(previews[1]?.[1]);
+    expect(h.render.mock.lastCall?.[0].messages).toHaveLength(2);
+    h.controller.dispose();
+  });
 
   it("sends the FTP intent and keeps daemon rejection copy", async () => {
     const h = harness({ status: "rejected", reason: "command-conflict" });
@@ -753,6 +838,20 @@ describe("Plan Change controller", () => {
     await h.controller.applyPlanChange("apply");
     expect(h.call).not.toHaveBeenCalled();
     expect(h.surface().notice).toBe("This preview is no longer pending. Training is unchanged.");
+  });
+
+  it("keeps a newer composer draft typed while a text submission is still starting", async () => {
+    const h = harness({ status: "previewed", change, version: 8 }, []);
+    h.setTodayChoice();
+    h.controller.openPlanChangeEditor();
+    const submission = h.controller.submit("wednesdays at most 30 minutes");
+    h.controller.saveAttachmentDraftText("newer composer text");
+    expect(await submission).toBe(true);
+    const saves = h.call.mock.calls
+      .filter(([method]) => method === "saveChatAttachmentDraftText")
+      .map(([, request]) => (request as { text: string }).text);
+    expect(saves.at(-1)).toBe("newer composer text");
+    h.controller.dispose();
   });
 
   it("ignores actions and late responses after disposal", async () => {

--- a/apps/desktop/tests/e2e/plan-change-daily-choice.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change-daily-choice.spec.ts
@@ -321,7 +321,7 @@ for (const appearance of appearances) {
       expect(PlanChangePreviewRpcParamsSchema.parse(chatRequests[0]?.params)).toMatchObject({
         planId: scenario.seed.planId,
         expectedVersion: 3,
-        intent: { kind: "choose-workout", workoutId: selected.workoutId },
+        request: { kind: "text", text: "WHAT SHOULD I RIDE TODAY?!" },
       });
       await chatPending.scrollIntoViewIfNeeded();
       await capture(scenario, "chat-choice");

--- a/apps/desktop/tests/e2e/plan-change-text.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change-text.spec.ts
@@ -1,0 +1,329 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Browser, type Page, type PlaywrightWorkerArgs } from "@playwright/test";
+import { PlanChangePreviewRpcParamsSchema } from "@enduragent/coach-contract";
+import { launchDesktopFixture, type RunningDesktopFixture } from "../helpers/desktop-fixture.js";
+import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
+
+const token = "d".repeat(43);
+const previews = fileURLToPath(new URL("./previews/plan-change-text/", import.meta.url));
+
+interface Scenario {
+  readonly backend: PlanCreationBackend;
+  readonly fixture: RunningDesktopFixture;
+  readonly scratch: string;
+  readonly colorScheme: "light" | "dark";
+  readonly width: number;
+  readonly seed: Awaited<ReturnType<PlanCreationBackend["seedActiveTraining"]>>;
+  browser: Browser;
+  page: Page;
+}
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+async function connect(
+  playwright: Playwright,
+  fixture: RunningDesktopFixture,
+  colorScheme: "light" | "dark",
+  initializeAppearance = false,
+) {
+  const browser = await playwright.chromium.connectOverCDP(fixture.remoteDebuggingUrl);
+  const page = browser
+    .contexts()[0]
+    ?.pages()
+    .find((candidate) => candidate.url().startsWith("enduragent://app/"));
+  if (page === undefined) throw new TypeError("Plan Change renderer is unavailable");
+  await expect(page.locator("[data-shell]")).toHaveAttribute("data-onboarding", "settled", {
+    timeout: 30_000,
+  });
+  await page.emulateMedia({ colorScheme, reducedMotion: "reduce" });
+  if (initializeAppearance) {
+    const navigation = page.getByRole("navigation", { name: "Main navigation" });
+    await navigation.getByRole("button", { name: "Settings", exact: true }).click();
+    const appearance = page
+      .getByRole("group", { name: "Appearance", exact: true })
+      .getByRole("button", { name: colorScheme === "light" ? "Light" : "Dark", exact: true });
+    await appearance.click();
+    await expect(appearance).toHaveAttribute("aria-pressed", "true");
+    await navigation.getByRole("button", { name: "Chat", exact: true }).click();
+  }
+  await expect(page.locator("html")).toHaveAttribute("data-theme", colorScheme);
+  expect(await page.evaluate(() => localStorage.getItem("enduragent.ui.appearance"))).toBe(
+    colorScheme,
+  );
+  return { browser, page };
+}
+
+async function launch(
+  playwright: Playwright,
+  appearance: { readonly width: number; readonly colorScheme: "light" | "dark" },
+): Promise<Scenario> {
+  const scratch = await mkdtemp(join(tmpdir(), "plan-change-text-"));
+  const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+  let fixture: RunningDesktopFixture | undefined;
+  try {
+    await backend.open();
+    const seed = await backend.seedActiveTraining();
+    fixture = await launchDesktopFixture({
+      script: backend.script,
+      token,
+      width: appearance.width,
+      height: 820,
+      colorScheme: appearance.colorScheme,
+      reducedMotion: true,
+      hidden: true,
+      routeChatAttachmentComposer: true,
+    });
+    await fixture.setViewport(appearance.width, 820);
+    const connected = await connect(playwright, fixture, appearance.colorScheme, true);
+    expect(await connected.page.evaluate(() => innerWidth)).toBe(appearance.width);
+    return { backend, fixture, scratch, seed, ...appearance, ...connected };
+  } catch (error) {
+    try {
+      await fixture?.close();
+    } finally {
+      try {
+        await backend.close();
+      } finally {
+        await rm(scratch, { recursive: true, force: true });
+      }
+    }
+    throw error;
+  }
+}
+
+async function capture(scenario: Scenario, name: string): Promise<void> {
+  await mkdir(previews, { recursive: true });
+  const screenshotPath = join(previews, `${name}-${scenario.width}-${scenario.colorScheme}.png`);
+  await scenario.page.screenshot({ path: screenshotPath });
+  await test.info().attach(`${name}-screenshot`, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  await test.info().attach(`${name}-dom`, {
+    body: await scenario.page.content(),
+    contentType: "text/html",
+  });
+  expect(
+    await scenario.page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+  ).toBe(true);
+  await expect(scenario.page.locator("html")).toHaveAttribute("data-theme", scenario.colorScheme);
+}
+
+async function close(scenario: Scenario): Promise<void> {
+  try {
+    await test.info().attach("stored-plan-change", {
+      body: JSON.stringify({
+        card: await scenario.backend.card(),
+        activation: await scenario.backend.inspectActivation(),
+        requests: scenario.backend.creationRequests,
+        seed: scenario.seed,
+        library: await scenario.backend.library(),
+        responses: scenario.backend.changeApplyResponses,
+      }),
+      contentType: "application/json",
+    });
+    await capture(scenario, "final");
+  } finally {
+    await scenario.browser.close().catch(() => {});
+    try {
+      const cleanup = await scenario.fixture.close();
+      await test.info().attach("cleanup", {
+        body: JSON.stringify(cleanup),
+        contentType: "application/json",
+      });
+      expect(cleanup).toEqual({ livePids: [], listenerCount: 0 });
+    } finally {
+      try {
+        await scenario.backend.close();
+      } finally {
+        await rm(scenario.scratch, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+const appearances = [
+  { width: 1180, colorScheme: "light" },
+  { width: 1180, colorScheme: "dark" },
+  { width: 720, colorScheme: "light" },
+  { width: 720, colorScheme: "dark" },
+] as const;
+const durationTitle = "Limit weekday duration";
+const ftpTitle = "Correct FTP";
+
+function changes(scenario: Scenario) {
+  return scenario.page.getByRole("region", { name: "Plan Changes", exact: true });
+}
+
+function pendingCard(scenario: Scenario, title: string) {
+  return changes(scenario)
+    .getByRole("region", { name: title, exact: true })
+    .filter({ has: scenario.page.getByText("Pending", { exact: true }) });
+}
+
+async function send(scenario: Scenario, text: string) {
+  const before = scenario.backend.creationRequests.length;
+  const composer = scenario.page.getByRole("combobox", { name: "Message your coach" });
+  await composer.fill(text);
+  await scenario.page.getByRole("button", { name: "Send message", exact: true }).click();
+  await expect(composer).toHaveValue("");
+  await expect(
+    scenario.page.locator("article.chat-message--athlete").getByText(text, { exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        scenario.backend.creationRequests
+          .slice(before)
+          .filter((request) => request.method === "plan_change.preview").length,
+    )
+    .toBe(1);
+  const requests = scenario.backend.creationRequests
+    .slice(before)
+    .filter((request) => request.method === "plan_change.preview");
+  expect(PlanChangePreviewRpcParamsSchema.parse(requests[0]?.params)).toMatchObject({
+    planId: scenario.seed.planId,
+    expectedVersion: 1,
+    request: { kind: "text", text },
+  });
+}
+
+for (const appearance of appearances) {
+  test(`previews typed changes and explains unsupported requests at ${appearance.width} in ${appearance.colorScheme}`, async ({
+    playwright,
+  }) => {
+    test.setTimeout(120_000);
+    const scenario = await launch(playwright, appearance);
+    try {
+      const initial = await scenario.backend.inspectActivation();
+      await scenario.page
+        .getByRole("navigation", { name: "Main navigation" })
+        .getByRole("button", { name: "Plan", exact: true })
+        .click();
+      await scenario.page
+        .getByRole("region", { name: "Plan library", exact: true })
+        .getByRole("button", { name: "Change in Chat", exact: true })
+        .click();
+      await changes(scenario)
+        .getByRole("button", { name: "Change one thing", exact: true })
+        .click();
+      const editor = changes(scenario).getByRole("region", {
+        name: "What needs to change?",
+        exact: true,
+      });
+      await expect(editor.getByRole("combobox", { name: "Change", exact: true })).toContainText(
+        "Weekday duration cap",
+      );
+      await expect(editor.getByRole("combobox", { name: "Weekday", exact: true })).toContainText(
+        "Wed",
+      );
+      await expect(
+        editor.getByRole("spinbutton", {
+          name: "Duration limit in minutes",
+          exact: true,
+        }),
+      ).toHaveValue("30");
+      await editor.getByRole("button", { name: "Preview change", exact: true }).click();
+      const card = pendingCard(scenario, durationTitle);
+      await expect(card.getByRole("heading")).toBeFocused();
+      const cardPreview = (await scenario.backend.library()).changes.find(
+        (change) => change.status === "pending",
+      );
+      if (!cardPreview) throw new TypeError("Weekday duration preview is unavailable");
+      expect(cardPreview.intent).toEqual({ kind: "weekday-duration", day: 3, minutes: 30 });
+      expect(cardPreview.diff).toHaveLength(4);
+      const cardRows = await card
+        .getByRole("table", {
+          name: "Affected individual Workouts",
+          exact: true,
+        })
+        .getByRole("cell")
+        .allTextContents();
+      await capture(scenario, "card-duration-preview");
+      await card.getByRole("button", { name: "Cancel", exact: true }).click();
+      await expect(card).toHaveCount(0);
+
+      await send(scenario, "wednesdays at most 30 minutes");
+      const typed = pendingCard(scenario, durationTitle);
+      await expect(typed.getByRole("heading")).toBeFocused();
+      const typedPreview = (await scenario.backend.library()).changes.find(
+        (change) => change.status === "pending",
+      );
+      expect(typedPreview?.intent).toEqual(cardPreview.intent);
+      expect(typedPreview?.diff).toEqual(cardPreview.diff);
+      expect(typedPreview?.totals).toEqual(cardPreview.totals);
+      await expect(
+        typed
+          .getByRole("table", {
+            name: "Affected individual Workouts",
+            exact: true,
+          })
+          .getByRole("cell"),
+      ).toHaveText(cardRows);
+      await typed.getByRole("heading").scrollIntoViewIfNeeded();
+      await capture(scenario, "text-duration-preview");
+      await typed.getByRole("button", { name: "Cancel", exact: true }).click();
+      await expect(typed).toHaveCount(0);
+
+      await send(scenario, "my ftp is 220");
+      const ftp = pendingCard(scenario, ftpTitle);
+      await expect(ftp.getByRole("heading")).toBeFocused();
+      const ftpPreview = (await scenario.backend.library()).changes.find(
+        (change) => change.status === "pending",
+      );
+      expect(ftpPreview?.intent).toEqual({ kind: "ftp", watts: 220 });
+      expect(ftpPreview?.diff).toHaveLength(12);
+      expect(
+        ftpPreview?.diff.every((row) => row.before?.power === null && row.after?.power === 220),
+      ).toBe(true);
+      await expect(
+        ftp
+          .getByRole("table", {
+            name: "Affected individual Workouts",
+            exact: true,
+          })
+          .getByRole("cell"),
+      ).toHaveText(ftpPreview?.diff.map(() => / → .* · \d+ min · 220 W$/) ?? []);
+      await ftp.getByRole("heading").scrollIntoViewIfNeeded();
+      await capture(scenario, "text-ftp-preview");
+      await ftp.getByRole("button", { name: "Cancel", exact: true }).click();
+      await expect(ftp).toHaveCount(0);
+
+      const previewsBeforeRejections = (await scenario.backend.library()).changes;
+      for (const request of [
+        {
+          text: "paint my bicycle blue",
+          explanation: "This request is not supported yet. Choose one of the available actions.",
+          screenshot: "unsupported-notice",
+        },
+        {
+          text: "wednesdays at most 30 minutes and my ftp is 220",
+          explanation: "Ask for one change at a time.",
+          screenshot: "combined-notice",
+        },
+      ]) {
+        await send(scenario, request.text);
+        const notice = changes(scenario).getByRole("status");
+        await expect(notice).toHaveText(request.explanation);
+        await expect(changes(scenario).getByText("Pending", { exact: true })).toHaveCount(0);
+        expect((await scenario.backend.library()).changes).toEqual(previewsBeforeRejections);
+        await notice.scrollIntoViewIfNeeded();
+        await capture(scenario, request.screenshot);
+      }
+      const previewRequests = scenario.backend.creationRequests
+        .filter((request) => request.method === "plan_change.preview")
+        .map((request) => PlanChangePreviewRpcParamsSchema.parse(request.params));
+      expect(previewRequests).toHaveLength(5);
+      expect(new Set(previewRequests.map((request) => request.commandId)).size).toBe(5);
+      const final = await scenario.backend.inspectActivation();
+      expect(final.workouts).toEqual(initial.workouts);
+      expect(final.revisions).toEqual(initial.revisions);
+      expect(final.planningPlans).toEqual(initial.planningPlans);
+    } finally {
+      await close(scenario);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- While the Plan Change surface is open for the active Plan, every composer message without attachments goes to `plan_change.preview` as `{ kind: "text", text }` through the existing preview path (one command id per attempt, busy state, focus on the preview heading) and appears in the transcript as an athlete message. Rejections render the backend explanation as a notice.
- Outside the surface, messages reach the coach as before, including commitments text on the creation surface. The special-case `what should i ride today` routing is replaced by the backend matcher.
- The legacy `plan_change` planning-request suggestion is hidden while a Chat-managed active Plan exists, including when the library is temporarily unavailable.
- A newer draft typed while a submission is starting is never overwritten (generation and revision guard).
- New Playwright spec plan-change-text.spec.ts: `wednesdays at most 30 minutes` previews the same diff as the card, `my ftp is 220` previews the FTP correction, an unsupported sentence and a combined sentence show their notices, at 1180/720 light and dark.

## Verification
astra high read-only: round 1 two findings (draft cleared after the planning-request wait, suggestion reappearing on an unavailable library), fixed inline with regression tests; round 2 pass.

| Check | Result |
|---|---|
| `pnpm check` | pass |
| `vitest --project renderer-dom --maxWorkers 2` | 739 passed |
| `vitest --project workspace` chat + Plan Change controllers | 200 passed |
| playwright text + plan-change + commitments + chat-core | pass |

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn