### PR TITLE
fix(desktop): load Electron fuse constants from the CommonJS package in the release verifier

### DIFF
--- a/.changeset/desktop-release-fuses-verifier.md
+++ b/.changeset/desktop-release-fuses-verifier.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+The macOS release lane reads the Electron fuse constants through the package's CommonJS entry points and exits non-zero when any release stage fails.

--- a/apps/desktop/scripts/macos-release-cli.mjs
+++ b/apps/desktop/scripts/macos-release-cli.mjs
@@ -26,9 +26,10 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(
   try {
     await main();
   } catch (error) {
-    process.exitCode = 1;
     const detail = safeMacosReleaseVerificationMessage(error) ?? safeMacosReleasePlanMessage(error);
     const suffix = detail === undefined ? "" : `: ${detail}`;
-    process.stderr.write(`macOS release build failed at ${activeStage}${suffix}\n`);
+    process.stderr.write(`macOS release build failed at ${activeStage}${suffix}\n`, () =>
+      process.exit(1),
+    );
   }
 }

--- a/apps/desktop/scripts/verify-electron-fuses.mjs
+++ b/apps/desktop/scripts/verify-electron-fuses.mjs
@@ -1,12 +1,11 @@
 import { lstat } from "node:fs/promises";
 import { isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  FuseState,
-  FuseV1Options,
-  FuseVersion,
-  getCurrentFuseWire,
-} from "@electron/fuses";
+import fuses from "@electron/fuses";
+import constants from "@electron/fuses/dist/constants.js";
+
+const { FuseV1Options, FuseVersion, getCurrentFuseWire } = fuses;
+const { FuseState } = constants;
 
 export const REQUIRED_ELECTRON_FUSES = Object.freeze({
   [FuseV1Options.RunAsNode]: FuseState.DISABLE,


### PR DESCRIPTION
## Summary
Desktop release 0.2.0 (run 34309605226) failed at the keychain-binding stage with no detail, and the packaging step still reported success, so the seal step failed on a missing envelope.

Root cause: `verify-electron-fuses.mjs` used named ESM imports from `@electron/fuses`, a CommonJS package whose root does not export `FuseState` (it lives in `dist/constants`). The verifier is imported lazily right after the keychain-binding stage marker, the SyntaxError is not a sanitized release error, and the CLI only set `process.exitCode`. The check was added in #703, after the last release, so this is its first live run.

Changes:
- Read `FuseV1Options`, `FuseVersion`, `getCurrentFuseWire` from the package default export and `FuseState` from `@electron/fuses/dist/constants.js`.
- The release CLI exits with status 1 after writing the failed-stage line.

## Verification
- Locally signed (not notarized) 0.2.0 build at 93531f24: keychain-binding, fuses and backend-selection verifiers pass; the staple checks can only run on the notarized CI build.
- Release-transaction and macOS release tests: 273 passed. Root `pnpm check` green.

Release tooling: needs explicit operator approval before merge. After merge the Version PR opens desktop 0.2.1; the draft release for 0.2.0 can be deleted.

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn