### PR TITLE
feat(engine): stream reply text on the ChatGPT lane

### DIFF
--- a/.changeset/codex-stream-deltas.md
+++ b/.changeset/codex-stream-deltas.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/engine": patch
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Replies now appear word by word while the coach is still writing, on ChatGPT sign-in as well as API keys.

--- a/packages/engine/src/agent/codex-bridge.ts
+++ b/packages/engine/src/agent/codex-bridge.ts
@@ -277,6 +277,7 @@ export async function codexGenerateText(
     cacheKey,
     signal,
     context,
+    onTextDelta,
   } = opts;
   const { getAccessToken, classifyFailure } = ports;
 
@@ -313,6 +314,7 @@ export async function codexGenerateText(
           accessToken,
           sessionId: cacheKey,
           signal,
+          onTextDelta,
         });
         break;
       } catch (err) {

--- a/packages/engine/src/agent/codex/responses.ts
+++ b/packages/engine/src/agent/codex/responses.ts
@@ -69,6 +69,7 @@ export interface CodexResponsesParams {
   serviceTier?: string;
   signal?: AbortSignal;
   baseUrl?: string;
+  onTextDelta?: (delta: string) => void;
 }
 
 // ============================================================================
@@ -396,6 +397,7 @@ interface ToolCallScratch {
 
 async function accumulate(
   events: AsyncIterable<Record<string, unknown>>,
+  onTextDelta?: (delta: string) => void,
 ): Promise<CodexResponsesResult> {
   let text = "";
   // The current message item's text accumulates here and is committed to `text`
@@ -403,6 +405,20 @@ async function accumulate(
   // server-authoritative reconciliation on output_item.done replaces only the
   // current item rather than clobbering text already committed by earlier items.
   let currentItemText = "";
+  let currentItemEmitted = "";
+  const emitTextDelta = (delta: string): void => {
+    if (delta === "") return;
+    currentItemEmitted += delta;
+    onTextDelta?.(delta);
+  };
+  const commitCurrentItem = (): void => {
+    if (currentItemText.startsWith(currentItemEmitted)) {
+      emitTextDelta(currentItemText.slice(currentItemEmitted.length));
+    }
+    text += currentItemText;
+    currentItemText = "";
+    currentItemEmitted = "";
+  };
   const toolScratch: ToolCallScratch[] = [];
   let currentItemType: "message" | "function_call" | "reasoning" | undefined;
   let currentMessageHasOutputText = false;
@@ -421,10 +437,7 @@ async function accumulate(
       const itemType = item?.type as string | undefined;
       // Commit any prior item's text before starting a new one (defensive: a
       // completed item normally commits via output_item.done first).
-      if (currentItemText) {
-        text += currentItemText;
-        currentItemText = "";
-      }
+      commitCurrentItem();
       if (itemType === "function_call") {
         currentItemType = "function_call";
         currentTool = {
@@ -448,7 +461,9 @@ async function accumulate(
       }
     } else if (type === "response.output_text.delta" || type === "response.refusal.delta") {
       if (currentItemType === "message" && currentMessageHasOutputText) {
-        currentItemText += (event as { delta?: string }).delta ?? "";
+        const delta = (event as { delta?: string }).delta ?? "";
+        currentItemText += delta;
+        emitTextDelta(delta);
       }
     } else if (type === "response.function_call_arguments.delta") {
       if (currentTool) currentTool.partialJson += (event as { delta?: string }).delta ?? "";
@@ -476,8 +491,7 @@ async function accumulate(
           if (authoritative) currentItemText = authoritative;
         }
       }
-      text += currentItemText;
-      currentItemText = "";
+      commitCurrentItem();
       currentItemType = undefined;
       currentTool = undefined;
       currentMessageHasOutputText = false;
@@ -512,10 +526,7 @@ async function accumulate(
 
   // Commit a message item whose output_item.done never arrived (e.g. a stream
   // truncated after its deltas).
-  if (currentItemText) {
-    text += currentItemText;
-    currentItemText = "";
-  }
+  commitCurrentItem();
 
   const toolCalls: CodexToolCall[] = toolScratch.map((t) => ({
     id: t.id,
@@ -656,7 +667,7 @@ export async function codexResponses(params: CodexResponsesParams): Promise<Code
 
   let result: CodexResponsesResult;
   try {
-    result = await accumulate(mapCodexEvents(parseSSE(response)));
+    result = await accumulate(mapCodexEvents(parseSSE(response)), params.onTextDelta);
   } catch (err) {
     if (err instanceof Error && (err.name === "AbortError" || params.signal?.aborted)) {
       throw abortError(params.signal, err);

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -185,22 +185,19 @@ export class LLM {
 
   private async dispatch(opts: GenerateOpts): Promise<GenerateResult> {
     if (this.config.llm.provider === "openai-codex") {
-      const result = await codexGenerateText(
+      return codexGenerateText(
         {
           ...opts,
           modelId: this.config.llm.model,
           profileName: this.config.llm.authProfile ?? "openai-codex",
           stepLimit: opts.maxSteps,
+          onTextDelta: opts.caller === "chat" ? opts.onTextDelta : undefined,
         },
         {
           getAccessToken: this.ports.getAccessToken,
           classifyFailure: this.ports.classifyFailure,
         },
       );
-      if (opts.caller === "chat" && result.text !== "") {
-        notifyTextDelta(opts.onTextDelta, result.text);
-      }
-      return result;
     }
 
     if (this.config.llm.provider === "claude-cli") {

--- a/packages/engine/tests/codex-bridge.test.ts
+++ b/packages/engine/tests/codex-bridge.test.ts
@@ -634,6 +634,44 @@ describe("codex-bridge", () => {
     expect(JSON.stringify(toolMsg!.content)).toContain("logged 60");
   });
 
+  it("forwards opts.onTextDelta to every step's request", async () => {
+    const tools = {
+      log_ride: {
+        description: "log a ride",
+        inputSchema: zodSchema(z.object({ minutes: z.number() })),
+        execute: vi.fn(async () => "logged"),
+      },
+    };
+    let step = 0;
+    const complete = vi.fn(async (params: { onTextDelta?: (delta: string) => void }) => {
+      step++;
+      if (step === 1) {
+        params.onTextDelta?.("Checking");
+        return asstMsg({
+          text: "Checking",
+          stopReason: "toolUse",
+          toolCalls: [{ id: "c1", name: "log_ride", arguments: { minutes: 60 } }],
+        });
+      }
+      params.onTextDelta?.("Logged ");
+      params.onTextDelta?.("60 min.");
+      return asstMsg({ text: "Logged 60 min." });
+    });
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+    const deltas: string[] = [];
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      tools: tools as never,
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+      onTextDelta: (delta) => deltas.push(delta),
+    });
+
+    expect(deltas).toEqual(["Checking", "Logged ", "60 min."]);
+    expect(result.text).toBe("Logged 60 min.");
+  });
+
   it("executes zero tools when a decision call has a sibling", async () => {
     const decide = vi.fn(async () => ({ status: "presented", decisionId: "d1" }));
     const mutate = vi.fn(async () => ({ saved: true }));

--- a/packages/engine/tests/codex/responses.test.ts
+++ b/packages/engine/tests/codex/responses.test.ts
@@ -121,6 +121,46 @@ describe("codexResponses SSE accumulation", () => {
     expect(result.responseId).toBe("resp_1");
   });
 
+  it("forwards each output_text delta in order and never re-emits the assembled text", async () => {
+    const events = [
+      { type: "response.created", response: { id: "resp_stream" } },
+      { type: "response.output_item.added", item: { type: "reasoning" } },
+      { type: "response.output_item.done", item: { type: "reasoning" } },
+      { type: "response.output_item.added", item: { type: "message" } },
+      { type: "response.content_part.added", part: { type: "output_text" } },
+      { type: "response.output_text.delta", delta: "Ride" },
+      { type: "response.output_text.delta", delta: " easy" },
+      { type: "response.output_text.delta", delta: "" },
+      { type: "response.output_text.delta", delta: " today." },
+      { type: "response.output_item.done", item: { type: "message", content: [{ type: "output_text", text: "Ride easy today." }] } },
+      { type: "response.completed", response: { status: "completed", usage: { input_tokens: 4, output_tokens: 3, total_tokens: 7 } } },
+    ];
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(okResp(events));
+    const deltas: string[] = [];
+
+    const result = await codexResponses(baseParams({ onTextDelta: (delta: string) => deltas.push(delta) }));
+
+    expect(deltas).toEqual(["Ride", " easy", " today."]);
+    expect(deltas.join("")).toBe(result.text);
+  });
+
+  it("emits the server-authoritative remainder once when deltas were dropped", async () => {
+    const events = [
+      { type: "response.created", response: { id: "resp_recover" } },
+      { type: "response.output_item.added", item: { type: "message" } },
+      { type: "response.output_text.delta", delta: "dropped" },
+      { type: "response.output_item.done", item: { type: "message", content: [{ type: "output_text", text: "recovered text" }] } },
+      { type: "response.completed", response: { status: "completed", usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 } } },
+    ];
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(okResp(events));
+    const deltas: string[] = [];
+
+    const result = await codexResponses(baseParams({ onTextDelta: (delta: string) => deltas.push(delta) }));
+
+    expect(deltas).toEqual(["recovered text"]);
+    expect(result.text).toBe("recovered text");
+  });
+
   it("recovers final text from output_item.done when content_part.added is missing", async () => {
     // No response.content_part.added, so the per-delta guard never opens and the
     // deltas are dropped — the completed item's content must still be recovered.

--- a/packages/engine/tests/llm-dispatch.test.ts
+++ b/packages/engine/tests/llm-dispatch.test.ts
@@ -242,6 +242,33 @@ describe("LLM dispatch — codex path forwards maxSteps to bridge", () => {
     expect(captured.cacheKey).toBe("deadbeefdeadbeef");
   });
 
+  it("streams chat text through the bridge without re-emitting the assembled reply", async () => {
+    const codexGenerateText = vi.fn(
+      async (o: { onTextDelta?: (delta: string) => void }) => {
+        o.onTextDelta?.("o");
+        o.onTextDelta?.("k");
+        return MINIMAL_RESULT;
+      },
+    );
+    vi.doMock("../src/agent/codex-bridge.js", () => ({ codexGenerateText }));
+    const { LLM } = await import("../src/llm.js");
+    const llm = new LLM(codexConfig(), llmTestPorts());
+
+    const chatDeltas: string[] = [];
+    const result = await llm.generate({
+      messages: [{ role: "user", content: "hi" }],
+      caller: "chat",
+      onTextDelta: (delta) => chatDeltas.push(delta),
+    });
+    expect(chatDeltas).toEqual(["o", "k"]);
+    expect(result.text).toBe("ok");
+
+    const onTextDelta = vi.fn();
+    await llm.generate({ prompt: "background", caller: "flush", onTextDelta });
+    expect(codexGenerateText.mock.calls[1][0].onTextDelta).toBeUndefined();
+    expect(onTextDelta).not.toHaveBeenCalled();
+  });
+
   it("creates the default deadline signal and forwards it to the bridge", async () => {
     const timeoutController = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);


### PR DESCRIPTION
## Problem

On the ChatGPT sign-in lane (`openai-codex`) the Responses SSE parser already consumed `response.output_text.delta` events, but `LLM.dispatch` only called `onTextDelta` once with the assembled text after the whole generate returned. The athlete saw nothing until the reply was complete: a real ledger turn measured 25.6 s to first token, equal to total time. The AI SDK lane streams through `streamText`, so the renderer, CLI and Telegram already handle incremental deltas.

## Change

- `codexResponses` accepts an optional `onTextDelta` and forwards each `response.output_text.delta` / `response.refusal.delta` for a message item as it arrives, under the same guard that already decides whether the delta is accumulated. The three item-commit sites now share one `commitCurrentItem` helper; when `output_item.done` carries server-authoritative text that extends what was emitted, only the remainder is forwarded, so the concatenation of deltas always equals the returned `text` in the recovery case the existing test covers.
- `codexGenerateText` passes `opts.onTextDelta` into every step's `codexResponses` call.
- `LLM.dispatch` passes `onTextDelta` to the bridge for `caller === "chat"` only and no longer re-sends the assembled text after generate returns.

Multi-step turns: the AI SDK lane forwards every `text-delta` from `fullStream`, so text produced by an intermediate step (before a tool call) already reaches the athlete there. This PR matches that: every step's message deltas are forwarded; `result.text` stays the final step's text, as before. The desktop renderer replaces the streamed draft with `final-text`, so the persisted reply is unchanged.

Not streamed, unchanged from today: reasoning items, tool-call argument deltas. Refusal deltas were already folded into the reply text; they now stream the same way.

## Follow-up (not in this PR)

`LLM.generate` still disables the chat-stream idle watchdog for keyless lanes (`usesKeylessTransport`). With deltas now flowing, the watchdog could get a heartbeat on this lane; that is deliberately left as is here and should be its own change.

## Tests

- `responses.test.ts`: deltas forwarded in order, empty delta skipped, concatenation equals `text`, no duplicate end emission; server-authoritative remainder emitted once when deltas were dropped.
- `codex-bridge.test.ts`: `onTextDelta` reaches every step's request in a two-step tool turn.
- `llm-dispatch.test.ts`: chat deltas pass through unchanged with no re-emission; a `flush` caller gets no callback.

No existing test was weakened or removed.

## Limits

None added or changed.

## Verification

- `pnpm check` (root): green.
- `pnpm vitest run --project workspace packages/engine/tests`: 128 files, 1403 tests passed.
- `pnpm s8a`: exit 0, 11 scenarios replayed; only the documented supersession warnings (S8A-SUP-012) that predate this branch. Replay patches `generate`, so the codex path is never reached there.

https://claude.ai/code/session_019oR1DgG887bERqaxhgrdYT
