### PR TITLE
fix(engine): re-flush a reset archive if the process died before the flush landed

### DIFF
--- a/.changeset/reflush-reset-archive.md
+++ b/.changeset/reflush-reset-archive.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/engine": patch
+"@enduragent/core": patch
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: If you close the app right after the first chat of the day, what you told the coach is still saved to memory the next time you open it.

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -80,7 +80,15 @@ type DirectoryDescriptor = number | null;
 interface DurableChatReset {
   readonly resetId: string;
   readonly boundaryAt: string;
+  readonly flushPending?: boolean;
 }
+
+export interface UnflushedResetArchive {
+  readonly archiveRef: string;
+  readonly messages: ModelMessage[];
+}
+
+const RESET_ARCHIVE_REF_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z\.[a-f0-9]{64}$/;
 
 const DURABLE_RESET_OPERATIONS = new WeakMap<
   ChatStore,
@@ -186,6 +194,15 @@ function parseSessionLine(line: string): JsonlLine | null {
   return value as JsonlLine;
 }
 
+function messagesOf(lines: readonly JsonlLine[]): ModelMessage[] {
+  return lines.map((p) =>
+    setMessageProvenance(
+      { role: p.role, content: p.content } as ModelMessage,
+      p.role === "user" ? UNKNOWN_PROVENANCE : (p.provenance ?? UNKNOWN_PROVENANCE),
+    ),
+  );
+}
+
 function sameProvenance(left: SourceProvenance, right: SourceProvenance): boolean {
   return (
     left.garmin === right.garmin &&
@@ -267,8 +284,61 @@ export class ChatStore {
       const ts = reset.boundaryAt.replace(/:/g, "-");
       const archivePath = `${path}.reset.${ts}.${reset.resetId}`;
       this.completeDurableReset(path, archivePath);
+      if (reset.flushPending === true && this.sessionExists(archivePath)) {
+        this.appendSessionContent(this.flushPendingPath(chatId, `${ts}.${reset.resetId}`), "");
+      }
       this.pruneArchives(chatId, "reset");
     });
+  }
+
+  private flushPendingPath(chatId: string, archiveRef: string): string {
+    return `${this.filePath(chatId)}.flush-pending.${archiveRef}`;
+  }
+
+  private unlinkIfPresent(path: string): void {
+    if (this.sessionExists(path)) this.unlinkSessionPath(path);
+  }
+
+  loadUnflushedResetArchive(chatId: string): UnflushedResetArchive | null {
+    const path = this.filePath(chatId);
+    const prefix = `${path}.flush-pending.`;
+    let names: string[];
+    try {
+      names = readdirSync(this.sessionsDir);
+    } catch (error) {
+      throw this.platform === "win32"
+        ? classifyWindowsPrivatePathFailure("read-check", error)
+        : error;
+    }
+    const markers = names
+      .map((name) => join(this.sessionsDir, name))
+      .filter((candidate) => candidate.startsWith(prefix))
+      .sort();
+    for (const marker of markers) {
+      const archiveRef = marker.slice(prefix.length);
+      if (!RESET_ARCHIVE_REF_PATTERN.test(archiveRef)) continue;
+      const archivePath = `${path}.reset.${archiveRef}`;
+      if (!this.sessionExists(archivePath)) {
+        this.unlinkSessionPath(marker);
+        continue;
+      }
+      const contents = this.readSessionText(archivePath);
+      if (this.platform === "win32") this.assertWindowsSessionContent(contents);
+      const parsed = contents
+        .split("\n")
+        .filter((line) => line.trim() !== "")
+        .map(parseSessionLine)
+        .filter((line): line is JsonlLine => line !== null);
+      return { archiveRef, messages: messagesOf(parsed) };
+    }
+    return null;
+  }
+
+  markResetArchiveFlushed(chatId: string, archiveRef: string): void {
+    if (!RESET_ARCHIVE_REF_PATTERN.test(archiveRef)) {
+      throw new TypeError("Reset archive reference is invalid.");
+    }
+    this.unlinkIfPresent(this.flushPendingPath(chatId, archiveRef));
   }
 
   private filePath(chatId: string): string {
@@ -763,12 +833,7 @@ export class ChatStore {
       }
     }
 
