### PR TITLE
fix(engine): return the newest memory first and keep the matched text in previews

### DIFF
--- a/.changeset/memory-query-recent-first.md
+++ b/.changeset/memory-query-recent-first.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/engine": patch
+"@enduragent/core": patch
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: When you ask the coach about something you told it before, it finds the exact note and shows your most recent notes first.

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -751,7 +751,7 @@ export class Memory implements MemoryStore {
       `Memory query ${record.from}..${record.to}` + (queryText ? ` matching "${queryText}"` : "");
     let rendered = header;
     let all = EMPTY_PROVENANCE;
-    for (const date of [...byDate.keys()].sort()) {
+    for (const date of [...byDate.keys()].sort().reverse()) {
       rendered += `\n\n## ${date}\n`;
       const items = byDate.get(date)!;
       for (const [index, item] of items.entries()) {

--- a/packages/core/tests/memory-retrieval.test.ts
+++ b/packages/core/tests/memory-retrieval.test.ts
@@ -132,6 +132,58 @@ describe("memory retrieval", () => {
     expect(result).toContain("[truncated — narrow the date range or add a query term]");
   });
 
+  it("windows a history preview around the matched text", async () => {
+    memory.writeSection("notes", `${"x".repeat(250)} ALLERGIC TO IBUPROFEN ${"y".repeat(50)}`);
+    const query = createMemoryTools(memory, sections).memory_query;
+    const result = await query.execute!(
+      { from: "1998-03-12", to: "1998-03-12", query: "ibuprofen" },
+      options,
+    );
+    expect(result).toContain("ALLERGIC TO IBUPROFEN");
+    expect(result).toMatch(/now: …x+ ALLERGIC TO IBUPROFEN y+$/m);
+    expect(result).not.toContain("x".repeat(201));
+    expect(result).not.toContain("now: x");
+  });
+
+  it("keeps the prefix shape when the match sits near the start", async () => {
+    memory.writeSection("notes", `Tolerates caffeine ${"z".repeat(300)}`);
+    const query = createMemoryTools(memory, sections).memory_query;
+    const result = await query.execute!(
+      { from: "1998-03-12", to: "1998-03-12", query: "caffeine" },
+      options,
+    );
+    expect(result).toMatch(/now: _updated: 1998-03-12 Tolerates caffeine z+…$/m);
+    expect(result).not.toContain("now: …");
+  });
+
+  it("never splits a surrogate pair at the preview window edge", async () => {
+    const emoji = "🚴".repeat(160);
+    memory.writeSection("notes", `${emoji} hates gels! ${emoji}`);
+    const query = createMemoryTools(memory, sections).memory_query;
+    const result = await query.execute!(
+      { from: "1998-03-12", to: "1998-03-12", query: "gels" },
+      options,
+    );
+    expect(result).not.toMatch(/\p{Cs}/u);
+    expect(result).toContain("hates gels!");
+    expect(result).toMatch(/now: …(?:🚴)+ hates gels! (?:🚴)+…$/m);
+  });
+
+  it("drops the oldest dates first when the combined result overflows", async () => {
+    memory.appendDailyNote(`older ${"o".repeat(21_000)}`, "1998-03-10");
+    memory.appendDailyNote("newer note survives", "1998-03-11");
+    const result = await createMemoryTools(memory, sections).memory_query.execute!(
+      { from: "1998-03-10", to: "1998-03-11" },
+      options,
+    );
+    expect(typeof result).toBe("string");
+    if (typeof result !== "string") throw new Error("Expected query text");
+    expect(result.indexOf("## 1998-03-11")).toBeLessThan(result.indexOf("## 1998-03-10"));
+    expect(result).toContain("newer note survives");
+    expect(result).not.toContain("o".repeat(21_000));
+    expect(result).toContain("[truncated — narrow the date range or add a query term]");
+  });
+
   it("marks journal history as unknown provenance", async () => {
     memory.writeSection("profile", "Historical threshold");
     const result = await createMemoryTools(memory, sections, { bindProvenance: true })

--- a/packages/core/tests/provenance-persistence.test.ts
+++ b/packages/core/tests/provenance-persistence.test.ts
@@ -759,8 +759,8 @@ describe("memory, daily-note, plan, and ledger digest binding", () => {
     const dir = tempDir("cc-memory-query-cap-");
     try {
       const memory = new Memory(dir, "UTC");
-      memory.appendDailyNote("x".repeat(21_000), "1998-05-09", UNKNOWN);
-      memory.appendDailyNote("Garmin note beyond the cap", "1998-05-10", GARMIN);
+      memory.appendDailyNote("Garmin note beyond the cap", "1998-05-09", GARMIN);
+      memory.appendDailyNote("x".repeat(21_000), "1998-05-10", UNKNOWN);
       const input = { from: "1998-05-09", to: "1998-05-10" };
       const result = await memoryQueryResult(memory, input);
 
@@ -777,12 +777,12 @@ describe("memory, daily-note, plan, and ledger digest binding", () => {
     const dir = tempDir("cc-memory-query-raw-cutoff-");
     try {
       const memory = new Memory(dir, "UTC");
+      memory.appendDailyNote("Garmin note beyond the raw cap", "1998-05-09", GARMIN);
       memory.appendDailyNote(
         "x".repeat(19_900) + "\u0000".repeat(2_000),
-        "1998-05-09",
+        "1998-05-10",
         UNKNOWN,
       );
-      memory.appendDailyNote("Garmin note beyond the raw cap", "1998-05-10", GARMIN);
       const query = createMemoryQueryTool(memory, true);
 
       const result = await query.execute!(

--- a/packages/engine/src/sport/memory-tools.ts
+++ b/packages/engine/src/sport/memory-tools.ts
@@ -134,8 +134,26 @@ const journalEntrySchema = z.object({
   newBody: z.string(),
 });
 
-function historyBodySummary(body: string | null): string {
-  return truncateUtf16Safe((body ?? "").trim().replace(/\s+/g, " "), 200);
+const HISTORY_PREVIEW_CHARS = 200;
+
+function historyBodySummary(body: string | null, query?: string): string {
+  const text = (body ?? "").trim().replace(/\s+/g, " ");
+  if (text.length <= HISTORY_PREVIEW_CHARS) return text;
+  const match = query ? text.toLowerCase().indexOf(query) : -1;
+  if (!query || match < 0) return truncateUtf16Safe(text, HISTORY_PREVIEW_CHARS);
+  let start = Math.max(
+    0,
+    Math.min(
+      match + Math.floor(query.length / 2) - HISTORY_PREVIEW_CHARS / 2,
+      text.length - HISTORY_PREVIEW_CHARS,
+    ),
+  );
+  const unit = text.charCodeAt(start);
+  if (unit >= 0xdc00 && unit <= 0xdfff) start -= 1;
+  const window = truncateUtf16Safe(text.slice(start), HISTORY_PREVIEW_CHARS);
+  const leading = start > 0 ? "…" : "";
+  const trailing = start + window.length < text.length ? "…" : "";
+  return `${leading}${window}${trailing}`;
 }
 
 export function createMemoryQueryTool(memory: MemoryStorePort, bindProvenance: boolean = false) {
@@ -209,7 +227,7 @@ export function createMemoryQueryTool(memory: MemoryStorePort, bindProvenance: b
           continue;
         const bucket = byDate.get(date) ?? [];
         bucket.push(
-          `history: ${historyBodySummary(section ?? op)} — was: ${historyBodySummary(oldBody)} / now: ${historyBodySummary(newBody)}`,
+          `history: ${historyBodySummary(section ?? op, q)} — was: ${historyBodySummary(oldBody, q)} / now: ${historyBodySummary(newBody, q)}`,
         );
         byDate.set(date, bucket);
       }
@@ -220,6 +238,7 @@ export function createMemoryQueryTool(memory: MemoryStorePort, bindProvenance: b
       }
       const sections = [...byDate.keys()]
         .sort()
+        .reverse()
         .map((d) => `## ${d}\n${byDate.get(d)!.join("\n")}`);
       const result = [header, ...sections].join("\n\n");
       const truncated = result.length > MEMORY_QUERY_MAX_RESULT_CHARS;


### PR DESCRIPTION
## Problem

`memory_query` sorted date sections ascending and then truncated the tail at the 20,000-character cap, so when a query overflowed, the newest days were the ones dropped — exactly the days an athlete asking "what did I tell you recently" needs. The notice told the model to narrow the date range, which could not recover them.

Separately, `historyBodySummary` rendered a 200-character prefix of each journaled section body while the query filter matched on the full body. A section body of 250 filler characters followed by `ALLERGIC TO IBUPROFEN`, queried with `ibuprofen`, returned a history hit whose preview did not contain the word and carried no omission marker, so the coach answered "no record".

## Change

- Date sections render newest first, so an overflow cuts the oldest days. The cap and the notice stay; the notice is still accurate (raising `from` now drops days the athlete is least likely to want).
- The store's provenance mirror (`provenanceForToolRead` for `memory_query`) renders in the same order. It uses visible-character offsets to decide which items count under truncation, so it has to agree with the tool's order or provenance would be attributed to hidden dates.
- When a query term is set, the history preview windows around the first match: same 200-character body budget, centred on the match, shifted to the body edges when the match sits near either end, with `…` on any side that was cut. Window edges back off a UTF-16 low surrogate on the left and use `truncateUtf16Safe` on the right. Without a query term, or when the term does not occur in the normalised body, the prefix behaviour is unchanged.
- Tool description untouched, so the template hash and s8a supersession register are unaffected.

## Tests

`packages/core/tests/memory-retrieval.test.ts` gains four cases: match at offset 250 appears with a leading `…`; match near the start keeps the prefix shape with a trailing `…`; an emoji body around both window edges yields no lone surrogate; two dates over the cap keep the newer date and cut the older. All four fail against the previous implementation.

Two existing tests in `packages/core/tests/provenance-persistence.test.ts` ("does not count a Garmin note hidden by memory-query truncation" and "uses raw offsets when sanitizable text precedes a truncated Garmin note") pinned the ascending order by placing the oversized note on the earlier date. Their dates are swapped so the Garmin note is still the one beyond the cap; the assertions are unchanged.

## Limits

- `HISTORY_PREVIEW_CHARS = 200` — names the existing 200-character history preview budget; value unchanged.

## Verification

- `pnpm vitest run packages/core/tests/memory-retrieval.test.ts packages/core/tests/memory-query.test.ts packages/core/tests/provenance-persistence.test.ts` → 56 passed
- `pnpm -r build` → exit 0
- `pnpm s8a` → exit 0, all 12 scenarios replay; the A3 warnings are the pre-existing documented supersession S8A-SUP-014. No fixture returns more than one date or a matched body over 200 characters, so no re-record was needed.
- root `pnpm check` → exit 0

https://claude.ai/code/session_019oR1DgG887bERqaxhgrdYT
