### PR TITLE
fix(coach-contract): describe every plan-change intent field for the model

### DIFF
--- a/.changeset/plan-change-intent-describe.md
+++ b/.changeset/plan-change-intent-describe.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: When you ask the coach to change your plan in chat, it understands weekdays, session lengths and weekly hours more reliably.

--- a/packages/coach-contract/src/plan-change.ts
+++ b/packages/coach-contract/src/plan-change.ts
@@ -42,7 +42,7 @@ export type PlanChangeEventSource = z.infer<typeof PlanChangeEventSourceSchema>;
 const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
   z
     .object({
-      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      kind: z.literal("supporting-event").describe("Add, update, or remove a supporting event in the plan"),
       operation: z.literal("add").describe("Add a supporting event to the plan"),
       name: z.string().trim().min(1).max(512).describe("Name of the supporting event"),
       date: TrainingExportCivilDateSchema.describe(
@@ -60,7 +60,7 @@ const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      kind: z.literal("supporting-event").describe("Add, update, or remove a supporting event in the plan"),
       operation: z.literal("remove").describe("Remove an existing supporting event from the plan"),
       eventId: z
         .string()
@@ -71,7 +71,7 @@ const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      kind: z.literal("supporting-event").describe("Add, update, or remove a supporting event in the plan"),
       operation: z
         .literal("role")
         .describe("Change the training priority of an existing supporting event"),
@@ -87,7 +87,7 @@ const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      kind: z.literal("supporting-event").describe("Add, update, or remove a supporting event in the plan"),
       operation: z
         .literal("manual")
         .describe("Correct the name and date of a manually added supporting event"),
@@ -104,7 +104,7 @@ const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      kind: z.literal("supporting-event").describe("Add, update, or remove a supporting event in the plan"),
       operation: z
         .literal("source-update")
         .describe("Accept synchronized name and date updates for a supporting event"),
@@ -117,7 +117,7 @@ const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      kind: z.literal("supporting-event").describe("Add, update, or remove a supporting event in the plan"),
       operation: z.literal("name").describe("Rename an existing supporting event"),
       eventId: z
         .string()
@@ -198,7 +198,7 @@ export const PlanChangeIntentSchema = z.discriminatedUnion("kind", [
         .number()
         .int()
         .positive()
-        .describe("Maximum session length for any weekday, in minutes"),
+        .describe("Maximum length of any single workout, in minutes"),
     })
     .strict(),
   z

--- a/packages/coach-contract/src/plan-change.ts
+++ b/packages/coach-contract/src/plan-change.ts
@@ -42,76 +42,172 @@ export type PlanChangeEventSource = z.infer<typeof PlanChangeEventSourceSchema>;
 const SupportingEventIntentSchema = z.discriminatedUnion("operation", [
   z
     .object({
-      kind: z.literal("supporting-event"),
-      operation: z.literal("add"),
-      name: z.string().trim().min(1).max(512),
-      date: TrainingExportCivilDateSchema,
-      role: SupportingEventRoleSchema,
-      providerId: z.string().min(1).optional(),
+      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      operation: z.literal("add").describe("Add a supporting event to the plan"),
+      name: z.string().trim().min(1).max(512).describe("Name of the supporting event"),
+      date: TrainingExportCivilDateSchema.describe(
+        "Date of the supporting event in YYYY-MM-DD format",
+      ),
+      role: SupportingEventRoleSchema.describe(
+        "Important = reduce training in the event week; Training = include the event without reducing surrounding training",
+      ),
+      providerId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Identifier of the synchronized source event, when adding a linked event"),
     })
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event"),
-      operation: z.literal("remove"),
-      eventId: z.string().min(1).max(128),
+      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      operation: z.literal("remove").describe("Remove an existing supporting event from the plan"),
+      eventId: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe("Identifier of the existing supporting event to change"),
     })
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event"),
-      operation: z.literal("role"),
-      eventId: z.string().min(1).max(128),
-      role: SupportingEventRoleSchema,
+      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      operation: z
+        .literal("role")
+        .describe("Change the training priority of an existing supporting event"),
+      eventId: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe("Identifier of the existing supporting event to change"),
+      role: SupportingEventRoleSchema.describe(
+        "Important = reduce training in the event week; Training = include the event without reducing surrounding training",
+      ),
     })
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event"),
-      operation: z.literal("manual"),
-      eventId: z.string().min(1).max(128),
-      name: z.string().trim().min(1).max(512),
-      date: TrainingExportCivilDateSchema,
+      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      operation: z
+        .literal("manual")
+        .describe("Correct the name and date of a manually added supporting event"),
+      eventId: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe("Identifier of the existing supporting event to change"),
+      name: z.string().trim().min(1).max(512).describe("Name of the supporting event"),
+      date: TrainingExportCivilDateSchema.describe(
+        "Date of the supporting event in YYYY-MM-DD format",
+      ),
     })
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event"),
-      operation: z.literal("source-update"),
-      eventId: z.string().min(1).max(128),
+      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      operation: z
+        .literal("source-update")
+        .describe("Accept synchronized name and date updates for a supporting event"),
+      eventId: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe("Identifier of the existing supporting event to change"),
     })
     .strict(),
   z
     .object({
-      kind: z.literal("supporting-event"),
-      operation: z.literal("name"),
-      eventId: z.string().min(1).max(128),
-      name: z.string().trim().min(1).max(512),
+      kind: z.literal("supporting-event").describe("Add or update a supporting event in the plan"),
+      operation: z.literal("name").describe("Rename an existing supporting event"),
+      eventId: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe("Identifier of the existing supporting event to change"),
+      name: z.string().trim().min(1).max(512).describe("Name of the supporting event"),
     })
     .strict(),
 ]);
 
-const WeekdaySchema = z.number().int().min(1).max(7);
+const WeekdaySchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(7)
+  .describe(
+    "ISO weekday, 1 = Monday, 2 = Tuesday, 3 = Wednesday, 4 = Thursday, 5 = Friday, 6 = Saturday, 7 = Sunday",
+  );
 
 export const PlanChangeIntentSchema = z.discriminatedUnion("kind", [
   SupportingEventIntentSchema,
-  z.object({ kind: z.literal("ftp"), watts: FtpWattsSchema }).strict(),
-  z.object({ kind: z.literal("choose-workout"), workoutId: z.string().min(1).max(128) }).strict(),
   z
     .object({
-      kind: z.literal("weekday-duration"),
-      day: WeekdaySchema,
-      minutes: z.number().int().positive(),
+      kind: z.literal("ftp").describe("Set the functional threshold power used by the plan"),
+      watts: FtpWattsSchema.describe("Functional threshold power, in watts"),
     })
     .strict(),
-  z.object({ kind: z.literal("weekday-unavailable"), day: WeekdaySchema }).strict(),
-  z.object({ kind: z.literal("hard-weekday"), day: WeekdaySchema }).strict(),
   z
-    .object({ kind: z.literal("weekly-duration"), hours: z.number().positive().multipleOf(0.25) })
+    .object({
+      kind: z.literal("choose-workout").describe("Choose an existing workout for today"),
+      workoutId: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe("Identifier of the existing workout to choose"),
+    })
     .strict(),
-  z.object({ kind: z.literal("longest-workout"), minutes: z.number().int().positive() }).strict(),
   z
-    .object({ kind: z.literal("inverse"), changeId: PlanCloseRpcParamsSchema.shape.planId })
+    .object({
+      kind: z.literal("weekday-duration").describe("Limit session length on a recurring weekday"),
+      day: WeekdaySchema,
+      minutes: z
+        .number()
+        .int()
+        .positive()
+        .describe("Maximum session length for that weekday, in minutes"),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z
+        .literal("weekday-unavailable")
+        .describe("Make a recurring weekday unavailable for training"),
+      day: WeekdaySchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("hard-weekday").describe("Disallow hard training on a recurring weekday"),
+      day: WeekdaySchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("weekly-duration").describe("Limit total training time each week"),
+      hours: z
+        .number()
+        .positive()
+        .multipleOf(0.25)
+        .describe("Maximum total training hours per week"),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("longest-workout").describe("Limit the length of any single workout"),
+      minutes: z
+        .number()
+        .int()
+        .positive()
+        .describe("Maximum session length for any weekday, in minutes"),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("inverse").describe("Undo a previously applied plan change"),
+      changeId: PlanCloseRpcParamsSchema.shape.planId.describe(
+        "Identifier of the applied plan change to undo",
+      ),
+    })
     .strict(),
 ]);
 export type PlanChangeIntent = z.infer<typeof PlanChangeIntentSchema>;

--- a/packages/coach-contract/tests/plan-change-contract.test.ts
+++ b/packages/coach-contract/tests/plan-change-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import {
   COACH_RPC_METHOD_REGISTRY,
   CoachRpcRequestEnvelopeSchema,
@@ -60,6 +61,43 @@ const change = {
 };
 
 describe("Plan Change contract", () => {
+  it("describes every intent field and its units in the generated JSON schema", () => {
+    const descriptions = new Map<string, unknown[]>();
+    function visit(value: unknown): void {
+      if (value === null || typeof value !== "object") return;
+      for (const [key, child] of Object.entries(value)) {
+        if (key === "properties" && child !== null && typeof child === "object") {
+          for (const [field, schema] of Object.entries(child)) {
+            expect(schema).toHaveProperty("description", expect.any(String));
+            if (schema !== null && typeof schema === "object" && "description" in schema) {
+              expect(schema.description).not.toBe("");
+              descriptions.set(field, [...(descriptions.get(field) ?? []), schema.description]);
+            }
+          }
+        }
+        visit(child);
+      }
+    }
+
+    visit(z.toJSONSchema(PlanChangeIntentSchema));
+
+    expect(descriptions.get("day")).toEqual(
+      Array(3).fill(
+        "ISO weekday, 1 = Monday, 2 = Tuesday, 3 = Wednesday, 4 = Thursday, 5 = Friday, 6 = Saturday, 7 = Sunday",
+      ),
+    );
+    expect(descriptions.get("minutes")).toEqual([
+      "Maximum session length for that weekday, in minutes",
+      "Maximum session length for any weekday, in minutes",
+    ]);
+    expect(descriptions.get("hours")).toEqual(["Maximum total training hours per week"]);
+    expect(descriptions.get("role")).toEqual(
+      Array(2).fill(
+        "Important = reduce training in the event week; Training = include the event without reducing surrounding training",
+      ),
+    );
+  });
+
   it.each([
     intent,
     { kind: "weekday-unavailable", day: 7 },

--- a/packages/coach-contract/tests/plan-change-contract.test.ts
+++ b/packages/coach-contract/tests/plan-change-contract.test.ts
@@ -88,7 +88,7 @@ describe("Plan Change contract", () => {
     );
     expect(descriptions.get("minutes")).toEqual([
       "Maximum session length for that weekday, in minutes",
-      "Maximum session length for any weekday, in minutes",
+      "Maximum length of any single workout, in minutes",
     ]);
     expect(descriptions.get("hours")).toEqual(["Maximum total training hours per week"]);
     expect(descriptions.get("role")).toEqual(


### PR DESCRIPTION
## Why

The plan-change intent translator sends the model the JSON schema of `PlanChangeIntentSchema` with a six-line preamble. No field carried a description, so the model had to guess whether `day` is ISO or Sunday-first, what `minutes` and `hours` bound, and what the two `role` values mean. A wrong guess passes validation and moves the wrong day. The deterministic regex fast path handles common phrasings; this affects only the LLM fallback.

## What changed

- `packages/coach-contract/src/plan-change.ts`: `.describe()` on every field of `PlanChangeIntentSchema` and its nested objects. `day` is spelled out as ISO weekday 1 = Monday … 7 = Sunday; `minutes` is the maximum session length for that weekday; `hours` is the maximum total training hours per week; `role` explains Important versus Training; each intent `kind` and `operation` literal carries one clause. No shape change.
- `packages/coach-contract/tests/plan-change-contract.test.ts`: asserts the generated JSON schema carries descriptions for `day`, `minutes`, `hours`, `role`, and every `kind`.

## Verification

- coach-contract + engine intent-translation tests: 16 files / 332 tests passed.
- `pnpm check:types`, `check:changeset-userfacing` pass.

Child of umbrella #855; targets `epic/plan-in-chat`. Issue: 339.

https://claude.ai/code/session_01HrEAXvcK4j4tUk9ZpTGy4f
