### PR TITLE
fix(engine): price AI SDK usage on the uncached input share

### DIFF
--- a/.changeset/ledger-cost-counts-cache-once.md
+++ b/.changeset/ledger-cost-counts-cache-once.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/engine": patch
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: The usage log now counts cached tokens once, so the cost it shows for API-key providers matches what the provider bills.

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -11,7 +11,8 @@ import { isKeylessProvider } from "@enduragent/coach-contract";
 import { dirname } from "node:path";
 
 import { splitSystemPromptAtBoundary } from "./agent/system-prompt.js";
-import { isPriced, priceUsage } from "./agent/codex/cost.js";
+import { isPriced } from "./agent/codex/cost.js";
+import { priceInclusiveUsage } from "./usage-cost.js";
 
 import type {
   EngineConfig,
@@ -573,11 +574,11 @@ function priceAiSdkUsage(
 ): GenerateResult["cost"] | undefined {
   if (!priced || !totalUsage) return undefined;
   const details = cacheTokenDetails(totalUsage);
-  return priceUsage(provider, modelId, {
-    input: totalUsage.inputTokens ?? 0,
-    output: totalUsage.outputTokens ?? 0,
-    cacheRead: details?.cacheReadTokens ?? 0,
-    cacheWrite: details?.cacheWriteTokens ?? 0,
+  return priceInclusiveUsage(provider, modelId, {
+    inputTokens: totalUsage.inputTokens ?? 0,
+    outputTokens: totalUsage.outputTokens ?? 0,
+    cacheReadTokens: details?.cacheReadTokens ?? 0,
+    cacheWriteTokens: details?.cacheWriteTokens ?? 0,
   });
 }
 

--- a/packages/engine/tests/ai-sdk-usage-cost.test.ts
+++ b/packages/engine/tests/ai-sdk-usage-cost.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EngineConfig, UsageLedgerLine } from "../src/host-ports.js";
+import { llmTestPorts } from "./helpers/base-agent-config.js";
+
+const config: EngineConfig = {
+  dataSource: "platform",
+  llm: {
+    provider: "anthropic",
+    model: "claude-sonnet-5",
+    ["api" + "Key"]: "test",
+  } as unknown as EngineConfig["llm"],
+  session: {
+    historyTokenBudgetRatio: 0.3,
+    idleMinutes: 0,
+    dailyResetHour: 4,
+    resetArchiveRetentionDays: 0,
+    timezone: "UTC",
+  },
+  contextWindowTokens: 1_000,
+  compactContextWindowTokens: 1_000,
+};
+
+const inclusiveUsage = {
+  inputTokens: 10_000,
+  outputTokens: 100,
+  totalTokens: 10_100,
+  inputTokenDetails: { noCacheTokens: 1_000, cacheReadTokens: 8_000, cacheWriteTokens: 1_000 },
+};
+
+const expectedTotal =
+  (1_000 * 2 + 8_000 * 0.2 + 1_000 * 2.5 + 100 * 10) / 1_000_000;
+
+function streamed() {
+  return {
+    fullStream: (async function* () {
+      yield { type: "text-delta", id: "text-1", text: "answer" };
+      yield {
+        type: "finish",
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        totalUsage: inclusiveUsage,
+      };
+    })(),
+    text: Promise.resolve("answer"),
+    toolCalls: Promise.resolve([]),
+    finishReason: Promise.resolve("stop"),
+    usage: Promise.resolve(inclusiveUsage),
+    totalUsage: Promise.resolve(inclusiveUsage),
+    steps: Promise.resolve([]),
+  };
+}
+
+async function subject(caller: "chat" | "flush") {
+  vi.doMock("@ai-sdk/anthropic", () => ({
+    createAnthropic: () => () => ({ provider: "anthropic-stub" }),
+  }));
+  vi.doMock("ai", () => ({
+    generateText: vi.fn(async () => ({
+      text: "answer",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: inclusiveUsage,
+      totalUsage: inclusiveUsage,
+      steps: [],
+    })),
+    streamText: vi.fn(() => streamed()),
+    stepCountIs: vi.fn((count: number) => ({ type: "step-count", count })),
+  }));
+  const { LLM } = await import("../src/llm.js");
+  const lines: UsageLedgerLine[] = [];
+  let now = 100;
+  const llm = new LLM(config, {
+    ...llmTestPorts(),
+    usage: { append: (line: UsageLedgerLine) => lines.push(line) },
+    now: () => now++,
+  });
+  const generated = await llm.generate({ prompt: "hello", caller });
+  return { generated, lines };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AI SDK usage pricing charges only the uncached input share", () => {
+  it.each(["chat", "flush"] as const)("%s caller", async (caller) => {
+    const { generated, lines } = await subject(caller);
+    expect(generated.cost?.total).toBeCloseTo(expectedTotal, 9);
+    expect(generated.cost?.input).toBeCloseTo((1_000 * 2) / 1_000_000, 9);
+    expect(lines.at(-1)?.cost?.total).toBeCloseTo(expectedTotal, 9);
+  });
+});

--- a/tools/usage-baseline.test.ts
+++ b/tools/usage-baseline.test.ts
@@ -207,16 +207,25 @@ describe("buildReport", () => {
     expect(g.cacheRead.overallRatio).toBeNull();
   });
 
-  it("cost: sums + means only lines carrying a cost object", () => {
+  it("cost: repriced from tokens on the uncached input share, never read from the ledger", () => {
+    const priced = {
+      model: "claude-sonnet-5",
+      inputTokens: 10_000,
+      outputTokens: 100,
+      cacheReadTokens: 8_000,
+      cacheWriteTokens: 1_000,
+    };
+    const inflated = { input: 0.02, output: 0.001, cacheRead: 0.0016, cacheWrite: 0.0025, total: 0.0251 };
     const raw = jsonl([
-      line({ cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 0.02 } }),
-      line({ cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 0.04 } }),
-      line({}), // no cost — skipped, NOT counted as 0
+      line({ ...priced, cost: inflated }),
+      line({ ...priced }),
+      line({ model: "not-in-catalog", inputTokens: 500, cost: inflated }),
     ]);
     const g = buildReport({ ledgerPath: "/p", dataDirSource: "x", raw, kind: "turn", caller: "chat" }).groups[0];
+    const perLine = (1_000 * 2 + 8_000 * 0.2 + 1_000 * 2.5 + 100 * 10) / 1_000_000;
     expect(g.cost.costedLines).toBe(2);
-    expect(g.cost.total).toBeCloseTo(0.06);
-    expect(g.cost.meanPerTurn).toBeCloseTo(0.03); // mean over costed lines only
+    expect(g.cost.total).toBeCloseTo(2 * perLine, 9);
+    expect(g.cost.meanPerTurn).toBeCloseTo(perLine, 9);
   });
 
   it("latency percentiles use durationMs", () => {

--- a/tools/usage-baseline.ts
+++ b/tools/usage-baseline.ts
@@ -27,6 +27,7 @@ import { join } from "node:path";
 import { USAGE_LEDGER_FILE, type UsageLedgerLine } from "../packages/core/src/usage-ledger.js";
 import { getCoachHome, expandTilde } from "../packages/core/src/coach-home.js";
 import { MS_PER_DAY } from "../packages/engine/src/sport/date-keys.js";
+import { priceInclusiveUsage } from "../packages/engine/src/usage-cost.js";
 
 const UNKNOWN_TEMPLATE = "unknown";
 const MIN_SPAN_DAYS = 3;
@@ -190,8 +191,8 @@ export interface GroupSummary {
     ratioSampleSize: number;
   };
   cost: {
-    // Only lines carrying a cost object contribute; lines lacking cost are
-    // skipped, NOT counted as 0.
+    // Lines whose provider/model is not in the price catalog are skipped,
+    // NOT counted as 0.
     total: number;
     meanPerTurn: number | null;
     costedLines: number;
@@ -234,7 +235,15 @@ function summarizeGroup(
   }
 
   const costTotals = lines
-    .map((l) => l.cost?.total)
+    .map(
+      (l) =>
+        priceInclusiveUsage(l.provider, l.model, {
+          inputTokens: l.inputTokens ?? 0,
+          outputTokens: l.outputTokens ?? 0,
+          cacheReadTokens: l.cacheReadTokens ?? 0,
+          cacheWriteTokens: l.cacheWriteTokens ?? 0,
+        })?.total,
+    )
     .filter((c): c is number => Number.isFinite(c));
 
   return {


### PR DESCRIPTION
## Problem

`priceAiSdkUsage` in `packages/engine/src/llm.ts` priced the whole `inputTokens` figure at the input rate and then added cache-read and cache-write again. In AI SDK 6 `inputTokens` already includes the cached share (`noCache + cacheRead + cacheWrite`, see `convertAnthropicMessagesUsage` in `@ai-sdk/anthropic`). Every `cost` the ledger wrote for the `anthropic`, `openai`, `google` and `openrouter` lanes overstated spend. On the test shape (87% cache hit) the ledger reported $0.0251 for a $0.0071 turn.

`packages/engine/src/usage-cost.ts` already priced correctly for the spend meter, so the fix routes the ledger through the same function. `tools/usage-baseline.ts` read the raw `cost.total`, so it now reprices from tokens the way `tools/usage-cache-band.ts` already does. Rows already on disk are not rewritten.

## Changes

- `llm.ts` prices via `priceInclusiveUsage`; the duplicate pricing path is gone.
- New `ai-sdk-usage-cost.test.ts` drives `LLM.generate` with an inclusive usage object on the anthropic lane for both the streaming (chat) and non-streaming (flush) paths and asserts the ledger cost.
- `usage-baseline.ts` reprices each line from tokens. Its cost test now feeds an inflated ledger `cost` and expects the repriced value.
- Changeset for engine, desktop, cycling-coach.

## Verification

- `vitest run` engine: 1869 passed, 9 skipped. One desktop-renderer test timed out at 5 s under full-suite load and passes alone (`onboarding-surface.test.tsx`, 55 passed).
- `vitest run tools/usage-baseline.test.ts tools/usage-cache-band.test.ts`: 56 passed.
- `pnpm check:types`, `oxlint` on changed files, `pnpm check:changeset-userfacing`: clean.

Subscription lanes (`claude-cli`, `openai-codex`) are untouched; they price through their own paths.

https://claude.ai/code/session_01HrEAXvcK4j4tUk9ZpTGy4f