### PR TITLE
fix(desktop): match the Plan-in-Chat prototype across creation, Draft, Change and library cards

### DIFF
--- a/.changeset/plan-in-chat-parity.md
+++ b/.changeset/plan-in-chat-parity.md
@@ -3,6 +3,6 @@
 "cycling-coach": patch
 ---
 
-Plan-in-Chat surfaces now follow the prototype: question cards carry Later in the header, the progress card shows Discard as a button, choice rows keep their detail lines, the availability weekdays are a labelled fieldset, Draft and Change cards use the prototype's spacing and status pills, compact layouts stack facts, and scroll areas no longer show permanent scrollbars.
+Plan-in-Chat surfaces now follow the prototype: question cards carry Later in the header, the progress card shows Discard as a button, choice rows omit filler details, the availability weekdays are a labelled fieldset, Draft and Change cards use the prototype's spacing and status pills, compact layouts stack facts, and scroll areas no longer show permanent scrollbars.
 
-User-facing: Plan cards in Chat look and behave like the approved design on wide and compact windows, in light and dark.
+User-facing: Plan cards in Chat use consistent dates, shorter choices, and clear calendar status. Repeated notices and labels have been removed.

--- a/.changeset/plan-in-chat-parity.md
+++ b/.changeset/plan-in-chat-parity.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Plan-in-Chat surfaces now follow the prototype: question cards carry Later in the header, the progress card shows Discard as a button, choice rows keep their detail lines, the availability weekdays are a labelled fieldset, Draft and Change cards use the prototype's spacing and status pills, compact layouts stack facts, and scroll areas no longer show permanent scrollbars.
+
+User-facing: Plan cards in Chat look and behave like the approved design on wide and compact windows, in light and dark.

--- a/.changeset/plan-slash-command-entry.md
+++ b/.changeset/plan-slash-command-entry.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+Plan creation in Chat starts from the `/plan` command in the composer; the Chat surface no longer shows a Start a Plan button. Pressing Enter on an exactly typed slash command sends it immediately.
+
+User-facing: Type /plan in the chat box to start a Plan. The Start a Plan button in Chat is gone; the Plan page keeps its own.

