### PR TITLE
fix(desktop): place the pending commitment card under the Plan creation progress card

### DIFF
--- a/.changeset/plan-creation-commitment-card-order.md
+++ b/.changeset/plan-creation-commitment-card-order.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: When a typed commitment needs clarifying, the Clarify your commitment card now sits right under the Plan creation progress card, next to the Build Draft button it holds back.

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -266,8 +266,9 @@ export function PlanCreationConversation(props: {
   return (
     <section className="grid min-w-0 gap-4" aria-label="Plan creation">
       <Notice inPlanCreation />
-      <PlanCreationCommitmentCard model={props.model} />
+      {props.model.draft === null ? null : <PlanCreationCommitmentCard model={props.model} />}
       <PlanCreationConversationContent model={props.model} />
+      {props.model.draft === null ? <PlanCreationCommitmentCard model={props.model} /> : null}
     </section>
   );
 }

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -3328,6 +3328,10 @@ describe("chat surface", () => {
       });
       render(<Harness />);
       const correction = screen.getByRole("region", { name: "Clarify your commitment" });
+      const progress = screen.getByRole("region", { name: "Plan Creation progress" });
+      expect(
+        progress.compareDocumentPosition(correction) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).not.toBe(0);
       expect(within(correction).getByRole("rowheader", { name: "Not understood" })).toBeVisible();
       expect(within(correction).queryByRole("button", { name: "Confirm limits" })).toBeNull();
       const editor = screen.getByRole("textbox", { name: "Commitments or time off" });


### PR DESCRIPTION
## Summary
Seen in the production 0.3.0 build: after typing a commitment the interpreter could not read (`ignore`), Build Draft was disabled with no visible reason. The `Clarify your commitment` card that explains it rendered at the top of the Plan creation section, above eight answer cards, out of view. The prototype renders the pending commitment card after the progress card.

Change: while no Draft exists the card follows the progress card (directly under Build Draft); once a Draft exists it stays ahead of the Draft cards as before. A renderer test asserts the DOM order.

## Verification
- renderer-dom 762 passed (one unrelated focus-trap flake passes in isolation)
- desktop E2E plan-creation-commitments + slice3: 14 passed
- root `pnpm check` green

https://claude.ai/code/session_018vUkD32TycpxL1PXxPQUvn