-    const messages = parsed.map((p) =>
-      setMessageProvenance(
-        { role: p.role, content: p.content } as ModelMessage,
-        p.role === "user" ? UNKNOWN_PROVENANCE : (p.provenance ?? UNKNOWN_PROVENANCE),
-      ),
-    );
+    const messages = messagesOf(parsed);
 
     let lastMessageTime: string | null = null;
     for (let i = parsed.length - 1; i >= 0; i--) {
@@ -1035,8 +1100,9 @@ export class ChatStore {
     ) {
       throw new TypeError("Reset archive deletion metadata is invalid.");
     }
-    const path = `${this.filePath(chatId)}.reset.${boundaryAt.replace(/:/g, "-")}.${boundaryRef}`;
-    return this.withSessionsDirectory((directoryDescriptor) => {
+    const archiveRef = `${boundaryAt.replace(/:/g, "-")}.${boundaryRef}`;
+    const path = `${this.filePath(chatId)}.reset.${archiveRef}`;
+    const deleted = this.withSessionsDirectory((directoryDescriptor) => {
       let beforeOpen: import("node:fs").Stats;
       try {
         beforeOpen = lstatSync(path);
@@ -1095,6 +1161,8 @@ export class ChatStore {
         closeSync(descriptor);
       }
     }, "rename");
+    if (deleted) this.unlinkIfPresent(this.flushPendingPath(chatId, archiveRef));
+    return deleted;
   }
 
   archivePreCompact(chatId: string): void {

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -8,7 +8,7 @@ import type {
   TranscriptInterruptedTurnInput,
   TranscriptWriterPort,
 } from "@enduragent/engine";
-import { archiveAndResetDurably, ChatStore } from "./chat-store.js";
+import { archiveAndResetDurably, ChatStore, type UnflushedResetArchive } from "./chat-store.js";
 import {
   ArchivedConversationDeletionConflictError,
   TranscriptBoundaryTargetUnchangedError,
@@ -375,10 +375,7 @@ export class ConversationStore implements ConversationStorePort {
     }
 
     try {
-      archiveAndResetDurably(this.chatStore, intent.chatId, {
-        resetId: intent.resetId,
-        boundaryAt: intent.boundaryAt,
-      });
+      this.archiveDurably(intent);
       this.chatQueueStore?.clear(intent.chatId);
       this.transcriptStore.removeResetIntent(intent);
       this.blockedChats.delete(intent.chatId);
@@ -386,6 +383,24 @@ export class ConversationStore implements ConversationStorePort {
       this.blockedChats.set(intent.chatId, error);
       throw error;
     }
+  }
+
+  private archiveDurably(intent: ResetIntentRecord): void {
+    archiveAndResetDurably(this.chatStore, intent.chatId, {
+      resetId: intent.resetId,
+      boundaryAt: intent.boundaryAt,
+      flushPending: intent.reason === "stale-reset",
+    });
+  }
+
+  loadUnflushedResetArchive(chatId: string): UnflushedResetArchive | null {
+    this.recoverBeforeAccess(chatId);
+    return this.chatStore.loadUnflushedResetArchive(chatId);
+  }
+
+  markResetArchiveFlushed(chatId: string, archiveRef: string): void {
+    this.recoverBeforeAccess(chatId);
+    this.chatStore.markResetArchiveFlushed(chatId, archiveRef);
   }
 
   private cleanupBeforeBoundary(intent: ResetIntentRecord, originalError: unknown): never {
@@ -422,19 +437,13 @@ export class ConversationStore implements ConversationStorePort {
     } catch (error) {
       if (!(error instanceof WindowsPrivatePathPolicyError)) throw error;
       this.transcriptStore.ensureConversationBoundary(intent);
-      archiveAndResetDurably(this.chatStore, intent.chatId, {
-        resetId: intent.resetId,
-        boundaryAt: intent.boundaryAt,
-      });
+      this.archiveDurably(intent);
       this.chatQueueStore?.clear(intent.chatId);
       this.transcriptStore.removeResetIntent(intent);
       return;
     }
     this.transcriptStore.ensureConversationBoundary(intent);
-    archiveAndResetDurably(this.chatStore, intent.chatId, {
-      resetId: intent.resetId,
-      boundaryAt: intent.boundaryAt,
-    });
+    this.archiveDurably(intent);
     this.chatQueueStore?.clear(intent.chatId);
     this.transcriptStore.removeResetIntent(intent);
   }

--- a/packages/core/tests/chat-store.test.ts
+++ b/packages/core/tests/chat-store.test.ts
@@ -466,6 +466,59 @@ describe("ChatStore durable reset — private race-checked targets", () => {
     expect(lstatSync(archive).nlink).toBe(1);
   });
 
+  it("marks a flush-pending archive, serves it oldest first, and clears it on flush or delete", () => {
+    const store = new ChatStore(dataDir);
+    const older = { resetId: "a".repeat(64), boundaryAt: "2026-07-21T01:02:03.000Z" };
+    const ref = (reset: typeof older) =>
+      `${reset.boundaryAt.replace(/:/g, "-")}.${reset.resetId}`;
+    const marker = (reset: typeof older) =>
+      join(sessionsDir, `pending.jsonl.flush-pending.${ref(reset)}`);
+    store.appendTurn("pending", "synthetic older user", "synthetic older coach", LINEAGE);
+    archiveAndResetDurably(store, "pending", { ...older, flushPending: true });
+    store.appendTurn("pending", "synthetic newer user", "synthetic newer coach", LINEAGE);
+    archiveAndResetDurably(store, "pending", { ...DURABLE_RESET, flushPending: true });
+    store.appendTurn("pending", "synthetic flushed user", "synthetic flushed coach", LINEAGE);
+    archiveAndResetDurably(store, "pending", {
+      resetId: "f".repeat(64),
+      boundaryAt: "2026-07-23T01:02:03.000Z",
+    });
+
+    expect(existsSync(marker(older))).toBe(true);
+    expect(existsSync(marker(DURABLE_RESET))).toBe(true);
+    expect(listArchives("pending")).toHaveLength(3);
+    expect(readdirSync(sessionsDir).filter((f) => f.includes("flush-pending"))).toHaveLength(2);
+
+    const first = store.loadUnflushedResetArchive("pending");
+    expect(first?.archiveRef).toBe(ref(older));
+    expect(first?.messages.map((m) => m.content)).toEqual([
+      "synthetic older user",
+      "synthetic older coach",
+    ]);
+
+    store.markResetArchiveFlushed("pending", ref(older));
+    expect(existsSync(marker(older))).toBe(false);
+    expect(store.loadUnflushedResetArchive("pending")?.archiveRef).toBe(ref(DURABLE_RESET));
+
+    expect(
+      store.deleteResetArchive("pending", DURABLE_RESET.resetId, DURABLE_RESET.boundaryAt),
+    ).toBe(true);
+    expect(existsSync(marker(DURABLE_RESET))).toBe(false);
+    expect(store.loadUnflushedResetArchive("pending")).toBeNull();
+    expect(() => store.markResetArchiveFlushed("pending", "../escape")).toThrow(
+      "Reset archive reference is invalid.",
+    );
+  });
+
+  it("drops a flush-pending marker whose archive is gone", () => {
+    const store = new ChatStore(dataDir);
+    store.appendTurn("orphan", "synthetic user", "synthetic coach", LINEAGE);
+    archiveAndResetDurably(store, "orphan", { ...DURABLE_RESET, flushPending: true });
+    rmSync(durableArchivePath("orphan"));
+
+    expect(store.loadUnflushedResetArchive("orphan")).toBeNull();
+    expect(readdirSync(sessionsDir).filter((f) => f.includes("flush-pending"))).toHaveLength(0);
+  });
+
   it("refuses a permissive active file without chmodding or archiving it", () => {
     const store = new ChatStore(dataDir);
     store.appendTurn("permissive", "synthetic user", "synthetic assistant", LINEAGE);

--- a/packages/core/tests/conversation-store.test.ts
+++ b/packages/core/tests/conversation-store.test.ts
@@ -368,6 +368,39 @@ describe("ConversationStore reset transaction recovery", () => {
     });
   });
 
+  it("marks only a stale-reset archive as flush-pending, including one recovered from an intent", () => {
+    const dataDir = makeDataDir();
+    const chat = new ChatStore(dataDir);
+    const transcript = new TranscriptStore(dataDir);
+    const store = new ConversationStore(chat, transcript, () => RESET_ID);
+    seedSession(chat, "explicit");
+    store.resetConversation({
+      chatId: "explicit",
+      boundaryAt: "2026-07-22T00:00:00.000Z",
+      reason: "explicit-reset",
+    });
+    seedSession(chat, "stale");
+    store.resetConversation({
+      chatId: "stale",
+      boundaryAt: "2026-07-22T00:00:00.000Z",
+      reason: "stale-reset",
+    });
+    const recoveredReset = { ...resetIntent("recovered"), reason: "stale-reset" as const };
+    seedSession(chat, recoveredReset.chatId);
+    transcript.createResetIntent(recoveredReset);
+    const recovered = new ConversationStore(chat, transcript);
+
+    expect(store.loadUnflushedResetArchive("explicit")).toBeNull();
+    const stale = store.loadUnflushedResetArchive("stale");
+    expect(stale?.messages.map((message) => message.content)).toEqual(["athlete", "coach"]);
+    expect(recovered.loadUnflushedResetArchive("recovered")?.archiveRef).toBe(
+      `${recoveredReset.boundaryAt.replace(/:/g, "-")}.${recoveredReset.resetId}`,
+    );
+
+    store.markResetArchiveFlushed("stale", stale!.archiveRef);
+    expect(store.loadUnflushedResetArchive("stale")).toBeNull();
+  });
+
   it("recovers intent-only by ensuring one boundary and archiving the active session", () => {
     const dataDir = makeDataDir();
     const chat = new ChatStore(dataDir);

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -929,6 +929,7 @@ export class CoachAgent {
           archivedAt = boundaryAt;
         }
 
+        let recoveryFlushQueued = false;
         const unflushed = this.chatStore.loadUnflushedResetArchive(chatId);
         if (unflushed !== null) {
           const markFlushed = () =>
@@ -936,7 +937,7 @@ export class CoachAgent {
           if (unflushed.messages.length === 0) {
             markFlushed();
           } else {
-            flushedThisTurn = true;
+            recoveryFlushQueued = true;
             this.queueFlush(chatId, unflushed.messages, "stale-reset", markFlushed);
           }
         }
@@ -1031,7 +1032,7 @@ export class CoachAgent {
           })
         ) {
           this.lastFlushMessageCount.set(chatId, history.length);
-          if (!flushedThisTurn) {
+          if (!flushedThisTurn && !recoveryFlushQueued) {
             flushedThisTurn = true;
             this.queueFlush(chatId, history, "soft-threshold");
           }

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -694,6 +694,7 @@ export class CoachAgent {
     chatId: string,
     messages: ModelMessage[],
     trigger: "stale-reset" | "soft-threshold",
+    onFlushed?: () => void,
   ): void {
     void withSessionLock(chatId, async () => {
       try {
@@ -711,6 +712,7 @@ export class CoachAgent {
           );
           await this.flushMemory(messages, trigger);
         }
+        onFlushed?.();
       } catch (err) {
         this.log.warn(`Queued ${trigger} memory flush failed`, err);
       }
@@ -916,10 +918,6 @@ export class CoachAgent {
         let archivedAt: string | undefined;
 
         if (!fresh && !deferDaily) {
-          if (history.length > 0 && !flushedThisTurn) {
-            flushedThisTurn = true;
-            this.queueFlush(chatId, history, "stale-reset");
-          }
           const boundaryAt = new Date(this.ports.now()).toISOString();
           this.chatStore.resetConversation({
             chatId,
@@ -929,6 +927,18 @@ export class CoachAgent {
           this.lastFlushMessageCount.delete(chatId);
           history = [];
           archivedAt = boundaryAt;
+        }
+
+        const unflushed = this.chatStore.loadUnflushedResetArchive(chatId);
+        if (unflushed !== null) {
+          const markFlushed = () =>
+            this.chatStore.markResetArchiveFlushed(chatId, unflushed.archiveRef);
+          if (unflushed.messages.length === 0) {
+            markFlushed();
+          } else {
+            flushedThisTurn = true;
+            this.queueFlush(chatId, unflushed.messages, "stale-reset", markFlushed);
+          }
         }
 
         if (this.memory.refreshPlanReadGate) await this.memory.refreshPlanReadGate();

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -162,6 +162,10 @@ export interface ChatStorePort {
   }): void;
   overwriteHistory(chatId: string, messages: ModelMessage[]): void;
   resetConversation(input: ConversationResetInput): void;
+  loadUnflushedResetArchive(
+    chatId: string,
+  ): { readonly archiveRef: string; readonly messages: ModelMessage[] } | null;
+  markResetArchiveFlushed(chatId: string, archiveRef: string): void;
   archivePreCompact(chatId: string): void;
   getChatQueue?(chatId: string): ChatQueueSnapshot;
   enqueueChatMessage?(

--- a/packages/engine/tests/coach-agent-garmin-attribution.test.ts
+++ b/packages/engine/tests/coach-agent-garmin-attribution.test.ts
@@ -189,6 +189,8 @@ async function setupAgentWithStore(
     resetConversation() {
       messages = [];
     },
+    loadUnflushedResetArchive: () => null,
+    markResetArchiveFlushed() {},
     archivePreCompact() {},
   };
   const ports: EngineHostPorts = {

--- a/packages/engine/tests/flush-dedupe-per-turn.test.ts
+++ b/packages/engine/tests/flush-dedupe-per-turn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ModelMessage } from "ai";
@@ -159,6 +159,50 @@ describe("flush dedupe — at most one memory flush per chat() turn", () => {
     const { withSessionLock } = await import("../src/agent/session-lock.js");
     await withSessionLock("daily", async () => {});
     expect(countFlushCalls(complete)).toBeLessThanOrEqual(2);
+  });
+
+  it("an over-budget turn with a pending archive still awaits its own trim flush and queues one recovery flush", async () => {
+    const complete = vi.fn(async (params: { system?: string; messages: unknown }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.includes(COMPACTION_MARKER)) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("trim-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("trim-pending", overBudgetLines(FRESH_TS));
+    const archiveRef = `2020-01-02T04-00-00.000Z.${"a".repeat(64)}`;
+    const sessionsDir = join(dataDir, "sessions");
+    writeFileSync(
+      join(sessionsDir, `trim-pending.jsonl.reset.${archiveRef}`),
+      JSON.stringify({ role: "user", content: "archived fact", ts: STALE_TS }) + "\n",
+      { encoding: "utf-8", mode: 0o600 },
+    );
+    writeFileSync(join(sessionsDir, `trim-pending.jsonl.flush-pending.${archiveRef}`), "", {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    const flushText = (call: unknown[]) =>
+      JSON.stringify((call[0] as { messages: unknown }).messages);
+
+    const text = await agent.chat("trim-pending", "hello");
+    const { withSessionLock } = await import("../src/agent/session-lock.js");
+    await withSessionLock("trim-pending", async () => {});
+
+    expect(text).toBe("trim-reply");
+    const calls = complete.mock.calls;
+    const replyIndex = calls.findIndex(
+      (c) => !isFlushCall(c) && !String((c[0] as { system?: string }).system).includes(COMPACTION_MARKER),
+    );
+    const flushIndexes = calls.map((c, i) => (isFlushCall(c) ? i : -1)).filter((i) => i >= 0);
+    expect(flushIndexes).toHaveLength(2);
+    expect(flushIndexes[0]).toBeLessThan(replyIndex);
+    expect(flushText(calls[flushIndexes[0]])).toContain("x".repeat(2_400));
+    expect(flushText(calls[flushIndexes[0]])).not.toContain("archived fact");
+    expect(flushIndexes[1]).toBeGreaterThan(replyIndex);
+    expect(flushText(calls[flushIndexes[1]])).toContain("archived fact");
+    expect(flushText(calls[flushIndexes[1]])).not.toContain("x".repeat(2_400));
+    expect(readdirSync(sessionsDir).filter((f) => f.includes("flush-pending"))).toHaveLength(0);
   });
 
   it("a normal single-flush trim turn is unchanged (no false suppression)", async () => {

--- a/packages/engine/tests/reset-flush-guard.test.ts
+++ b/packages/engine/tests/reset-flush-guard.test.ts
@@ -31,7 +31,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function setupAgent(complete: ReturnType<typeof vi.fn>, timezone?: string) {
+async function setupAgent(
+  complete: ReturnType<typeof vi.fn>,
+  timezone?: string,
+  now?: () => number,
+) {
   vi.doMock("../src/agent/codex/responses.js", () => ({
     codexResponses: complete,
   }));
@@ -48,11 +52,29 @@ async function setupAgent(complete: ReturnType<typeof vi.fn>, timezone?: string)
 
   const { CoachAgent } = await import("../src/agent/coach-agent.js");
   const base = baseAgentConfig(dataDir);
-  const ports =
+  const withTz =
     timezone === undefined
       ? base
       : { ...base, config: { ...base.config, session: { ...base.config.session, timezone } } };
+  const ports = now === undefined ? withTz : { ...withTz, now };
   return new CoachAgent(cyclingSport as unknown as Sport, ports);
+}
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+
+function isFlushCall(params: unknown): boolean {
+  const system = (params as { system?: unknown } | undefined)?.system;
+  return typeof system === "string" && system.includes(FLUSH_MARKER);
+}
+
+function flushMessagesText(params: unknown): string {
+  return JSON.stringify((params as { messages: unknown }).messages);
+}
+
+function listFlushMarkers(chatId: string): string[] {
+  return readdirSync(join(dataDir, "sessions")).filter((f) =>
+    f.startsWith(`${chatId}.jsonl.flush-pending.`),
+  );
 }
 
 function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
@@ -225,5 +247,143 @@ describe("reset-path flush guards", () => {
     expect(
       warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset memory flush failed")),
     ).toBe(false);
+  });
+});
+
+describe("reset archive re-flush", () => {
+  it("a stale reset marks the archive pending until its queued flush completes", async () => {
+    let releaseFlush: () => void = () => {};
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    const complete = vi.fn(async (params: unknown) => {
+      if (!isFlushCall(params)) return mkAssistant("reply");
+      await flushGate;
+      return mkAssistant("noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("mark", [
+      { role: "user", content: "yesterday's talk", ts: STALE_TS },
+      { role: "assistant", content: "yesterday's reply", ts: STALE_TS },
+    ]);
+
+    await agent.chat("mark", "morning");
+
+    const archives = listArchives("mark");
+    expect(archives).toHaveLength(1);
+    const archiveRef = archives[0].slice("mark.jsonl.reset.".length);
+    expect(listFlushMarkers("mark")).toEqual([`mark.jsonl.flush-pending.${archiveRef}`]);
+
+    releaseFlush();
+    await drain("mark");
+
+    expect(listFlushMarkers("mark")).toHaveLength(0);
+    expect(listArchives("mark")).toEqual(archives);
+  });
+
+  it("a flush lost to a process exit is re-queued once on the next turn, then never again", async () => {
+    const flushCalls: string[] = [];
+    let replies = 0;
+    const complete = vi.fn(async (params: unknown) => {
+      if (!isFlushCall(params)) return mkAssistant(`reply-${++replies}`);
+      flushCalls.push(flushMessagesText(params));
+      if (flushCalls.length === 1) await new Promise<void>(() => {});
+      return mkAssistant("noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const before = await setupAgent(complete);
+    seedSession("lost", [
+      { role: "user", content: "yesterday's talk", ts: STALE_TS },
+      { role: "assistant", content: "yesterday's reply", ts: STALE_TS },
+    ]);
+
+    const first = await before.chat("lost", "morning");
+    expect(first).toContain("reply-1");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(flushCalls).toHaveLength(1);
+    expect(listFlushMarkers("lost")).toHaveLength(1);
+
+    vi.resetModules();
+    const restarted = await setupAgent(complete);
+
+    expect(await restarted.chat("lost", "and another thing")).toBe("reply-2");
+    await drain("lost");
+
+    expect(flushCalls).toHaveLength(2);
+    expect(flushCalls[1]).toContain("yesterday's talk");
+    expect(flushCalls[1]).not.toContain("and another thing");
+    expect(listFlushMarkers("lost")).toHaveLength(0);
+    expect(listArchives("lost")).toHaveLength(1);
+
+    expect(await restarted.chat("lost", "third")).toBe("reply-3");
+    await drain("lost");
+
+    expect(flushCalls).toHaveLength(2);
+    expect(listFlushMarkers("lost")).toHaveLength(0);
+  });
+
+  it("a failed queued flush keeps the marker and the next turn retries it", async () => {
+    const flushCalls: string[] = [];
+    let replies = 0;
+    const complete = vi.fn(async (params: unknown) => {
+      if (!isFlushCall(params)) return mkAssistant(`reply-${++replies}`);
+      flushCalls.push(flushMessagesText(params));
+      if (flushCalls.length <= 2) throw new Error("boom");
+      return mkAssistant("noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("retry", [
+      { role: "user", content: "yesterday's talk", ts: STALE_TS },
+      { role: "assistant", content: "yesterday's reply", ts: STALE_TS },
+    ]);
+
+    await agent.chat("retry", "morning");
+    await drain("retry");
+    expect(flushCalls).toHaveLength(2);
+    expect(listFlushMarkers("retry")).toHaveLength(1);
+
+    await agent.chat("retry", "again");
+    await drain("retry");
+    expect(flushCalls).toHaveLength(3);
+    expect(flushCalls[2]).toContain("yesterday's talk");
+    expect(listFlushMarkers("retry")).toHaveLength(0);
+  });
+
+  it("recovers pending archives oldest first, one per turn", async () => {
+    const flushCalls: string[] = [];
+    let replies = 0;
+    const complete = vi.fn(async (params: unknown) => {
+      if (!isFlushCall(params)) return mkAssistant(`reply-${++replies}`);
+      flushCalls.push(flushMessagesText(params));
+      if (flushCalls.length === 1) await new Promise<void>(() => {});
+      return mkAssistant("noted");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    let clock = 0;
+    const now = () => (clock += 60_000);
+    const before = await setupAgent(complete, undefined, now);
+    seedSession("oldest", [{ role: "user", content: "day one", ts: STALE_TS }]);
+    await before.chat("oldest", "morning one");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(flushCalls).toHaveLength(1);
+
+    vi.resetModules();
+    const restarted = await setupAgent(complete, undefined, now);
+    seedSession("oldest", [{ role: "user", content: "day two", ts: STALE_TS }]);
+
+    await restarted.chat("oldest", "morning two");
+    await drain("oldest");
+    expect(listArchives("oldest")).toHaveLength(2);
+    expect(flushCalls).toHaveLength(2);
+    expect(flushCalls[1]).toContain("day one");
+    expect(listFlushMarkers("oldest")).toHaveLength(1);
+
+    await restarted.chat("oldest", "later");
+    await drain("oldest");
+    expect(flushCalls).toHaveLength(3);
+    expect(flushCalls[2]).toContain("day two");
+    expect(listFlushMarkers("oldest")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Problem

On the daily reset path the engine archives the stale conversation and queues its memory flush behind the reply on the per-chat session lock. Quitting the desktop app sends `shutdown` to the utility process and kills it after 5 s, while a flush takes 6-25 s. An athlete who sends the first message of the day and quits within seconds loses that archived conversation's facts for good: the archive exists on disk, but nothing ever re-flushes it. The soft-threshold flush self-heals on the next turn; the reset flush did not.

## Change

- `ChatStore` writes an empty sidecar `<chat>.jsonl.flush-pending.<boundary>.<resetId>` inside the durable reset operation, right after the archive completes, when the reset is a stale reset. The sidecar name never collides with the `.jsonl.reset.` archive prefix, so nothing that lists archives sees it. Because the sidecar is written inside the reset-intent transaction, a crash between archive and sidecar is replayed by the existing intent recovery, which re-runs the same operation idempotently.
- `ChatStore.loadUnflushedResetArchive(chatId)` does one `readdirSync` of the sessions directory per turn, returns the oldest pending archive (name sort on the ISO boundary) with its messages parsed the same way `load` parses the active session, and removes a sidecar whose archive is gone on the spot. `markResetArchiveFlushed(chatId, archiveRef)` removes the sidecar. `deleteResetArchive` removes the sidecar after a successful delete so an athlete-deleted archive is never re-flushed.
- `ConversationStore` passes `flushPending: reason === "stale-reset"` from the intent on all three archive paths (now one private `archiveDurably`) and exposes the two new port methods. An explicit reset flushes before archiving, so it gets no sidecar.
- `CoachAgent.chat` no longer queues the stale-reset flush from the in-memory history. After the freshness block it asks the store for the oldest unflushed reset archive and queues exactly one flush for it (source `stale-reset`, after the reply, same `queueFlush` path). On success the sidecar is cleared. On a normal day the oldest pending archive is the one just created, so the wire behavior of a reset turn is unchanged (verified by the untouched call counts in the existing reset and zero-write-retry tests). With a backlog, one archive is recovered per turn, oldest first. An empty archive is marked flushed without a model call.
- The recovery flush is a different conversation from the live one, so it does not touch the per-turn `flushedThisTurn` latch: an over-budget turn that finds a pending archive still awaits its own trim flush over the live history before compacting. A separate `recoveryFlushQueued` local only stops the soft-threshold queued flush from stacking a second post-reply flush in the same turn (the soft-threshold flush self-heals next turn, as it already does after a trim).

## Why a repeat flush is safe

- `memory_write` replaces the whole section; the flush prompt instructs the model to carry all current facts forward and write only changed sections. A second flush over the same conversation yields the same section content; at worst the section's `_updated` stamp is refreshed.
- `ledger_append` dedupes on `(date, kind, normalized text)` in `MemoryStore.appendEvent` and returns `duplicate: true`, so a repeated event never lands twice.
- The recovery flush reads the archived file, so it never includes messages from the current session.

## Failure handling

A queued flush that throws keeps the sidecar, so the next turn retries it; the bound is one recovery flush per turn. The previous behavior silently dropped the facts after `MAX_FLUSH_ATTEMPTS` (2) in-process retries. Both retries and the cross-turn retry are idempotent per the section above.

## Limits

No new numeric limits. The archive reference pattern only accepts the existing `<ISO boundary with dashes>.<64 hex reset id>` archive suffix.

## Tests

- `packages/engine/tests/reset-flush-guard.test.ts`: (a) a stale reset marks the archive pending and a completed flush clears it; (b) a flush parked forever, then a module reset simulating a process restart, re-queues exactly one recovery flush for the archived history, clears the marker, and a later turn queues nothing; a flush that throws keeps the marker and the next turn retries it; two lost archives are recovered oldest first, one per turn. The `setupAgent` helper gained an optional `now` port for deterministic archive ordering.
- `packages/engine/tests/flush-dedupe-per-turn.test.ts`: an over-budget turn with a pending archive marker awaits its own trim flush over the live history before the reply and queues exactly one recovery flush over the archive after it; the marker clears.
- `packages/core/tests/chat-store.test.ts`: marker written only with `flushPending`, oldest served first, cleared by `markResetArchiveFlushed` and by `deleteResetArchive`, invalid refs rejected, orphaned markers dropped.
- `packages/core/tests/conversation-store.test.ts`: only a `stale-reset` boundary gets a marker, including one recovered from a persisted intent.
- `packages/engine/tests/coach-agent-garmin-attribution.test.ts`: the hand-written `ChatStorePort` fake gained the two methods.

No existing test was weakened. s8a `session-stale-reset-flush` stays green without re-recording or re-baselining: the sidecar is removed once the replayed flush lands, so the session directory matches the baseline.

## Changeset

`@enduragent/engine`, `@enduragent/core`, `@enduragent/desktop`, `cycling-coach` patch, with a `User-facing:` line.

https://claude.ai/code/session_019oR1DgG887bERqaxhgrdYT