--- a/apps/desktop-renderer/src/chat/commands.ts
+++ b/apps/desktop-renderer/src/chat/commands.ts
@@ -5,7 +5,7 @@ export interface SlashCommand {
 
 export const SLASH_COMMANDS: readonly SlashCommand[] = Object.freeze([
   Object.freeze({ command: "/start", description: "Start a fresh session" }),
-  Object.freeze({ command: "/plan", description: "Generate a training plan" }),
+  Object.freeze({ command: "/plan", description: "Start a Plan in Chat" }),
   Object.freeze({ command: "/workout", description: "Get today's workout" }),
   Object.freeze({ command: "/status", description: "Check current fitness, fatigue, and form" }),
   Object.freeze({ command: "/review", description: "Review your last session" }),

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -2205,6 +2205,7 @@ export function createChatController(input: {
         if (planCreation === null) await controller.startPlanCreation();
         else if (planCreationPaused) controller.continuePlanCreation();
         else return false;
+        if (planCreation === null) return false;
         if (
           attachmentGenerationIsCurrent(submittedAttachmentGeneration) &&
           submittedTextRevision === attachmentTextRevision

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -2194,6 +2194,27 @@ export function createChatController(input: {
       const submittedAttachmentGeneration = attachmentGeneration;
       await waitForPlanningRequestLoad();
       if (
+        message.trim().toLowerCase() === "/plan" &&
+        attachmentIds.length === 0 &&
+        canChat() &&
+        queueLoaded &&
+        !disposed &&
+        !resetBlocksWork() &&
+        !decisionBlocksWork()
+      ) {
+        if (planCreation === null) await controller.startPlanCreation();
+        else if (planCreationPaused) controller.continuePlanCreation();
+        else return false;
+        if (
+          attachmentGenerationIsCurrent(submittedAttachmentGeneration) &&
+          submittedTextRevision === attachmentTextRevision
+        ) {
+          saveAttachmentDraftText("");
+          await attachmentTextSaveTask;
+        }
+        return true;
+      }
+      if (
         !canChat() ||
         !queueLoaded ||
         (!/\S/u.test(message) && attachmentIds.length === 0) ||

--- a/apps/desktop-renderer/src/lib/date.ts
+++ b/apps/desktop-renderer/src/lib/date.ts
@@ -1,20 +1,4 @@
-const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
-
-function civilDate(value: string): Date | null {
-  if (!CIVIL_DATE_PATTERN.test(value)) return null;
-  const date = new Date(`${value}T00:00:00.000Z`);
-  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value ? date : null;
-}
-
-export function formatCivilDate(value: string, options?: Intl.DateTimeFormatOptions): string {
-  const date = civilDate(value);
-  if (date === null) return "Unknown date";
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: options === undefined ? "medium" : undefined,
-    ...options,
-    timeZone: "UTC",
-  }).format(date);
-}
+export { formatCivilDate } from "@enduragent/coach-contract";
 
 export function formatInstantDateTime(value: string): string {
   const date = new Date(value);

--- a/apps/desktop-renderer/src/plan/creation-title.ts
+++ b/apps/desktop-renderer/src/plan/creation-title.ts
@@ -1,0 +1,25 @@
+import type { PlanCreationCardModel } from "@enduragent/coach-contract";
+
+function dateLabel(value: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T12:00:00Z`));
+}
+
+export function creationTitle(creation: PlanCreationCardModel): string {
+  const summary = creation.answeredSummaries.find((answer) => answer.answerKey === "goal");
+  if (summary?.answer.kind !== "goal") return "New Plan";
+  const goal = summary.answer.goal;
+  if (goal.kind === "fitness") return goal.outcome ?? "Improve fitness";
+  if (goal.kind === "event-manual") return `${goal.name} · ${dateLabel(goal.date)}`;
+  const candidate =
+    summary.question.kind === "goal-question"
+      ? summary.question.candidates.find((item) => item.candidateId === goal.candidateId)
+      : undefined;
+  return candidate === undefined
+    ? summary.detail
+    : `${candidate.name} · ${dateLabel(candidate.date)}`;
+}

--- a/apps/desktop-renderer/src/plan/creation-title.ts
+++ b/apps/desktop-renderer/src/plan/creation-title.ts
@@ -1,25 +1,17 @@
+import { formatCivilDate } from "../lib/date";
 import type { PlanCreationCardModel } from "@enduragent/coach-contract";
-
-function dateLabel(value: string): string {
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(`${value}T12:00:00Z`));
-}
 
 export function creationTitle(creation: PlanCreationCardModel): string {
   const summary = creation.answeredSummaries.find((answer) => answer.answerKey === "goal");
   if (summary?.answer.kind !== "goal") return "New Plan";
   const goal = summary.answer.goal;
   if (goal.kind === "fitness") return goal.outcome ?? "Improve fitness";
-  if (goal.kind === "event-manual") return `${goal.name} · ${dateLabel(goal.date)}`;
+  if (goal.kind === "event-manual") return `${goal.name} · ${formatCivilDate(goal.date)}`;
   const candidate =
     summary.question.kind === "goal-question"
       ? summary.question.candidates.find((item) => item.candidateId === goal.candidateId)
       : undefined;
   return candidate === undefined
     ? summary.detail
-    : `${candidate.name} · ${dateLabel(candidate.date)}`;
+    : `${candidate.name} · ${formatCivilDate(candidate.date)}`;
 }

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -381,6 +381,7 @@ export function createChatViewAdapter(input: {
         ? null
         : (state.activeTurn?.error?.athleteMessage ??
           (planActivated ? null : planCreation?.notice) ??
+          (planCreation?.value == null ? planCreation?.error : null) ??
           (state.status === "streaming" ? null : state.progress)),
       coachProgress:
         state.status === "streaming" && state.activeTurn?.error === null ? state.progress : null,

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -638,7 +638,7 @@ export function createPlanViewAdapter(input: {
         sourceScenarioId: model.scenarioId,
         destinationScenarioId: model.scenarioId === "PL-S079" ? "PL-S004" : "PL-S001",
         returnFocusId:
-          model.scenarioId === "PL-S079" ? "plan-replacement-trigger" : "plan-start-coach",
+          model.scenarioId === "PL-S079" ? "plan-replacement-trigger" : "start-plan",
       });
     },
     async submitCoach(message) {

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -161,7 +161,7 @@ export function ChatView(): ReactElement {
       ref={surface}
       className="chat-surface grid min-h-0 min-w-0 flex-1 grid-rows-[52px_minmax(0,1fr)] bg-bg"
     >
-      <header className="flex items-center justify-between border-b border-line px-[calc(var(--inset)*3)] max-[760px]:px-[calc(var(--inset)*2)]">
+      <header className="flex items-center justify-between border-b border-line px-[calc(var(--inset)*3)] max-md:px-[calc(var(--inset)*2)]">
         <h1 className="m-0 text-sm font-semibold">Chat</h1>
         {compact ? (
           <Dialog open={contextDrawerOpen} onOpenChange={setContextDrawerOpen}>
@@ -177,7 +177,7 @@ export function ChatView(): ReactElement {
             >
               <PanelRightOpen />
             </DialogTrigger>
-            <DialogContent className="top-0 right-0 left-auto h-full max-h-none w-[min(320px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 content-start overflow-auto rounded-none rounded-l-card border-y-0 border-r-0 p-0">
+            <DialogContent className="top-0 right-0 left-auto h-full max-h-none w-[min(320px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 content-start overflow-auto [scrollbar-width:none] rounded-none rounded-l-card border-y-0 border-r-0 p-0">
               <DialogTitle className="sr-only">Training context</DialogTitle>
               <DialogDescription className="sr-only">
                 Training data available to Coach.
@@ -199,24 +199,24 @@ export function ChatView(): ReactElement {
         )}
       </header>
       <div
-        className={`chat-layout row-start-2 grid min-h-0 min-w-0 ${contextOpen && !compact ? "grid-cols-[minmax(0,1fr)_300px]" : "grid-cols-[minmax(0,1fr)]"}`}
+        className={`chat-layout row-start-2 grid min-h-0 min-w-0 ${contextOpen && !compact ? "grid-cols-[minmax(0,1fr)_252px]" : "grid-cols-[minmax(0,1fr)]"}`}
       >
         <div className="chat-reading-column grid min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto] has-[[data-parity='question.card']]:grid-rows-[minmax(calc(var(--ctl-h-lg)*4),1fr)_minmax(0,auto)]">
           <main
-            className="conversation overflow-auto pt-[calc(var(--inset)*4)] pb-[calc(var(--inset)*3)] [overflow-anchor:none] max-[760px]:pt-[calc(var(--inset)*3)]"
+            className="conversation overflow-auto [scrollbar-width:none] pt-[calc(var(--inset)*4)] pb-[calc(var(--inset)*3)] [overflow-anchor:none] max-md:pt-5.5"
             aria-label="Coaching conversation"
             data-chat-status={status}
             ref={conversation}
           >
-            <div className="thread mx-auto w-[min(720px,calc(100%-48px))] max-[760px]:w-[calc(100%-32px)]">
+            <div className="thread mx-auto w-[min(720px,calc(100%-48px))] max-md:w-[calc(100%-32px)]">
               <Transcript />
               <PlanChangeCards />
               <CoachProgress />
               <FirstSyncCard />
             </div>
           </main>
-          <div className="composer-wrap z-2 grid max-h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] px-[max(24px,calc((100%-720px)/2))] pt-[calc(var(--inset)*3)] pb-row max-[760px]:px-[calc(var(--inset)*2)]">
-            <div className="composer-projections min-h-0 overflow-y-auto overscroll-contain empty:hidden">
+          <div className="composer-wrap z-2 grid max-h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] px-[max(24px,calc((100%-720px)/2))] pt-7 pb-3.5 max-md:px-[calc(var(--inset)*2)]">
+            <div className="composer-projections min-h-0 overflow-y-auto [scrollbar-width:none] overscroll-contain empty:hidden">
               <div className="chat-notice-host empty:hidden">
                 <p
                   className="new-conversation-status m-0 text-sm text-ink-2 not-empty:px-3.5 not-empty:pb-inset"
@@ -229,7 +229,7 @@ export function ChatView(): ReactElement {
                 <Notice />
                 <RetryBar />
               </div>
-              <div className="mb-2.5 grid gap-2.5 empty:hidden">
+              <div className="mb-inset grid gap-inset empty:hidden">
                 <CoachDecisionPanel onCustomOpenChange={setCustomDecisionOpen} />
                 <PlanCreationDock onEditorOpenChange={setPlanEditorOpen} />
               </div>
@@ -239,7 +239,7 @@ export function ChatView(): ReactElement {
             {decisionCustomOpen || planCreationEditorOpen ? null : (
               <Composer handle={composer} draftMemory={composerDraft} />
             )}
-            <p className="mt-inset mb-0 text-center text-xs text-ink-3">
+            <p className="mt-inset mb-0 text-center text-xs text-ink-3 max-md:hidden">
               {changeSurfaceVisible ? "Training changes need your confirmation." : CHAT_DISCLAIMER}
             </p>
           </div>

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -189,6 +189,13 @@ export function Composer(props: {
       }
       if (event.key === "Enter" || event.key === "Tab") {
         event.preventDefault();
+        if (
+          event.key === "Enter" &&
+          matches[active]?.command === event.currentTarget.value.trim().toLowerCase()
+        ) {
+          void submit();
+          return;
+        }
         accept(active);
         return;
       }

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -191,6 +191,7 @@ export function Composer(props: {
         event.preventDefault();
         if (
           event.key === "Enter" &&
+          !event.shiftKey &&
           matches[active]?.command === event.currentTarget.value.trim().toLowerCase()
         ) {
           void submit();

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -246,6 +246,7 @@ export function Composer(props: {
         {props.surface?.label ?? "Message your coach"}
       </label>
       <ComposerControls
+        className="gap-1.5 pt-[calc(var(--row-inset)+1px)]"
         actions={
           <>
             {props.leadingAction ??
@@ -253,7 +254,8 @@ export function Composer(props: {
                 <Button
                   type="button"
                   variant="ghost"
-                  size="icon"
+                  size="icon-sm"
+                  className="gap-inset text-ink-3 disabled:text-ink-3 disabled:opacity-100"
                   aria-label="Attach files"
                   disabled={
                     actions === null || inputDisabled || !canChat || attachmentSurface === null
@@ -273,7 +275,11 @@ export function Composer(props: {
                 }}
               />
             ) : (
-              <ComposerAction mode="send" disabled={sendDisabled || submitting || !canChat} />
+              <ComposerAction
+                mode="send"
+                className="gap-inset border-0 px-1.5 py-px text-base leading-6 disabled:bg-sunk disabled:text-ink-3 disabled:opacity-100"
+                disabled={sendDisabled || submitting || !canChat}
+              />
             )}
           </>
         }
@@ -283,7 +289,8 @@ export function Composer(props: {
           ref={textarea}
           data-parity="composer.textarea"
           defaultValue={props.draftMemory?.current ?? ""}
-          rows={2}
+          rows={1}
+          className="pb-1.5"
           placeholder={
             status === "streaming"
               ? "Coach is responding…"

--- a/apps/desktop-renderer/src/ui/chat/Notice.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Notice.tsx
@@ -2,10 +2,23 @@ import type { ReactElement } from "react";
 import { Button, ProgressDisplay } from "@enduragent/ui";
 import { useEnduragentStore } from "../../state/store";
 
-export function Notice(): ReactElement {
+export function Notice(props: { readonly inPlanCreation?: boolean }): ReactElement | null {
   const notice = useEnduragentStore((state) => state.chat.notice);
+  const planCreation = useEnduragentStore((state) => state.chat.planCreation);
+  if ((planCreation !== null) !== (props.inPlanCreation === true)) return null;
+  if (props.inPlanCreation) {
+    return (
+      <div
+        className="chat-notice rounded-ctl bg-surface-2 p-row text-sm leading-5 text-ink"
+        role="status"
+        hidden={notice === null}
+      >
+        <p className="m-0 text-xs leading-4 text-ink-2">{notice ?? ""}</p>
+      </div>
+    );
+  }
   return (
-    <p className="chat-notice m-0 text-sm text-ink-2" hidden={notice === null}>
+    <p className="chat-notice m-0 text-sm leading-5 text-ink-2" hidden={notice === null}>
       {notice ?? ""}
     </p>
   );

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -12,7 +12,7 @@ import {
 } from "@enduragent/coach-contract";
 import { useEffect, useRef, useState, type ReactElement, type ReactNode, type Ref } from "react";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent } from "@enduragent/ui";
+import { Card, CardContent, CardHeader } from "@enduragent/ui";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@enduragent/ui";
 import { PLAN_CHANGES_PAUSED_NOTICE } from "../../state/chat-slice";
 import { useEnduragentStore } from "../../state/store";
@@ -47,14 +47,23 @@ function ChangeCard(props: {
   children: ReactNode;
 }): ReactElement {
   return (
-    <Card size="sm" className="min-w-0" role="region" aria-label={props.title}>
-      <CardContent className="grid gap-inset">
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
-          <div className="grid min-w-0 gap-[calc(var(--inset)/2)]">
-            <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+    <Card
+      size="sm"
+      className="block min-w-0 gap-[normal] py-0"
+      role="region"
+      aria-label={props.title}
+    >
+      <CardHeader className="block rounded-none p-4">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+          <div className="min-w-0 justify-self-start">
+            <p
+              data-plan-card-eyebrow
+              className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
+            >
               {props.eyebrow}
             </p>
             <h3
+              data-plan-card-title
               ref={props.headingRef}
               tabIndex={-1}
               className="m-0 text-base leading-6 font-semibold break-words"
@@ -63,14 +72,21 @@ function ChangeCard(props: {
             </h3>
           </div>
           {props.status ? (
-            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+            <span
+              data-plan-card-status
+              className="inline-flex shrink-0 items-center gap-[calc(var(--row-inset)/2)] text-xs font-normal whitespace-nowrap text-ink-2"
+            >
               {props.status}
             </span>
           ) : null}
         </div>
-        {props.summary ? <p className="m-0 text-sm leading-5 text-ink-2">{props.summary}</p> : null}
-        {props.children}
-      </CardContent>
+        {props.summary ? (
+          <p data-plan-card-summary className="mt-inset mb-0 text-sm leading-5 text-ink-2">
+            {props.summary}
+          </p>
+        ) : null}
+      </CardHeader>
+      <CardContent className="px-4 pt-0 pb-4">{props.children}</CardContent>
     </Card>
   );
 }
@@ -79,14 +95,14 @@ function Fact(props: { label: string; children: ReactNode }): ReactElement {
   return (
     <div
       role="row"
-      className="grid grid-cols-[minmax(104px,0.72fr)_minmax(0,1.28fr)] gap-4 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-1 max-[560px]:gap-1"
+      className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] max-md:grid-cols-1 max-md:gap-1"
     >
       <span role="rowheader" className="text-xs leading-4 text-ink-2">
         {props.label}
       </span>
       <div
         role="cell"
-        className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left"
+        className="text-right text-sm leading-5 font-medium [overflow-wrap:anywhere] max-md:text-left"
       >
         {props.children}
       </div>
@@ -117,12 +133,38 @@ function eventDate(date: string): string {
   }).format(new Date(`${date}T12:00:00Z`));
 }
 
-function Difference({
+function SupportingEventFacts({
   change,
   library,
 }: {
   change: PlanChangeModel;
   library: ListPlansResult;
+}): ReactElement {
+  const events = supportingEventDifference(library, change);
+  return (
+    <>
+      <Fact label="Supporting Events before">
+        {events.before
+          .map((event) => `${event.name} · ${eventDate(event.date)} · ${event.role}`)
+          .join("; ") || "None"}
+      </Fact>
+      <Fact label="Supporting Events after">
+        {events.after
+          .map((event) => `${event.name} · ${eventDate(event.date)} · ${event.role}`)
+          .join("; ") || "None"}
+      </Fact>
+    </>
+  );
+}
+
+function Difference({
+  change,
+  library,
+  showSupportingEvents = true,
+}: {
+  change: PlanChangeModel;
+  library: ListPlansResult;
+  showSupportingEvents?: boolean;
 }): ReactElement {
   const events = supportingEventDifference(library, change);
   const weekNumbers = [
@@ -132,23 +174,23 @@ function Difference({
   ];
   return (
     <>
-      {change.intent.kind === "supporting-event" ||
-      (change.intent.kind === "inverse" &&
-        JSON.stringify(events.before) !== JSON.stringify(events.after)) ? (
-        <div role="table" aria-label="Supporting Events">
-          <Fact label="Supporting Events before">
-            {events.before
-              .map((event) => `${event.name} · ${eventDate(event.date)} · ${event.role}`)
-              .join("; ") || "None"}
-          </Fact>
-          <Fact label="Supporting Events after">
-            {events.after
-              .map((event) => `${event.name} · ${eventDate(event.date)} · ${event.role}`)
-              .join("; ") || "None"}
-          </Fact>
+      {showSupportingEvents &&
+      (change.intent.kind === "supporting-event" ||
+        (change.intent.kind === "inverse" &&
+          JSON.stringify(events.before) !== JSON.stringify(events.after))) ? (
+        <div
+          role="table"
+          className="border-t border-line [&+[role=table]]:border-t-0"
+          aria-label="Supporting Events"
+        >
+          <SupportingEventFacts change={change} library={library} />
         </div>
       ) : null}
-      <div role="table" aria-label="Affected individual Workouts">
+      <div
+        role="table"
+        className="border-t border-line [&+[role=table]]:border-t-0"
+        aria-label="Affected individual Workouts"
+      >
         {change.diff.map((row) => (
           <Fact key={row.workoutId} label={row.before?.name ?? row.after?.name ?? "Workout"}>
             {workoutValue(row.before)} → {workoutValue(row.after)}
@@ -158,7 +200,11 @@ function Difference({
           </Fact>
         ))}
       </div>
-      <div role="table" aria-label="Before and after totals">
+      <div
+        role="table"
+        className="border-t border-line [&+[role=table]]:border-t-0"
+        aria-label="Before and after totals"
+      >
         <Fact label="Plan totals">
           {change.totals.before.plan} min → {change.totals.after.plan} min
         </Fact>
@@ -414,10 +460,11 @@ function ChangeEditor(): ReactElement {
             {state.error}
           </p>
         ) : null}
-        <div className="mt-row flex flex-wrap gap-inset">
+        <div className="flex flex-wrap gap-inset">
           <Button
             type="button"
             variant="outline"
+            className="border-line bg-surface"
             disabled={state.busy}
             onClick={() => actions?.backFromPlanChangeEditor()}
           >
@@ -444,7 +491,7 @@ export function PlanChangeCards(): ReactElement | null {
   const sourceHeading = useRef<HTMLHeadingElement>(null);
   const sourceOpener = useRef<HTMLButtonElement | null>(null);
   const changeButton = useRef<HTMLButtonElement>(null);
-  const pauseNotice = useRef<HTMLParagraphElement>(null);
+  const pauseNotice = useRef<HTMLDivElement>(null);
   const previewHeading = useRef<HTMLHeadingElement>(null);
   const pending = library?.changes.find((change) => change.status === "pending");
   const paused = library?.changesPaused != null;
@@ -481,17 +528,17 @@ export function PlanChangeCards(): ReactElement | null {
     : (state.notice ?? (pending ? "Review the exact changes before confirming." : null));
   const pausedReason = paused ? "plan-changes-notice" : undefined;
   return (
-    <section aria-label="Plan Changes" className="grid min-w-0 gap-inset">
+    <section aria-label="Plan Changes" className="grid min-w-0 gap-4">
       {notice ? (
-        <p
+        <div
           ref={pauseNotice}
           id="plan-changes-notice"
           role="status"
           tabIndex={-1}
-          className="m-0 text-sm text-ink-2"
+          className="m-0 rounded-ctl bg-surface-2 p-row text-sm text-ink"
         >
-          {notice}
-        </p>
+          <p className="m-0 text-xs leading-4 text-ink-2">{notice}</p>
+        </div>
       ) : null}
       {!state.editorOpen && state.error ? (
         <p role="alert" className="m-0 text-xs text-danger">
@@ -507,16 +554,22 @@ export function PlanChangeCards(): ReactElement | null {
             : "Changes affect future, uncompleted training."
         }
       >
-        <div className="mt-row flex flex-wrap gap-inset">
+        <div className="flex flex-wrap gap-inset">
           <Button
             ref={changeButton}
+            variant="outline"
+            className="border-line bg-surface"
             disabled={paused || state.busy || actions === null}
             aria-describedby={pausedReason}
             onClick={() => actions?.openPlanChangeEditor()}
           >
             Change one thing
           </Button>
-          <Button variant="outline" onClick={() => setActiveView("plan")}>
+          <Button
+            variant="outline"
+            className="border-line bg-surface"
+            onClick={() => setActiveView("plan")}
+          >
             Open Plan
           </Button>
         </div>
@@ -528,13 +581,14 @@ export function PlanChangeCards(): ReactElement | null {
             {library.active.todayChoice.eligible.map((workout) => (
               <li
                 key={workout.workoutId}
-                className="flex flex-wrap items-center justify-between gap-inset border-t border-line py-3 first:border-t-0"
+                className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] last:border-b-0 max-md:grid-cols-1 max-md:gap-1"
               >
-                <span className="text-sm leading-5">
+                <span className="text-xs leading-4 text-ink-2">
                   {workout.name} · {workout.minutes} min
                 </span>
                 <Button
                   variant="outline"
+                  className="justify-self-start border-line bg-surface"
                   disabled={paused || state.busy || actions === null}
                   aria-describedby={pausedReason}
                   onClick={() =>
@@ -551,10 +605,10 @@ export function PlanChangeCards(): ReactElement | null {
             {library.active.todayChoice.blocked.map((workout) => (
               <li
                 key={workout.workoutId}
-                className="flex flex-wrap items-center justify-between gap-inset border-t border-line py-3 first:border-t-0"
+                className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] last:border-b-0 max-md:grid-cols-1 max-md:gap-1"
               >
-                <span className="text-sm leading-5">{workout.name}</span>
-                <span className="text-sm leading-5 text-ink-2">{workout.reason}</span>
+                <span className="text-xs leading-4 text-ink-2">{workout.name}</span>
+                <div className="text-sm leading-5">{workout.reason}</div>
               </li>
             ))}
           </ul>
@@ -576,16 +630,27 @@ export function PlanChangeCards(): ReactElement | null {
           }
         >
           {pending.details ? (
-            <p className="m-0 text-sm leading-5 text-ink-2">{pending.details}</p>
+            <div
+              data-plan-change-details
+              className="m-0 rounded-ctl bg-surface-2 p-row text-sm leading-5 text-ink"
+            >
+              <p className="m-0 text-xs leading-4 text-ink-2">{pending.details}</p>
+            </div>
           ) : null}
-          <Difference change={pending} library={library} />
-          <div role="table" aria-label="Facts">
+          <Difference change={pending} library={library} showSupportingEvents={false} />
+          <div
+            role="table"
+            className="border-t border-line [&+[role=table]]:border-t-0"
+            aria-label="Facts"
+          >
             <Fact label="Main Goal">{library.active.name}</Fact>
+            <SupportingEventFacts change={pending} library={library} />
             <Fact label="Confidence">{pending.confidence}</Fact>
           </div>
           <div>
             <Button
               variant="outline"
+              className="border-line bg-surface"
               onClick={(event) => openSource(pending, false, event.currentTarget)}
             >
               View evidence
@@ -594,6 +659,7 @@ export function PlanChangeCards(): ReactElement | null {
           <div className="mt-row flex flex-wrap gap-inset">
             <Button
               variant="outline"
+              className="border-line bg-surface"
               disabled={state.busy || actions === null}
               onClick={() => actions?.applyPlanChange("cancel")}
             >
@@ -619,9 +685,10 @@ export function PlanChangeCards(): ReactElement | null {
             status={statusLabels[change.status]}
             summary="Earlier decisions remain readable."
           >
-            <div className="mt-row flex flex-wrap gap-inset">
+            <div className="flex flex-wrap gap-inset">
               <Button
                 variant="outline"
+                className="border-line bg-surface"
                 onClick={(event) => openSource(change, false, event.currentTarget)}
               >
                 Read historical evidence
@@ -629,6 +696,7 @@ export function PlanChangeCards(): ReactElement | null {
               {change.status === "applied" && change.undo?.eligible ? (
                 <Button
                   variant="outline"
+                  className="border-line bg-surface"
                   disabled={paused || state.busy || actions === null}
                   aria-describedby={pausedReason}
                   onClick={() =>
@@ -640,6 +708,7 @@ export function PlanChangeCards(): ReactElement | null {
               ) : null}
               <Button
                 variant="outline"
+                className="border-line bg-surface"
                 onClick={(event) => openSource(change, true, event.currentTarget)}
               >
                 Read this difference
@@ -655,7 +724,11 @@ export function PlanChangeCards(): ReactElement | null {
               <Difference change={source.change} library={library} />
             </>
           ) : null}
-          <div role="table" aria-label="Source details">
+          <div
+            role="table"
+            className="border-t border-line [&+[role=table]]:border-t-0"
+            aria-label="Source details"
+          >
             {source.change.premises.map((premise) => (
               <Fact key={premise.id} label={`${premise.label} · ${premise.source}`}>
                 {premiseValue(premise)}
@@ -665,6 +738,7 @@ export function PlanChangeCards(): ReactElement | null {
           <div className="mt-row flex flex-wrap gap-inset">
             <Button
               variant="outline"
+              className="border-line bg-surface"
               onClick={() => {
                 setSource(null);
                 sourceOpener.current?.focus();

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -513,7 +513,12 @@ export function PlanChangeCards(): ReactElement | null {
   useEffect(() => {
     setSource(null);
   }, [activePlanId]);
-  if (!library?.active || (!pending && !(state.open && state.planId === library.active.planId)))
+  if (
+    !library?.active ||
+    (library.creation !== null &&
+      !pending &&
+      !(state.open && state.planId === library.active.planId))
+  )
     return null;
   const openSource = (
     change: PlanChangeModel,

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -491,17 +491,15 @@ export function PlanChangeCards(): ReactElement | null {
       <ChangeCard
         eyebrow="Active Plan"
         title={library.active.name}
-        summary={`${
+        summary={
           library.creation
             ? "Your separate Plan creation is still open."
             : "Changes affect future, uncompleted training."
-        }${library.active.calendar.status === "verified" ? " · Calendar up to date" : ""}`}
+        }
       >
-        {library.active.calendar.status === "verified" ? null : (
-          <p aria-live="polite" className="m-0 mb-inset text-sm leading-5 text-ink-2">
-            {calendarStatusLabel(library.active.calendar)}
-          </p>
-        )}
+        <p aria-live="polite" className="m-0 mb-inset text-sm leading-5 text-ink-2">
+          {calendarStatusLabel(library.active.calendar)}
+        </p>
         <div className="flex flex-wrap gap-inset">
           <Button
             ref={changeButton}

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -583,7 +583,7 @@ export function PlanChangeCards(): ReactElement | null {
                 key={workout.workoutId}
                 className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] last:border-b-0 max-md:grid-cols-1 max-md:gap-1"
               >
-                <span className="text-xs leading-4 text-ink-2">
+                <span className="text-sm leading-5">
                   {workout.name} · {workout.minutes} min
                 </span>
                 <Button
@@ -607,7 +607,7 @@ export function PlanChangeCards(): ReactElement | null {
                 key={workout.workoutId}
                 className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] last:border-b-0 max-md:grid-cols-1 max-md:gap-1"
               >
-                <span className="text-xs leading-4 text-ink-2">{workout.name}</span>
+                <span className="text-sm leading-5">{workout.name}</span>
                 <div className="text-sm leading-5">{workout.reason}</div>
               </li>
             ))}

--- a/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanChangeCards.tsx
@@ -1,3 +1,5 @@
+import { calendarStatusLabel } from "../plan/PlanLibrary";
+import { formatCivilDate } from "../../lib/date";
 import type {
   ListPlansResult,
   PlanChangeIntent,
@@ -12,7 +14,7 @@ import {
 } from "@enduragent/coach-contract";
 import { useEffect, useRef, useState, type ReactElement, type ReactNode, type Ref } from "react";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent, CardHeader } from "@enduragent/ui";
+import { Fact, PlanCard } from "../plan/plan-card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@enduragent/ui";
 import { PLAN_CHANGES_PAUSED_NOTICE } from "../../state/chat-slice";
 import { useEnduragentStore } from "../../state/store";
@@ -47,90 +49,19 @@ function ChangeCard(props: {
   children: ReactNode;
 }): ReactElement {
   return (
-    <Card
-      size="sm"
-      className="block min-w-0 gap-[normal] py-0"
-      role="region"
+    <PlanCard
+      {...props}
       aria-label={props.title}
-    >
-      <CardHeader className="block rounded-none p-4">
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-          <div className="min-w-0 justify-self-start">
-            <p
-              data-plan-card-eyebrow
-              className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
-            >
-              {props.eyebrow}
-            </p>
-            <h3
-              data-plan-card-title
-              ref={props.headingRef}
-              tabIndex={-1}
-              className="m-0 text-base leading-6 font-semibold break-words"
-            >
-              {props.title}
-            </h3>
-          </div>
-          {props.status ? (
-            <span
-              data-plan-card-status
-              className="inline-flex shrink-0 items-center gap-[calc(var(--row-inset)/2)] text-xs font-normal whitespace-nowrap text-ink-2"
-            >
-              {props.status}
-            </span>
-          ) : null}
-        </div>
-        {props.summary ? (
-          <p data-plan-card-summary className="mt-inset mb-0 text-sm leading-5 text-ink-2">
-            {props.summary}
-          </p>
-        ) : null}
-      </CardHeader>
-      <CardContent className="px-4 pt-0 pb-4">{props.children}</CardContent>
-    </Card>
-  );
-}
-
-function Fact(props: { label: string; children: ReactNode }): ReactElement {
-  return (
-    <div
-      role="row"
-      className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] max-md:grid-cols-1 max-md:gap-1"
-    >
-      <span role="rowheader" className="text-xs leading-4 text-ink-2">
-        {props.label}
-      </span>
-      <div
-        role="cell"
-        className="text-right text-sm leading-5 font-medium [overflow-wrap:anywhere] max-md:text-left"
-      >
-        {props.children}
-      </div>
-    </div>
+      headingTabIndex={-1}
+      statusClassName="inline-flex shrink-0 items-center gap-[calc(var(--row-inset)/2)] text-xs font-normal whitespace-nowrap text-ink-2"
+    />
   );
 }
 
 function workoutValue(workout: PlanChangeWorkout | null): string {
   if (workout === null) return "Not in Plan";
-  const date =
-    workout.date === null
-      ? "Undated"
-      : new Intl.DateTimeFormat("en-GB", {
-          day: "numeric",
-          month: "short",
-          year: "numeric",
-          timeZone: "UTC",
-        }).format(new Date(`${workout.date}T12:00:00Z`));
+  const date = workout.date === null ? "Undated" : formatCivilDate(workout.date);
   return `${date} · ${workout.minutes} min${workout.power === null ? "" : ` · ${workout.power} W`}`;
-}
-
-function eventDate(date: string): string {
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(`${date}T12:00:00Z`));
 }
 
 function SupportingEventFacts({
@@ -143,14 +74,14 @@ function SupportingEventFacts({
   const events = supportingEventDifference(library, change);
   return (
     <>
-      <Fact label="Supporting Events before">
+      <Fact valueAs="div" label="Supporting Events before">
         {events.before
-          .map((event) => `${event.name} · ${eventDate(event.date)} · ${event.role}`)
+          .map((event) => `${event.name} · ${formatCivilDate(event.date)} · ${event.role}`)
           .join("; ") || "None"}
       </Fact>
-      <Fact label="Supporting Events after">
+      <Fact valueAs="div" label="Supporting Events after">
         {events.after
-          .map((event) => `${event.name} · ${eventDate(event.date)} · ${event.role}`)
+          .map((event) => `${event.name} · ${formatCivilDate(event.date)} · ${event.role}`)
           .join("; ") || "None"}
       </Fact>
     </>
@@ -192,7 +123,11 @@ function Difference({
         aria-label="Affected individual Workouts"
       >
         {change.diff.map((row) => (
-          <Fact key={row.workoutId} label={row.before?.name ?? row.after?.name ?? "Workout"}>
+          <Fact
+            valueAs="div"
+            key={row.workoutId}
+            label={row.before?.name ?? row.after?.name ?? "Workout"}
+          >
             {workoutValue(row.before)} → {workoutValue(row.after)}
             {row.before && row.after && row.before.name !== row.after.name
               ? ` · ${row.after.name}`
@@ -205,11 +140,11 @@ function Difference({
         className="border-t border-line [&+[role=table]]:border-t-0"
         aria-label="Before and after totals"
       >
-        <Fact label="Plan totals">
+        <Fact valueAs="div" label="Plan totals">
           {change.totals.before.plan} min → {change.totals.after.plan} min
         </Fact>
         {weekNumbers.map((number) => (
-          <Fact key={number} label={`Week ${number}`}>
+          <Fact valueAs="div" key={number} label={`Week ${number}`}>
             {change.totals.before.weeks.find((week) => week.number === number)?.minutes ??
               "Not in Plan"}{" "}
             min →{" "}
@@ -227,13 +162,16 @@ function Difference({
 }
 
 function premiseValue(premise: PlanChangeModel["premises"][number]): ReactNode {
+  if (premise.id === "confirmed-limits") {
+    return typeof premise.value === "string" && premise.value.trim() ? premise.value : null;
+  }
   if (premise.id === "request") {
     const parsed = PlanChangeRequestSchema.safeParse(premise.value);
     if (parsed.success && parsed.data.kind === "text") return parsed.data.text;
   }
   if (premise.id === "ftp-sources") {
     const parsed = PlanChangeFtpSourcesSchema.safeParse(premise.value);
-    if (!parsed.success) return premise.label;
+    if (!parsed.success) return null;
     const labels = {
       manual: "Saved athlete FTP",
       "intervals-ftp": "Intervals.icu FTP",
@@ -256,8 +194,8 @@ function premiseValue(premise: PlanChangeModel["premises"][number]): ReactNode {
   if (premise.id === "event-source") {
     const parsed = PlanChangeEventSourceSchema.safeParse(premise.value);
     return parsed.success
-      ? `${parsed.data.name} · ${eventDate(parsed.data.date)} · ${parsed.data.category}`
-      : premise.label;
+      ? `${parsed.data.name} · ${formatCivilDate(parsed.data.date)} · ${parsed.data.category}`
+      : null;
   }
   if (premise.id === "undone-change") {
     const value = premise.value;
@@ -266,10 +204,10 @@ function premiseValue(premise: PlanChangeModel["premises"][number]): ReactNode {
       "title" in value &&
       typeof value.title === "string"
       ? value.title
-      : premise.label;
+      : null;
   }
   const parsed = PlanChangeIntentSchema.safeParse(premise.value);
-  if (!parsed.success) return premise.label;
+  if (!parsed.success) return null;
   const intent = parsed.data;
   switch (intent.kind) {
     case "weekday-duration":
@@ -285,7 +223,7 @@ function premiseValue(premise: PlanChangeModel["premises"][number]): ReactNode {
     case "choose-workout":
     case "inverse":
     case "supporting-event":
-      return premise.label;
+      return null;
     case "ftp":
       return `${intent.watts} W`;
   }
@@ -553,12 +491,17 @@ export function PlanChangeCards(): ReactElement | null {
       <ChangeCard
         eyebrow="Active Plan"
         title={library.active.name}
-        summary={
+        summary={`${
           library.creation
             ? "Your separate Plan creation is still open."
             : "Changes affect future, uncompleted training."
-        }
+        }${library.active.calendar.status === "verified" ? " · Calendar up to date" : ""}`}
       >
+        {library.active.calendar.status === "verified" ? null : (
+          <p aria-live="polite" className="m-0 mb-inset text-sm leading-5 text-ink-2">
+            {calendarStatusLabel(library.active.calendar)}
+          </p>
+        )}
         <div className="flex flex-wrap gap-inset">
           <Button
             ref={changeButton}
@@ -648,9 +591,13 @@ export function PlanChangeCards(): ReactElement | null {
             className="border-t border-line [&+[role=table]]:border-t-0"
             aria-label="Facts"
           >
-            <Fact label="Main Goal">{library.active.name}</Fact>
+            <Fact valueAs="div" label="Main Goal">
+              {library.active.name}
+            </Fact>
             <SupportingEventFacts change={pending} library={library} />
-            <Fact label="Confidence">{pending.confidence}</Fact>
+            <Fact valueAs="div" label="Confidence">
+              {pending.confidence}
+            </Fact>
           </div>
           <div>
             <Button
@@ -734,11 +681,14 @@ export function PlanChangeCards(): ReactElement | null {
             className="border-t border-line [&+[role=table]]:border-t-0"
             aria-label="Source details"
           >
-            {source.change.premises.map((premise) => (
-              <Fact key={premise.id} label={`${premise.label} · ${premise.source}`}>
-                {premiseValue(premise)}
-              </Fact>
-            ))}
+            {source.change.premises.map((premise) => {
+              const value = premiseValue(premise);
+              return value === null ? null : (
+                <Fact valueAs="div" key={premise.id} label={`${premise.label} · ${premise.source}`}>
+                  {value}
+                </Fact>
+              );
+            })}
           </div>
           <div className="mt-row flex flex-wrap gap-inset">
             <Button

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -226,31 +226,14 @@ export function PlanCreationDock(props: {
   const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
   const focusRevision = useEnduragentStore((state) => state.chat.planCreationFocusRevision);
   const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
-  const decision = useEnduragentStore((state) => state.chat.decision);
   const actions = useEnduragentStore((state) => state.chatActions);
-  const startButton = useRef<HTMLButtonElement>(null);
-  const decisionPending =
-    decision?.status === "unanswered" ||
-    (decision?.status === "answered" && decision.continuation.status === "pending");
   useEffect(() => {
-    if (focusRequest?.target === "start") startButton.current?.focus();
+    if (focusRequest?.target === "start") {
+      queueMicrotask(() => document.getElementById("message")?.focus());
+    }
   }, [focusRequest?.revision, focusRequest?.target]);
   if (!loaded) return null;
-  if (model === null) {
-    return (
-      <div className="flex min-w-0 justify-end gap-inset" data-parity="start.row">
-        <Button
-          ref={startButton}
-          variant="outline"
-          data-parity="start.button"
-          disabled={busy || actions === null || decisionPending}
-          onClick={() => actions?.startPlanCreation()}
-        >
-          Start a Plan
-        </Button>
-      </div>
-    );
-  }
+  if (model === null) return null;
   if (paused || (editingKey === null && model.openQuestion === null)) return null;
   const editedSummary =
     editingKey === null

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -1,4 +1,5 @@
-import type { ListPlansResult, PlanCreationCardModel } from "@enduragent/coach-contract";
+import { formatCivilDate } from "../../lib/date";
+import type { PlanCreationCardModel } from "@enduragent/coach-contract";
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Button } from "@enduragent/ui";
 import {
@@ -16,6 +17,11 @@ import { Card, CardContent } from "@enduragent/ui";
 import { PlanCreationDraftCards, PlanCreationCommitmentCard } from "./PlanCreationDraftCards";
 import { PlanCreationSummary } from "./PlanCreationSummary";
 import { Notice } from "./Notice";
+
+const discardDialogCopy =
+  "Your answers are discarded. Your active Plan, Schedule, restrictions, saved preferences, and history stay unchanged.";
+const discardConsequenceCopy =
+  "No Plan was created. Your active Plan, Schedule, training restrictions, saved preferences, and chat history are unchanged.";
 
 export function PlanCreationDiscardDialog(): ReactElement {
   const open = useEnduragentStore((state) => state.chat.planCreationDiscardConfirmationOpen);
@@ -48,10 +54,7 @@ export function PlanCreationDiscardDialog(): ReactElement {
           <DialogTitle className="mt-0 mb-inset text-lg font-semibold">
             Discard this Plan creation?
           </DialogTitle>
-          <DialogDescription className="m-0 leading-5">
-            No Plan is created. Your active Plan, Schedule, training restrictions, closed Plans,
-            saved preferences, and chat history are unchanged.
-          </DialogDescription>
+          <DialogDescription className="m-0 leading-5">{discardDialogCopy}</DialogDescription>
         </DialogHeader>
         {error === null ? null : (
           <p className="mt-inset mb-0 text-xs text-danger" role="alert">
@@ -84,19 +87,6 @@ export function PlanCreationDiscardDialog(): ReactElement {
       </DialogContent>
     </Dialog>
   );
-}
-
-function calendarWindowEnd(endDate: string): string {
-  const year = Number(endDate.slice(0, 4));
-  const month = Number(endDate.slice(5, 7));
-  const day = Number(endDate.slice(8, 10));
-  const date = new Date(Date.UTC(year, month - 1, day));
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(date);
 }
 
 export function PlanCreationActivateDialog(): ReactElement | null {
@@ -174,7 +164,7 @@ export function PlanCreationActivateDialog(): ReactElement | null {
           {connection === "checking" ? null : (
             <p className="mt-inset mb-0 text-sm leading-5 text-ink-2">
               {calendarWindow !== null
-                ? `Dated Workouts sync from ${activePlanName === null ? "today" : "tomorrow"} through ${calendarWindowEnd(calendarWindow.endDate)}.`
+                ? `Dated Workouts sync from ${activePlanName === null ? "today" : "tomorrow"} through ${formatCivilDate(calendarWindow.endDate)}.`
                 : "Calendar updates wait until intervals.icu is connected."}
             </p>
           )}
@@ -271,29 +261,15 @@ export function PlanCreationDock(props: {
 
 export function PlanCreationConversation(props: {
   readonly model: PlanCreationCardModel | null;
-}): ReactElement {
+}): ReactElement | null {
+  if (props.model === null) return null;
   return (
     <section className="grid min-w-0 gap-4" aria-label="Plan creation">
       <Notice inPlanCreation />
-      {props.model === null ? null : <PlanCreationCommitmentCard model={props.model} />}
+      <PlanCreationCommitmentCard model={props.model} />
       <PlanCreationConversationContent model={props.model} />
     </section>
   );
-}
-
-function activationNotice(library: ListPlansResult | null): string {
-  const active = library?.active ?? null;
-  if (active === null) return "Plan activated locally.";
-  const calendar = active.calendar;
-  const status =
-    calendar.status === "not-connected"
-      ? "Connect intervals.icu to mirror Workouts."
-      : calendar.status === "verified"
-        ? "Calendar is up to date."
-        : calendar.status === "failed"
-          ? "Calendar update failed; see the Plan library."
-          : "Calendar Workouts are being added.";
-  return `${active.name} is active. ${status}`;
 }
 
 function PlanCreationConversationContent(props: {
@@ -302,13 +278,7 @@ function PlanCreationConversationContent(props: {
   const [editVersion, setEditVersion] = useState<number | null>(null);
   const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
   const actions = useEnduragentStore((state) => state.chatActions);
-  const library = useEnduragentStore((state) => state.planLibrary.value);
-  if (props.model === null)
-    return (
-      <p role="status" className="m-0 rounded-ctl bg-surface-2 p-row text-sm text-ink">
-        {activationNotice(library)}
-      </p>
-    );
+  if (props.model === null) return null;
   const model = props.model;
   if (model.draft === null) return <PlanCreationSummary model={model} />;
   if (editVersion === model.version)
@@ -360,10 +330,7 @@ export function PlanCreationDiscardConsequence(props: { readonly eventId: string
       data-parity="discarded.record"
     >
       <strong className="text-sm font-semibold leading-5">Plan creation discarded</strong>
-      <p className="mt-1 mb-0 text-xs leading-4 text-ink-2">
-        No Plan was created. Your active Plan, Schedule, training restrictions, saved preferences,
-        and chat history are unchanged.
-      </p>
+      <p className="mt-1 mb-0 text-xs leading-4 text-ink-2">{discardConsequenceCopy}</p>
     </article>
   );
 }

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -1,4 +1,4 @@
-import type { PlanCreationCardModel } from "@enduragent/coach-contract";
+import type { ListPlansResult, PlanCreationCardModel } from "@enduragent/coach-contract";
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Button } from "@enduragent/ui";
 import {
@@ -281,16 +281,32 @@ export function PlanCreationConversation(props: {
   );
 }
 
+function activationNotice(library: ListPlansResult | null): string {
+  const active = library?.active ?? null;
+  if (active === null) return "Plan activated locally.";
+  const calendar = active.calendar;
+  const status =
+    calendar.status === "not-connected"
+      ? "Connect intervals.icu to mirror Workouts."
+      : calendar.status === "verified"
+        ? "Calendar is up to date."
+        : calendar.status === "failed"
+          ? "Calendar update failed; see the Plan library."
+          : "Calendar Workouts are being added.";
+  return `${active.name} is active. ${status}`;
+}
+
 function PlanCreationConversationContent(props: {
   readonly model: PlanCreationCardModel | null;
 }): ReactElement | null {
   const [editVersion, setEditVersion] = useState<number | null>(null);
   const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
   const actions = useEnduragentStore((state) => state.chatActions);
+  const library = useEnduragentStore((state) => state.planLibrary.value);
   if (props.model === null)
     return (
       <p role="status" className="m-0 rounded-ctl bg-surface-2 p-row text-sm text-ink">
-        Plan activated locally.
+        {activationNotice(library)}
       </p>
     );
   const model = props.model;

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -15,6 +15,7 @@ import { PlanCreationQuestionCard } from "./PlanCreationQuestionCard";
 import { Card, CardContent } from "@enduragent/ui";
 import { PlanCreationDraftCards, PlanCreationCommitmentCard } from "./PlanCreationDraftCards";
 import { PlanCreationSummary } from "./PlanCreationSummary";
+import { Notice } from "./Notice";
 
 export function PlanCreationDiscardDialog(): ReactElement {
   const open = useEnduragentStore((state) => state.chat.planCreationDiscardConfirmationOpen);
@@ -37,14 +38,14 @@ export function PlanCreationDiscardDialog(): ReactElement {
       }}
     >
       <DialogContent
-        className="w-[min(520px,calc(100vw-32px))] max-w-none gap-0 border-line p-5 shadow-elev-4 sm:max-w-none"
+        className="w-[min(420px,calc(100vw-32px))] max-w-none gap-0 border-line p-4 shadow-elev-4 sm:max-w-none"
         showCloseButton={false}
         initialFocus={keepCreating}
         finalFocus={false}
         aria-busy={busy ? "true" : undefined}
       >
-        <DialogHeader className="gap-inset">
-          <DialogTitle className="m-0 text-lg font-semibold">
+        <DialogHeader className="gap-0">
+          <DialogTitle className="mt-0 mb-inset text-lg font-semibold">
             Discard this Plan creation?
           </DialogTitle>
           <DialogDescription className="m-0 leading-5">
@@ -63,7 +64,8 @@ export function PlanCreationDiscardDialog(): ReactElement {
               <Button
                 ref={keepCreating}
                 variant="outline"
-                size="lg"
+                className="border-line bg-surface"
+                size="default"
                 disabled={busy || actions === null}
               />
             }
@@ -72,7 +74,7 @@ export function PlanCreationDiscardDialog(): ReactElement {
           </DialogClose>
           <Button
             variant="destructive-solid"
-            size="lg"
+            size="default"
             disabled={busy || actions === null}
             onClick={confirmDiscard}
           >
@@ -156,21 +158,21 @@ export function PlanCreationActivateDialog(): ReactElement | null {
       }}
     >
       <DialogContent
-        className="w-[min(520px,calc(100vw-32px))] max-w-none gap-0 border-line p-5 shadow-elev-4 sm:max-w-none"
+        className="w-[min(420px,calc(100vw-32px))] max-w-none gap-0 border-line p-4 shadow-elev-4 sm:max-w-none"
         showCloseButton={false}
         initialFocus={cancelButton}
         finalFocus={false}
         aria-busy={busy ? "true" : undefined}
       >
-        <DialogHeader className="gap-inset">
-          <DialogTitle className="m-0 text-lg font-semibold">
+        <DialogHeader className="gap-0">
+          <DialogTitle className="mt-0 mb-inset text-lg font-semibold">
             {activePlanName === null ? "Activate Plan?" : "Close and activate?"}
           </DialogTitle>
           <DialogDescription className="m-0 leading-5">
             {`${activePlanName === null ? "" : `${activePlanName} closes. Today’s calendar Workout stays. `}The new Plan activates now.`}
           </DialogDescription>
           {connection === "checking" ? null : (
-            <p className="m-0 text-sm leading-5 text-ink-2">
+            <p className="mt-inset mb-0 text-sm leading-5 text-ink-2">
               {calendarWindow !== null
                 ? `Dated Workouts sync from ${activePlanName === null ? "today" : "tomorrow"} through ${calendarWindowEnd(calendarWindow.endDate)}.`
                 : "Calendar updates wait until intervals.icu is connected."}
@@ -188,7 +190,8 @@ export function PlanCreationActivateDialog(): ReactElement | null {
               <Button
                 ref={cancelButton}
                 variant="outline"
-                size="lg"
+                className="border-line bg-surface"
+                size="default"
                 disabled={busy || actions === null}
               />
             }
@@ -197,7 +200,7 @@ export function PlanCreationActivateDialog(): ReactElement | null {
           </DialogClose>
           <Button
             variant="default"
-            size="lg"
+            size="default"
             disabled={
               busy ||
               actions === null ||
@@ -270,7 +273,8 @@ export function PlanCreationConversation(props: {
   readonly model: PlanCreationCardModel | null;
 }): ReactElement {
   return (
-    <section className="grid min-w-0 gap-inset" aria-label="Plan creation">
+    <section className="grid min-w-0 gap-4" aria-label="Plan creation">
+      <Notice inPlanCreation />
       {props.model === null ? null : <PlanCreationCommitmentCard model={props.model} />}
       <PlanCreationConversationContent model={props.model} />
     </section>
@@ -285,7 +289,7 @@ function PlanCreationConversationContent(props: {
   const actions = useEnduragentStore((state) => state.chatActions);
   if (props.model === null)
     return (
-      <p role="status" className="m-0 text-sm text-ink-2">
+      <p role="status" className="m-0 rounded-ctl bg-surface-2 p-row text-sm text-ink">
         Plan activated locally.
       </p>
     );
@@ -304,6 +308,7 @@ function PlanCreationConversationContent(props: {
             <div>
               <Button
                 variant="outline"
+                className="border-line bg-surface"
                 onClick={() => {
                   actions?.cancelPlanCreationEdit("edit");
                   setEditVersion(null);
@@ -334,12 +339,12 @@ function PlanCreationConversationContent(props: {
 export function PlanCreationDiscardConsequence(props: { readonly eventId: string }): ReactElement {
   return (
     <article
-      className="grid gap-[calc(var(--inset)/2)] rounded-ctl bg-surface-2 p-row"
+      className="block gap-row rounded-ctl bg-surface-2 p-row"
       data-plan-creation-discard-event={props.eventId}
       data-parity="discarded.record"
     >
-      <strong className="text-sm font-medium leading-5">Plan creation discarded</strong>
-      <p className="m-0 text-xs leading-4 text-ink-2">
+      <strong className="text-sm font-semibold leading-5">Plan creation discarded</strong>
+      <p className="mt-1 mb-0 text-xs leading-4 text-ink-2">
         No Plan was created. Your active Plan, Schedule, training restrictions, saved preferences,
         and chat history are unchanged.
       </p>

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
@@ -6,7 +6,7 @@ import type {
 } from "@enduragent/coach-contract";
 import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent } from "@enduragent/ui";
+import { Card, CardContent, CardHeader } from "@enduragent/ui";
 import { useEnduragentStore } from "../../state/store";
 
 const answerLabels: ReadonlyArray<readonly [PlanCreationAnswerSummary["answerKey"], string]> = [
@@ -34,14 +34,14 @@ function Fact(props: { readonly label: string; readonly children: ReactNode }): 
   return (
     <div
       role="row"
-      className="grid grid-cols-[minmax(104px,0.72fr)_minmax(0,1.28fr)] gap-4 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-1 max-[560px]:gap-1"
+      className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] max-md:grid-cols-1 max-md:gap-1"
     >
       <span role="rowheader" className="text-xs leading-4 text-ink-2">
         {props.label}
       </span>
       <strong
         role="cell"
-        className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left"
+        className="text-right text-sm leading-5 font-medium [overflow-wrap:anywhere] max-md:text-left"
       >
         {props.children}
       </strong>
@@ -85,33 +85,45 @@ function ReviewCard(props: {
   return (
     <Card
       size="sm"
-      className="min-w-0"
+      className="block min-w-0 gap-[normal] py-0"
       role="region"
       aria-label={props.eyebrow === "Draft inputs" ? "Draft inputs" : props.title}
     >
-      <CardContent className="grid gap-inset">
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
-          <div className="grid gap-[calc(var(--inset)/2)] min-w-0">
+      <CardHeader className="block rounded-none p-4">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+          <div className="min-w-0 justify-self-start">
             {props.eyebrow ? (
-              <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+              <p
+                data-plan-card-eyebrow
+                className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
+              >
                 {props.eyebrow}
               </p>
             ) : null}
-            <h3 className="m-0 text-base leading-6 font-semibold break-words">{props.title}</h3>
+            <h3 data-plan-card-title className="m-0 text-base leading-6 font-semibold break-words">
+              {props.title}
+            </h3>
           </div>
           {props.status ? (
-            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+            <span
+              data-plan-card-status
+              className="inline-flex shrink-0 items-center justify-self-start gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2"
+            >
               {props.status}
             </span>
           ) : null}
         </div>
         {props.summary ? (
-          <p id={props.summaryId} className="m-0 text-sm leading-5 text-ink-2">
+          <p
+            data-plan-card-summary
+            id={props.summaryId}
+            className="mt-inset mb-0 text-sm leading-5 text-ink-2"
+          >
             {props.summary}
           </p>
         ) : null}
-        {props.children}
-      </CardContent>
+      </CardHeader>
+      <CardContent className="px-4 pt-0 pb-4">{props.children}</CardContent>
     </Card>
   );
 }
@@ -147,10 +159,10 @@ export function PlanCreationDraftCards(props: {
   const title =
     draft.goal.kind === "event" ? draft.goal.name : (draft.goal.outcome ?? "Improve fitness");
   return (
-    <section className="grid min-w-0 gap-inset" aria-label="Plan Draft review">
+    <section className="grid min-w-0 gap-4" aria-label="Plan Draft review">
       {stale ? (
         <ReviewCard title="Changed answers">
-          <div role="table" aria-label="Changed answers">
+          <div role="table" className="border-t border-line" aria-label="Changed answers">
             <AnswerFacts summaries={props.model.answeredSummaries} current />
           </div>
         </ReviewCard>
@@ -165,7 +177,7 @@ export function PlanCreationDraftCards(props: {
             : "Review the whole Draft before activating."
         }
       >
-        <div role="table" aria-label="Draft inputs">
+        <div role="table" className="border-t border-line" aria-label="Draft inputs">
           <Fact
             label={`Main Goal · ${goal?.source.kind === "derived" ? goal.source.label : "your answer"}`}
           >
@@ -180,9 +192,11 @@ export function PlanCreationDraftCards(props: {
           </Fact>
           <AnswerFacts summaries={draft.answeredSummaries} omitGoal />
         </div>
-        <details className="border-t border-line pt-3">
-          <summary className="cursor-pointer text-sm font-medium">How this Plan was built</summary>
-          <div role="table" aria-label="How this Plan was built">
+        <details className="mt-row border-t border-line">
+          <summary className="cursor-pointer py-inset text-sm font-normal text-ink-2">
+            How this Plan was built
+          </summary>
+          <div role="table" className="border-t border-line" aria-label="How this Plan was built">
             <Fact label="Guidance">Heart rate or perceived effort. No FTP test.</Fact>
             <Fact label="Training approach">Balanced · default</Fact>
             {draft.notes.map((note, index) => (
@@ -200,30 +214,34 @@ export function PlanCreationDraftCards(props: {
         summary={`${draft.weeks.length} weeks · ${workouts.length} Workouts · ${workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min`}
       >
         {draft.weeks.map((week) => (
-          <div key={week.number} className="grid min-w-0 gap-inset">
-            <p className="m-0 text-xs font-semibold text-ink-2">
+          <div key={week.number} className="min-w-0 [&:not(:first-child)]:pt-4">
+            <p className="m-0 pb-inset text-xs font-semibold uppercase tracking-wide text-ink-2">
               Week {week.number} · {dateLabel(week.start)} to {dateLabel(week.end)} ·{" "}
               {week.workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min
             </p>
-            <div role="list" aria-label={`Week ${week.number} Workouts`}>
+            <div
+              role="list"
+              className="border-t border-line"
+              aria-label={`Week ${week.number} Workouts`}
+            >
               {week.workouts.length === 0 ? (
-                <p className="m-0 text-sm leading-5 text-ink-2">No Workouts this week.</p>
+                <p className="m-0 text-sm leading-5 text-ink">No Workouts this week.</p>
               ) : (
                 week.workouts.map((workout, index) => (
                   <div
                     key={workout.id}
                     role="listitem"
-                    className="grid grid-cols-[minmax(0,0.6fr)_minmax(0,1.4fr)_auto] items-start gap-3 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-[minmax(0,1fr)_auto]"
+                    className="grid grid-cols-[minmax(72px,0.6fr)_minmax(0,1.5fr)_auto] items-center gap-inset border-t border-line py-row first:border-t-0 max-md:grid-cols-1 max-md:gap-1 max-md:px-3 max-md:py-inset"
                   >
-                    <span className="text-xs leading-4 text-ink-2 max-[560px]:col-span-2">
+                    <span className="text-xs leading-4 text-ink-2">
                       {workout.date === null
                         ? `Priority ${index + 1} · Undated`
                         : dateLabel(workout.date)}
                     </span>
-                    <strong className="text-sm leading-5 font-medium [overflow-wrap:anywhere]">
+                    <strong className="text-sm leading-5 font-semibold [overflow-wrap:anywhere]">
                       {workout.name} · {workout.minutes} min · {workout.guidance}
                     </strong>
-                    <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+                    <span className="inline-flex shrink-0 items-center justify-self-start gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2">
                       planned{workout.pinned ? " · Pinned" : ""}
                     </span>
                   </div>
@@ -231,7 +249,7 @@ export function PlanCreationDraftCards(props: {
               )}
             </div>
             {week.notes.map((note, index) => (
-              <p key={`${index}:${note}`} className="m-0 text-sm leading-5 text-ink-2">
+              <p key={`${index}:${note}`} className="mt-inset mb-0 text-sm leading-5 text-ink-2">
                 {note}
               </p>
             ))}
@@ -242,10 +260,11 @@ export function PlanCreationDraftCards(props: {
             {error}
           </p>
         )}
-        <div className="mt-inset flex flex-wrap gap-inset">
+        <div className="mt-4 flex flex-wrap gap-inset">
           <Button
             ref={discardButton}
             variant="destructive"
+            className="border-[color-mix(in_srgb,var(--danger)_52%,var(--line))]"
             data-plan-creation-discard={props.model.creationId}
             aria-haspopup="dialog"
             disabled={busy || actions === null}
@@ -255,6 +274,7 @@ export function PlanCreationDraftCards(props: {
           </Button>
           <Button
             variant="outline"
+            className="border-line bg-surface"
             ref={editButton}
             disabled={busy || actions === null || editingKey !== null}
             onClick={props.onEditAnswers}
@@ -350,7 +370,7 @@ export function PlanCreationCommitmentCard(props: {
       summary={pendingCommitmentSummary}
       summaryId={commitmentSummaryId(props.model)}
     >
-      <div role="table" aria-label="Schedule correction">
+      <div role="table" className="border-t border-line" aria-label="Schedule correction">
         <Fact label="Submitted">{pending.text}</Fact>
         {pending.rules.map((rule, index) => (
           <Fact key={index} label="Interpreted limit">
@@ -375,6 +395,7 @@ export function PlanCreationCommitmentCard(props: {
       <div className="mt-inset flex flex-wrap gap-inset">
         <Button
           variant="outline"
+          className="border-line bg-surface"
           disabled={disabled}
           onClick={() => actions?.answerPlanCreation({ kind: "commitments-cancel" })}
         >
@@ -382,6 +403,7 @@ export function PlanCreationCommitmentCard(props: {
         </Button>
         <Button
           variant="outline"
+          className="border-line bg-surface"
           disabled={disabled || editingKey !== null}
           onClick={() => actions?.editPlanCreation("commitments")}
         >

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
@@ -1,3 +1,4 @@
+import { formatCivilDate } from "../../lib/date";
 import type {
   PlanCreationAnswerSummary,
   PlanCreationCardModel,
@@ -6,7 +7,7 @@ import type {
 } from "@enduragent/coach-contract";
 import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent, CardHeader } from "@enduragent/ui";
+import { Fact, PlanCard } from "../plan/plan-card";
 import { useEnduragentStore } from "../../state/store";
 
 const answerLabels: ReadonlyArray<readonly [PlanCreationAnswerSummary["answerKey"], string]> = [
@@ -20,34 +21,6 @@ const answerLabels: ReadonlyArray<readonly [PlanCreationAnswerSummary["answerKey
   ["success", "Success"],
   ["restriction", "Training restriction"],
 ];
-
-function dateLabel(value: string): string {
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(`${value}T12:00:00Z`));
-}
-
-function Fact(props: { readonly label: string; readonly children: ReactNode }): ReactElement {
-  return (
-    <div
-      role="row"
-      className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] max-md:grid-cols-1 max-md:gap-1"
-    >
-      <span role="rowheader" className="text-xs leading-4 text-ink-2">
-        {props.label}
-      </span>
-      <strong
-        role="cell"
-        className="text-right text-sm leading-5 font-medium [overflow-wrap:anywhere] max-md:text-left"
-      >
-        {props.children}
-      </strong>
-    </div>
-  );
-}
 
 function AnswerFacts(props: {
   readonly summaries: readonly PlanCreationAnswerSummary[];
@@ -80,52 +53,10 @@ function ReviewCard(props: {
   readonly status?: string;
   readonly summary?: string;
   readonly summaryId?: string;
+  readonly "aria-label"?: string;
   readonly children: ReactNode;
 }): ReactElement {
-  return (
-    <Card
-      size="sm"
-      className="block min-w-0 gap-[normal] py-0"
-      role="region"
-      aria-label={props.eyebrow === "Draft inputs" ? "Draft inputs" : props.title}
-    >
-      <CardHeader className="block rounded-none p-4">
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-          <div className="min-w-0 justify-self-start">
-            {props.eyebrow ? (
-              <p
-                data-plan-card-eyebrow
-                className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
-              >
-                {props.eyebrow}
-              </p>
-            ) : null}
-            <h3 data-plan-card-title className="m-0 text-base leading-6 font-semibold break-words">
-              {props.title}
-            </h3>
-          </div>
-          {props.status ? (
-            <span
-              data-plan-card-status
-              className="inline-flex shrink-0 items-center justify-self-start gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2"
-            >
-              {props.status}
-            </span>
-          ) : null}
-        </div>
-        {props.summary ? (
-          <p
-            data-plan-card-summary
-            id={props.summaryId}
-            className="mt-inset mb-0 text-sm leading-5 text-ink-2"
-          >
-            {props.summary}
-          </p>
-        ) : null}
-      </CardHeader>
-      <CardContent className="px-4 pt-0 pb-4">{props.children}</CardContent>
-    </Card>
-  );
+  return <PlanCard {...props} aria-label={props["aria-label"] ?? props.title} />;
 }
 
 export function PlanCreationDraftCards(props: {
@@ -169,6 +100,7 @@ export function PlanCreationDraftCards(props: {
       ) : null}
       <ReviewCard
         eyebrow="Draft inputs"
+        aria-label="Draft inputs"
         title={title}
         status={stale ? "Stale" : "Needs review"}
         summary={
@@ -182,13 +114,13 @@ export function PlanCreationDraftCards(props: {
             label={`Main Goal · ${goal?.source.kind === "derived" ? goal.source.label : "your answer"}`}
           >
             {draft.goal.kind === "event"
-              ? `${draft.goal.name} · ${dateLabel(draft.goal.date)}`
+              ? `${draft.goal.name} · ${formatCivilDate(draft.goal.date)}`
               : title}
           </Fact>
           <Fact label="Calendar">Local review only</Fact>
           <Fact label="Plan span">
-            {dateLabel(draft.start)} to {dateLabel(draft.end)} · {draft.weeks.length} weeks ·{" "}
-            {draft.spanKind}
+            {formatCivilDate(draft.start)} to {formatCivilDate(draft.end)} · {draft.weeks.length}{" "}
+            weeks · {draft.spanKind}
           </Fact>
           <AnswerFacts summaries={draft.answeredSummaries} omitGoal />
         </div>
@@ -216,7 +148,7 @@ export function PlanCreationDraftCards(props: {
         {draft.weeks.map((week) => (
           <div key={week.number} className="min-w-0 [&:not(:first-child)]:pt-4">
             <p className="m-0 pb-inset text-xs font-semibold uppercase tracking-wide text-ink-2">
-              Week {week.number} · {dateLabel(week.start)} to {dateLabel(week.end)} ·{" "}
+              Week {week.number} · {formatCivilDate(week.start)} to {formatCivilDate(week.end)} ·{" "}
               {week.workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min
             </p>
             <div
@@ -236,7 +168,7 @@ export function PlanCreationDraftCards(props: {
                     <span className="text-xs leading-4 text-ink-2">
                       {workout.date === null
                         ? `Priority ${index + 1} · Undated`
-                        : dateLabel(workout.date)}
+                        : formatCivilDate(workout.date)}
                     </span>
                     <strong className="text-sm leading-5 font-semibold [overflow-wrap:anywhere]">
                       {workout.name} · {workout.minutes} min · {workout.guidance}
@@ -319,25 +251,6 @@ export function commitmentSummaryId(model: PlanCreationCardModel): string {
   return `commitment-summary-${model.creationId}`;
 }
 
-function commitmentDateLabel(value: string): string {
-  const [year, month, day] = value.split("-");
-  const months = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
-  return `${Number(day)} ${months[Number(month) - 1]} ${year}`;
-}
-
 function commitmentRuleText(rule: PlanCreationCommitmentRule): string {
   const days = ["", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
   switch (rule.kind) {
@@ -348,7 +261,7 @@ function commitmentRuleText(rule: PlanCreationCommitmentRule): string {
     case "hard-weekday":
       return `${days[rule.day]} · no hard training`;
     case "time-off":
-      return `Off ${commitmentDateLabel(rule.start)} to ${commitmentDateLabel(rule.end)}`;
+      return `Off ${formatCivilDate(rule.start)} to ${formatCivilDate(rule.end)}`;
   }
 }
 

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationQuestionCard.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationQuestionCard.tsx
@@ -15,7 +15,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@enduragent/ui";
 const fieldClass =
   "min-h-[var(--ctl-h-lg)] rounded-ctl border border-line-2 bg-sunk px-ctl-px-sm py-2 text-sm font-semibold leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20";
 const choiceClass =
-  "grid min-h-[calc(var(--ctl-h-lg)+var(--row-inset))] w-full grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)_20px] max-md:grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)] items-center gap-2 rounded-ctl border-0 bg-transparent px-2 py-1.5 text-left text-ink hover:bg-ink/5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50";
+  "grid min-h-[calc(var(--ctl-h-lg)+var(--row-inset))] w-full grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)_20px] max-md:grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)] items-center gap-2 rounded-ctl border-0 bg-transparent px-2 py-1.5 text-left text-ink hover:bg-ink/5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-pressed:bg-primary/10 disabled:pointer-events-none disabled:opacity-50";
 
 interface QuestionFormProps {
   readonly commitmentStatus?: "confirm" | "clarify";
@@ -53,7 +53,11 @@ function ChoiceRow(props: {
       onClick={props.onClick}
     >
       <span
-        className="grid size-ctl-sm place-items-center rounded-full border border-line-2 text-xs leading-4 text-ink-2"
+        className={
+          props.selected
+            ? "grid size-ctl-sm place-items-center rounded-full border border-primary bg-primary text-xs leading-4 text-primary-foreground"
+            : "grid size-ctl-sm place-items-center rounded-full border border-line-2 text-xs leading-4 text-ink-2"
+        }
         data-parity="choice.row.number"
       >
         {props.number === undefined ? <Plus className="size-4" aria-hidden="true" /> : props.number}

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationQuestionCard.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationQuestionCard.tsx
@@ -1,3 +1,4 @@
+import { formatCivilDate } from "../../lib/date";
 import type { PlanCreationAnswerInput, PlanCreationOpenQuestion } from "@enduragent/coach-contract";
 import {
   useEffect,
@@ -32,7 +33,7 @@ interface QuestionFormProps {
 function ChoiceRow(props: {
   readonly answerId: string;
   readonly label: string;
-  readonly detail: string;
+  readonly detail?: string;
   readonly number?: number;
   readonly selected?: boolean;
   readonly custom?: boolean;
@@ -66,12 +67,14 @@ function ChoiceRow(props: {
         <strong className="block text-sm font-medium leading-5" data-parity="choice.row.label">
           {props.label}
         </strong>
-        <span
-          className="mt-[calc(var(--inset)/2)] block text-sm leading-5 text-ink-2"
-          data-parity="choice.row.detail"
-        >
-          {props.detail}
-        </span>
+        {props.detail === undefined ? null : (
+          <span
+            className="mt-[calc(var(--inset)/2)] block text-sm leading-5 text-ink-2"
+            data-parity="choice.row.detail"
+          >
+            {props.detail}
+          </span>
+        )}
       </span>
       <ChevronRight className="size-4 text-ink-2 max-md:hidden" aria-hidden="true" />
     </button>
@@ -94,19 +97,15 @@ function ChoiceList(props: {
 function ChoiceActions(props: QuestionFormProps): ReactElement | null {
   if (!props.editing) return null;
   return (
-    <div className="flex justify-end gap-inset px-2 pt-[calc(var(--inset)/2)] pb-2">
-      {props.editing ? (
-        <Button
-          type="button"
-          variant="outline"
-          className="mr-auto border-line bg-surface"
-          disabled={props.busy}
-          onClick={props.onCancel}
-        >
-          Back to answers
-        </Button>
-      ) : null}
-    </div>
+    <Button
+      type="button"
+      variant="outline"
+      className="mr-auto border-line bg-surface"
+      disabled={props.busy}
+      onClick={props.onCancel}
+    >
+      Back to answers
+    </Button>
   );
 }
 
@@ -164,16 +163,12 @@ function GoalForm(props: QuestionFormProps): ReactElement {
   const question = props.question.kind === "goal-question" ? props.question : null;
   if (question === null) throw new TypeError("goal question required");
   const currentGoal = props.currentAnswer?.kind === "goal" ? props.currentAnswer.goal : null;
-  const [manualSource, setManualSource] = useState<"event-not-listed" | "custom" | null>(
-    currentGoal?.kind === "event-manual" ? "event-not-listed" : null,
-  );
-  const manual = manualSource !== null;
+  const [manual, setManual] = useState(currentGoal?.kind === "event-manual");
   const [name, setName] = useState(currentGoal?.kind === "event-manual" ? currentGoal.name : "");
   const [date, setDate] = useState(currentGoal?.kind === "event-manual" ? currentGoal.date : "");
   const [errors, setErrors] = useState<{ name?: string; date?: string }>({});
   const editor = useRef<HTMLInputElement>(null);
   const eventNotListedTrigger = useRef<HTMLButtonElement>(null);
-  const customTrigger = useRef<HTMLButtonElement>(null);
   const nameErrorId = useId();
   const dateErrorId = useId();
   useEffect(() => {
@@ -182,14 +177,12 @@ function GoalForm(props: QuestionFormProps): ReactElement {
     return () => props.onEditorOpenChange(false);
   }, [manual, props.onEditorOpenChange]);
   const back = (): void => {
-    const trigger = manualSource === "custom" ? customTrigger : eventNotListedTrigger;
     setErrors({});
-    setManualSource(null);
-    queueMicrotask(() => trigger.current?.focus());
+    setManual(false);
+    queueMicrotask(() => eventNotListedTrigger.current?.focus());
   };
   if (manual) {
-    const editorCopy =
-      manualSource === "custom" ? question.authoredOption : question.eventNotListedOption;
+    const editorCopy = question.eventNotListedOption;
     const submit = (event: FormEvent<HTMLFormElement>): void => {
       event.preventDefault();
       const nextErrors = {
@@ -212,9 +205,6 @@ function GoalForm(props: QuestionFormProps): ReactElement {
         }}
         noValidate
       >
-        <p className="m-0 text-xs font-semibold leading-4 text-ink-2" data-parity="custom.label">
-          {editorCopy.editorLabel}
-        </p>
         <div className="grid gap-inset">
           <label className="grid gap-[calc(var(--inset)/2)] text-xs font-semibold leading-4 text-ink-2">
             {question.eventNotListedOption.nameLabel}
@@ -256,9 +246,6 @@ function GoalForm(props: QuestionFormProps): ReactElement {
   }
   const selectedCandidate =
     currentGoal?.kind === "event-candidate" ? currentGoal.candidateId : null;
-  const openManual = (source: "event-not-listed" | "custom"): void => {
-    setManualSource(source);
-  };
   return (
     <div>
       <ChoiceList>
@@ -268,7 +255,7 @@ function GoalForm(props: QuestionFormProps): ReactElement {
               key={candidate.candidateId}
               answerId={candidate.candidateId}
               number={index + 1}
-              label={`${candidate.name} · ${candidate.date}`}
+              label={`${candidate.name} · ${formatCivilDate(candidate.date)}`}
               detail={candidate.sourceLabel}
               selected={candidate.candidateId === selectedCandidate}
               disabled={props.busy}
@@ -289,7 +276,7 @@ function GoalForm(props: QuestionFormProps): ReactElement {
             detail={question.eventNotListedOption.detail}
             selected={currentGoal?.kind === "event-manual"}
             disabled={props.busy}
-            onClick={() => openManual("event-not-listed")}
+            onClick={() => setManual(true)}
           />,
           <ChoiceRow
             key="fitness"
@@ -300,16 +287,6 @@ function GoalForm(props: QuestionFormProps): ReactElement {
             selected={currentGoal?.kind === "fitness"}
             disabled={props.busy}
             onClick={() => props.onAnswer({ kind: "goal", goal: { kind: "fitness" } })}
-          />,
-          <ChoiceRow
-            key="custom"
-            buttonRef={customTrigger}
-            answerId="custom"
-            label={question.authoredOption.label}
-            detail={question.authoredOption.detail}
-            custom
-            disabled={props.busy}
-            onClick={() => openManual("custom")}
           />,
         ]}
       </ChoiceList>
@@ -656,7 +633,7 @@ function StartTimingForm(props: QuestionFormProps): ReactElement {
           return;
         }
         if (date.length === 0 || date < question.earliestAllowed) {
-          setError(`Choose a date on or after ${question.earliestAllowed}.`);
+          setError(`Choose a date on or after ${formatCivilDate(question.earliestAllowed)}.`);
           return;
         }
         setError(undefined);

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationQuestionCard.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationQuestionCard.tsx
@@ -13,9 +13,9 @@ import { Button } from "@enduragent/ui";
 import { Card, CardContent, CardHeader, CardTitle } from "@enduragent/ui";
 
 const fieldClass =
-  "min-h-[var(--ctl-h-lg)] rounded-ctl border border-line-2 bg-sunk px-ctl-px-sm py-2 text-sm font-normal leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20";
+  "min-h-[var(--ctl-h-lg)] rounded-ctl border border-line-2 bg-sunk px-ctl-px-sm py-2 text-sm font-semibold leading-5 text-ink outline-none focus:border-ring focus:ring-3 focus:ring-ring/20";
 const choiceClass =
-  "grid min-h-[calc(var(--ctl-h-lg)+var(--row-inset))] w-full grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)_20px] items-center gap-2 rounded-ctl border-0 bg-transparent px-2 py-1.5 text-left text-ink hover:bg-ink/5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50";
+  "grid min-h-[calc(var(--ctl-h-lg)+var(--row-inset))] w-full grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)_20px] max-md:grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)] items-center gap-2 rounded-ctl border-0 bg-transparent px-2 py-1.5 text-left text-ink hover:bg-ink/5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50";
 
 interface QuestionFormProps {
   readonly commitmentStatus?: "confirm" | "clarify";
@@ -53,7 +53,7 @@ function ChoiceRow(props: {
       onClick={props.onClick}
     >
       <span
-        className="grid size-8 place-items-center rounded-full border border-line-2 text-xs leading-4 text-ink-2"
+        className="grid size-ctl-sm place-items-center rounded-full border border-line-2 text-xs leading-4 text-ink-2"
         data-parity="choice.row.number"
       >
         {props.number === undefined ? <Plus className="size-4" aria-hidden="true" /> : props.number}
@@ -69,7 +69,7 @@ function ChoiceRow(props: {
           {props.detail}
         </span>
       </span>
-      <ChevronRight className="size-4 text-ink-2" aria-hidden="true" />
+      <ChevronRight className="size-4 text-ink-2 max-md:hidden" aria-hidden="true" />
     </button>
   );
 }
@@ -87,23 +87,21 @@ function ChoiceList(props: {
   );
 }
 
-function ChoiceActions(props: QuestionFormProps): ReactElement {
+function ChoiceActions(props: QuestionFormProps): ReactElement | null {
+  if (!props.editing) return null;
   return (
     <div className="flex justify-end gap-inset px-2 pt-[calc(var(--inset)/2)] pb-2">
       {props.editing ? (
         <Button
           type="button"
           variant="outline"
-          className="mr-auto"
+          className="mr-auto border-line bg-surface"
           disabled={props.busy}
           onClick={props.onCancel}
         >
           Back to answers
         </Button>
       ) : null}
-      <Button type="button" variant="outline" disabled={props.busy} onClick={props.onLater}>
-        Later
-      </Button>
     </div>
   );
 }
@@ -122,7 +120,7 @@ function CustomActions(props: {
         <Button
           type="button"
           variant="outline"
-          className="mr-auto"
+          className="mr-auto border-line bg-surface"
           disabled={props.busy}
           onClick={props.onCancel}
         >
@@ -130,7 +128,13 @@ function CustomActions(props: {
         </Button>
       ) : null}
       <div className="flex gap-inset">
-        <Button type="button" variant="outline" disabled={props.busy} onClick={props.onBack}>
+        <Button
+          type="button"
+          variant="outline"
+          className="border-line bg-surface"
+          disabled={props.busy}
+          onClick={props.onBack}
+        >
           Back
         </Button>
         <Button type="submit" disabled={props.busy || props.continueDisabled}>
@@ -207,7 +211,7 @@ function GoalForm(props: QuestionFormProps): ReactElement {
         <p className="m-0 text-xs font-semibold leading-4 text-ink-2" data-parity="custom.label">
           {editorCopy.editorLabel}
         </p>
-        <div className="grid gap-inset sm:grid-cols-2">
+        <div className="grid gap-inset">
           <label className="grid gap-[calc(var(--inset)/2)] text-xs font-semibold leading-4 text-ink-2">
             {question.eventNotListedOption.nameLabel}
             <input
@@ -573,16 +577,23 @@ function AvailabilityForm(props: QuestionFormProps): ReactElement {
         <ErrorText id={longestErrorId}>{errors.longest}</ErrorText>
       </label>
       {question.mode === "fixed" ? (
-        <fieldset className="m-0 grid gap-2 border-0 px-4 py-0" aria-describedby={weekdaysErrorId}>
-          <legend className="text-xs font-semibold leading-4 text-ink-2">Usable weekdays</legend>
-          <div className="grid grid-cols-4 gap-2 sm:grid-cols-7">
+        <fieldset
+          className="mx-4 my-0 flex min-w-0 flex-wrap gap-inset border-0 p-0"
+          aria-describedby={weekdaysErrorId}
+        >
+          <legend className="mb-inset px-0.5 text-sm font-normal leading-5 text-ink">
+            Usable weekdays
+          </legend>
+          <div className="flex flex-wrap gap-inset">
             {question.weekdayOptions.map((option) => (
               <label
                 key={option.weekday}
-                className="grid justify-items-center gap-1 rounded-ctl border border-line-2 bg-surface px-2 py-2 text-xs"
+                className="flex items-center gap-[calc(var(--inset)/2)] text-xs font-semibold leading-4 text-ink-2"
               >
                 <input
                   type="checkbox"
+                  className="my-0.75 size-4 accent-primary"
+                  disabled={props.busy}
                   name="usableWeekdays"
                   value={option.weekday}
                   defaultChecked={
@@ -604,16 +615,13 @@ function AvailabilityForm(props: QuestionFormProps): ReactElement {
           <Button
             type="button"
             variant="outline"
-            className="mr-auto"
+            className="mr-auto border-line bg-surface"
             disabled={props.busy}
             onClick={props.onCancel}
           >
             Back to answers
           </Button>
         ) : null}
-        <Button type="button" variant="outline" disabled={props.busy} onClick={props.onLater}>
-          Later
-        </Button>
         <Button type="submit" disabled={props.busy}>
           Continue
         </Button>
@@ -701,16 +709,13 @@ function StartTimingForm(props: QuestionFormProps): ReactElement {
           <Button
             type="button"
             variant="outline"
-            className="mr-auto"
+            className="mr-auto border-line bg-surface"
             disabled={props.busy}
             onClick={props.onCancel}
           >
             Back to answers
           </Button>
         ) : null}
-        <Button type="button" variant="outline" disabled={props.busy} onClick={props.onLater}>
-          Later
-        </Button>
         {timing === "earliest" ? (
           <Button type="submit" disabled={props.busy}>
             Continue
@@ -967,16 +972,13 @@ function RestrictionForm(props: QuestionFormProps): ReactElement {
           <Button
             type="button"
             variant="outline"
-            className="mr-auto"
+            className="mr-auto border-line bg-surface"
             disabled={props.busy}
             onClick={props.onCancel}
           >
             Back to answers
           </Button>
         ) : null}
-        <Button type="button" variant="outline" disabled={props.busy} onClick={props.onLater}>
-          Later
-        </Button>
         {kind === null ? null : (
           <Button type="submit" disabled={props.busy}>
             Continue
@@ -1051,23 +1053,35 @@ export function PlanCreationQuestionCard(
         props.onLater();
       }}
     >
-      <CardHeader className="gap-0 border-b border-line">
-        <p
-          className="m-0 mb-[calc(var(--inset)/2)] text-xs font-semibold leading-4 text-ink-2"
-          data-parity="question.eyebrow"
-        >
-          Plan creation · question {props.question.step.current} of {props.question.step.total}
-        </p>
-        <CardTitle>
-          <h2
-            ref={heading}
-            tabIndex={-1}
-            className="m-0 font-medium outline-none"
-            data-parity="question.title"
+      <CardHeader className="flex items-center justify-between gap-inset rounded-none border-b border-line pt-4 pr-3 pb-inset! pl-4">
+        <div className="min-w-0">
+          <p
+            className="m-0 mb-[calc(var(--inset)/2)] text-xs font-semibold leading-4 text-ink-2"
+            data-parity="question.eyebrow"
           >
-            {props.question.prompt}
-          </h2>
-        </CardTitle>
+            Plan creation · question {props.question.step.current} of {props.question.step.total}
+          </p>
+          <CardTitle>
+            <h2
+              ref={heading}
+              tabIndex={-1}
+              className="m-0 font-medium outline-none"
+              data-parity="question.title"
+            >
+              {props.question.prompt}
+            </h2>
+          </CardTitle>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="border-line bg-surface"
+          aria-label="Later"
+          disabled={props.busy}
+          onClick={props.onLater}
+        >
+          Later
+        </Button>
       </CardHeader>
       <CardContent className="grid min-w-0 gap-inset p-0">
         <QuestionForm {...props} />

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, type ReactElement } from "react";
 import { Check } from "lucide-react";
 import { Button } from "@enduragent/ui";
 import { Card, CardContent } from "@enduragent/ui";
+import { creationTitle } from "../../plan/creation-title";
 import { useEnduragentStore } from "../../state/store";
 
 import { commitmentSummaryId } from "./PlanCreationDraftCards";
@@ -29,7 +30,7 @@ export function PlanCreationSummary(props: {
     }
   }, [focusRequest?.revision, focusRequest?.target]);
   return (
-    <section className="grid min-w-0 gap-inset" aria-label="Plan Creation progress">
+    <section className="grid min-w-0 gap-4" aria-label="Plan Creation progress">
       {props.model.answeredSummaries.length === 0 ? null : (
         <ul className="m-0 grid list-none gap-2 p-0" role="list">
           {props.model.answeredSummaries.map((summary) => (
@@ -39,7 +40,7 @@ export function PlanCreationSummary(props: {
               data-parity="summary.row"
               aria-label={`${summary.title} answer`}
             >
-              <span className="grid size-8 place-items-center rounded-full bg-primary/10 text-primary">
+              <span className="grid size-8 place-items-center rounded-full bg-[color-mix(in_srgb,var(--ok)_16%,var(--surface))] text-ok">
                 <Check className="size-4" aria-hidden="true" />
               </span>
               <div className="min-w-0">
@@ -80,45 +81,53 @@ export function PlanCreationSummary(props: {
         </ul>
       )}
       {props.answersOnly ? null : (
-        <Card size="sm" className="min-w-0" data-parity="progress.card">
-          <CardContent className="grid gap-inset">
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-inset">
-              <div className="grid gap-[calc(var(--inset)/2)]">
+        <Card size="sm" className="block min-w-0 gap-0 py-0" data-parity="progress.card">
+          <CardContent className="p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
                 <p
-                  className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2"
+                  className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
                   data-parity="progress.eyebrow"
                 >
                   Plan creation
                 </p>
-                <strong data-parity="progress.title">New Plan</strong>
+                <strong
+                  className="block text-base font-semibold leading-6"
+                  data-parity="progress.title"
+                >
+                  {creationTitle(props.model)}
+                </strong>
               </div>
               <div className="flex items-center gap-inset self-start">
                 <span
-                  className="rounded-full bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2"
+                  className="inline-flex items-center gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal leading-4 text-ink-2"
                   data-parity="progress.status"
                 >
-                  {ready ? "Ready" : "In progress"}
+                  {ready ? "Ready" : paused ? "Paused" : "In progress"}
                 </span>
-                <Button
-                  ref={discardButton}
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  data-plan-creation-discard={props.model.creationId}
-                  aria-haspopup="dialog"
-                  disabled={busy || actions === null}
-                  onClick={() => actions?.openPlanCreationDiscard()}
-                >
-                  Discard
-                </Button>
               </div>
             </div>
-            <p className="m-0 text-xs text-ink-2" data-parity="progress.summary">
+            <p
+              className="mt-inset mb-0 text-sm leading-5 text-ink-2"
+              data-parity="progress.summary"
+            >
               {ready
                 ? "The essentials are complete."
                 : `${props.model.answeredSummaries.length} of ${total} answered.`}
             </p>
-            <div className="flex flex-wrap gap-inset" data-parity="progress.actions">
+            <div className="mt-4 flex flex-wrap gap-inset" data-parity="progress.actions">
+              <Button
+                ref={discardButton}
+                type="button"
+                variant="destructive"
+                className="border-[color-mix(in_srgb,var(--danger)_52%,var(--line))] bg-transparent"
+                data-plan-creation-discard={props.model.creationId}
+                aria-haspopup="dialog"
+                disabled={busy || actions === null}
+                onClick={() => actions?.openPlanCreationDiscard()}
+              >
+                Discard
+              </Button>
               {ready && props.model.draft === null ? (
                 <Button
                   disabled={
@@ -140,7 +149,7 @@ export function PlanCreationSummary(props: {
               {canContinue ? (
                 <Button
                   type="button"
-                  variant="outline"
+                  variant="default"
                   disabled={actions === null || busy}
                   onClick={() => actions?.continuePlanCreation()}
                 >

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
@@ -13,6 +13,7 @@ export function PlanCreationSummary(props: {
   readonly answersOnly?: boolean;
 }): ReactElement {
   const actions = useEnduragentStore((state) => state.chatActions);
+  const library = useEnduragentStore((state) => state.planLibrary.value);
   const paused = useEnduragentStore((state) => state.chat.planCreationPaused);
   const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
   const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
@@ -103,7 +104,7 @@ export function PlanCreationSummary(props: {
                   className="inline-flex items-center gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal leading-4 text-ink-2"
                   data-parity="progress.status"
                 >
-                  {ready ? "Ready" : paused ? "Paused" : "In progress"}
+                  {paused ? "Paused" : "In progress"}
                 </span>
               </div>
             </div>
@@ -113,7 +114,7 @@ export function PlanCreationSummary(props: {
             >
               {ready
                 ? "The essentials are complete."
-                : `${props.model.answeredSummaries.length} of ${total} answered.`}
+                : `${props.model.answeredSummaries.length} of ${total} answered.${library === null ? "" : ` ${library.active ? `${library.active.name} keeps running.` : "No Plan is active."}`}`}
             </p>
             <div className="mt-4 flex flex-wrap gap-inset" data-parity="progress.actions">
               <Button

--- a/apps/desktop-renderer/src/ui/chat/TrainingContextPanel.tsx
+++ b/apps/desktop-renderer/src/ui/chat/TrainingContextPanel.tsx
@@ -41,7 +41,7 @@ export function TrainingContextPanel(props: {
 
   return (
     <aside
-      className={`training-context min-h-0 overflow-auto border-l border-line bg-surface-2 px-[calc(var(--inset)*2)] py-[calc(var(--inset)*2)] ${props.className ?? ""}`}
+      className={`training-context min-h-0 overflow-auto [scrollbar-width:none] border-l border-line bg-surface-2 px-[calc(var(--inset)*2)] py-[calc(var(--inset)*2)] ${props.className ?? ""}`}
       aria-label={props.labelledBy === undefined ? "Training context" : undefined}
       aria-labelledby={props.labelledBy}
     >

--- a/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
@@ -1,7 +1,9 @@
+import { formatCivilDate } from "../../lib/date";
 import type { PlanCreationAnswerSummary, PlanHistoryResult } from "@enduragent/coach-contract";
-import type { ReactElement, ReactNode } from "react";
+import type { ReactElement } from "react";
 import { Button } from "@enduragent/ui";
 import { Card, CardContent, CardHeader } from "@enduragent/ui";
+import { Fact, PlanCard } from "./plan-card";
 
 const answerLabels: ReadonlyArray<readonly [PlanCreationAnswerSummary["answerKey"], string]> = [
   ["plan-length", "Plan length"],
@@ -41,34 +43,6 @@ function calendarLabel(
   }
 }
 
-function dateLabel(value: string): string {
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(`${value}T12:00:00Z`));
-}
-
-function Fact(props: { readonly label: string; readonly children: ReactNode }): ReactElement {
-  return (
-    <div
-      role="row"
-      className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] max-md:grid-cols-1 max-md:gap-1"
-    >
-      <span role="rowheader" className="text-xs leading-4 text-ink-2">
-        {props.label}
-      </span>
-      <strong
-        role="cell"
-        className="text-right text-sm leading-5 font-medium [overflow-wrap:anywhere] max-md:text-left"
-      >
-        {props.children}
-      </strong>
-    </div>
-  );
-}
-
 export function PlanFinalDetails(props: {
   readonly history: NonNullable<PlanHistoryResult>;
   readonly notice?: string | null;
@@ -91,35 +65,22 @@ export function PlanFinalDetails(props: {
           {props.notice}
         </p>
       ) : null}
-      <Card
-        size="sm"
-        className="block min-w-0 gap-[normal] py-0"
-        role="region"
+      <PlanCard
+        eyebrow="Closed Plan"
+        title={plan.name}
+        status="Closed"
         aria-label="Closed Plan"
-      >
-        <CardHeader className="block rounded-none p-4">
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-            <div className="min-w-0 justify-self-start">
-              <p className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2">
-                Closed Plan
-              </p>
-              <h3 className="m-0 text-base leading-6 font-semibold break-words">{plan.name}</h3>
-            </div>
-            <span className="inline-flex shrink-0 items-center justify-self-start gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2">
-              Closed
-            </span>
-          </div>
-          <p className="mt-inset mb-0 text-sm leading-5 text-ink-2">
-            {dateLabel(plan.start)} to {dateLabel(plan.end)} · {plan.weeks} weeks · {reason}
-          </p>
-          {draft.goal.kind === "event" && draft.goal.date > draft.end ? (
+        parityAttributes={false}
+        summary={`${formatCivilDate(plan.start)} to ${formatCivilDate(plan.end)} · ${plan.weeks} weeks · ${reason}`}
+        headerChildren={
+          draft.goal.kind === "event" && draft.goal.date > draft.end ? (
             <p role="status" className="m-0 text-sm leading-5 text-ink-2">
-              Your Event Goal is still {dateLabel(draft.goal.date)}. Start a new Plan for event
-              preparation when it is within 24 weeks.
+              Your Event Goal is still {formatCivilDate(draft.goal.date)}. Start a new Plan for
+              event preparation when it is within 24 weeks.
             </p>
-          ) : null}
-        </CardHeader>
-      </Card>
+          ) : null
+        }
+      />
       <Card
         size="sm"
         className="block min-w-0 gap-[normal] py-0"
@@ -135,13 +96,13 @@ export function PlanFinalDetails(props: {
               label={`Main Goal · ${goal?.source.kind === "derived" ? goal.source.label : "your answer"}`}
             >
               {draft.goal.kind === "event"
-                ? `${draft.goal.name} · ${dateLabel(draft.goal.date)}`
+                ? `${draft.goal.name} · ${formatCivilDate(draft.goal.date)}`
                 : (draft.goal.outcome ?? "Improve fitness")}
             </Fact>
             <Fact label="Calendar">{calendarLabel(plan.calendar, cleanup)}</Fact>
             <Fact label="Plan span">
-              {dateLabel(draft.start)} to {dateLabel(draft.end)} · {draft.weeks.length} weeks ·{" "}
-              {draft.spanKind}
+              {formatCivilDate(draft.start)} to {formatCivilDate(draft.end)} · {draft.weeks.length}{" "}
+              weeks · {draft.spanKind}
             </Fact>
             {answerLabels.map(([key, label]) => {
               const summary = draft.answeredSummaries.find((answer) => answer.answerKey === key);
@@ -158,7 +119,7 @@ export function PlanFinalDetails(props: {
           {draft.weeks.map((week) => (
             <div key={week.number} className="min-w-0">
               <p className="m-0 pt-4 pb-inset text-xs font-semibold uppercase tracking-wide text-ink-2">
-                Week {week.number} · {dateLabel(week.start)} to {dateLabel(week.end)} ·{" "}
+                Week {week.number} · {formatCivilDate(week.start)} to {formatCivilDate(week.end)} ·{" "}
                 {week.workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min
               </p>
               <div
@@ -178,7 +139,7 @@ export function PlanFinalDetails(props: {
                       <span className="text-xs leading-4 text-ink-2">
                         {workout.date === null
                           ? `Priority ${index + 1} · Undated`
-                          : dateLabel(workout.date)}
+                          : formatCivilDate(workout.date)}
                       </span>
                       <strong className="text-sm leading-5 font-semibold [overflow-wrap:anywhere]">
                         {workout.name} · {workout.minutes} min · {workout.guidance}

--- a/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanFinalDetails.tsx
@@ -1,7 +1,7 @@
 import type { PlanCreationAnswerSummary, PlanHistoryResult } from "@enduragent/coach-contract";
 import type { ReactElement, ReactNode } from "react";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent } from "@enduragent/ui";
+import { Card, CardContent, CardHeader } from "@enduragent/ui";
 
 const answerLabels: ReadonlyArray<readonly [PlanCreationAnswerSummary["answerKey"], string]> = [
   ["plan-length", "Plan length"],
@@ -54,14 +54,14 @@ function Fact(props: { readonly label: string; readonly children: ReactNode }): 
   return (
     <div
       role="row"
-      className="grid grid-cols-[minmax(104px,0.72fr)_minmax(0,1.28fr)] gap-4 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-1 max-[560px]:gap-1"
+      className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] max-md:grid-cols-1 max-md:gap-1"
     >
       <span role="rowheader" className="text-xs leading-4 text-ink-2">
         {props.label}
       </span>
       <strong
         role="cell"
-        className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left"
+        className="text-right text-sm leading-5 font-medium [overflow-wrap:anywhere] max-md:text-left"
       >
         {props.children}
       </strong>
@@ -85,26 +85,31 @@ export function PlanFinalDetails(props: {
         ? "Stopped"
         : "Unknown reason";
   return (
-    <section aria-label="Final Plan history" className="grid min-w-0 gap-inset">
+    <section aria-label="Final Plan history" className="grid min-w-0 gap-4">
       {props.notice ? (
         <p role="status" className="m-0 text-sm leading-5 text-ink-2">
           {props.notice}
         </p>
       ) : null}
-      <Card size="sm" className="min-w-0" role="region" aria-label="Closed Plan">
-        <CardContent className="grid gap-inset">
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
-            <div className="grid min-w-0 gap-[calc(var(--inset)/2)]">
-              <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+      <Card
+        size="sm"
+        className="block min-w-0 gap-[normal] py-0"
+        role="region"
+        aria-label="Closed Plan"
+      >
+        <CardHeader className="block rounded-none p-4">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+            <div className="min-w-0 justify-self-start">
+              <p className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2">
                 Closed Plan
               </p>
               <h3 className="m-0 text-base leading-6 font-semibold break-words">{plan.name}</h3>
             </div>
-            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+            <span className="inline-flex shrink-0 items-center justify-self-start gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2">
               Closed
             </span>
           </div>
-          <p className="m-0 text-sm leading-5 text-ink-2">
+          <p className="mt-inset mb-0 text-sm leading-5 text-ink-2">
             {dateLabel(plan.start)} to {dateLabel(plan.end)} · {plan.weeks} weeks · {reason}
           </p>
           {draft.goal.kind === "event" && draft.goal.date > draft.end ? (
@@ -113,12 +118,19 @@ export function PlanFinalDetails(props: {
               preparation when it is within 24 weeks.
             </p>
           ) : null}
-        </CardContent>
+        </CardHeader>
       </Card>
-      <Card size="sm" className="min-w-0" role="region" aria-label="Final Plan details">
-        <CardContent className="grid gap-inset">
+      <Card
+        size="sm"
+        className="block min-w-0 gap-[normal] py-0"
+        role="region"
+        aria-label="Final Plan details"
+      >
+        <CardHeader className="block rounded-none p-4">
           <h3 className="m-0 text-base leading-6 font-semibold break-words">Final Plan details</h3>
-          <div role="table" aria-label="Draft inputs">
+        </CardHeader>
+        <CardContent className="px-4 pt-0 pb-4">
+          <div role="table" aria-label="Draft inputs" className="border-t border-line">
             <Fact
               label={`Main Goal · ${goal?.source.kind === "derived" ? goal.source.label : "your answer"}`}
             >
@@ -144,12 +156,16 @@ export function PlanFinalDetails(props: {
             })}
           </div>
           {draft.weeks.map((week) => (
-            <div key={week.number} className="grid min-w-0 gap-inset">
-              <p className="m-0 text-xs font-semibold text-ink-2">
+            <div key={week.number} className="min-w-0">
+              <p className="m-0 pt-4 pb-inset text-xs font-semibold uppercase tracking-wide text-ink-2">
                 Week {week.number} · {dateLabel(week.start)} to {dateLabel(week.end)} ·{" "}
                 {week.workouts.reduce((minutes, workout) => minutes + workout.minutes, 0)} min
               </p>
-              <div role="list" aria-label={`Week ${week.number} Workouts`}>
+              <div
+                role="list"
+                aria-label={`Week ${week.number} Workouts`}
+                className="border-t border-line"
+              >
                 {week.workouts.length === 0 ? (
                   <p className="m-0 text-sm leading-5 text-ink-2">No Workouts this week.</p>
                 ) : (
@@ -157,17 +173,17 @@ export function PlanFinalDetails(props: {
                     <div
                       key={workout.id}
                       role="listitem"
-                      className="grid grid-cols-[minmax(0,0.6fr)_minmax(0,1.4fr)_auto] items-start gap-3 border-t border-line py-3 first:border-t-0 max-[560px]:grid-cols-[minmax(0,1fr)_auto]"
+                      className="grid grid-cols-[minmax(72px,0.6fr)_minmax(0,1.5fr)_auto] items-center gap-inset border-t border-line py-row first:border-t-0 max-md:grid-cols-1 max-md:gap-1 max-md:px-3 max-md:py-inset"
                     >
-                      <span className="text-xs leading-4 text-ink-2 max-[560px]:col-span-2">
+                      <span className="text-xs leading-4 text-ink-2">
                         {workout.date === null
                           ? `Priority ${index + 1} · Undated`
                           : dateLabel(workout.date)}
                       </span>
-                      <strong className="text-sm leading-5 font-medium [overflow-wrap:anywhere]">
+                      <strong className="text-sm leading-5 font-semibold [overflow-wrap:anywhere]">
                         {workout.name} · {workout.minutes} min · {workout.guidance}
                       </strong>
-                      <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+                      <span className="inline-flex shrink-0 items-center justify-self-start gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2">
                         {workout.date === null && !workout.pinned ? "Not chosen" : "planned"}
                         {workout.pinned ? " · Pinned" : ""}
                       </span>
@@ -176,7 +192,7 @@ export function PlanFinalDetails(props: {
                 )}
               </div>
               {week.notes.map((note, index) => (
-                <p key={`${index}:${note}`} className="m-0 text-sm leading-5 text-ink-2">
+                <p key={`${index}:${note}`} className="mt-inset mb-0 text-sm leading-5 text-ink-2">
                   {note}
                 </p>
               ))}
@@ -194,7 +210,7 @@ export function PlanFinalDetails(props: {
             Retry calendar
           </Button>
         ) : null}
-        <Button variant="outline" onClick={props.backToLibrary}>
+        <Button variant="outline" className="border-line bg-surface" onClick={props.backToLibrary}>
           Back to library
         </Button>
       </div>

--- a/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
@@ -1,8 +1,9 @@
+import { formatCivilDate } from "../../lib/date";
 import type { LegacyPlanSummary, ListPlansResult, PlanSummary } from "@enduragent/coach-contract";
 import { useEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
 import { CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY } from "../../chat/controller";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent, CardHeader } from "@enduragent/ui";
+import { PlanCard } from "./plan-card";
 import {
   Dialog,
   DialogClose,
@@ -16,15 +17,6 @@ import { creationTitle } from "../../plan/creation-title";
 import { requestPlanCalendarRetry } from "../../plan/library-refresh";
 import { useEnduragentStore } from "../../state/store";
 
-function dateLabel(value: string): string {
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(`${value}T12:00:00Z`));
-}
-
 function LibraryCard(props: {
   readonly eyebrow?: string;
   readonly title: string;
@@ -33,43 +25,32 @@ function LibraryCard(props: {
   readonly children?: ReactNode;
 }): ReactElement {
   return (
-    <Card
-      size="sm"
-      className="block min-w-0 gap-[normal] py-0"
-      role="region"
+    <PlanCard
+      {...props}
       aria-label={props.eyebrow ?? props.title}
-    >
-      <CardHeader className="block rounded-none p-4">
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-          <div className="min-w-0 justify-self-start">
-            {props.eyebrow ? (
-              <p
-                data-plan-card-eyebrow
-                className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
-              >
-                {props.eyebrow}
-              </p>
-            ) : null}
-            <h3 data-plan-card-title className="m-0 text-base leading-6 font-semibold break-words">
-              {props.title}
-            </h3>
-          </div>
-          {props.status ? (
-            <span
-              data-plan-card-status
-              className="inline-flex shrink-0 items-center gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2"
-            >
-              {props.status}
-            </span>
-          ) : null}
-        </div>
-        <p data-plan-card-summary className="mt-inset mb-0 text-sm leading-5 text-ink-2">
-          {props.summary}
-        </p>
-      </CardHeader>
-      {props.children ? <CardContent className="p-0">{props.children}</CardContent> : null}
-    </Card>
+      contentClassName="p-0"
+      statusClassName="inline-flex shrink-0 items-center gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2"
+    />
   );
+}
+
+export function calendarStatusLabel(calendar: PlanSummary["calendar"]): string {
+  switch (calendar.status) {
+    case "verified":
+      return calendar.window === null
+        ? "Up to date"
+        : `${formatCivilDate(calendar.window.start)} to ${formatCivilDate(calendar.window.end)} · Up to date`;
+    case "pending":
+      return calendar.window === null ? "Local only" : "Updating calendar";
+    case "running":
+      return "Updating calendar";
+    case "not-connected":
+      return "Connect to mirror Workouts";
+    case "failed":
+      return calendar.error.endsWith("Retry available.")
+        ? "Calendar sync failed. Retry available."
+        : "Calendar sync failed.";
+  }
 }
 
 function CalendarStatus(props: {
@@ -82,7 +63,7 @@ function CalendarStatus(props: {
     return (
       <div className="mx-4 mb-inset grid gap-inset">
         <p role="alert" className="m-0 text-sm text-danger">
-          {retryAvailable ? "Calendar sync failed. Retry available." : "Calendar sync failed."}
+          {calendarStatusLabel(calendar)}
         </p>
         {retryAvailable ? (
           <div>
@@ -99,38 +80,21 @@ function CalendarStatus(props: {
       </div>
     );
   }
-  let label: string;
-  switch (calendar.status) {
-    case "verified":
-      label =
-        calendar.window === null
-          ? "Up to date"
-          : `${dateLabel(calendar.window.start)} to ${dateLabel(calendar.window.end)} · Up to date`;
-      break;
-    case "pending":
-      label = calendar.window === null ? "Local only" : "Updating calendar";
-      break;
-    case "running":
-      label = "Updating calendar";
-      break;
-    case "not-connected":
-      label = "Connect to mirror Workouts";
-      break;
-  }
+
   return (
     <p role="status" className="mx-4 mt-0 mb-inset text-sm leading-5 text-ink-2">
-      Calendar · {label}
+      Calendar · {calendarStatusLabel(calendar)}
     </p>
   );
 }
 
 function spanLabel(plan: PlanSummary): string {
-  return `${dateLabel(plan.start)} to ${dateLabel(plan.end)} · ${plan.weeks} weeks`;
+  return `${formatCivilDate(plan.start)} to ${formatCivilDate(plan.end)} · ${plan.weeks} weeks`;
 }
 
 function legacySummary(legacy: LegacyPlanSummary): string {
   const parts: string[] = [];
-  if (legacy.targetDate !== null) parts.push(`Target ${dateLabel(legacy.targetDate)}`);
+  if (legacy.targetDate !== null) parts.push(`Target ${formatCivilDate(legacy.targetDate)}`);
   if (legacy.weeks !== null) parts.push(`${legacy.weeks} ${legacy.weeks === 1 ? "week" : "weeks"}`);
   if (legacy.goal !== null) parts.push(`Goal: ${legacy.goal}`);
   parts.push("Unknown reason");

--- a/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanLibrary.tsx
@@ -1,13 +1,8 @@
-import type {
-  LegacyPlanSummary,
-  ListPlansResult,
-  PlanCreationCardModel,
-  PlanSummary,
-} from "@enduragent/coach-contract";
+import type { LegacyPlanSummary, ListPlansResult, PlanSummary } from "@enduragent/coach-contract";
 import { useEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
 import { CHAT_PLAN_CREATION_CONTINUE_MISSING_COPY } from "../../chat/controller";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent } from "@enduragent/ui";
+import { Card, CardContent, CardHeader } from "@enduragent/ui";
 import {
   Dialog,
   DialogClose,
@@ -17,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@enduragent/ui";
+import { creationTitle } from "../../plan/creation-title";
 import { requestPlanCalendarRetry } from "../../plan/library-refresh";
 import { useEnduragentStore } from "../../state/store";
 
@@ -37,26 +33,41 @@ function LibraryCard(props: {
   readonly children?: ReactNode;
 }): ReactElement {
   return (
-    <Card size="sm" className="min-w-0" role="region" aria-label={props.eyebrow ?? props.title}>
-      <CardContent className="grid gap-inset">
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-inset">
-          <div className="grid min-w-0 gap-[calc(var(--inset)/2)]">
+    <Card
+      size="sm"
+      className="block min-w-0 gap-[normal] py-0"
+      role="region"
+      aria-label={props.eyebrow ?? props.title}
+    >
+      <CardHeader className="block rounded-none p-4">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+          <div className="min-w-0 justify-self-start">
             {props.eyebrow ? (
-              <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+              <p
+                data-plan-card-eyebrow
+                className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
+              >
                 {props.eyebrow}
               </p>
             ) : null}
-            <h3 className="m-0 text-base leading-6 font-semibold break-words">{props.title}</h3>
+            <h3 data-plan-card-title className="m-0 text-base leading-6 font-semibold break-words">
+              {props.title}
+            </h3>
           </div>
           {props.status ? (
-            <span className="rounded-chip bg-ink/7 px-2 py-1 text-xs font-medium text-ink-2">
+            <span
+              data-plan-card-status
+              className="inline-flex shrink-0 items-center gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2"
+            >
               {props.status}
             </span>
           ) : null}
         </div>
-        <p className="m-0 text-sm leading-5 text-ink-2">{props.summary}</p>
-        {props.children}
-      </CardContent>
+        <p data-plan-card-summary className="mt-inset mb-0 text-sm leading-5 text-ink-2">
+          {props.summary}
+        </p>
+      </CardHeader>
+      {props.children ? <CardContent className="p-0">{props.children}</CardContent> : null}
     </Card>
   );
 }
@@ -69,7 +80,7 @@ function CalendarStatus(props: {
   if (calendar.status === "failed") {
     const retryAvailable = calendar.error.endsWith("Retry available.");
     return (
-      <div className="grid gap-inset">
+      <div className="mx-4 mb-inset grid gap-inset">
         <p role="alert" className="m-0 text-sm text-danger">
           {retryAvailable ? "Calendar sync failed. Retry available." : "Calendar sync failed."}
         </p>
@@ -77,6 +88,7 @@ function CalendarStatus(props: {
           <div>
             <Button
               variant="outline"
+              className="border-line bg-surface"
               disabled={props.retry === undefined}
               onClick={() => void props.retry?.()}
             >
@@ -106,25 +118,10 @@ function CalendarStatus(props: {
       break;
   }
   return (
-    <p role="status" className="m-0 text-sm leading-5 text-ink-2">
+    <p role="status" className="mx-4 mt-0 mb-inset text-sm leading-5 text-ink-2">
       Calendar · {label}
     </p>
   );
-}
-
-function creationTitle(creation: PlanCreationCardModel): string {
-  const summary = creation.answeredSummaries.find((answer) => answer.answerKey === "goal");
-  if (summary?.answer.kind !== "goal") return "New Plan";
-  const goal = summary.answer.goal;
-  if (goal.kind === "fitness") return goal.outcome ?? "Improve fitness";
-  if (goal.kind === "event-manual") return `${goal.name} · ${dateLabel(goal.date)}`;
-  const candidate =
-    summary.question.kind === "goal-question"
-      ? summary.question.candidates.find((item) => item.candidateId === goal.candidateId)
-      : undefined;
-  return candidate === undefined
-    ? summary.detail
-    : `${candidate.name} · ${dateLabel(candidate.date)}`;
 }
 
 function spanLabel(plan: PlanSummary): string {
@@ -235,7 +232,7 @@ export function PlanLibrary(props: {
     if (target !== null) queueMicrotask(() => target.current?.focus());
   }, [focusRequest, busy, creation?.creationId, active?.planId]);
   return (
-    <section aria-label="Plan library" className="grid min-w-0 gap-inset">
+    <section aria-label="Plan library" className="grid min-w-0 gap-4">
       {closeError === null || closing !== null ? null : (
         <p role="alert" className="m-0 text-sm text-danger">
           {closeError}
@@ -270,7 +267,15 @@ export function PlanLibrary(props: {
           )}
           <DialogFooter className="mx-0 mt-row mb-0 flex-row justify-end rounded-none border-0 bg-transparent p-0">
             <DialogClose
-              render={<Button ref={cancel} variant="outline" size="lg" disabled={saving} />}
+              render={
+                <Button
+                  ref={cancel}
+                  variant="outline"
+                  className="border-line bg-surface"
+                  size="lg"
+                  disabled={saving}
+                />
+              }
             >
               Cancel
             </DialogClose>
@@ -310,10 +315,11 @@ export function PlanLibrary(props: {
           }
           summary={`${creation.answeredSummaries.length} of ${total} answered. ${active === null ? "No Plan is active." : `${active.name} keeps running.`}`}
         >
-          <div className="flex flex-wrap gap-inset">
+          <div className="flex flex-wrap gap-inset px-4 pb-4">
             <Button
               ref={discard}
               variant="destructive"
+              className="border-[color-mix(in_srgb,var(--danger)_52%,var(--line))]"
               aria-haspopup="dialog"
               disabled={
                 busy || chatActions === null || chatCreation?.creationId !== creation.creationId
@@ -352,10 +358,11 @@ export function PlanLibrary(props: {
                 : undefined
             }
           />
-          <div className="flex flex-wrap gap-inset">
+          <div className="flex flex-wrap gap-inset px-4 pb-4">
             <Button
               ref={stop}
               variant="destructive"
+              className="border-[color-mix(in_srgb,var(--danger)_52%,var(--line))]"
               aria-haspopup="dialog"
               disabled={actions === null || saving}
               onClick={() => {
@@ -365,7 +372,11 @@ export function PlanLibrary(props: {
             >
               Stop Plan
             </Button>
-            <Button variant="outline" onClick={props.readDetails}>
+            <Button
+              variant="outline"
+              className="border-line bg-surface"
+              onClick={props.readDetails}
+            >
               Read Plan details
             </Button>
             <Button
@@ -386,9 +397,10 @@ export function PlanLibrary(props: {
           status="Closed"
           summary={`${spanLabel(plan)} · ${plan.closeReason === "stopped" ? "Stopped" : plan.closeReason === "completed" ? "Completed" : "Unknown reason"}`}
         >
-          <div className="flex flex-wrap gap-inset">
+          <div className="flex flex-wrap gap-inset px-4 pb-4">
             <Button
               variant="outline"
+              className="border-line bg-surface"
               disabled={actions === null}
               onClick={() => props.readFinalDetails(plan.planId)}
             >
@@ -404,7 +416,7 @@ export function PlanLibrary(props: {
           status="Closed"
           summary={legacySummary(legacy)}
         >
-          <p className="m-0 text-sm leading-5 text-ink-2">
+          <p className="m-0 px-4 pb-4 text-sm leading-5 text-ink-2">
             Read only · Saved before Plans moved to Chat
           </p>
         </LibraryCard>

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -4495,15 +4495,7 @@ export function PlanView(): ReactElement {
     ? "Loading…"
     : historyPage
       ? `${activeData.plan.name} · active Plan · mutation and recovery log`
-      : activeOverview && activeData !== null
-        ? `${activeData.plan.name}${
-            activeData.plan.targetDate === null
-              ? ""
-              : ` · ${formatCivilDate(activeData.plan.targetDate)}`
-          } · Active`
-        : model?.lifecycle === "none"
-          ? "No active plan"
-          : undefined;
+      : undefined;
 
   useEffect(() => {
     if (returnFocusId === null || finalDetails.status !== "library") return;

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -4543,7 +4543,11 @@ export function PlanView(): ReactElement {
         : "Plan closed. Calendar cleanup pending."
       : null;
     return (
-      <Page title="Plan" className="plan-view" busy={finalDetails.status === "loading"}>
+      <Page
+        title="Plan"
+        className="plan-view [&_[data-page-scroll]>div]:w-[min(720px,calc(100%-64px))] max-md:[&_[data-page-scroll]>div]:w-[calc(100%-32px)]"
+        busy={finalDetails.status === "loading"}
+      >
         {finalDetails.status === "ready" && finalDetails.history !== null ? (
           <PlanFinalDetails
             history={finalDetails.history}
@@ -4638,7 +4642,7 @@ export function PlanView(): ReactElement {
           </Button>
         ) : undefined
       }
-      className="plan-view"
+      className="plan-view [&_[data-page-scroll]>div]:w-[min(720px,calc(100%-64px))] max-md:[&_[data-page-scroll]>div]:w-[calc(100%-32px)]"
       contentMode={coachWorkspace ? "workspace" : "scroll"}
     >
       <div className={coachWorkspace ? "h-full min-h-0" : "grid gap-6"}>

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -887,32 +887,6 @@ function CoursePickerDialog(): ReactElement {
   );
 }
 
-function NoPlan(): ReactElement {
-  const actions = useEnduragentStore((state) => state.planActions);
-  const creationExists = useEnduragentStore((state) => state.planLibrary.value?.creation != null);
-
-  return (
-    <div className="grid gap-6" data-plan-scenario="PL-S001">
-      <section className={SUPPORT_PAIR}>
-        <h2 className="m-0 text-lg font-semibold">No active Plan</h2>
-        <p className="m-0 text-ink-2">Create a Plan when you are ready.</p>
-      </section>
-      {creationExists ? null : (
-        <div className="flex flex-wrap gap-inset">
-          <Button
-            id="plan-start-coach"
-            type="button"
-            disabled={actions === null}
-            onClick={() => actions?.startPlan()}
-          >
-            Start a Plan
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
-
 function PlanQueue(): ReactElement | null {
   const queue = useEnduragentStore((state) => state.plan.coach.queued);
   const retry = useEnduragentStore((state) => state.plan.coach.retryRequired);
@@ -4411,7 +4385,7 @@ function EndedProjection(): ReactElement {
   );
 }
 
-function ReadyProjection(): ReactElement {
+function ReadyProjection(): ReactElement | null {
   const model = useEnduragentStore((state) => planReadModel(state.plan));
   const transition = useEnduragentStore((state) => state.plan.transition);
   if (
@@ -4429,7 +4403,7 @@ function ReadyProjection(): ReactElement {
       <StatusCard title={model.title} support={model.summary} />
     );
   }
-  if (model.lifecycle === "none" || model.projection === "no-plan") return <NoPlan />;
+  if (model.lifecycle === "none" || model.projection === "no-plan") return null;
   if (model.projection === "coach") return <PlanCoach />;
   if (model.projection === "draft") return <DraftProjection />;
   if (model.projection === "active") return <ActiveProjection />;

--- a/apps/desktop-renderer/src/ui/plan/plan-card.tsx
+++ b/apps/desktop-renderer/src/ui/plan/plan-card.tsx
@@ -1,0 +1,101 @@
+import type { ReactElement, ReactNode, Ref } from "react";
+import { Card, CardContent, CardHeader } from "@enduragent/ui";
+
+export function PlanCard(props: {
+  readonly eyebrow?: string;
+  readonly title: string;
+  readonly status?: string;
+  readonly summary?: string;
+  readonly summaryId?: string;
+  readonly "aria-label": string;
+  readonly headingRef?: Ref<HTMLHeadingElement>;
+  readonly headingTabIndex?: number;
+  readonly statusClassName?: string;
+  readonly contentClassName?: string;
+  readonly parityAttributes?: boolean;
+  readonly headerChildren?: ReactNode;
+  readonly children?: ReactNode;
+}): ReactElement {
+  const parity = props.parityAttributes !== false ? true : undefined;
+  return (
+    <Card
+      size="sm"
+      className="block min-w-0 gap-[normal] py-0"
+      role="region"
+      aria-label={props["aria-label"]}
+    >
+      <CardHeader className="block rounded-none p-4">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+          <div className="min-w-0 justify-self-start">
+            {props.eyebrow ? (
+              <p
+                data-plan-card-eyebrow={parity}
+                className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
+              >
+                {props.eyebrow}
+              </p>
+            ) : null}
+            <h3
+              data-plan-card-title={parity}
+              ref={props.headingRef}
+              tabIndex={props.headingTabIndex}
+              className="m-0 text-base leading-6 font-semibold break-words"
+            >
+              {props.title}
+            </h3>
+          </div>
+          {props.status ? (
+            <span
+              data-plan-card-status={parity}
+              className={
+                props.statusClassName ??
+                "inline-flex shrink-0 items-center justify-self-start gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal whitespace-nowrap text-ink-2"
+              }
+            >
+              {props.status}
+            </span>
+          ) : null}
+        </div>
+        {props.summary ? (
+          <p
+            data-plan-card-summary={parity}
+            id={props.summaryId}
+            className="mt-inset mb-0 text-sm leading-5 text-ink-2"
+          >
+            {props.summary}
+          </p>
+        ) : null}
+        {props.headerChildren}
+      </CardHeader>
+      {props.children ? (
+        <CardContent className={props.contentClassName ?? "px-4 pt-0 pb-4"}>
+          {props.children}
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+export function Fact(props: {
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly valueAs?: "strong" | "div";
+}): ReactElement {
+  const Value = props.valueAs ?? "strong";
+  return (
+    <div
+      role="row"
+      className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] items-start gap-3 border-b border-line py-[calc(var(--row-inset)+1px)] max-md:grid-cols-1 max-md:gap-1"
+    >
+      <span role="rowheader" className="text-xs leading-4 text-ink-2">
+        {props.label}
+      </span>
+      <Value
+        role="cell"
+        className="text-right text-sm leading-5 font-medium [overflow-wrap:anywhere] max-md:text-left"
+      >
+        {props.children}
+      </Value>
+    </div>
+  );
+}

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -520,6 +520,8 @@ describe("chat view adapter", () => {
 
     expect(published.at(-1)).toMatchObject({
       planCreation: null,
+      planCreationFocusRequest: { target: "start", revision: 1 },
+      inputDisabled: false,
       timeline: [{ kind: "plan-creation-discard", eventId: "01J00000000000000000000000" }],
     });
 

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -251,7 +251,6 @@ describe("chat view adapter", () => {
         eventNotListedOption: {
           label: "Event not listed" as const,
           detail: "Tell me the event name and its exact date.",
-          editorLabel: "Name the event.",
           placeholder: "Event name",
           nameLabel: "Event name",
           dateLabel: "Event date",
@@ -259,12 +258,6 @@ describe("chat view adapter", () => {
         fitnessOption: {
           label: "Improve without an event",
           detail: "Build fitness for a fixed number of weeks.",
-        },
-        authoredOption: {
-          label: "Something else" as const,
-          detail: "Tell me the event name and its exact date.",
-          editorLabel: "Name the event.",
-          placeholder: "Event name",
         },
       },
     };
@@ -602,7 +595,6 @@ describe("chat view adapter", () => {
               eventNotListedOption: {
                 label: "Event not listed",
                 detail: "Tell me the event name and its exact date.",
-                editorLabel: "Name the event.",
                 placeholder: "Event name",
                 nameLabel: "Event name",
                 dateLabel: "Event date",
@@ -610,12 +602,6 @@ describe("chat view adapter", () => {
               fitnessOption: {
                 label: "Improve without an event",
                 detail: "Build fitness for a fixed number of weeks.",
-              },
-              authoredOption: {
-                label: "Something else",
-                detail: "Tell me the event name and its exact date.",
-                editorLabel: "Name the event.",
-                placeholder: "Event name",
               },
             },
           },

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -2342,7 +2342,7 @@ describe("chat controller", () => {
     });
     await expect(controller.submit("Chat continues")).resolves.toBe(true);
     expect(chatMessages(fake)).toEqual(["Chat continues"]);
-    await controller.startPlanCreation();
+    await expect(controller.submit("/plan")).resolves.toBe(true);
     expect(controls.at(-1)?.planCreation).toMatchObject({
       value: nextCard,
       discardEvents: [{ eventId: completeCard.creationId, afterMessageId: null }],
@@ -2486,7 +2486,7 @@ describe("chat controller", () => {
     });
   });
 
-  it("returns focus to Start when refresh removes a Card behind its discard dialog", async () => {
+  it("requests composer focus when refresh removes a Card behind its discard dialog", async () => {
     const card: PlanCreationCardModel = {
       draft: null,
       calendarWindow: null,
@@ -4324,6 +4324,74 @@ describe("Plan library Chat entry", () => {
       value: draft,
       focusRequest: { target: "activate" },
     });
+    controller.dispose();
+  });
+
+  it("starts Plan Creation with /plan and clears the saved composer without sending to the coach", async () => {
+    const start = vi.fn(async (): Promise<PlanCreationStartRpcResult> => ({
+      status: "started",
+      outcome: "created",
+      planCreation: creation,
+    }));
+    const saveText = vi.fn(async () => emptyComposer());
+    const fake = client(replies(), {
+      startPlanCreation: start,
+      saveAttachmentDraftText: saveText,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+
+    await expect(controller.submit("/plan")).resolves.toBe(true);
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(start).toHaveBeenCalledWith({ commandId: expect.any(String) });
+    expect(saveText).toHaveBeenCalledWith("");
+    expect(controls.at(-1)?.planCreation?.value).toEqual(creation);
+    expect(chatMessages(fake)).toEqual([]);
+    controller.dispose();
+  });
+
+  it("resumes a paused Plan question with /plan without starting another creation", async () => {
+    const start =
+      vi.fn<(request: PlanCreationStartRpcParams) => Promise<PlanCreationStartRpcResult>>();
+    const fake = client(replies(), {
+      listPlanningRequests: async () => ({ deliveries: [], planCreation: creation }),
+      startPlanCreation: start,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    controller.pausePlanCreation();
+    expect(controls.at(-1)?.planCreation?.paused).toBe(true);
+    const revision = controls.at(-1)?.planCreation?.focusRevision ?? 0;
+
+    await expect(controller.submit("/plan")).resolves.toBe(true);
+
+    expect(controls.at(-1)?.planCreation).toMatchObject({ value: creation, paused: false });
+    expect(controls.at(-1)?.planCreation?.focusRevision).toBeGreaterThan(revision);
+    expect(start).not.toHaveBeenCalled();
+    expect(chatMessages(fake)).toEqual([]);
+    controller.dispose();
+  });
+
+  it("ignores /plan during an open question without sending to the coach", async () => {
+    const start =
+      vi.fn<(request: PlanCreationStartRpcParams) => Promise<PlanCreationStartRpcResult>>();
+    const saveText = vi.fn(async () => emptyComposer());
+    const fake = client(replies(), {
+      listPlanningRequests: async () => ({ deliveries: [], planCreation: creation }),
+      startPlanCreation: start,
+      saveAttachmentDraftText: saveText,
+    });
+    const { controller, controls } = subject(fake);
+    await controller.start();
+    const before = controls.at(-1)?.planCreation;
+
+    await expect(controller.submit("/plan")).resolves.toBe(false);
+
+    expect(controls.at(-1)?.planCreation).toEqual(before);
+    expect(start).not.toHaveBeenCalled();
+    expect(saveText).not.toHaveBeenCalled();
+    expect(chatMessages(fake)).toEqual([]);
     controller.dispose();
   });
 

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -67,7 +67,6 @@ function goalQuestion(
     eventNotListedOption: {
       label: "Event not listed",
       detail: "Tell me the event name and its exact date.",
-      editorLabel: "Name the event.",
       placeholder: "Event name",
       nameLabel: "Event name",
       dateLabel: "Event date",
@@ -75,12 +74,6 @@ function goalQuestion(
     fitnessOption: {
       label: "Improve without an event",
       detail: "Build fitness.",
-    },
-    authoredOption: {
-      label: "Something else",
-      detail: "Name an event.",
-      editorLabel: "Name the event.",
-      placeholder: "Event name",
     },
   };
 }

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -3092,6 +3092,86 @@ describe("chat surface", () => {
       expect(composer()).toBeEnabled();
     });
 
+    it("preserves pinned-event-first Workout order within the Draft week", () => {
+      const draft = planCreationDraft();
+      const workouts = [
+        {
+          id: "pinned-event",
+          name: "Autumn event",
+          kind: "event",
+          date: "1998-10-04",
+          minutes: 120,
+          pinned: true,
+          guidance: "Ride at a sustainable effort",
+          power: null,
+        },
+        {
+          id: "monday-endurance",
+          name: "Monday endurance ride",
+          kind: "endurance",
+          date: "1998-09-28",
+          minutes: 60,
+          pinned: false,
+          guidance: "Ride at a comfortable effort",
+          power: null,
+        },
+      ] satisfies (typeof draft.weeks)[number]["workouts"];
+      draft.weeks = draft.weeks.map((week) =>
+        week.number === 4
+          ? { ...week, start: "1998-09-28", end: "1998-10-04", workouts }
+          : week,
+      );
+      const original = structuredClone(draft);
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null),
+        status: "review",
+        draft,
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+
+      const rows = within(screen.getByRole("list", { name: "Week 4 Workouts" })).getAllByRole(
+        "listitem",
+      );
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toHaveTextContent("4 Oct 1998");
+      expect(rows[0]).toHaveTextContent("Autumn event");
+      expect(rows[0]).toHaveTextContent("Pinned");
+      expect(rows[1]).toHaveTextContent("28 Sept 1998");
+      expect(rows[1]).toHaveTextContent("Monday endurance ride");
+      expect(draft).toEqual(original);
+    });
+
+    it("shows the creation notice once above the Draft review", () => {
+      const notice = "Your confirmed limits leave no Workouts in this Draft.";
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null),
+        status: "review",
+        draft: planCreationDraft(),
+      };
+      setChat({
+        notice,
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+
+      const creation = screen.getByRole("region", { name: "Plan creation" });
+      const notices = screen.getAllByText(notice, { exact: true });
+      expect(notices).toHaveLength(1);
+      const status = within(creation).getByRole("status");
+      expect(status).toBeVisible();
+      expect(status).toHaveTextContent(notice);
+      const review = within(creation).getByRole("region", { name: "Plan Draft review" });
+      expect(status.compareDocumentPosition(review) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(document.querySelector(".chat-notice-host")).not.toHaveTextContent(notice);
+    });
+
     it.each(["question", "review", "stale"] as const)(
       "shows interpreted limits and disables building or activation in %s",
       async (stage) => {
@@ -3312,7 +3392,9 @@ describe("chat surface", () => {
       await waitFor(() =>
         expect(screen.getByRole("heading", { name: "What would success mean?" })).toHaveFocus(),
       );
-      expect(screen.getByText("Build steady power")).toBeVisible();
+      expect(
+        within(screen.getByLabelText("Goal answer")).getByText("Build steady power"),
+      ).toBeVisible();
       expect(screen.getByText("Goal · your answer", { exact: true })).toBeVisible();
       expect(screen.getByText("1 of 9 answered.")).toBeVisible();
       const answerRow = screen.getByRole("listitem", { name: "Goal answer" });
@@ -3627,7 +3709,8 @@ describe("chat surface", () => {
       });
 
       const discard = screen.getByRole("button", { name: "Discard" });
-      expect(discard).toHaveClass("bg-destructive/10");
+      expect(discard).toHaveClass("text-destructive", "bg-transparent");
+      expect(discard.closest('[data-parity="progress.actions"]')).not.toBeNull();
       await userEvent.click(discard);
 
       expect(screen.getByRole("heading", { name: "Discard this Plan creation?" })).toBeVisible();
@@ -3764,12 +3847,16 @@ describe("chat surface", () => {
       await userEvent.click(screen.getByRole("button", { name: "Discard creation" }));
 
       expect(screen.queryByRole("heading", { name: "Discard this Plan creation?" })).toBeNull();
-      expect(screen.getByText("Build steady power", { exact: true })).toBeVisible();
+      expect(
+        within(screen.getByLabelText("Goal answer")).getByText("Build steady power", {
+          exact: true,
+        }),
+      ).toBeVisible();
       expect(
         screen.getByText(
           "Plan Creation changed before it could be discarded. The latest version is shown.",
-        ),
-      ).toHaveClass("chat-notice");
+        ).closest(".chat-notice"),
+      ).toBeVisible();
       await waitFor(() => expect(screen.getByRole("button", { name: "Discard" })).toHaveFocus());
     });
 

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -2627,6 +2627,18 @@ describe("chat surface", () => {
         "aria-pressed",
         "true",
       );
+      const selected = screen.getByRole("button", { name: "No training" });
+      expect(selected).toHaveClass("aria-pressed:bg-primary/10");
+      expect(selected.querySelector('[data-parity="choice.row.number"]')).toHaveClass(
+        "bg-primary",
+        "text-primary-foreground",
+        "border-primary",
+      );
+      expect(
+        screen
+          .getByRole("button", { name: "No hard training" })
+          .querySelector('[data-parity="choice.row.number"]'),
+      ).not.toHaveClass("bg-primary");
       fireEvent.change(screen.getByLabelText("Optional end date"), {
         target: { value: "1998-10-15" },
       });

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -2323,14 +2323,13 @@ describe("chat surface", () => {
       useEnduragentStore.getState().bindChatActions(actions);
       render(<Harness />);
       setChat({ planCreationLoaded: true, decision: unansweredDecision() });
-      const startButton = screen.getByRole("button", { name: "Start a Plan" });
-      expect(startButton).toBeDisabled();
-      await userEvent.click(startButton);
-      expect(actions.startPlanCreation).not.toHaveBeenCalled();
+      expect(screen.queryByRole("button", { name: "Start a Plan" })).toBeNull();
       setChat({ decision: null });
-      expect(startButton).toBeEnabled();
-      await userEvent.click(startButton);
-      expect(actions.startPlanCreation).toHaveBeenCalledOnce();
+      await userEvent.type(composer(), "/plan");
+      await userEvent.keyboard("{Enter}");
+      expect(actions.submit).toHaveBeenCalledTimes(1);
+      expect(actions.submit).toHaveBeenCalledWith("/plan");
+      await waitFor(() => expect(composer()).toHaveValue(""));
       setChat({
         planCreation: planCreationModel(goalQuestion("What are you preparing for?")),
         sendDisabled: true,
@@ -3654,7 +3653,7 @@ describe("chat surface", () => {
       await waitFor(() => expect(discard).toHaveFocus());
     });
 
-    it("disables discard confirmation in flight and focuses Start after success", async () => {
+    it("disables discard confirmation in flight and focuses the composer after success", async () => {
       const actions = stubActions();
       const model = planCreationModel(null, {
         version: 3,
@@ -3701,11 +3700,11 @@ describe("chat surface", () => {
         inputDisabled: false,
         timeline: [{ kind: "plan-creation-discard", eventId: "01J00000000000000000000000" }],
       });
-      const start = screen.getByRole("button", { name: "Start a Plan" });
-      await waitFor(() => expect(start).toHaveFocus());
+      await waitFor(() => expect(composer()).toHaveFocus());
+      expect(screen.queryByRole("button", { name: "Start a Plan" })).toBeNull();
       const discarded = document.querySelector('[data-parity="discarded.record"]');
       expect(discarded).not.toBeNull();
-      expect(discarded?.compareDocumentPosition(start)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(discarded?.compareDocumentPosition(composer())).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
       expect(composer()).toBeEnabled();
       expect(screen.queryByText("Build steady power", { exact: true })).toBeNull();
       expect(screen.getByText("Plan creation discarded")).toBeVisible();

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -7,6 +7,7 @@ import type {
   AttachmentCapabilitiesReadModel,
   ChatAttachmentComposerReadModel,
   CoachDecisionReadModel,
+  ListPlansResult,
   PlanCreationCardModel,
   PlanCreationOpenQuestion,
   PlanningRequestDelivery,
@@ -27,6 +28,7 @@ import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice";
 import { useEnduragentStore } from "../src/state/store";
 import { SLASH_COMMANDS } from "../src/chat/commands";
 import { ChatView } from "../src/ui/chat/ChatView";
+import { PlanCreationSummary } from "../src/ui/chat/PlanCreationSummary";
 import { planCreationDraft } from "./plan-creation-draft-fixtures";
 import { planReadModel } from "./plan-fixtures";
 import { EMPTY_PLAN_SURFACE } from "../src/state/plan-slice";
@@ -142,7 +144,6 @@ function goalQuestion(prompt: string): GoalQuestion {
     eventNotListedOption: {
       label: "Event not listed",
       detail: "Tell me the event name and its exact date.",
-      editorLabel: "Name the event and include its exact date.",
       placeholder: "Event name",
       nameLabel: "Event name",
       dateLabel: "Event date",
@@ -151,7 +152,6 @@ function goalQuestion(prompt: string): GoalQuestion {
       label: "Improve without an event",
       detail: "Build fitness for a fixed number of weeks.",
     },
-    authoredOption: fixtureAuthoredOption,
   } satisfies PlanCreationOpenQuestion;
 }
 
@@ -220,10 +220,10 @@ function planLengthQuestion(prompt: string): PlanLengthQuestion {
     step: fixtureStep,
     prompt,
     options: [
-      { weeks: 4, label: "4 weeks", detail: "Choose a 4-week Plan." },
+      { weeks: 4, label: "4 weeks" },
       { weeks: 8, label: "8 weeks", detail: "Choose an 8-week Plan." },
-      { weeks: 12, label: "12 weeks", detail: "Choose a 12-week Plan." },
-      { weeks: 16, label: "16 weeks", detail: "Choose a 16-week Plan." },
+      { weeks: 12, label: "12 weeks" },
+      { weeks: 16, label: "16 weeks" },
     ],
   } satisfies PlanCreationOpenQuestion;
 }
@@ -251,7 +251,7 @@ function commitmentsQuestion(prompt: string, placeholder: string): CommitmentsQu
     kind: "commitments-question",
     step: fixtureStep,
     prompt,
-    noneOption: { label: "No fixed commitments", detail: "There is nothing fixed to add." },
+    noneOption: { label: "No fixed commitments" },
     authoredOption: {
       ...fixtureAuthoredOption,
       label: "Add commitments or time off",
@@ -292,9 +292,9 @@ function availabilityQuestion(
     prompt,
     mode,
     weeklyHoursOptions: [
-      { id: "hours-6", weeklyHoursLimit: 6, label: "5–6 hours", detail: "Usual volume." },
-      { id: "hours-8", weeklyHoursLimit: 8, label: "7–8 hours", detail: "A small step." },
-      { id: "hours-10", weeklyHoursLimit: 10, label: "9+ hours", detail: "More volume." },
+      { id: "hours-6", weeklyHoursLimit: 6, label: "5–6 hours" },
+      { id: "hours-8", weeklyHoursLimit: 8, label: "7–8 hours" },
+      { id: "hours-10", weeklyHoursLimit: 10, label: "9–10 hours" },
     ],
     longestWorkoutLabel: "Longest ride in hours",
     weekdayOptions: [
@@ -329,7 +329,7 @@ function restrictionQuestion(prompt: string): RestrictionQuestion {
     step: fixtureStep,
     prompt,
     options: [
-      { kind: "none", label: "None", detail: "No Training Restriction." },
+      { kind: "none", label: "None" },
       { kind: "no-training", label: "No training", detail: "Schedule no training." },
       {
         kind: "no-hard-training",
@@ -539,17 +539,73 @@ describe("chat surface", () => {
     resetChatStream();
   });
 
-  it("renders completed Plan activation once as a transcript status", () => {
+  it("renders no completed Plan creation transcript content", () => {
     render(<Harness />);
     setChat({
       planCreation: null,
       planCreationLoaded: true,
       timeline: [{ kind: "plan-creation", model: null }],
     });
-    expect(screen.getAllByText("Plan activated locally.")).toHaveLength(1);
-    expect(screen.getByText("Plan activated locally.")).toHaveAttribute("role", "status");
+    expect(screen.queryByText("Plan activated locally.")).toBeNull();
+    expect(screen.queryByRole("region", { name: "Plan Creation" })).toBeNull();
     expect(document.querySelector(".chat-notice")).not.toBeVisible();
   });
+
+  it.each(["unloaded", "empty", "active"] as const)(
+    "describes progress with an %s Plan library",
+    (state) => {
+      const library: ListPlansResult = {
+        calendarConnected: false,
+        legacy: null,
+        active:
+          state === "active"
+            ? {
+                supportingEventCandidates: [],
+                planId: "progress-plan",
+                version: 1,
+                name: "Build steady power",
+                start: "1998-09-07",
+                end: "1998-10-04",
+                weeks: 4,
+                status: "active",
+                closeReason: null,
+                closedAt: null,
+                activatedAt: "1998-09-07",
+                todayChoice: null,
+                calendar: {
+                  status: "not-connected",
+                  window: null,
+                  currentThrough: null,
+                  error: null,
+                },
+                creationId: null,
+              }
+            : null,
+        creation: null,
+        closed: [],
+        changesPaused: null,
+        changes: [],
+      };
+      useEnduragentStore.setState({
+        planLibrary:
+          state === "unloaded"
+            ? { status: "loading", value: null }
+            : { status: "ready", value: library },
+      });
+      render(
+        <PlanCreationSummary
+          model={planCreationModel(goalQuestion("What are you preparing for?"))}
+        />,
+      );
+      const tail =
+        state === "unloaded"
+          ? ""
+          : state === "active"
+            ? " Build steady power keeps running."
+            : " No Plan is active.";
+      expect(screen.getByText(`0 of 9 answered.${tail}`, { exact: true })).toBeVisible();
+    },
+  );
 
   it("preserves and focuses the draft after enqueue failure and clears only after acknowledgment", async () => {
     const user = userEvent.setup();
@@ -2343,7 +2399,7 @@ describe("chat surface", () => {
       expect(composer()).toHaveAttribute("placeholder", "Finish the Plan question above");
       expect(screen.getByRole("button", { name: "Attach files" })).toBeDisabled();
       expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
-      expect(screen.getByRole("button", { name: "Something else" })).toBeEnabled();
+      expect(screen.queryByRole("button", { name: "Something else" })).toBeNull();
       expect(document.querySelector('[data-parity="question.card"]')).toHaveAttribute(
         "data-question",
         "goal",
@@ -2364,7 +2420,7 @@ describe("chat surface", () => {
           answeredSummaries: [
             {
               answerKey: "goal",
-              title: "Goal",
+              title: "Main Goal",
               detail: "Build steady power",
               question: goalQuestion("What are you preparing for?"),
               answer: { kind: "goal", goal: { kind: "fitness", outcome: "Build steady power" } },
@@ -2391,11 +2447,11 @@ describe("chat surface", () => {
         planCreationLoaded: true,
         planCreation: planCreationModel(goalQuestion("What are you preparing for?")),
       });
-      await userEvent.click(screen.getByRole("button", { name: "Something else" }));
+      await userEvent.click(screen.getByRole("button", { name: "Event not listed" }));
       const eventName = screen.getByRole("textbox", { name: "Event name" });
       const eventDate = screen.getByLabelText("Event date");
-      expect(screen.getByText("Write your answer.")).toBeVisible();
-      expect(eventName).toHaveAttribute("placeholder", "Type an answer");
+      expect(screen.queryByText("Write your answer.")).toBeNull();
+      expect(eventName).toHaveAttribute("placeholder", "Event name");
       expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
       await userEvent.type(eventName, "Highland Tour");
       fireEvent.change(eventDate, { target: { value: "1998-10-18" } });
@@ -2417,8 +2473,8 @@ describe("chat surface", () => {
           answeredSummaries: [
             {
               answerKey: "goal",
-              title: "Goal",
-              detail: "Highland Tour · 1998-10-18",
+              title: "Main Goal",
+              detail: "Highland Tour · 18 Oct 1998",
               question: goalQuestion("What are you preparing for?"),
               answer: {
                 kind: "goal",
@@ -2727,7 +2783,7 @@ describe("chat surface", () => {
           answeredSummaries: [
             {
               answerKey: "goal",
-              title: "Goal",
+              title: "Main Goal",
               detail: "Build steady power",
               question: goalQuestion("What are you preparing for?"),
               answer: {
@@ -2763,7 +2819,7 @@ describe("chat surface", () => {
       const editActions = screen.getAllByRole("button", { name: /^Edit /u });
       expect(editActions).toHaveLength(2);
       for (const editAction of editActions) expect(editAction).toBeDisabled();
-      await user.click(screen.getByRole("button", { name: "Edit Goal" }));
+      await user.click(screen.getByRole("button", { name: "Edit Main Goal" }));
       expect(actions.editPlanCreation).toHaveBeenCalledOnce();
     });
 
@@ -2775,8 +2831,8 @@ describe("chat surface", () => {
         answeredSummaries: [
           {
             answerKey: "goal",
-            title: "Goal",
-            detail: "Highland Tour · 1998-10-18",
+            title: "Main Goal",
+            detail: "Highland Tour · 18 Oct 1998",
             question: goalQuestion("What do you want this Plan to prepare you for?"),
             answer: {
               kind: "goal",
@@ -2795,7 +2851,7 @@ describe("chat surface", () => {
       });
       render(<Harness />);
 
-      await user.click(screen.getByRole("button", { name: "Edit Goal" }));
+      await user.click(screen.getByRole("button", { name: "Edit Main Goal" }));
       expect(screen.getByRole("textbox", { name: "Event name" })).toHaveValue("Highland Tour");
       await user.click(screen.getByRole("button", { name: "Back" }));
 
@@ -2851,7 +2907,7 @@ describe("chat surface", () => {
           answeredSummaries: [
             {
               answerKey: "goal",
-              title: "Goal",
+              title: "Main Goal",
               detail: "Build Fitness by 1998-12-01",
               question: goalQuestion("What do you want this Plan to prepare you for?"),
               answer: {
@@ -2872,7 +2928,7 @@ describe("chat surface", () => {
             {
               answerKey: "start-timing",
               title: "Start timing",
-              detail: "Earliest start 1998-10-10",
+              detail: "Earliest start 10 Oct 1998",
               question: startTimingQuestion("When could this Plan start?", "1998-10-01"),
               answer: {
                 kind: "start-timing",
@@ -2978,7 +3034,9 @@ describe("chat surface", () => {
       render(<Harness />);
 
       await user.click(
-        screen.getByRole("button", { name: /^(Something else|Add commitments or time off)$/u }),
+        screen.getByRole("button", {
+          name: /^(Event not listed|Something else|Add commitments or time off)$/u,
+        }),
       );
       expect(document.querySelector('[data-parity="custom.editor"]')).not.toBeNull();
       expect(document.querySelector('[data-parity="composer"]')).toBeNull();
@@ -2986,7 +3044,9 @@ describe("chat surface", () => {
       expect(actions.pausePlanCreation).not.toHaveBeenCalled();
       expect(document.querySelector('[data-parity="custom.editor"]')).toBeNull();
       expect(
-        screen.getByRole("button", { name: /^(Something else|Add commitments or time off)$/u }),
+        screen.getByRole("button", {
+          name: /^(Event not listed|Something else|Add commitments or time off)$/u,
+        }),
       ).toBeVisible();
       expect(document.querySelector('[data-parity="composer"]')).not.toBeNull();
     });
@@ -3052,6 +3112,8 @@ describe("chat surface", () => {
         sendDisabled: false,
       });
       expect(screen.getByText("The essentials are complete.")).toBeVisible();
+      expect(screen.queryByText("Ready", { exact: true })).toBeNull();
+      expect(screen.getByText("In progress", { exact: true })).toBeVisible();
       expect(screen.getByRole("button", { name: "Build Draft" })).toBeVisible();
       expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
       await user.click(screen.getByRole("button", { name: "Build Draft" }));
@@ -3129,9 +3191,7 @@ describe("chat surface", () => {
         },
       ] satisfies (typeof draft.weeks)[number]["workouts"];
       draft.weeks = draft.weeks.map((week) =>
-        week.number === 4
-          ? { ...week, start: "1998-09-28", end: "1998-10-04", workouts }
-          : week,
+        week.number === 4 ? { ...week, start: "1998-09-28", end: "1998-10-04", workouts } : week,
       );
       const original = structuredClone(draft);
       const model: PlanCreationCardModel = {
@@ -3180,7 +3240,9 @@ describe("chat surface", () => {
       expect(status).toBeVisible();
       expect(status).toHaveTextContent(notice);
       const review = within(creation).getByRole("region", { name: "Plan Draft review" });
-      expect(status.compareDocumentPosition(review) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(
+        status.compareDocumentPosition(review) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
       expect(document.querySelector(".chat-notice-host")).not.toHaveTextContent(notice);
     });
 
@@ -3215,7 +3277,7 @@ describe("chat surface", () => {
           "Wed · at most 45 min",
           "Sat · unavailable",
           "Mon · no hard training",
-          "Off 3 Sep 1998 to 9 Sep 1998",
+          "Off 3 Sept 1998 to 9 Sept 1998",
         ]) {
           expect(within(correction).getByText(text)).toBeVisible();
         }
@@ -3383,7 +3445,7 @@ describe("chat surface", () => {
         answeredSummaries: [
           {
             answerKey: "goal" as const,
-            title: "Goal",
+            title: "Main Goal",
             detail: "Build steady power",
             question: goalQuestion("What are you preparing for?"),
             answer: {
@@ -3405,11 +3467,11 @@ describe("chat surface", () => {
         expect(screen.getByRole("heading", { name: "What would success mean?" })).toHaveFocus(),
       );
       expect(
-        within(screen.getByLabelText("Goal answer")).getByText("Build steady power"),
+        within(screen.getByLabelText("Main Goal answer")).getByText("Build steady power"),
       ).toBeVisible();
-      expect(screen.getByText("Goal · your answer", { exact: true })).toBeVisible();
+      expect(screen.getByText("Main Goal · your answer", { exact: true })).toBeVisible();
       expect(screen.getByText("1 of 9 answered.")).toBeVisible();
-      const answerRow = screen.getByRole("listitem", { name: "Goal answer" });
+      const answerRow = screen.getByRole("listitem", { name: "Main Goal answer" });
       expect(answerRow).not.toHaveAttribute("role", "status");
       expect(composer()).toBeDisabled();
       expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
@@ -3687,7 +3749,7 @@ describe("chat surface", () => {
         answeredSummaries: [
           {
             answerKey: "goal",
-            title: "Goal",
+            title: "Main Goal",
             detail: "Build steady power",
             question: goalQuestion("What are you preparing for?"),
             answer: { kind: "goal", goal: { kind: "fitness", outcome: "Build steady power" } },
@@ -3729,7 +3791,7 @@ describe("chat surface", () => {
       expect(composer()).toBeDisabled();
       expect(
         screen.getByText(
-          "No Plan is created. Your active Plan, Schedule, training restrictions, closed Plans, saved preferences, and chat history are unchanged.",
+          "Your answers are discarded. Your active Plan, Schedule, restrictions, saved preferences, and history stay unchanged.",
         ),
       ).toBeVisible();
       await waitFor(() =>
@@ -3755,7 +3817,7 @@ describe("chat surface", () => {
         answeredSummaries: [
           {
             answerKey: "goal",
-            title: "Goal",
+            title: "Main Goal",
             detail: "Build steady power",
             question: goalQuestion("What are you preparing for?"),
             answer: { kind: "goal", goal: { kind: "fitness", outcome: "Build steady power" } },
@@ -3817,7 +3879,7 @@ describe("chat surface", () => {
         answeredSummaries: [
           {
             answerKey: "goal",
-            title: "Goal",
+            title: "Main Goal",
             detail: "Build steady power",
             question: goalQuestion("What are you preparing for?"),
             answer: {
@@ -3860,14 +3922,16 @@ describe("chat surface", () => {
 
       expect(screen.queryByRole("heading", { name: "Discard this Plan creation?" })).toBeNull();
       expect(
-        within(screen.getByLabelText("Goal answer")).getByText("Build steady power", {
+        within(screen.getByLabelText("Main Goal answer")).getByText("Build steady power", {
           exact: true,
         }),
       ).toBeVisible();
       expect(
-        screen.getByText(
-          "Plan Creation changed before it could be discarded. The latest version is shown.",
-        ).closest(".chat-notice"),
+        screen
+          .getByText(
+            "Plan Creation changed before it could be discarded. The latest version is shown.",
+          )
+          .closest(".chat-notice"),
       ).toBeVisible();
       await waitFor(() => expect(screen.getByRole("button", { name: "Discard" })).toHaveFocus());
     });

--- a/apps/desktop-renderer/tests/date.test.ts
+++ b/apps/desktop-renderer/tests/date.test.ts
@@ -7,11 +7,11 @@ afterEach(() => {
 });
 
 describe("regional date and time formatting", () => {
-  it("uses US date order and a 12-hour wall clock", () => {
+  it("keeps civil dates British with a US locale and a 12-hour wall clock", () => {
     pinDefaultLocale("en-US");
 
-    expect(formatCivilDate("1998-07-18")).toBe("Jul 18, 1998");
-    expect(formatCivilDate("1998-07-18", { day: "numeric", month: "numeric" })).toBe("7/18");
+    expect(formatCivilDate("1998-07-18")).toBe("18 Jul 1998");
+    expect(formatCivilDate("1998-07-18", { day: "numeric", month: "numeric" })).toBe("18/07");
     expect(formatOffsetWallTime(900_000_000, 21_600)).toBe("10:00 PM");
     expect(formatInstantDateTime("1998-07-20T08:00:00.000Z")).toBe("Jul 20, 1998, 8:00 AM");
   });

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -351,7 +351,7 @@ describe("Plan view adapter", () => {
       action: "close",
       sourceScenarioId: "PL-S017",
       destinationScenarioId: "PL-S001",
-      returnFocusId: "plan-start-coach",
+      returnFocusId: "start-plan",
     });
   });
 

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -931,6 +931,13 @@ describe("Plan Change cards", () => {
     ).toEqual(["Plan totals", "Week 1"]);
     expect(totals).toHaveTextContent("1234 min → 1204 min");
     expect(totals).toHaveTextContent("321 min → 291 min");
+    const facts = screen.getByRole("table", { name: "Facts" });
+    expect(
+      within(facts)
+        .getAllByRole("rowheader")
+        .map((row) => row.textContent),
+    ).toEqual(["Main Goal", "Supporting Events before", "Supporting Events after", "Confidence"]);
+    expect(within(facts).getAllByText("None", { exact: true })).toHaveLength(2);
     expect(screen.getByText("Main Goal", { exact: true })).toBeVisible();
     expect(screen.getByText("Confidence", { exact: true })).toBeVisible();
     expect(screen.getByText("Confirmed schedule limits", { exact: true })).toBeVisible();
@@ -1137,7 +1144,7 @@ describe("Plan Change cards", () => {
       }),
     ]);
     render(<PlanChangeCards />);
-    const facts = screen.getByRole("table", { name: "Supporting Events" });
+    const facts = screen.getByRole("table", { name: "Facts" });
     expect(facts).toHaveTextContent("Supporting Events beforeNone");
     expect(facts).toHaveTextContent("Supporting Events afterRiver ride · 13 Sept 1998 · Training");
     await userEvent.click(screen.getByRole("button", { name: "View evidence" }));

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -567,10 +567,26 @@ describe("Plan Change cards", () => {
     expect(composer).toHaveValue("How should I pace tomorrow?");
   });
 
-  it("shows the active Plan only after entry and restores a pending preview without entry", () => {
+  it("renders the Active Plan actions without a creation, pending Change, or open Change surface", async () => {
+    patchChange({ open: false, planId: null });
+    render(<PlanChangeCards />);
+
+    expect(screen.getByRole("heading", { name: active.name })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Apply to Plan" })).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Change one thing" }));
+    expect(useEnduragentStore.getState().chatActions?.openPlanChangeEditor).toHaveBeenCalledOnce();
+    await userEvent.click(screen.getByRole("button", { name: "Open Plan" }));
+    expect(useEnduragentStore.getState().activeView).toBe("plan");
+  });
+
+  it("shows the active Plan before entry and restores a pending preview without entry", () => {
     patchChange({ open: false, planId: null });
     const view = render(<PlanChangeCards />);
-    expect(screen.queryByRole("region", { name: "Plan Changes" })).toBeNull();
+    expect(screen.getByRole("region", { name: "Plan Changes" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: active.name })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Change one thing" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Open Plan" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Apply to Plan" })).toBeNull();
     setChanges([change()]);
     expect(screen.getByRole("heading", { name: active.name })).toBeVisible();
     expect(screen.getByRole("heading", { name: "Limit Wednesday training" })).toBeVisible();

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -863,7 +863,7 @@ describe("Plan Change cards", () => {
     ]);
   });
 
-  it("omits an entry when Undo restores an unset FTP and falls back for malformed evidence", async () => {
+  it("omits an entry when Undo restores an unset FTP and omits malformed evidence", async () => {
     setChanges([
       change({
         premises: [
@@ -900,8 +900,8 @@ describe("Plan Change cards", () => {
     render(<PlanChangeCards />);
     await userEvent.click(screen.getByRole("button", { name: "View evidence" }));
     expect(
-      within(screen.getByRole("region", { name: "Source details" })).getByRole("cell"),
-    ).toHaveTextContent("FTP comparison unavailable");
+      within(screen.getByRole("region", { name: "Source details" })).queryByRole("cell"),
+    ).toBeNull();
     expect(screen.queryByRole("list")).toBeNull();
   });
 
@@ -986,7 +986,7 @@ describe("Plan Change cards", () => {
     expect(within(history).queryByRole("button", { name: "Cancel" })).toBeNull();
   });
 
-  it("renders unrecognized premise values as their plain labels", async () => {
+  it("omits unrecognized premise values and renders confirmed text", async () => {
     const values: PlanChangeModel["premises"][number]["value"][] = [
       null,
       true,
@@ -1000,7 +1000,7 @@ describe("Plan Change cards", () => {
     setChanges([
       change({
         premises: values.map((value, index) => ({
-          id: `premise-${index}`,
+          id: typeof value === "string" ? "confirmed-limits" : `premise-${index}`,
           label: `Evidence ${index}`,
           source: "Your confirmed request",
           value,
@@ -1014,7 +1014,8 @@ describe("Plan Change cards", () => {
       within(source)
         .getAllByRole("cell")
         .map((cell) => cell.textContent),
-    ).toEqual(values.map((_, index) => `Evidence ${index}`));
+    ).toEqual(["text"]);
+    expect(within(source).queryByText("Evidence 0")).toBeNull();
   });
 
   it("moves focus to the editor, back to Change one thing, and to a new preview heading", async () => {

--- a/apps/desktop-renderer/tests/plan-creation-activation-status.test.tsx
+++ b/apps/desktop-renderer/tests/plan-creation-activation-status.test.tsx
@@ -1,0 +1,102 @@
+import type { ListPlansResult, PlanCalendarStatus } from "@enduragent/coach-contract";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { EMPTY_CHAT_SURFACE } from "../src/state/chat-slice";
+import { useEnduragentStore } from "../src/state/store";
+import { PlanCreationConversation } from "../src/ui/chat/PlanCreationCards";
+
+const emptyLibrary: ListPlansResult = {
+  calendarConnected: false,
+  legacy: null,
+  active: null,
+  creation: null,
+  closed: [],
+  changesPaused: null,
+  changes: [],
+};
+
+const calendarCases = [
+  {
+    calendar: { status: "not-connected", window: null, currentThrough: null, error: null },
+    sentence: "Connect intervals.icu to mirror Workouts.",
+  },
+  {
+    calendar: { status: "pending", window: null, currentThrough: null, error: null },
+    sentence: "Calendar Workouts are being added.",
+  },
+  {
+    calendar: { status: "running", window: null, currentThrough: null, error: null },
+    sentence: "Calendar Workouts are being added.",
+  },
+  {
+    calendar: {
+      status: "verified",
+      window: { start: "1998-09-07", end: "1998-10-04" },
+      currentThrough: "1998-10-04",
+      error: null,
+    },
+    sentence: "Calendar is up to date.",
+  },
+  {
+    calendar: {
+      status: "failed",
+      window: null,
+      currentThrough: null,
+      error: "Calendar update unavailable",
+    },
+    sentence: "Calendar update failed; see the Plan library.",
+  },
+] satisfies readonly { calendar: PlanCalendarStatus; sentence: string }[];
+
+beforeEach(() => {
+  useEnduragentStore.setState({
+    chat: EMPTY_CHAT_SURFACE,
+    planLibrary: { status: "ready", value: emptyLibrary },
+  });
+});
+
+describe("Plan creation activation status", () => {
+  it.each(calendarCases)(
+    "names the active Plan and reports the $calendar.status calendar state",
+    ({ calendar, sentence }) => {
+      useEnduragentStore.setState({
+        planLibrary: {
+          status: "ready",
+          value: {
+            ...emptyLibrary,
+            calendarConnected: calendar.status !== "not-connected",
+            active: {
+              supportingEventCandidates: [],
+              planId: "activation-status-plan",
+              version: 1,
+              name: "Build steady power",
+              start: "1998-09-07",
+              end: "1998-10-04",
+              weeks: 4,
+              status: "active",
+              closeReason: null,
+              closedAt: null,
+              activatedAt: "1998-09-07",
+              todayChoice: null,
+              calendar,
+              creationId: null,
+            },
+          },
+        },
+      });
+
+      render(<PlanCreationConversation model={null} />);
+
+      expect(screen.getByRole("status")).toHaveTextContent(
+        `Build steady power is active. ${sentence}`,
+      );
+      expect(screen.queryByText("Plan activated locally.")).not.toBeInTheDocument();
+    },
+  );
+
+  it("keeps the local activation status until an active Plan is available", () => {
+    render(<PlanCreationConversation model={null} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Plan activated locally.");
+  });
+});

--- a/apps/desktop-renderer/tests/plan-creation-activation-status.test.tsx
+++ b/apps/desktop-renderer/tests/plan-creation-activation-status.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { EMPTY_CHAT_SURFACE } from "../src/state/chat-slice";
 import { useEnduragentStore } from "../src/state/store";
+import { PlanChangeCards } from "../src/ui/chat/PlanChangeCards";
 import { PlanCreationConversation } from "../src/ui/chat/PlanCreationCards";
 
 const emptyLibrary: ListPlansResult = {
@@ -18,15 +19,15 @@ const emptyLibrary: ListPlansResult = {
 const calendarCases = [
   {
     calendar: { status: "not-connected", window: null, currentThrough: null, error: null },
-    sentence: "Connect intervals.icu to mirror Workouts.",
+    sentence: "Connect to mirror Workouts",
   },
   {
     calendar: { status: "pending", window: null, currentThrough: null, error: null },
-    sentence: "Calendar Workouts are being added.",
+    sentence: "Local only",
   },
   {
     calendar: { status: "running", window: null, currentThrough: null, error: null },
-    sentence: "Calendar Workouts are being added.",
+    sentence: "Updating calendar",
   },
   {
     calendar: {
@@ -35,7 +36,7 @@ const calendarCases = [
       currentThrough: "1998-10-04",
       error: null,
     },
-    sentence: "Calendar is up to date.",
+    sentence: "Calendar up to date",
   },
   {
     calendar: {
@@ -44,7 +45,7 @@ const calendarCases = [
       currentThrough: null,
       error: "Calendar update unavailable",
     },
-    sentence: "Calendar update failed; see the Plan library.",
+    sentence: "Calendar sync failed.",
   },
 ] satisfies readonly { calendar: PlanCalendarStatus; sentence: string }[];
 
@@ -85,18 +86,18 @@ describe("Plan creation activation status", () => {
         },
       });
 
-      render(<PlanCreationConversation model={null} />);
+      render(<PlanChangeCards />);
 
-      expect(screen.getByRole("status")).toHaveTextContent(
-        `Build steady power is active. ${sentence}`,
+      expect(screen.getByRole("region", { name: "Build steady power" })).toHaveTextContent(
+        sentence,
       );
       expect(screen.queryByText("Plan activated locally.")).not.toBeInTheDocument();
     },
   );
 
-  it("keeps the local activation status until an active Plan is available", () => {
-    render(<PlanCreationConversation model={null} />);
+  it("renders no transcript content after activation", () => {
+    const { container } = render(<PlanCreationConversation model={null} />);
 
-    expect(screen.getByRole("status")).toHaveTextContent("Plan activated locally.");
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/apps/desktop-renderer/tests/plan-creation-activation-status.test.tsx
+++ b/apps/desktop-renderer/tests/plan-creation-activation-status.test.tsx
@@ -36,7 +36,7 @@ const calendarCases = [
       currentThrough: "1998-10-04",
       error: null,
     },
-    sentence: "Calendar up to date",
+    sentence: "7 Sept 1998 to 4 Oct 1998 · Up to date",
   },
   {
     calendar: {

--- a/apps/desktop-renderer/tests/plan-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-fixtures.ts
@@ -1,5 +1,6 @@
 import type {
   ChatQueueSnapshot,
+  ListPlansResult,
   CoachDecisionReadModel,
   PlanAttention,
   PlanDraftProjection,
@@ -13,6 +14,18 @@ import type {
   PlanStartDateProjection,
   PlanReadModel,
 } from "@enduragent/coach-contract";
+
+export function emptyPlanLibrary(): ListPlansResult {
+  return {
+    calendarConnected: false,
+    legacy: null,
+    active: null,
+    creation: null,
+    closed: [],
+    changesPaused: null,
+    changes: [],
+  };
+}
 
 export const PLAN_ERROR: PlanError = Object.freeze({
   code: "unavailable",

--- a/apps/desktop-renderer/tests/plan-library.test.tsx
+++ b/apps/desktop-renderer/tests/plan-library.test.tsx
@@ -165,18 +165,11 @@ const creation: PlanCreationCardModel = {
     eventNotListedOption: {
       label: "Event not listed",
       detail: "Add your event.",
-      editorLabel: "Event",
       placeholder: "Event name",
       nameLabel: "Name",
       dateLabel: "Date",
     },
     fitnessOption: { label: "General fitness", detail: "Build fitness." },
-    authoredOption: {
-      label: "Something else",
-      detail: "Name an event.",
-      editorLabel: "Event",
-      placeholder: "Event name",
-    },
   },
 };
 const active: NonNullable<ListPlansResult["active"]> = {

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -5,12 +5,16 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlanActiveProjectionDataSchema } from "@enduragent/coach-contract";
-import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice";
+import {
+  EMPTY_PLAN_SURFACE,
+  type PlanActions,
+  type PlanLibraryActions,
+} from "../src/state/plan-slice";
 import { useEnduragentStore } from "../src/state/store";
 import { IDLE_TRAINING_EXPORT } from "../src/training-export/controller";
 import { PlanView } from "../src/ui/plan/PlanView";
 import { pinDefaultLocale } from "./intl";
-import { PLAN_ERROR, planCoachData, planReadModel } from "./plan-fixtures";
+import { PLAN_ERROR, emptyPlanLibrary, planCoachData, planReadModel } from "./plan-fixtures";
 
 function actions(): PlanActions {
   return {
@@ -123,6 +127,8 @@ beforeEach(() => {
   pinDefaultLocale("en-US");
   useEnduragentStore.setState({
     plan: EMPTY_PLAN_SURFACE,
+    planLibrary: { status: "loading", value: null },
+    planLibraryActions: null,
     planActions: actions(),
     trainingExport: IDLE_TRAINING_EXPORT,
     trainingExportActions: null,
@@ -134,6 +140,8 @@ afterEach(() => {
   document.documentElement.removeAttribute("data-theme");
   useEnduragentStore.setState({
     plan: EMPTY_PLAN_SURFACE,
+    planLibrary: { status: "loading", value: null },
+    planLibraryActions: null,
     planActions: null,
     planningReadActions: null,
     trainingExport: IDLE_TRAINING_EXPORT,
@@ -166,7 +174,15 @@ describe("Plan surface", () => {
 
   it("renders the no-Plan hierarchy and starts Plan creation from the keyboard", async () => {
     const user = userEvent.setup();
-    const planActions = actions();
+    const startCreation = vi.fn();
+    const planLibraryActions: PlanLibraryActions = {
+      startCreation,
+      closePlan: vi.fn(),
+      readPlanHistory: vi.fn(),
+      refresh: vi.fn(),
+      continueCreation: vi.fn(),
+      changeInChat: vi.fn(),
+    };
     const noPlan = {
       ...planReadModel(),
       transitions: [{ transitionId: "PL-T01", status: "blocked", reason: "Retired wizard" }],
@@ -177,33 +193,49 @@ describe("Plan surface", () => {
         hydration: { status: "ready", state: noPlan },
         lastReady: noPlan,
       },
-      planActions,
+      planLibrary: { status: "ready", value: emptyPlanLibrary() },
+      planLibraryActions,
     });
     render(<PlanView />);
 
-    expect(screen.getByRole("heading", { name: "No active Plan" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "No active Plan", level: 3 })).toBeInTheDocument();
     expect(screen.getByText("Create a Plan when you are ready.")).toBeInTheDocument();
     expect(screen.queryByText(/GPX\/FIT/u)).not.toBeInTheDocument();
 
     const start = screen.getByRole("button", { name: "Start a Plan" });
+    expect(start).toHaveAttribute("id", "start-plan");
+    expect(screen.getAllByRole("button", { name: "Start a Plan" })).toHaveLength(1);
+    expect(screen.getAllByText("No active Plan", { exact: true })).toHaveLength(1);
     start.focus();
     await user.keyboard("{Enter}");
-    expect(planActions.startPlan).toHaveBeenCalledOnce();
+    expect(startCreation).toHaveBeenCalledOnce();
   });
 
   it("returns focus to the no-Plan action after closing the Coach workspace", async () => {
-    const state = planReadModel({ data: { returnFocusId: "plan-start-coach" } });
+    const state = planReadModel({ data: { returnFocusId: "start-plan" } });
     useEnduragentStore.setState({
       plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planLibrary: { status: "ready", value: emptyPlanLibrary() },
+      planLibraryActions: {
+        startCreation: vi.fn(),
+        closePlan: vi.fn(),
+        readPlanHistory: vi.fn(),
+        refresh: vi.fn(),
+        continueCreation: vi.fn(),
+        changeInChat: vi.fn(),
+      },
     });
     render(<PlanView />);
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "Start a Plan" })).toHaveFocus());
+    const start = screen.getByRole("button", { name: "Start a Plan" });
+    expect(start).toHaveAttribute("id", "start-plan");
+    await waitFor(() => expect(start).toHaveFocus());
   });
 
   it("keeps the last ready no-Plan screen visible when hydration becomes stale", () => {
     const state = planReadModel();
     useEnduragentStore.setState({
+      planLibrary: { status: "ready", value: emptyPlanLibrary() },
       plan: {
         ...EMPTY_PLAN_SURFACE,
         hydration: { status: "ready", state },
@@ -215,8 +247,13 @@ describe("Plan surface", () => {
     });
     render(<PlanView />);
 
+    expect(screen.getByText("Create a Plan when you are ready.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Start a Plan" })).toHaveAttribute(
+      "id",
+      "start-plan",
+    );
     expect(screen.getByText(PLAN_ERROR.message)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "No active Plan" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "No active Plan", level: 3 })).toBeInTheDocument();
   });
 
   it("renders the server attention projection without deriving a count", async () => {

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -2231,11 +2231,11 @@ describe("Plan surface", () => {
     render(<PlanView />);
 
     expect(
-      screen.getByRole("heading", { name: /Aug 31, 2026 already has a Workout/u }),
+      screen.getByRole("heading", { name: /31 Aug 2026 already has a Workout/u }),
     ).toBeVisible();
     expect(screen.getByText("Protected")).toBeVisible();
     expect(screen.queryByRole("button", { name: /Replace Club ride/u })).not.toBeInTheDocument();
-    const recommendedButtons = screen.getAllByRole("button", { name: /Use Sep 1, 2026/u });
+    const recommendedButtons = screen.getAllByRole("button", { name: /Use 1 Sept 2026/u });
     await user.click(recommendedButtons[recommendedButtons.length - 1]!);
     expect(planActions.resolvePlanningRequestDate).toHaveBeenCalledWith(requestId, {
       kind: "use-date",
@@ -2253,7 +2253,7 @@ describe("Plan surface", () => {
     const date = screen.getByLabelText("Date");
     await user.clear(date);
     await user.type(date, "2026-09-02");
-    await user.click(screen.getByRole("button", { name: /Use Sep 2, 2026/u }));
+    await user.click(screen.getByRole("button", { name: /Use 2 Sept 2026/u }));
     expect(planActions.resolvePlanningRequestDate).toHaveBeenLastCalledWith(requestId, {
       kind: "use-date",
       date: "2026-09-02",

--- a/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
@@ -217,7 +217,7 @@ describe("resident ride import glue", () => {
     expect(screen.queryByText("Training history is not available yet.")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", {
-        name: "Open ride review: Road ride, Jul 9, 1998 · 4:00 PM",
+        name: "Open ride review: Road ride, 9 Jul 1998 · 4:00 PM",
       }),
     ).toBeInTheDocument();
   });

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -25,7 +25,7 @@ import {
   requestTrainingRestrictionFocus,
   takeTrainingRestrictionFocusRequest,
 } from "../src/ui/settings/restriction-focus";
-import { planReadModel } from "./plan-fixtures";
+import { emptyPlanLibrary, planReadModel } from "./plan-fixtures";
 
 const REPAIR_REQUIRED_CREDENTIALS: CredentialSettingsState = {
   status: "ready",
@@ -269,6 +269,7 @@ describe("shell", () => {
       onboardingActions: null,
       onboardingStartupSettled: true,
       plan: EMPTY_PLAN_SURFACE,
+      planLibrary: { status: "loading", value: null },
       planActions: stubPlanActions(),
       settings: {
         ...useEnduragentStore.getState().settings,
@@ -289,6 +290,7 @@ describe("shell", () => {
       onboardingActions: null,
       onboardingStartupSettled: false,
       plan: EMPTY_PLAN_SURFACE,
+      planLibrary: { status: "loading", value: null },
       planActions: null,
       settings: {
         ...useEnduragentStore.getState().settings,
@@ -356,11 +358,17 @@ describe("shell", () => {
           hydration: { status: "ready", state: planState },
           lastReady: planState,
         },
+        planLibrary: { status: "ready", value: emptyPlanLibrary() },
       });
     });
     await user.click(screen.getByRole("button", { name: "Plan" }));
     expect(await screen.findByRole("region", { name: "Plan" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "No active Plan" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "No active Plan", level: 3 })).toBeInTheDocument();
+    expect(screen.getByText("Create a Plan when you are ready.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Start a Plan" })).toHaveAttribute(
+      "id",
+      "start-plan",
+    );
     expect(document.querySelector("div.thread")).not.toBeNull();
     const conversation = screen.getByLabelText("Coaching conversation");
     expect(conversation.closest(".hidden")).not.toBeNull();

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -305,7 +305,7 @@ function setRideImport(next: RideImportState): void {
 async function openFirstRide(user: ReturnType<typeof userEvent.setup>): Promise<void> {
   await user.click(
     screen.getByRole("button", {
-      name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+      name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
     }),
   );
 }
@@ -358,7 +358,7 @@ describe("training landing page", () => {
     render(<TrainingView />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Training" })).toBeInTheDocument();
-    expect(screen.getByText("Jul 6–12")).toBeInTheDocument();
+    expect(screen.getByText("6 Jul–12")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Import ride files" })).toBeInTheDocument();
     expect(
       [...document.querySelectorAll("[data-panel]")].map((node) => node.getAttribute("data-panel")),
@@ -381,9 +381,9 @@ describe("training landing page", () => {
   });
 
   it.each([
-    ["en-US", "1998-07-06", "1998-07-12", "Jul 6–12"],
-    ["en-US", "1998-06-29", "1998-07-05", "Jun 29–Jul 5"],
-    ["en-US", "1997-12-29", "1998-01-04", "Dec 29, 1997–Jan 4, 1998"],
+    ["en-US", "1998-07-06", "1998-07-12", "6 Jul–12"],
+    ["en-US", "1998-06-29", "1998-07-05", "29 Jun–5 Jul"],
+    ["en-US", "1997-12-29", "1998-01-04", "29 Dec 1997–4 Jan 1998"],
     ["en-GB", "1998-07-06", "1998-07-12", "6 Jul–12"],
     ["en-GB", "1998-06-29", "1998-07-05", "29 Jun–5 Jul"],
     ["en-GB", "1997-12-29", "1998-01-04", "29 Dec 1997–4 Jan 1998"],
@@ -441,7 +441,7 @@ describe("training landing page", () => {
     expect(current).toHaveAttribute("aria-pressed", "false");
     expect(previous).toBeDisabled();
     expect(next).toBeEnabled();
-    expect(screen.getByText("Jun 29–Jul 5")).toBeInTheDocument();
+    expect(screen.getByText("29 Jun–5 Jul")).toBeInTheDocument();
     expect(document.querySelector('[data-parity="rides-previous-week"]')).not.toBeInTheDocument();
     const periodStatus = screen
       .getAllByRole("status")
@@ -553,8 +553,8 @@ describe("training landing page", () => {
     const table = within(figure).getByRole("table", {
       name: "Weekly time 6 weeks",
     });
-    expect(within(figure).getByText("6/15")).toBeInTheDocument();
-    expect(within(table).getByText("Jun 15, 1998 to Jun 21, 1998")).toBeInTheDocument();
+    expect(within(figure).getByText("15/06")).toBeInTheDocument();
+    expect(within(table).getByText("15 Jun 1998 to 21 Jun 1998")).toBeInTheDocument();
     expect(within(table).getByText("0 rides")).toBeInTheDocument();
     expect(within(table).getByText("0m")).toBeInTheDocument();
   });
@@ -582,7 +582,7 @@ describe("training landing page", () => {
 
     const recent = screen.getByRole("region", { name: "Recent rides" });
     const firstRide = within(recent).getByRole("button", {
-      name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+      name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
     });
     const rideDay = firstRide.querySelector('[data-parity="ride-day"]');
     const rideMeta = firstRide.querySelector('[data-parity="ride-meta"]');
@@ -618,7 +618,7 @@ describe("training landing page", () => {
     expect(rideStats?.children[1]).toHaveTextContent("Load 91");
     expect(rideStats?.children[1]).not.toHaveClass("max-[761px]:hidden");
     const reason = within(firstRide).getByText(
-      "Longest recorded ride in the 28 days ending Jul 9, 1998",
+      "Longest recorded ride in the 28 days ending 9 Jul 1998",
     );
     expect(reason.previousElementSibling).toBe(rideMeta);
     expect(reason).toHaveClass(
@@ -632,12 +632,12 @@ describe("training landing page", () => {
     );
     expect(reason).toHaveAttribute(
       "title",
-      "Longest recorded ride in the 28 days ending Jul 9, 1998",
+      "Longest recorded ride in the 28 days ending 9 Jul 1998",
     );
     const arrow = firstRide.lastElementChild;
     expect(arrow).toHaveClass("text-base", "leading-4", "text-ink-3");
     const indoorRide = within(recent).getByRole("button", {
-      name: "Open ride review: Indoor ride, Jul 8, 1998",
+      name: "Open ride review: Indoor ride, 8 Jul 1998",
     });
     expect(indoorRide.querySelector('[data-parity="ride-day"]')).toHaveTextContent("Wed8");
     expect(indoorRide.querySelector('[data-parity="ride-meta"]')).toHaveTextContent(
@@ -659,7 +659,7 @@ describe("training landing page", () => {
     expect(
       within(screen.getByRole("region", { name: "Recent rides" }))
         .getByRole("button", {
-          name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+          name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
         })
         .querySelector('[data-parity="ride-meta"]'),
     ).toHaveTextContent("Road · 26.2 mi");
@@ -737,7 +737,7 @@ describe("ride review", () => {
     const user = userEvent.setup();
     render(<TrainingView />);
     const opener = screen.getByRole("button", {
-      name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+      name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
     });
     opener.focus();
 
@@ -747,7 +747,7 @@ describe("ride review", () => {
     await user.click(screen.getByRole("button", { name: "Back to training" }));
     expect(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+        name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
       }),
     ).toHaveFocus();
   });
@@ -760,11 +760,11 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+        name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
       }),
     );
 
-    expect(screen.getByText("Jul 9, 1998")).toBeInTheDocument();
+    expect(screen.getByText("9 Jul 1998")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Back to training" })).toHaveClass(
       "h-ctl-sm",
       "px-ctl-px-sm",
@@ -777,7 +777,7 @@ describe("ride review", () => {
     const eyebrow = within(overview).getByText("Road ride");
     expect(eyebrow).toHaveClass("m-0", "font-semibold");
     expect(eyebrow).not.toHaveClass("mb-2", "font-medium");
-    const reviewDate = within(overview).getByText("Jul 9, 1998 · 10:00 PM");
+    const reviewDate = within(overview).getByText("9 Jul 1998 · 10:00 PM");
     expect(reviewDate).toBeInTheDocument();
     expect(reviewDate).toHaveAttribute("datetime", "1998-07-09");
     expect(within(overview).getByText("1h 25m")).toBeInTheDocument();
@@ -848,7 +848,7 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: Indoor ride, Jul 8, 1998",
+        name: "Open ride review: Indoor ride, 8 Jul 1998",
       }),
     );
 
@@ -1185,7 +1185,7 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+        name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
       }),
     );
     await user.click(screen.getByText("Recorded analysis"));
@@ -1199,7 +1199,7 @@ describe("ride review", () => {
     render(<TrainingView />);
     await user.click(
       screen.getByRole("button", {
-        name: "Open ride review: River tempo, Jul 9, 1998 · 10:00 PM",
+        name: "Open ride review: River tempo, 9 Jul 1998 · 10:00 PM",
       }),
     );
     const withoutFirst = week("anchor", {
@@ -1455,19 +1455,19 @@ describe("training history states and import status", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "This week" })).not.toBeInTheDocument();
     expect(screen.queryByText("Worth a look")).not.toBeInTheDocument();
-    expect(screen.getByText("Recorded through Jul 12, 1998").tagName).toBe("STRONG");
+    expect(screen.getByText("Recorded through 12 Jul 1998").tagName).toBe("STRONG");
     expect(screen.getByRole("region", { name: "Recorded rides" })).toBeInTheDocument();
     const notice = screen
       .getByText("Training could not be refreshed. Showing the last recorded data.")
       .closest('[data-tone="warning"]');
-    expect(notice).toHaveTextContent("Recorded through Jul 12, 1998");
+    expect(notice).toHaveTextContent("Recorded through 12 Jul 1998");
   });
 
   it("leads a complete last-recorded notice with its recorded-through date", () => {
     setTraining(ready(history({ displayMode: "last-recorded" })));
     render(<TrainingView />);
 
-    const coverage = screen.getByText("Recorded through Jul 12, 1998");
+    const coverage = screen.getByText("Recorded through 12 Jul 1998");
     const notice = screen.getByText("Training may be out of date.");
     expect(coverage.tagName).toBe("STRONG");
     expect(coverage.parentElement).toBe(notice);
@@ -1497,7 +1497,7 @@ describe("training history states and import status", () => {
     useEnduragentStore.setState({ training: ready(panel) });
     render(<TrainingView />);
 
-    expect(screen.getByText("Recorded through Jul 9, 1998")).toBeInTheDocument();
+    expect(screen.getByText("Recorded through 9 Jul 1998")).toBeInTheDocument();
     expect(
       screen.getByText("Training may be out of date, and some rides may be missing."),
     ).toBeInTheDocument();

--- a/apps/desktop/tests/e2e/plan-calendar.spec.ts
+++ b/apps/desktop/tests/e2e/plan-calendar.spec.ts
@@ -203,7 +203,7 @@ async function confirmReplacement(scenario: Scenario, connected = true) {
   await expect(activeCard).toContainText("Improve fitness");
   await expect(
     activeCard.getByText(
-      connected ? /Calendar up to date|Updating calendar/ : "Connect to mirror Workouts",
+      connected ? /Up to date|Updating calendar/ : "Connect to mirror Workouts",
     ),
   ).toBeVisible();
 }

--- a/apps/desktop/tests/e2e/plan-calendar.spec.ts
+++ b/apps/desktop/tests/e2e/plan-calendar.spec.ts
@@ -152,7 +152,11 @@ async function replacementDraft(scenario: Scenario, mode: "fixed" | "flexible" =
   await navigate(scenario, "Plan");
   await expect(active(scenario)).toBeVisible();
   await navigate(scenario, "Chat");
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await expect.poll(async () => (await scenario.backend.card())?.status).toBe("in-progress");
   await choose(scenario, "fitness");
   await choose(scenario, "4");

--- a/apps/desktop/tests/e2e/plan-calendar.spec.ts
+++ b/apps/desktop/tests/e2e/plan-calendar.spec.ts
@@ -199,12 +199,12 @@ async function confirmReplacement(scenario: Scenario, connected = true) {
   );
   await dialog.getByRole("button", { name: "Activate new Plan", exact: true }).click();
   await expect(dialog).toHaveCount(0);
+  const activeCard = scenario.page.getByRole("region", { name: "Improve fitness", exact: true });
+  await expect(activeCard).toContainText("Improve fitness");
   await expect(
-    scenario.page.getByRole("status").filter({
-      hasText: connected
-        ? /^Improve fitness is active\. Calendar (is up to date|Workouts are being added)\.$/
-        : "Improve fitness is active. Connect intervals.icu to mirror Workouts.",
-    }),
+    activeCard.getByText(
+      connected ? /Calendar up to date|Updating calendar/ : "Connect to mirror Workouts",
+    ),
   ).toBeVisible();
 }
 

--- a/apps/desktop/tests/e2e/plan-calendar.spec.ts
+++ b/apps/desktop/tests/e2e/plan-calendar.spec.ts
@@ -199,7 +199,13 @@ async function confirmReplacement(scenario: Scenario, connected = true) {
   );
   await dialog.getByRole("button", { name: "Activate new Plan", exact: true }).click();
   await expect(dialog).toHaveCount(0);
-  await expect(scenario.page.getByText("Plan activated locally.", { exact: true })).toBeVisible();
+  await expect(
+    scenario.page.getByRole("status").filter({
+      hasText: connected
+        ? /^Improve fitness is active\. Calendar (is up to date|Workouts are being added)\.$/
+        : "Improve fitness is active. Connect intervals.icu to mirror Workouts.",
+    }),
+  ).toBeVisible();
 }
 
 test("shows calendar progress and the verified seven-day window", async ({ playwright }) => {

--- a/apps/desktop/tests/e2e/plan-change.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change.spec.ts
@@ -405,8 +405,13 @@ async function assertPreview(scenario: Scenario, change: ChangeCase) {
     ),
   ]);
   const facts = pending.getByRole("table", { name: "Facts", exact: true });
-  await expect(facts.getByRole("rowheader")).toHaveText(["Main Goal", "Confidence"]);
-  await expect(facts.getByRole("cell")).toHaveText(["Improve fitness", confidence]);
+  await expect(facts.getByRole("rowheader")).toHaveText([
+    "Main Goal",
+    "Supporting Events before",
+    "Supporting Events after",
+    "Confidence",
+  ]);
+  await expect(facts.getByRole("cell")).toHaveText(["Improve fitness", "None", "None", confidence]);
   await expect(pending.getByRole("button")).toHaveText([
     "View evidence",
     "Cancel",

--- a/apps/desktop/tests/e2e/plan-change.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change.spec.ts
@@ -210,6 +210,8 @@ async function navigate(scenario: Scenario, destination: "Chat" | "Plan") {
 }
 
 async function enterChanges(scenario: Scenario) {
+  await expect(changes(scenario)).toBeVisible();
+  await expect(changes(scenario).getByRole("button")).toHaveText(["Change one thing", "Open Plan"]);
   await navigate(scenario, "Plan");
   await scenario.page
     .getByRole("region", { name: "Plan library", exact: true })

--- a/apps/desktop/tests/e2e/plan-change.spec.ts
+++ b/apps/desktop/tests/e2e/plan-change.spec.ts
@@ -538,7 +538,9 @@ for (const appearance of appearances) {
       await expect(details.getByRole("rowheader")).toHaveText([
         "Confirmed Plan limits · Your confirmed answers",
       ]);
-      await expect(details.getByRole("cell")).toHaveText(["Wed · 30 min"]);
+      await expect(details.getByRole("cell")).toHaveText([
+        "Up to 6 h a week, longest Workout 2 h, Mon, Wed, Sat · No fixed commitments · No training restrictions",
+      ]);
       await source.getByRole("button", { name: "Back", exact: true }).click();
       await expect(card.getByRole("button", { name: "View evidence", exact: true })).toBeFocused();
       await expect(source).toHaveCount(0);

--- a/apps/desktop/tests/e2e/plan-creation-slice1.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice1.spec.ts
@@ -90,7 +90,11 @@ async function choose(page: Page, backend: PlanCreationBackend, version: number,
 }
 
 async function answerThroughFitnessSuccess(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await waitForVersion(scenario.backend, 1);
   await choose(scenario.page, scenario.backend, 2, "fitness");
   await choose(scenario.page, scenario.backend, 3, "8");
@@ -148,7 +152,11 @@ test("persists the Fitness success choice and restores the Restriction Card", as
 test("restores the Plan length Card after relaunching between answers", async ({ playwright }) => {
   const scenario = await launch(playwright);
   try {
-    await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+    await scenario.page.locator("#message").fill("/plan");
+    await scenario.page.locator("#message").press("Enter");
+    await expect(
+      scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+    ).toBeVisible();
     await waitForVersion(scenario.backend, 1);
     await choose(scenario.page, scenario.backend, 2, "fitness");
     await relaunch(scenario, playwright);

--- a/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
@@ -217,7 +217,11 @@ async function choose(page: Page, backend: PlanCreationBackend, version: number,
 }
 
 async function startFitnessGoal(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await waitForVersion(scenario.backend, 1);
   await choose(scenario.page, scenario.backend, 2, "fitness");
 }
@@ -482,7 +486,11 @@ for (const appearance of [
       expect(await scenario.backend.answers()).toEqual(answers);
     };
     try {
-      await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+      await scenario.page.locator("#message").fill("/plan");
+      await scenario.page.locator("#message").press("Enter");
+      await expect(
+        scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+      ).toBeVisible();
       await waitForVersion(scenario.backend, 1);
       await expect(question("goal").getByRole("heading")).toBeFocused();
       await capture("goal");
@@ -689,8 +697,12 @@ test("preserves ordinary Chat, Past chats, and active Plan editing during creati
   try {
     const originalPlan = await readPlanFacts();
     await expect(scenario.page.getByText(historyText, { exact: true })).toBeVisible();
-    await composer.fill("Keep this ordinary Chat draft.");
     await startFitnessGoal(scenario);
+    await expect(composer).toHaveValue("");
+    await scenario.page.getByRole("button", { name: "Later", exact: true }).click();
+    await expect(composer).toBeEnabled();
+    await composer.fill("Keep this ordinary Chat draft.");
+    await scenario.page.getByRole("button", { name: "Continue", exact: true }).click();
     await expect(composer).toBeDisabled();
     await expect(composer).toHaveValue("Keep this ordinary Chat draft.");
     await scenario.page.getByRole("button", { name: "Later", exact: true }).click();

--- a/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
@@ -507,8 +507,8 @@ for (const appearance of [
       await scenario.page.getByLabel("Event date", { exact: true }).fill("1998-11-08");
       await scenario.page.getByRole("button", { name: "Continue", exact: true }).click();
       await waitForVersion(scenario.backend, 2);
-      await cancelAuthoredEdit("Goal", '[data-parity="custom.textarea"]', "schedule-mode");
-      await scenario.page.getByRole("button", { name: "Edit Goal", exact: true }).click();
+      await cancelAuthoredEdit("Main Goal", '[data-parity="custom.textarea"]', "schedule-mode");
+      await scenario.page.getByRole("button", { name: "Edit Main Goal", exact: true }).click();
       await scenario.page.keyboard.press("Escape");
       await expect(
         scenario.page.getByRole("button", { name: "Event not listed", exact: true }),

--- a/apps/desktop/tests/e2e/plan-creation-slice3.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice3.spec.ts
@@ -249,7 +249,7 @@ async function openDiscardConfirmation(page: Page) {
   await expect(page.getByRole("heading", { name: "Discard this Plan creation?" })).toBeVisible();
   await expect(
     page.getByText(
-      "No Plan is created. Your active Plan, Schedule, training restrictions, closed Plans, saved preferences, and chat history are unchanged.",
+      "Your answers are discarded. Your active Plan, Schedule, restrictions, saved preferences, and history stay unchanged.",
       { exact: true },
     ),
   ).toBeVisible();

--- a/apps/desktop/tests/e2e/plan-creation-slice3.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice3.spec.ts
@@ -130,9 +130,7 @@ async function relaunch(scenario: Scenario, playwright: Playwright): Promise<voi
   await scenario.fixture.setViewport(scenario.width, 820);
   Object.assign(scenario, await connect(playwright, scenario.fixture, scenario.colorScheme));
   expect(await scenario.page.evaluate(() => innerWidth)).toBe(scenario.width);
-  await expect(
-    scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
-  ).toBeVisible();
+  await expect(scenario.page.locator("#message")).toBeVisible();
   await test.info().attach("relaunch-timing", {
     body: JSON.stringify({ milliseconds: performance.now() - started }),
     contentType: "application/json",
@@ -181,7 +179,7 @@ async function capture(page: Page, name: string): Promise<void> {
       header: '[data-slot="dialog-header"]',
       actions: '[data-slot="dialog-footer"]',
       consequence: '[data-parity="discarded.record"]',
-      start: '[data-parity="start.row"]',
+      composer: "#message",
     };
     const result: Record<string, unknown> = {};
     for (const [key, selector] of Object.entries(selectors)) {
@@ -206,10 +204,10 @@ async function capture(page: Page, name: string): Promise<void> {
       };
     }
     const consequence = document.querySelector('[data-parity="discarded.record"]');
-    const start = document.querySelector('[data-parity="start.row"]');
-    result.consequenceBeforeStart =
-      consequence !== null && start !== null
-        ? Boolean(consequence.compareDocumentPosition(start) & Node.DOCUMENT_POSITION_FOLLOWING)
+    const composer = document.querySelector("#message");
+    result.consequenceBeforeComposer =
+      consequence !== null && composer !== null
+        ? Boolean(consequence.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING)
         : null;
     result.environment = {
       width: innerWidth,
@@ -231,7 +229,11 @@ async function waitForVersion(backend: PlanCreationBackend, version: number): Pr
 }
 
 async function startAndAnswerGoal(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await waitForVersion(scenario.backend, 1);
   await scenario.page.getByRole("button", { name: "Improve without an event" }).click();
   await waitForVersion(scenario.backend, 2);
@@ -262,7 +264,7 @@ async function discardPlanCreation(page: Page): Promise<void> {
   await openDiscardConfirmation(page);
   const started = performance.now();
   await page.getByRole("button", { name: "Discard creation" }).click();
-  await expect(page.getByRole("button", { name: "Start a Plan", exact: true })).toBeFocused();
+  await expect(page.locator("#message")).toBeFocused();
   await test.info().attach("discard-timing", {
     body: JSON.stringify({ milliseconds: performance.now() - started }),
     contentType: "application/json",
@@ -275,14 +277,14 @@ async function discardPlanCreation(page: Page): Promise<void> {
       { exact: true },
     ),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Start a Plan" })).toBeVisible();
+  await expect(page.locator("#message")).toBeVisible();
   await expect(page.getByRole("combobox", { name: "Message your coach" })).toBeEnabled();
   expect(
     await page.locator('[data-parity="discarded.record"]').evaluate((record) => {
-      const start = document.querySelector('[data-parity="start.row"]');
+      const composer = document.querySelector("#message");
       return (
-        start !== null &&
-        Boolean(record.compareDocumentPosition(start) & Node.DOCUMENT_POSITION_FOLLOWING)
+        composer !== null &&
+        Boolean(record.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING)
       );
     }),
   ).toBe(true);
@@ -341,8 +343,7 @@ for (const appearance of [
       await expect(scenario.backend.inspectDiscard()).resolves.toEqual(beforeDiscard);
 
       await discardPlanCreation(scenario.page);
-      const start = scenario.page.getByRole("button", { name: "Start a Plan" });
-      await expect(start).toBeFocused();
+      await expect(scenario.page.locator("#message")).toBeFocused();
       const afterDiscard = await scenario.backend.inspectDiscard();
       expect(afterDiscard.creations).toEqual([
         {
@@ -362,7 +363,7 @@ for (const appearance of [
       await expectNoPlanCreationSummaries(scenario.page);
 
       await relaunch(scenario, playwright);
-      await expect(scenario.page.getByRole("button", { name: "Start a Plan" })).toBeVisible();
+      await expect(scenario.page.locator("#message")).toBeVisible();
       await expectNoPlanCreationSummaries(scenario.page);
     } finally {
       await close(scenario);
@@ -385,7 +386,7 @@ test("preserves an ordinary Chat turn after discard and relaunch", async ({ play
 
     await relaunch(scenario, playwright);
     await expect(scenario.backend.inspectUnrelated()).resolves.toEqual(unrelatedBeforeDiscard);
-    await expect(scenario.page.getByRole("button", { name: "Start a Plan" })).toBeVisible();
+    await expect(scenario.page.locator("#message")).toBeVisible();
     await expect(scenario.page.getByText(ordinaryPrompt, { exact: true })).toBeVisible();
     await expect(scenario.page.getByText(ordinaryCoachReply, { exact: true })).toBeVisible();
   } finally {
@@ -402,7 +403,11 @@ test("starts a distinct Plan Creation after discard", async ({ playwright }) => 
     if (discardedId === undefined) throw new TypeError("Plan Creation row is unavailable");
     await discardPlanCreation(scenario.page);
 
-    await scenario.page.getByRole("button", { name: "Start a Plan" }).click();
+    await scenario.page.locator("#message").fill("/plan");
+    await scenario.page.locator("#message").press("Enter");
+    await expect(
+      scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+    ).toBeVisible();
     await expect(
       scenario.page.getByRole("heading", {
         name: "What do you want this Plan to prepare you for?",
@@ -439,9 +444,7 @@ for (const failure of ["before", "after"] as const) {
       if (failure === "before") expect(await scenario.backend.inspectDiscard()).toEqual(before);
       else expect((await scenario.backend.inspectDiscard()).creations[0]?.status).toBe("discarded");
       await scenario.page.getByRole("button", { name: "Discard creation", exact: true }).click();
-      await expect(
-        scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
-      ).toBeFocused();
+      await expect(scenario.page.locator("#message")).toBeFocused();
       const requests = scenario.backend.creationRequests.filter(
         (request) => request.method === "plan_creation.discard",
       );

--- a/apps/desktop/tests/e2e/plan-creation-slice4.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice4.spec.ts
@@ -184,7 +184,11 @@ async function continueAnswer(scenario: Scenario): Promise<void> {
 }
 
 async function completeFitness(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await expect.poll(async () => (await scenario.backend.card())?.version).toBe(1);
   await choose(scenario, "fitness");
   await choose(scenario, "4");

--- a/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
@@ -380,12 +380,12 @@ for (const appearance of [
           })
           .click();
         await assertActivated(scenario, reviewed, before);
+        const activationStatus =
+          "Improve fitness is active. Connect intervals.icu to mirror Workouts.";
         await expect(
-          scenario.page.getByRole("status").filter({ hasText: "Plan activated locally." }),
+          scenario.page.getByRole("status").filter({ hasText: activationStatus }),
         ).toBeVisible();
-        await expect(
-          scenario.page.getByText("Plan activated locally.", { exact: true }),
-        ).toHaveCount(1);
+        await expect(scenario.page.getByText(activationStatus, { exact: true })).toHaveCount(1);
         const request = scenario.backend.creationRequests.at(-1);
         expect(request).toMatchObject({
           method: "plan_creation.activate",

--- a/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
@@ -167,7 +167,11 @@ async function continueAnswer(scenario: Scenario): Promise<void> {
 }
 
 async function completeFitness(scenario: Scenario): Promise<void> {
-  await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+  await scenario.page.locator("#message").fill("/plan");
+  await scenario.page.locator("#message").press("Enter");
+  await expect(
+    scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+  ).toBeVisible();
   await expect.poll(async () => (await scenario.backend.card())?.version).toBe(1);
   await choose(scenario, "fitness");
   await choose(scenario, "4");

--- a/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice5.spec.ts
@@ -380,12 +380,15 @@ for (const appearance of [
           })
           .click();
         await assertActivated(scenario, reviewed, before);
-        const activationStatus =
-          "Improve fitness is active. Connect intervals.icu to mirror Workouts.";
+        const activeCard = scenario.page.getByRole("region", {
+          name: "Improve fitness",
+          exact: true,
+        });
+        await expect(activeCard).toContainText("Improve fitness");
         await expect(
-          scenario.page.getByRole("status").filter({ hasText: activationStatus }),
+          activeCard.getByText("Connect to mirror Workouts", { exact: true }),
         ).toBeVisible();
-        await expect(scenario.page.getByText(activationStatus, { exact: true })).toHaveCount(1);
+        await expect(scenario.page.getByText("Plan activated locally.")).toHaveCount(0);
         const request = scenario.backend.creationRequests.at(-1);
         expect(request).toMatchObject({
           method: "plan_creation.activate",

--- a/apps/desktop/tests/e2e/plan-library.spec.ts
+++ b/apps/desktop/tests/e2e/plan-library.spec.ts
@@ -300,7 +300,12 @@ for (const appearance of [
       const library = () =>
         scenario.page.getByRole("region", { name: "Plan library", exact: true });
       await expect(library().getByRole("heading")).toHaveText(["No active Plan"]);
+      await expect(
+        scenario.page.getByRole("heading", { name: "No active Plan", exact: true }),
+      ).toHaveCount(1);
       await expect(library()).toContainText("Create a Plan when you are ready.");
+      await expect(library().getByRole("button")).toHaveCount(0);
+      await expect(scenario.page.locator("#start-plan")).toBeVisible();
       await capture(scenario, "empty-library");
       await relaunch(scenario, playwright);
       await expect(library().getByRole("heading")).toHaveText(["No active Plan"]);

--- a/apps/desktop/tests/e2e/plan-library.spec.ts
+++ b/apps/desktop/tests/e2e/plan-library.spec.ts
@@ -261,9 +261,7 @@ for (const appearance of [
       await expect(
         scenario.page.getByText("Plan creation discarded", { exact: true }),
       ).toBeVisible();
-      await expect(
-        scenario.page.getByRole("button", { name: "Start a Plan", exact: true }),
-      ).toBeFocused();
+      await expect(scenario.page.locator("#message")).toBeFocused();
       await expect(
         scenario.page.getByRole("button", { name: "Continue in Chat", exact: true }),
       ).toHaveCount(0);
@@ -271,7 +269,11 @@ for (const appearance of [
       expect(after.active).toEqual(before.active);
       expect(after.closed).toEqual(before.closed);
       await capture(scenario, "creation-discarded");
-      await scenario.page.getByRole("button", { name: "Start a Plan", exact: true }).click();
+      await scenario.page.locator("#message").fill("/plan");
+      await scenario.page.locator("#message").press("Enter");
+      await expect(
+        scenario.page.locator('[data-parity="question.card"][data-question="goal"]'),
+      ).toBeVisible();
       await expect(
         scenario.page
           .locator('[data-parity="question.card"][data-question="goal"]')

--- a/packages/coach-contract/src/format-civil-date.ts
+++ b/packages/coach-contract/src/format-civil-date.ts
@@ -1,0 +1,10 @@
+export function formatCivilDate(value: string, options?: Intl.DateTimeFormatOptions): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(value)) return "Unknown date";
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(date.getTime()) || date.toISOString().slice(0, 10) !== value)
+    return "Unknown date";
+  return new Intl.DateTimeFormat("en-GB", {
+    ...(options ?? { day: "numeric", month: "short", year: "numeric" }),
+    timeZone: "UTC",
+  }).format(date);
+}

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -20,3 +20,4 @@ export * from "./plan-chat-card.js";
 export * from "./planning-request.js";
 export * from "./plan-creation.js";
 export * from "./plan-change.js";
+export * from "./format-civil-date.js";

--- a/packages/coach-contract/src/plan-creation.ts
+++ b/packages/coach-contract/src/plan-creation.ts
@@ -287,7 +287,7 @@ export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
         .object({
           label: z.literal("Event not listed"),
           detail: z.string().min(1).max(240),
-          editorLabel: z.string().min(1).max(240),
+          editorLabel: z.string().min(1).max(240).optional(),
           placeholder: z.string().min(1).max(240),
           nameLabel: z.string().min(1).max(128),
           dateLabel: z.string().min(1).max(128),
@@ -299,7 +299,7 @@ export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
           detail: z.string().min(1).max(240),
         })
         .strict(),
-      authoredOption: PlanCreationAuthoredOptionSchema,
+      authoredOption: PlanCreationAuthoredOptionSchema.optional(),
     })
     .strict(),
   z
@@ -363,7 +363,7 @@ export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
             .object({
               weeks: PlanCreationPlanLengthWeeksSchema,
               label: z.string().min(1).max(128),
-              detail: z.string().min(1).max(240),
+              detail: z.string().min(1).max(240).optional(),
             })
             .strict(),
         )
@@ -439,7 +439,7 @@ export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
               id: z.enum(["hours-6", "hours-8", "hours-10"]),
               weeklyHoursLimit: z.union([z.literal(6), z.literal(8), z.literal(10)]),
               label: z.string().min(1).max(128),
-              detail: z.string().min(1).max(240),
+              detail: z.string().min(1).max(240).optional(),
             })
             .strict(),
         )
@@ -472,7 +472,7 @@ export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
             [1, 2, 3, 4, 5, 6, 7],
           ),
         ),
-      derivedPoolNote: z.string().min(1).max(240),
+      derivedPoolNote: z.string().min(1).max(240).optional(),
     })
     .strict(),
   z
@@ -483,7 +483,7 @@ export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
       noneOption: z
         .object({
           label: z.string().min(1).max(128),
-          detail: z.string().min(1).max(240),
+          detail: z.string().min(1).max(240).optional(),
         })
         .strict(),
       authoredOption: PlanCreationAuthoredOptionSchema,
@@ -524,7 +524,7 @@ export const PlanCreationOpenQuestionSchema = z.discriminatedUnion("kind", [
             .object({
               kind: z.enum(["none", "no-training", "no-hard-training", "max-duration"]),
               label: z.string().min(1).max(128),
-              detail: z.string().min(1).max(240),
+              detail: z.string().min(1).max(240).optional(),
             })
             .strict(),
         )

--- a/packages/coach-contract/tests/format-civil-date.test.ts
+++ b/packages/coach-contract/tests/format-civil-date.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { formatCivilDate } from "../src/format-civil-date.js";
+
+describe("formatCivilDate", () => {
+  it("formats civil dates in en-GB without shifting the day", () => {
+    expect(formatCivilDate("1998-10-04")).toBe("4 Oct 1998");
+    expect(formatCivilDate("1998-09-14")).toBe("14 Sept 1998");
+  });
+
+  it.each(["1998-02-30", "1998-13-01", "04/10/1998", "invalid"])(
+    "rejects an invalid civil date: %s",
+    (value) => expect(formatCivilDate(value)).toBe("Unknown date"),
+  );
+
+  it("supports explicit date fields", () => {
+    expect(formatCivilDate("1998-10-04", { weekday: "short" })).toBe("Sun");
+  });
+});

--- a/packages/coach-contract/tests/plan-creation-contract.test.ts
+++ b/packages/coach-contract/tests/plan-creation-contract.test.ts
@@ -43,7 +43,6 @@ const goalQuestion = {
   eventNotListedOption: {
     label: "Event not listed",
     detail: "Tell me the event name and its exact date.",
-    editorLabel: "Name the event and include its exact date.",
     placeholder: "Event name",
     nameLabel: "Event name",
     dateLabel: "Event date",
@@ -52,7 +51,6 @@ const goalQuestion = {
     label: "Improve without an event",
     detail: "Build fitness for a fixed number of weeks.",
   },
-  authoredOption,
 };
 const card = {
   creationId,
@@ -145,10 +143,10 @@ const newQuestions = [
     step,
     prompt: "How long should this Plan be?",
     options: [
-      { weeks: 4, label: "4 weeks", detail: "A short block." },
-      { weeks: 8, label: "8 weeks", detail: "One training cycle." },
-      { weeks: 12, label: "12 weeks", detail: "Steady progression." },
-      { weeks: 16, label: "16 weeks", detail: "The longest build." },
+      { weeks: 4, label: "4 weeks" },
+      { weeks: 8, label: "8 weeks" },
+      { weeks: 12, label: "12 weeks" },
+      { weeks: 16, label: "16 weeks" },
     ],
   },
   {
@@ -185,9 +183,9 @@ const newQuestions = [
     prompt: "How much time is available?",
     mode: "flexible",
     weeklyHoursOptions: [
-      { id: "hours-6", weeklyHoursLimit: 6, label: "5–6 hours", detail: "Usual volume." },
-      { id: "hours-8", weeklyHoursLimit: 8, label: "7–8 hours", detail: "A small step." },
-      { id: "hours-10", weeklyHoursLimit: 10, label: "9+ hours", detail: "More volume." },
+      { id: "hours-6", weeklyHoursLimit: 6, label: "5–6 hours" },
+      { id: "hours-8", weeklyHoursLimit: 8, label: "7–8 hours" },
+      { id: "hours-10", weeklyHoursLimit: 10, label: "9–10 hours" },
     ],
     longestWorkoutLabel: "Longest ride in hours",
     weekdayOptions: [
@@ -205,8 +203,8 @@ const newQuestions = [
     kind: "commitments-question",
     step,
     prompt: "Any fixed commitments or other training?",
-    noneOption: { label: "No fixed commitments", detail: "There is nothing fixed to add." },
-    authoredOption: authoredOption,
+    noneOption: { label: "No fixed commitments" },
+    authoredOption: { ...authoredOption, label: "Add commitments or time off" },
   },
   {
     kind: "baseline-question",
@@ -231,7 +229,7 @@ const newQuestions = [
     step,
     prompt: "Is any Training Restriction active?",
     options: [
-      { kind: "none", label: "None", detail: "No restriction." },
+      { kind: "none", label: "None" },
       { kind: "no-training", label: "No training", detail: "No Workouts." },
       { kind: "no-hard-training", label: "No hard training", detail: "No intensity." },
       { kind: "max-duration", label: "Maximum duration", detail: "Set a limit." },
@@ -240,6 +238,14 @@ const newQuestions = [
 ] as const;
 
 const invalidNewQuestions = [
+  [
+    "goal",
+    {
+      ...goalQuestion,
+      authoredOption: { ...authoredOption, label: "Add commitments or time off" },
+      extra: true,
+    },
+  ],
   [
     "plan-length",
     {
@@ -284,7 +290,7 @@ const invalidNewQuestions = [
 const summaryFixtures = [
   {
     answerKey: "goal",
-    title: "Goal",
+    title: "Main Goal",
     detail: "Build power",
     source: { kind: "athlete" },
     question: card.openQuestion,
@@ -362,7 +368,7 @@ const summaryFixtures = [
   },
   {
     answerKey: "baseline",
-    title: "Training baseline",
+    title: "Recent training",
     detail: "Regular",
     source: { kind: "derived", label: "recent training" },
     question: newQuestions[5],
@@ -498,6 +504,18 @@ describe("Plan Creation contract", () => {
     newQuestions.forEach((question) =>
       expect(PlanCreationOpenQuestionSchema.parse(question)).toEqual(question),
     );
+  });
+
+  it("accepts a saved goal question that still carries the retired authored fields", () => {
+    const saved = {
+      ...goalQuestion,
+      eventNotListedOption: {
+        ...goalQuestion.eventNotListedOption,
+        editorLabel: "Name the event.",
+      },
+      authoredOption,
+    };
+    expect(PlanCreationOpenQuestionSchema.parse(saved)).toEqual(saved);
   });
 
   it.each(invalidNewQuestions)("rejects an invalid %s question", (_kind, question) => {
@@ -976,7 +994,7 @@ const draft = {
   answeredSummaries: [
     {
       answerKey: "goal",
-      title: "Goal",
+      title: "Main Goal",
       detail: "Build fitness",
       source: { kind: "athlete" },
       question: goalQuestion,

--- a/packages/coach/src/plan-change-operations.ts
+++ b/packages/coach/src/plan-change-operations.ts
@@ -1,4 +1,9 @@
 import {
+  availabilityDetail,
+  commitmentsDetail,
+  restrictionDetail,
+} from "./plan-creation-answers.js";
+import {
   PlanChangeModelSchema,
   PlanChangeIntentSchema,
   PlanCloseRpcParamsSchema,
@@ -601,7 +606,16 @@ export function createPlanChangeOperations(input: {
                   id: "confirmed-limits",
                   label: "Confirmed Plan limits",
                   source: "Your confirmed answers",
-                  value: intent,
+                  value: draft.answeredSummaries
+                    .flatMap(({ answer }) => {
+                      if (answer.kind === "availability") return [availabilityDetail(answer)];
+                      if (answer.kind === "restriction")
+                        return [restrictionDetail(answer.restriction)];
+                      if (answer.kind === "commitments")
+                        return [commitmentsDetail(answer.commitments)];
+                      return [];
+                    })
+                    .join(" · "),
                 },
                 ...(intent.kind === "inverse" && newestApplied !== null
                   ? [

--- a/packages/coach/src/plan-creation-answers.ts
+++ b/packages/coach/src/plan-creation-answers.ts
@@ -1,3 +1,4 @@
+import { formatCivilDate } from "@enduragent/coach-contract";
 import {
   PLAN_CREATION_ANSWER_KEYS,
   PlanCreationAnswerSchema,
@@ -213,25 +214,7 @@ export function resolvePlanCreationAnswer(
 const commitmentRuleDetail = (rule: PlanCreationCommitmentRule): string => {
   const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
   if (rule.kind === "time-off") {
-    const format = (date: string): string => {
-      const [year, month, day] = date.split("-");
-      const months = [
-        "Jan",
-        "Feb",
-        "Mar",
-        "Apr",
-        "May",
-        "Jun",
-        "Jul",
-        "Aug",
-        "Sep",
-        "Oct",
-        "Nov",
-        "Dec",
-      ];
-      return `${Number(day)} ${months[Number(month) - 1]} ${year}`;
-    };
-    return `Off ${format(rule.start)} to ${format(rule.end)}`;
+    return `Off ${formatCivilDate(rule.start)} to ${formatCivilDate(rule.end)}`;
   }
   const day = days[rule.day - 1];
   if (rule.kind === "weekday-duration") return `${day} · at most ${rule.minutes} min`;
@@ -387,8 +370,8 @@ const requireGoal = (flow: PlanCreationAnswerFlow): PlanCreationGoal => {
 const hours = (value: number): string => `${value} h`;
 
 const baselineDetail = (baseline: "regular" | "occasional" | "starting-again"): string => {
-  if (baseline === "regular") return "Training regularly";
-  if (baseline === "occasional") return "Training occasionally";
+  if (baseline === "regular") return "Regular";
+  if (baseline === "occasional") return "Occasional";
   return "Starting again";
 };
 
@@ -396,12 +379,12 @@ function goalDetail(snapshot: PlanCreationSnapshot, goal: PlanCreationGoal): str
   if (goal.kind === "fitness") {
     return goal.outcome ?? "Build fitness for a fixed number of weeks.";
   }
-  if (goal.kind === "event-manual") return `${goal.name} · ${goal.date}`;
+  if (goal.kind === "event-manual") return `${goal.name} · ${formatCivilDate(goal.date)}`;
   const candidate = snapshot.seed?.eventCandidates.find(
     (item) => item.candidateId === goal.candidateId,
   );
   if (candidate === undefined) return corrupt();
-  return `${candidate.name} · ${candidate.date} · ${candidate.sourceLabel}`;
+  return `${candidate.name} · ${formatCivilDate(candidate.date)} · ${candidate.sourceLabel}`;
 }
 
 const successDetail = (answer: Extract<PlanCreationAnswer, { kind: "success" }>): string => {
@@ -416,7 +399,7 @@ const successDetail = (answer: Extract<PlanCreationAnswer, { kind: "success" }>)
   return "Race for a result";
 };
 
-const availabilityDetail = (
+export const availabilityDetail = (
   answer: Extract<PlanCreationAnswer, { kind: "availability" }>,
 ): string => {
   const limits = `Up to ${hours(answer.weeklyHoursLimit)} a week, longest Workout ${hours(answer.longestWorkoutHours)}`;
@@ -428,19 +411,29 @@ const availabilityDetail = (
   const weekdays = [...answer.usableWeekdays]
     .sort((left, right) => left - right)
     .map((weekday) => names[weekday - 1])
-    .join(" ");
+    .join(", ");
   return `${limits}, ${weekdays}`;
 };
 
-const restrictionDetail = (
+export const restrictionDetail = (
   restriction: Extract<PlanCreationAnswer, { kind: "restriction" }>["restriction"],
 ): string => {
   if (restriction.kind === "none") return "No training restrictions";
-  const end = restriction.endDate === undefined ? "" : ` until ${restriction.endDate}`;
+  const end =
+    restriction.endDate === undefined ? "" : ` until ${formatCivilDate(restriction.endDate)}`;
   if (restriction.kind === "no-training") return `No training${end}`;
   if (restriction.kind === "no-hard-training") return `No hard training${end}`;
   return `Maximum Workout duration ${hours(restriction.hours)}${end}`;
 };
+
+export const commitmentsDetail = (
+  commitments: Extract<PlanCreationAnswer, { kind: "commitments" }>["commitments"],
+): string =>
+  commitments.kind === "none"
+    ? "No fixed commitments"
+    : commitments.rules.length === 0
+      ? commitments.text
+      : commitmentRulesDetail(commitments.rules);
 
 function answerSummary(
   snapshot: PlanCreationSnapshot,
@@ -451,7 +444,7 @@ function answerSummary(
   const shared = { answerKey: answer.kind, question, answer, source: stored.source };
   switch (answer.kind) {
     case "goal":
-      return { ...shared, title: "Goal", detail: goalDetail(snapshot, answer.goal) };
+      return { ...shared, title: "Main Goal", detail: goalDetail(snapshot, answer.goal) };
     case "success":
       return { ...shared, title: "Success", detail: successDetail(answer) };
     case "plan-length":
@@ -463,7 +456,7 @@ function answerSummary(
         detail:
           answer.timing.kind === "as-soon-as-possible"
             ? "As soon as possible"
-            : `Earliest start ${answer.timing.date}`,
+            : `Earliest start ${formatCivilDate(answer.timing.date)}`,
       };
     case "schedule-mode":
       return {
@@ -477,17 +470,12 @@ function answerSummary(
       return {
         ...shared,
         title: "Commitments",
-        detail:
-          answer.commitments.kind === "none"
-            ? "No fixed commitments, other training, or time off"
-            : answer.commitments.rules.length === 0
-              ? answer.commitments.text
-              : commitmentRulesDetail(answer.commitments.rules),
+        detail: commitmentsDetail(answer.commitments),
       };
     case "baseline":
       return {
         ...shared,
-        title: "Training baseline",
+        title: "Recent training",
         detail: baselineDetail(answer.baseline),
       };
     case "restriction":
@@ -519,7 +507,6 @@ function questionForKey(
         eventNotListedOption: {
           label: "Event not listed",
           detail: "Tell me the event name and its exact date.",
-          editorLabel: "Name the event and include its exact date.",
           placeholder: "Event name",
           nameLabel: "Event name",
           dateLabel: "Event date",
@@ -527,12 +514,6 @@ function questionForKey(
         fitnessOption: {
           label: "Improve without an event",
           detail: "Build fitness for a fixed number of weeks.",
-        },
-        authoredOption: {
-          label: "Something else",
-          detail: "Answer in your own words.",
-          editorLabel: "Name the event and include its exact date.",
-          placeholder: "Event name",
         },
       };
     case "success":
@@ -605,10 +586,10 @@ function questionForKey(
         step,
         prompt: "How long should this Fitness Plan be?",
         options: [
-          { weeks: 4, label: "4 weeks", detail: "A short, focused block." },
-          { weeks: 8, label: "8 weeks", detail: "One full training cycle." },
-          { weeks: 12, label: "12 weeks", detail: "Room for steady progression." },
-          { weeks: 16, label: "16 weeks", detail: "The longest steady build." },
+          { weeks: 4, label: "4 weeks" },
+          { weeks: 8, label: "8 weeks" },
+          { weeks: 12, label: "12 weeks" },
+          { weeks: 16, label: "16 weeks" },
         ],
       };
     case "start-timing":
@@ -662,19 +643,16 @@ function questionForKey(
             id: "hours-6",
             weeklyHoursLimit: 6,
             label: "5–6 hours",
-            detail: "Up to about six hours of riding a week.",
           },
           {
             id: "hours-8",
             weeklyHoursLimit: 8,
             label: "7–8 hours",
-            detail: "Up to about eight hours of riding a week.",
           },
           {
             id: "hours-10",
             weeklyHoursLimit: 10,
-            label: "9+ hours",
-            detail: "About nine hours or more of riding a week.",
+            label: "9–10 hours",
           },
         ],
         longestWorkoutLabel: "Longest ride in hours",
@@ -687,10 +665,12 @@ function questionForKey(
           { weekday: 6, label: "Sat" },
           { weekday: 7, label: "Sun" },
         ],
-        derivedPoolNote:
-          scheduleMode.mode === "flexible"
-            ? "Your weekly limit sets 3 Workouts up to 6 h, 4 up to 8 h, or 5 above 8 h."
-            : "Choose every weekday you can usually train.",
+        ...(scheduleMode.mode === "flexible"
+          ? {
+              derivedPoolNote:
+                "Your weekly limit sets 3 Workouts up to 6 h, 4 up to 8 h, or 5 above 8 h.",
+            }
+          : {}),
       };
     }
     case "commitments":
@@ -700,7 +680,6 @@ function questionForKey(
         prompt: "Any fixed commitments or time off?",
         noneOption: {
           label: "No fixed commitments",
-          detail: "No fixed commitments, other training, or time off to account for.",
         },
         authoredOption: {
           label: "Add commitments or time off",
@@ -736,12 +715,11 @@ function questionForKey(
       return {
         kind: "restriction-question",
         step,
-        prompt: "What Training Restriction should this Plan respect?",
+        prompt: "Does anything need to limit training right now?",
         options: [
           {
             kind: "none",
             label: "No training restrictions",
-            detail: "No temporary operational limit needs to shape this Plan.",
           },
           {
             kind: "no-training",

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2365,7 +2365,6 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         eventNotListedOption: {
           label: "Event not listed",
           detail: "Tell me the event name and its exact date.",
-          editorLabel: "Name the event.",
           placeholder: "Event name",
           nameLabel: "Event name",
           dateLabel: "Event date",
@@ -2373,12 +2372,6 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         fitnessOption: {
           label: "Improve without an event",
           detail: "Build fitness for a fixed number of weeks.",
-        },
-        authoredOption: {
-          label: "Something else",
-          detail: "Tell me the event name and its exact date.",
-          editorLabel: "Name the event.",
-          placeholder: "Event name",
         },
       },
     };
@@ -2394,7 +2387,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       answeredSummaries: [
         {
           answerKey: "goal",
-          title: "Goal",
+          title: "Main Goal",
           detail: "Build power",
           source: { kind: "athlete" },
           question: {
@@ -2405,7 +2398,6 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
             eventNotListedOption: {
               label: "Event not listed",
               detail: "Tell me the event name and its exact date.",
-              editorLabel: "Name the event.",
               placeholder: "Event name",
               nameLabel: "Event name",
               dateLabel: "Event date",
@@ -2413,12 +2405,6 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
             fitnessOption: {
               label: "Improve without an event",
               detail: "Build fitness for a fixed number of weeks.",
-            },
-            authoredOption: {
-              label: "Something else",
-              detail: "Tell me the event name and its exact date.",
-              editorLabel: "Name the event.",
-              placeholder: "Event name",
             },
           },
           answer: { kind: "goal", goal: { kind: "fitness", outcome: "Build power" } },

--- a/packages/coach/tests/plan-change-operations.test.ts
+++ b/packages/coach/tests/plan-change-operations.test.ts
@@ -386,7 +386,8 @@ describe("Plan Change operations", () => {
           id: "confirmed-limits",
           label: "Confirmed Plan limits",
           source: "Your confirmed answers",
-          value: { kind: "longest-workout", minutes: 30 },
+          value:
+            "Up to 8 h a week, longest Workout 3 h, Tue, Thu, Sat · No fixed commitments · No training restrictions",
         },
       ],
     });
@@ -678,7 +679,7 @@ describe("confirmed inverse Changes", () => {
         undo: null,
         intent: { kind: "inverse", changeId: forward.change.changeId },
         premises: [
-          { id: "confirmed-limits", value: { kind: "inverse", changeId: forward.change.changeId } },
+          { id: "confirmed-limits", value: expect.stringContaining("No training restrictions") },
           {
             id: "undone-change",
             value: { changeId: forward.change.changeId, title: forward.change.title },

--- a/packages/coach/tests/plan-creation-operations.test.ts
+++ b/packages/coach/tests/plan-creation-operations.test.ts
@@ -299,7 +299,6 @@ describe("Plan Creation operations", () => {
     expect(projectPlanCreationCard(test.current(), { today }).openQuestion).toMatchObject({
       kind: "goal-question",
       step: { current: 1, total: 9 },
-      authoredOption: { detail: "Answer in your own words." },
     });
     const answers = [
       eventGoal,
@@ -336,11 +335,11 @@ describe("Plan Creation operations", () => {
         { answerKey: "schedule-mode" },
         {
           answerKey: "availability",
-          detail: "Up to 8 h a week, longest Workout 3 h, Tue Thu Sat",
+          detail: "Up to 8 h a week, longest Workout 3 h, Tue, Thu, Sat",
         },
         { answerKey: "start-timing" },
-        { answerKey: "commitments" },
-        { answerKey: "baseline" },
+        { answerKey: "commitments", detail: "No fixed commitments" },
+        { answerKey: "baseline", title: "Recent training", detail: "Regular" },
         { answerKey: "success" },
         { answerKey: "restriction", detail: "No training restrictions" },
       ],
@@ -365,7 +364,7 @@ describe("Plan Creation operations", () => {
           kind: "restriction",
           restriction: { kind: "no-training", endDate: "1998-09-14" },
         },
-        "No training until 1998-09-14",
+        "No training until 14 Sept 1998",
       ],
       [{ kind: "restriction", restriction: { kind: "no-hard-training" } }, "No hard training"],
       [
@@ -373,7 +372,7 @@ describe("Plan Creation operations", () => {
           kind: "restriction",
           restriction: { kind: "no-hard-training", endDate: "1998-09-14" },
         },
-        "No hard training until 1998-09-14",
+        "No hard training until 14 Sept 1998",
       ],
       [
         { kind: "restriction", restriction: { kind: "max-duration", hours: 1.5 } },
@@ -384,7 +383,7 @@ describe("Plan Creation operations", () => {
           kind: "restriction",
           restriction: { kind: "max-duration", hours: 1.5, endDate: "1998-09-14" },
         },
-        "Maximum Workout duration 1.5 h until 1998-09-14",
+        "Maximum Workout duration 1.5 h until 14 Sept 1998",
       ],
     ];
     for (const [answer, detail] of cases) {
@@ -434,9 +433,9 @@ describe("Plan Creation operations", () => {
           mode: "flexible",
           derivedPoolNote: expect.stringContaining("3 Workouts up to 6 h"),
           weeklyHoursOptions: [
-            { detail: "Up to about six hours of riding a week." },
-            { detail: "Up to about eight hours of riding a week." },
-            { detail: "About nine hours or more of riding a week." },
+            { id: "hours-6", weeklyHoursLimit: 6, label: "5–6 hours" },
+            { id: "hours-8", weeklyHoursLimit: 8, label: "7–8 hours" },
+            { id: "hours-10", weeklyHoursLimit: 10, label: "9–10 hours" },
           ],
         });
       }
@@ -2526,7 +2525,7 @@ VALUES (?,'active',1,1,882748800000,882748800000,'test-device',882748800000,0)`,
     expect(
       confirmed.answeredSummaries.find((answer) => answer.answerKey === "commitments")?.detail,
     ).toBe(
-      "Wed · at most 45 min; Sat · unavailable; Mon · no hard training; Off 3 Sep 1998 to 9 Sep 1998",
+      "Wed · at most 45 min; Sat · unavailable; Mon · no hard training; Off 3 Sept 1998 to 9 Sept 1998",
     );
   });
 

--- a/packages/coach/tests/planning-request-delivery.test.ts
+++ b/packages/coach/tests/planning-request-delivery.test.ts
@@ -291,7 +291,6 @@ describe("Planning request delivery", () => {
         eventNotListedOption: {
           label: "Event not listed" as const,
           detail: "Tell me the event name and its exact date.",
-          editorLabel: "Name the event.",
           placeholder: "Event name",
           nameLabel: "Event name",
           dateLabel: "Event date",
@@ -299,12 +298,6 @@ describe("Planning request delivery", () => {
         fitnessOption: {
           label: "Improve without an event",
           detail: "Build fitness for a fixed number of weeks.",
-        },
-        authoredOption: {
-          label: "Something else" as const,
-          detail: "Tell me the event name and its exact date.",
-          editorLabel: "Name the event.",
-          placeholder: "Event name",
         },
       },
     };


### PR DESCRIPTION
## Summary
A full prototype-parity pass over Plan-in-Chat (prototype plan-in-chat-2026-09-01, 97 scenario and variation states, 158 anchored element pairs, four cells: wide and compact, light and dark). The local parity tool compares computed styles and geometry; screenshot pairs were inspected by eye for the creation, Draft, Change and library states.

Renderer changes:
- Question card: `Later` moves into the header beside the eyebrow and title; choice rows keep their detail line and chevron; card width and padding follow the prototype.
- Progress card: Discard is an outline button under the answered count.
- Availability: usable weekdays are a labelled fieldset of checkboxes.
- Draft review and Change cards: prototype padding, gaps, status pills, table borders; compact layouts stack facts.
- Plan library and final details: card spacing and action rows per prototype.
- Transcript, question column and training context rail hide permanent scrollbars.
- Dark theme tokens aligned.

Results per cell (unallowed rows before → after): wide-light 6640 → 589, wide-dark → 589, compact-light 1619 → 552, compact-dark → 552. Every remaining row is classified: recorded-decision differences (font weights capped at 600 per DESIGN.md, label-plus-detail choices, calendar status in the library, existing action orders from issues 317 to 321), fixture-data count differences, or focus and disabled-state artefacts of the scan. None unclassified.

Later commits from operator testing and a three-model copy review (Fable, Codex Sol; Grok unavailable):
- Plan page: the empty state is the library card plus the header Start a Plan button only; the header subtitle no longer repeats the library card.
- Chat: the Active Plan card renders after activation with Change one thing and Open Plan, and carries the calendar status line in the library vocabulary; the "Plan activated locally." notice is gone.
- Every athlete-visible date goes through one shared formatter in coach-contract (day month year); weekdays join with commas.
- Goal question: the "Something else" row is removed (it opened the same editor as Event not listed); the editor lead line is gone. Saved Drafts that still carry those fields parse.
- Filler choice details removed (weekly hours, Plan length, no commitments, no restriction); "9+ hours" is now "9–10 hours" since it stores a ten-hour limit; the restriction prompt is the prototype's.
- Progress card drops the Ready chip; answer summary labels match the Draft table (Main Goal, Recent training); discard dialog and consequence copy are the prototype's, one constant each.
- Change evidence: the confirmed-limits premise stores the confirmed limits instead of the requested change.
- Draft, Change, library and final-details cards share one PlanCard and Fact component.

Accepted: Drafts saved by pre-release builds keep raw ISO strings in their stored summaries; no released build ever wrote one.

## Verification
- Root `pnpm check` green; workspace 1872 passed; renderer-dom 761 passed; full desktop E2E 128 passed (plus 50 targeted after the last commit); astra high verifier two rounds, blockers fixed or decided as above.

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn
