### PR TITLE
feat(desktop): start Plan creation from the /plan command in Chat

### DIFF
--- a/.changeset/plan-slash-command-entry.md
+++ b/.changeset/plan-slash-command-entry.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Plan creation in Chat starts from the `/plan` command in the composer; the Chat surface no longer shows a Start a Plan button. Pressing Enter on an exactly typed slash command sends it immediately.
+
+User-facing: Type /plan in the chat box to start a Plan. The Start a Plan button in Chat is gone; the Plan page keeps its own.

--- a/apps/desktop-renderer/src/chat/commands.ts
+++ b/apps/desktop-renderer/src/chat/commands.ts
@@ -5,7 +5,7 @@ export interface SlashCommand {
 
 export const SLASH_COMMANDS: readonly SlashCommand[] = Object.freeze([
   Object.freeze({ command: "/start", description: "Start a fresh session" }),
-  Object.freeze({ command: "/plan", description: "Generate a training plan" }),
+  Object.freeze({ command: "/plan", description: "Start a Plan in Chat" }),
   Object.freeze({ command: "/workout", description: "Get today's workout" }),
   Object.freeze({ command: "/status", description: "Check current fitness, fatigue, and form" }),
   Object.freeze({ command: "/review", description: "Review your last session" }),

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -2194,6 +2194,27 @@ export function createChatController(input: {
       const submittedAttachmentGeneration = attachmentGeneration;
       await waitForPlanningRequestLoad();
       if (
+        message.trim().toLowerCase() === "/plan" &&
+        attachmentIds.length === 0 &&
+        canChat() &&
+        queueLoaded &&
+        !disposed &&
+        !resetBlocksWork() &&
+        !decisionBlocksWork()
+      ) {
+        if (planCreation === null) await controller.startPlanCreation();
+        else if (planCreationPaused) controller.continuePlanCreation();
+        else return false;
+        if (
+          attachmentGenerationIsCurrent(submittedAttachmentGeneration) &&
+          submittedTextRevision === attachmentTextRevision
+        ) {
+          saveAttachmentDraftText("");
+          await attachmentTextSaveTask;
+        }
+        return true;
+      }
+      if (
         !canChat() ||
         !queueLoaded ||
         (!/\S/u.test(message) && attachmentIds.length === 0) ||

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -189,6 +189,13 @@ export function Composer(props: {
       }
       if (event.key === "Enter" || event.key === "Tab") {
         event.preventDefault();
+        if (
+          event.key === "Enter" &&
+          matches[active]?.command === event.currentTarget.value.trim().toLowerCase()
+        ) {
+          void submit();
+          return;
+        }
         accept(active);
         return;
       }

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -226,31 +226,14 @@ export function PlanCreationDock(props: {
   const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
   const focusRevision = useEnduragentStore((state) => state.chat.planCreationFocusRevision);
   const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
-  const decision = useEnduragentStore((state) => state.chat.decision);
   const actions = useEnduragentStore((state) => state.chatActions);
-  const startButton = useRef<HTMLButtonElement>(null);
-  const decisionPending =
-    decision?.status === "unanswered" ||
-    (decision?.status === "answered" && decision.continuation.status === "pending");
   useEffect(() => {
-    if (focusRequest?.target === "start") startButton.current?.focus();
+    if (focusRequest?.target === "start") {
+      queueMicrotask(() => document.getElementById("message")?.focus());
+    }
   }, [focusRequest?.revision, focusRequest?.target]);
   if (!loaded) return null;
-  if (model === null) {
-    return (
-      <div className="flex min-w-0 justify-end gap-inset" data-parity="start.row">
-        <Button
-          ref={startButton}
-          variant="outline"
-          data-parity="start.button"
-          disabled={busy || actions === null || decisionPending}
-          onClick={() => actions?.startPlanCreation()}
-        >
-          Start a Plan
-        </Button>
-      </div>
-    );
-  }
+  if (model === null) return null;
   if (paused || (editingKey === null && model.openQuestion === null)) return null;
   const editedSummary =
     editingKey === null

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -520,6 +520,8 @@ describe("chat view adapter", () => {
 
     expect(published.at(-1)).toMatchObject({
       planCreation: null,
+      planCreationFocusRequest: { target: "start", revision: 1 },
+      inputDisabled: false,
       timeline: [{ kind: "plan-creation-discard", eventId: "01J00000000000000000000000" }],
     });
 

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -2342,7 +2342,7 @@ describe("chat controller", () => {
     });
     await expect(controller.submit("Chat continues")).resolves.toBe(true);
     expect(chatMessages(fake)).toEqual(["Chat continues"]);
-    await controller.startPlanCreation();
+    await expect(controller.submit("/plan")).resolves.toBe(true);
     expect(controls.at(-1)?.planCreation).toMatchObject({
       value: nextCard,
       discardEvents: [{ eventId: completeCard.creationId, afterMessageId: null }],
@@ -2486,7 +2486,7 @@ describe("chat controller", () => {
     });
   });
 
-  it("returns focus to Start when refresh removes a Card behind its discard dialog", async () => {
+  it("requests composer focus when refresh removes a Card behind its discard dialog", async () => {
     const card: PlanCreationCardModel = {
       draft: null,
       calendarWindow: null,
@@ -4324,6 +4324,74 @@ describe("Plan library Chat entry", () => {
       value: draft,
       focusRequest: { target: "activate" },
     });
+    controller.dispose();
+  });
+
+  it("starts Plan Creation with /plan and clears the saved composer without sending to the coach", async () => {
+    const start = vi.fn(async (): Promise<PlanCreationStartRpcResult> => ({
+      status: "started",
+      outcome: "created",
+      planCreation: creation,
+    }));
+    const saveText = vi.fn(async () => emptyComposer());
+    const fake = client(replies(), {
+      startPlanCreation: start,
+      saveAttachmentDraftText: saveText,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+
+    await expect(controller.submit("/plan")).resolves.toBe(true);
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(start).toHaveBeenCalledWith({ commandId: expect.any(String) });
+    expect(saveText).toHaveBeenCalledWith("");
+    expect(controls.at(-1)?.planCreation?.value).toEqual(creation);
+    expect(chatMessages(fake)).toEqual([]);
+    controller.dispose();
+  });
+
+  it("resumes a paused Plan question with /plan without starting another creation", async () => {
+    const start =
+      vi.fn<(request: PlanCreationStartRpcParams) => Promise<PlanCreationStartRpcResult>>();
+    const fake = client(replies(), {
+      listPlanningRequests: async () => ({ deliveries: [], planCreation: creation }),
+      startPlanCreation: start,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    controller.pausePlanCreation();
+    expect(controls.at(-1)?.planCreation?.paused).toBe(true);
+    const revision = controls.at(-1)?.planCreation?.focusRevision ?? 0;
+
+    await expect(controller.submit("/plan")).resolves.toBe(true);
+
+    expect(controls.at(-1)?.planCreation).toMatchObject({ value: creation, paused: false });
+    expect(controls.at(-1)?.planCreation?.focusRevision).toBeGreaterThan(revision);
+    expect(start).not.toHaveBeenCalled();
+    expect(chatMessages(fake)).toEqual([]);
+    controller.dispose();
+  });
+
+  it("ignores /plan during an open question without sending to the coach", async () => {
+    const start =
+      vi.fn<(request: PlanCreationStartRpcParams) => Promise<PlanCreationStartRpcResult>>();
+    const saveText = vi.fn(async () => emptyComposer());
+    const fake = client(replies(), {
+      listPlanningRequests: async () => ({ deliveries: [], planCreation: creation }),
+      startPlanCreation: start,
+      saveAttachmentDraftText: saveText,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    const before = controls.at(-1)?.planCreation;
+
+    await expect(controller.submit("/plan")).resolves.toBe(false);
+
+    expect(controls.at(-1)?.planCreation).toEqual(before);
+    expect(start).not.toHaveBeenCalled();
+    expect(saveText).not.toHaveBeenCalled();
+    expect(chatMessages(fake)).toEqual([]);
     controller.dispose();
   });
 

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -2323,14 +2323,13 @@ describe("chat surface", () => {
       useEnduragentStore.getState().bindChatActions(actions);
       render(<Harness />);
       setChat({ planCreationLoaded: true, decision: unansweredDecision() });
-      const startButton = screen.getByRole("button", { name: "Start a Plan" });
-      expect(startButton).toBeDisabled();
-      await userEvent.click(startButton);
-      expect(actions.startPlanCreation).not.toHaveBeenCalled();
+      expect(screen.queryByRole("button", { name: "Start a Plan" })).toBeNull();
       setChat({ decision: null });
-      expect(startButton).toBeEnabled();
-      await userEvent.click(startButton);
-      expect(actions.startPlanCreation).toHaveBeenCalledOnce();
+      await userEvent.type(composer(), "/plan");
+      await userEvent.keyboard("{Enter}");
+      expect(actions.submit).toHaveBeenCalledTimes(1);
+      expect(actions.submit).toHaveBeenCalledWith("/plan");
+      await waitFor(() => expect(composer()).toHaveValue(""));
       setChat({
         planCreation: planCreationModel(goalQuestion("What are you preparing for?")),
         sendDisabled: true,
@@ -3654,7 +3653,7 @@ describe("chat surface", () => {
       await waitFor(() => expect(discard).toHaveFocus());
     });
 
-    it("disables discard confirmation in flight and focuses Start after success", async () => {
+    it("disables discard confirmation in flight and focuses the composer after success", async () => {
       const actions = stubActions();
       const model = planCreationModel(null, {
         version: 3,
@@ -3701,11 +3700,11 @@ describe("chat surface", () => {
         inputDisabled: false,
         timeline: [{ kind: "plan-creation-discard", eventId: "01J00000000000000000000000" }],
       });
-      const start = screen.getByRole("button", { name: "Start a Plan" });
-      await waitFor(() => expect(start).toHaveFocus());
+      await waitFor(() => expect(composer()).toHaveFocus());
+      expect(screen.queryByRole("button", { name: "Start a Plan" })).toBeNull();
       const discarded = document.querySelector('[data-parity="discarded.record"]');
       expect(discarded).not.toBeNull();
-      expect(discarded?.compareDocumentPosition(start)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(discarded?.compareDocumentPosition(composer())).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
       expect(composer()).toBeEnabled();
       expect(screen.queryByText("Build steady power", { exact: true })).toBeNull();
       expect(screen.getByText("Plan creation discarded")).toBeVisible();

--- a/apps/desktop/tests/e2e/plan-calendar.spec.ts
+++ b/apps/desktop/tests/e2e/plan-calendar.spec.ts
@@ -152,7 +152,11 @@ async function replacementDraft(scenario: Scenario, mode: "fixed" | "flexible" =
   await navigate(scenario, "Plan");
   await expect(active(scenario)).toBeVisible();
   await navigate(scenario, "Chat");
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await expect.poll(async () => (await scenario.backend.card())?.status).toBe("in-progress");
   await choose(scenario, "fitness");
   await choose(scenario, "4");

--- a/apps/desktop/tests/e2e/plan-creation-slice1.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice1.spec.ts
@@ -90,7 +90,11 @@ async function choose(page: Page, backend: PlanCreationBackend, version: number,
 }
 
 async function answerThroughFitnessSuccess(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await waitForVersion(scenario.backend, 1);
   await choose(scenario.page, scenario.backend, 2, "fitness");
   await choose(scenario.page, scenario.backend, 3, "8");
@@ -148,7 +152,11 @@ test("persists the Fitness success choice and restores the Restriction Card", as
 test("restores the Plan length Card after relaunching between answers", async ({ playwright }) => {
   const scenario = await launch(playwright);
   try {
-    await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+    await scenario.page.locator("#message").fill("/plan");
+    await scenario.page.locator("#message").press("Enter");
+    await expect(
+      scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+    ).toBeVisible();
     await waitForVersion(scenario.backend, 1);
     await choose(scenario.page, scenario.backend, 2, "fitness");
     await relaunch(scenario, playwright);

--- a/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
@@ -217,7 +217,11 @@ async function choose(page: Page, backend: PlanCreationBackend, version: number,
 }
 
 async function startFitnessGoal(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await waitForVersion(scenario.backend, 1);
   await choose(scenario.page, scenario.backend, 2, "fitness");
 }
@@ -482,7 +486,11 @@ for (const appearance of [
       expect(await scenario.backend.answers()).toEqual(answers);
     };
     try {
-      await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+      await scenario.page.locator("#message").fill("/plan");
+      await scenario.page.locator("#message").press("Enter");
+      await expect(
+        scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+      ).toBeVisible();
       await waitForVersion(scenario.backend, 1);
       await expect(question("goal").getByRole("heading")).toBeFocused();
       await capture("goal");
@@ -689,8 +697,12 @@ test("preserves ordinary Chat, Past chats, and active Plan editing during creati
   try {
     const originalPlan = await readPlanFacts();
     await expect(scenario.page.getByText(historyText, { exact: true })).toBeVisible();
-    await composer.fill("Keep this ordinary Chat draft.");
     await startFitnessGoal(scenario);
+    await expect(composer).toHaveValue("");
+    await scenario.page.getByRole("button", { name: "Later", exact: true }).click();
+    await expect(composer).toBeEnabled();
+    await composer.fill("Keep this ordinary Chat draft.");
+    await scenario.page.getByRole("button", { name: "Continue", exact: true }).click();
     await expect(composer).toBeDisabled();
     await expect(composer).toHaveValue("Keep this ordinary Chat draft.");
     await scenario.page.getByRole("button", { name: "Later", exact: true }).click();

--- a/apps/desktop/tests/e2e/plan-creation-slice3.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice3.spec.ts
@@ -130,9 +130,7 @@ async function relaunch(scenario: Scenario, playwright: Playwright): Promise<voi
   await scenario.fixture.setViewport(scenario.width, 820);
   Object.assign(scenario, await connect(playwright, scenario.fixture, scenario.colorScheme));
   expect(await scenario.page.evaluate(() => innerWidth)).toBe(scenario.width);
-  await expect(
-    scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
-  ).toBeVisible();
+  await expect(scenario.page.locator("#message")).toBeVisible();
   await test.info().attach("relaunch-timing", {
     body: JSON.stringify({ milliseconds: performance.now() - started }),
     contentType: "application/json",
@@ -181,7 +179,7 @@ async function capture(page: Page, name: string): Promise<void> {
       header: '[data-slot="dialog-header"]',
       actions: '[data-slot="dialog-footer"]',
       consequence: '[data-parity="discarded.record"]',
-      start: '[data-parity="start.row"]',
+      composer: "#message",
     };
     const result: Record<string, unknown> = {};
     for (const [key, selector] of Object.entries(selectors)) {
@@ -206,10 +204,10 @@ async function capture(page: Page, name: string): Promise<void> {
       };
     }
     const consequence = document.querySelector('[data-parity="discarded.record"]');
-    const start = document.querySelector('[data-parity="start.row"]');
-    result.consequenceBeforeStart =
-      consequence !== null && start !== null
-        ? Boolean(consequence.compareDocumentPosition(start) & Node.DOCUMENT_POSITION_FOLLOWING)
+    const composer = document.querySelector("#message");
+    result.consequenceBeforeComposer =
+      consequence !== null && composer !== null
+        ? Boolean(consequence.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING)
         : null;
     result.environment = {
       width: innerWidth,
@@ -231,7 +229,11 @@ async function waitForVersion(backend: PlanCreationBackend, version: number): Pr
 }
 
 async function startAndAnswerGoal(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await waitForVersion(scenario.backend, 1);
   await scenario.page.getByRole("button", { name: "Improve without an event" }).click();
   await waitForVersion(scenario.backend, 2);
@@ -262,7 +264,7 @@ async function discardPlanCreation(page: Page): Promise<void> {
   await openDiscardConfirmation(page);
   const started = performance.now();
   await page.getByRole("button", { name: "Discard creation" }).click();
-  await expect(page.getByRole("button", { name: "Start a Plan", exact: true })).toBeFocused();
+  await expect(page.locator("#message")).toBeFocused();
   await test.info().attach("discard-timing", {
     body: JSON.stringify({ milliseconds: performance.now() - started }),
     contentType: "application/json",
@@ -275,14 +277,14 @@ async function discardPlanCreation(page: Page): Promise<void> {
       { exact: true },
     ),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Start a Plan" })).toBeVisible();
+  await expect(page.locator("#message")).toBeVisible();
   await expect(page.getByRole("combobox", { name: "Message your coach" })).toBeEnabled();
   expect(
     await page.locator('[data-parity="discarded.record"]').evaluate((record) => {
-      const start = document.querySelector('[data-parity="start.row"]');
+      const composer = document.querySelector("#message");
       return (
-        start !== null &&
-        Boolean(record.compareDocumentPosition(start) & Node.DOCUMENT_POSITION_FOLLOWING)
+        composer !== null &&
+        Boolean(record.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING)
       );
     }),
   ).toBe(true);
@@ -341,8 +343,7 @@ for (const appearance of [
       await expect(scenario.backend.inspectDiscard()).resolves.toEqual(beforeDiscard);
 
       await discardPlanCreation(scenario.page);
-      const start = scenario.page.getByRole("button", { name: "Start a Plan" });
-      await expect(start).toBeFocused();
+      await expect(scenario.page.locator("#message")).toBeFocused();
       const afterDiscard = await scenario.backend.inspectDiscard();
       expect(afterDiscard.creations).toEqual([
         {
@@ -362,7 +363,7 @@ for (const appearance of [
       await expectNoPlanCreationSummaries(scenario.page);
 
       await relaunch(scenario, playwright);
-      await expect(scenario.page.getByRole("button", { name: "Start a Plan" })).toBeVisible();
+      await expect(scenario.page.locator("#message")).toBeVisible();
       await expectNoPlanCreationSummaries(scenario.page);
     } finally {
       await close(scenario);
@@ -385,7 +386,7 @@ test("preserves an ordinary Chat turn after discard and relaunch", async ({ play
 
     await relaunch(scenario, playwright);
     await expect(scenario.backend.inspectUnrelated()).resolves.toEqual(unrelatedBeforeDiscard);
-    await expect(scenario.page.getByRole("button", { name: "Start a Plan" })).toBeVisible();
+    await expect(scenario.page.locator("#message")).toBeVisible();
     await expect(scenario.page.getByText(ordinaryPrompt, { exact: true })).toBeVisible();
     await expect(scenario.page.getByText(ordinaryCoachReply, { exact: true })).toBeVisible();
   } finally {
@@ -402,7 +403,11 @@ test("starts a distinct Plan Creation after discard", async ({ playwright }) => 
     if (discardedId === undefined) throw new TypeError("Plan Creation row is unavailable");
     await discardPlanCreation(scenario.page);
 
-    await scenario.page.getByRole("button", { name: "Start a Plan" }).click();
+    await scenario.page.locator("#message").fill("/plan");
+    await scenario.page.locator("#message").press("Enter");
+    await expect(
+      scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+    ).toBeVisible();
     await expect(
       scenario.page.getByRole("heading", {
         name: "What do you want this Plan to prepare you for?",
@@ -439,9 +444,7 @@ for (const failure of ["before", "after"] as const) {
       if (failure === "before") expect(await scenario.backend.inspectDiscard()).toEqual(before);
       else expect((await scenario.backend.inspectDiscard()).creations[0]?.status).toBe("discarded");
       await scenario.page.getByRole("button", { name: "Discard creation", exact: true }).click();
-      await expect(
-        scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
-      ).toBeFocused();
+      await expect(scenario.page.locator("#message")).toBeFocused();
       const requests = scenario.backend.creationRequests.filter(
         (request) => request.method === "plan_creation.discard",
       );

--- a/apps/desktop/tests/e2e/plan-creation-slice4.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice4.spec.ts
@@ -184,7 +184,11 @@ async function continueAnswer(scenario: Scenario): Promise<void> {
 }
 
 async function completeFitness(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await expect.poll(async () => (await scenario.backend.card())?.version).toBe(1);
   await choose(scenario, "fitness");
   await choose(scenario, "4");

--- a/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
@@ -167,7 +167,11 @@ async function continueAnswer(scenario: Scenario): Promise<void> {
 }
 
 async function completeFitness(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await expect.poll(async () => (await scenario.backend.card())?.version).toBe(1);
   await choose(scenario, "fitness");
   await choose(scenario, "4");

--- a/apps/desktop/tests/e2e/plan-library.spec.ts
+++ b/apps/desktop/tests/e2e/plan-library.spec.ts
@@ -261,9 +261,7 @@ for (const appearance of [
       await expect(
         scenario.page.getByText("Plan creation discarded", { exact: true }),
       ).toBeVisible();
-      await expect(
-        scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
-      ).toBeFocused();
+      await expect(scenario.page.locator("#message")).toBeFocused();
       await expect(
         scenario.page.getByRole("button", { name: "Continue in Chat", exact: true }),
       ).toHaveCount(0);
@@ -271,7 +269,11 @@ for (const appearance of [
       expect(after.active).toEqual(before.active);
       expect(after.closed).toEqual(before.closed);
       await capture(scenario, "creation-discarded");
-      await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+      await scenario.page.locator("#message").fill("/plan");
+      await scenario.page.locator("#message").press("Enter");
+      await expect(
+        scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+      ).toBeVisible();
       await expect(
         scenario.page
           .locator('[data-parity="question.card"][data-question="goal"]')


### PR DESCRIPTION
## Summary
- Removes the `Start a Plan` button from the Chat surface; the prototype (plan-in-chat-2026-09-01) offers that action only in the Plan library, which keeps its header button.
- `/plan` typed in the composer starts Plan creation, or resumes a paused one; the slash list describes it as `Start a Plan in Chat`.
- Enter on an exactly typed slash command submits it instead of completing it first (Tab and partial text still complete).
- Discarding a creation returns focus to the composer.

## Verification
- Root `pnpm check` green; renderer-dom 749 passed; controller and adapter suites 117 passed.
- E2E: plan-creation-slice1 to slice5, plan-calendar and plan-library specs re-pointed at the `/plan` entry, 52 scenarios passed.

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn