### PR TITLE
feat(desktop): render Settings preferences and the first-launch language screen from catalogs

### DIFF
--- a/.changeset/renderer-language-wiring.md
+++ b/.changeset/renderer-language-wiring.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop-renderer": minor
+"@enduragent/desktop": minor
+"@enduragent/i18n": minor
+---
+
+User-facing: On first launch the app asks for your language when your computer's language is not one it speaks, and Settings preferences now show in your chosen language.

--- a/apps/desktop-renderer/src/app/App.tsx
+++ b/apps/desktop-renderer/src/app/App.tsx
@@ -2,10 +2,17 @@ import { useEffect, type ReactElement } from "react";
 import { useEnduragentStore } from "../state/store";
 import { DARK_MEDIA_QUERY } from "@enduragent/ui";
 import { Shell } from "./Shell";
+import { LanguageProvider } from "@enduragent/i18n/react";
+import { rendererLocale, resolvedLanguageTag } from "../language";
 
 export function App(props: { readonly onReady: () => void }): ReactElement {
   const appearance = useEnduragentStore((state) => state.appearance);
   const refreshTheme = useEnduragentStore((state) => state.refreshTheme);
+  const tag = useEnduragentStore(resolvedLanguageTag);
+
+  useEffect(() => {
+    document.documentElement.lang = tag;
+  }, [tag]);
 
   useEffect(() => {
     if (appearance !== "system" || typeof matchMedia !== "function") return;
@@ -19,5 +26,9 @@ export function App(props: { readonly onReady: () => void }): ReactElement {
     };
   }, [appearance, refreshTheme]);
 
-  return <Shell onReady={props.onReady} />;
+  return (
+    <LanguageProvider tag={tag} locale={rendererLocale(tag)}>
+      <Shell onReady={props.onReady} />
+    </LanguageProvider>
+  );
 }

--- a/apps/desktop-renderer/src/app/SetupGate.tsx
+++ b/apps/desktop-renderer/src/app/SetupGate.tsx
@@ -6,6 +6,7 @@ export function SetupGate(): ReactElement {
     <main
       className="grid min-h-0 place-items-center overflow-auto px-6 pt-10 pb-14"
       aria-labelledby="setup-panel-title"
+      lang="en"
     >
       <SetupPanel placement="gate" />
     </main>

--- a/apps/desktop-renderer/src/app/Shell.tsx
+++ b/apps/desktop-renderer/src/app/Shell.tsx
@@ -6,10 +6,13 @@ import { clearTrainingRestrictionFocusRequest } from "../ui/settings/restriction
 import { Sidebar } from "../ui/sidebar/Sidebar";
 import { SetupGate } from "./SetupGate";
 import { REACT_CHAT_REGION, VIEWS } from "./views";
+import { languageRequired } from "../language";
+import { LanguageGate } from "../ui/onboarding/LanguageGate";
 
 export function Shell(props: { readonly onReady: () => void }): ReactElement {
   const activeView = useEnduragentStore((state) => state.activeView);
   const disposition = useEnduragentStore(setupDisposition);
+  const needsLanguage = useEnduragentStore(languageRequired);
   const onboardingStartupSettled = useEnduragentStore((state) => state.onboardingStartupSettled);
   const onReady = props.onReady;
   const onboardingState = onboardingStartupSettled ? "settled" : "pending";
@@ -32,7 +35,13 @@ export function Shell(props: { readonly onReady: () => void }): ReactElement {
       data-view={activeView}
       data-onboarding={onboardingState}
       data-shell={
-        disposition === "unknown" ? "unknown" : disposition === "required" ? "gate" : "app"
+        needsLanguage
+          ? "language"
+          : disposition === "unknown"
+            ? "unknown"
+            : disposition === "required"
+              ? "gate"
+              : "app"
       }
     >
       {disposition === "unknown" ? (
@@ -41,11 +50,16 @@ export function Shell(props: { readonly onReady: () => void }): ReactElement {
           role="status"
           aria-live="polite"
           aria-busy="true"
+          lang="en"
         >
           Checking setup…
         </div>
       ) : disposition === "required" ? (
-        <SetupGate />
+        needsLanguage ? (
+          <LanguageGate />
+        ) : (
+          <SetupGate />
+        )
       ) : (
         <>
           <Sidebar />

--- a/apps/desktop-renderer/src/language.ts
+++ b/apps/desktop-renderer/src/language.ts
@@ -1,0 +1,27 @@
+import type { LanguageTag } from "@enduragent/coach-contract";
+import { describeLanguage, normalizeLocaleHint } from "@enduragent/i18n";
+import { setupDisposition } from "./state/onboarding-slice";
+import type { EnduragentState } from "./state/store";
+
+export function resolvedLanguageTag(state: Pick<EnduragentState, "settings">): LanguageTag {
+  const language = state.settings.language;
+  const fallback = normalizeLocaleHint(navigator.languages) ?? "en";
+  return language.status === "loading" ? fallback : (language.value ?? fallback);
+}
+
+export function rendererLocale(tag: LanguageTag): string {
+  try {
+    const locale = Intl.getCanonicalLocales(navigator.language.trim().replaceAll("_", "-"))[0];
+    if (locale !== undefined) return locale;
+  } catch {}
+  return describeLanguage(tag).defaultLocale;
+}
+
+export function languageRequired(state: Pick<EnduragentState, "onboarding" | "settings">): boolean {
+  return (
+    setupDisposition(state) === "required" &&
+    (state.settings.language.status === "ready" || state.settings.language.status === "saving") &&
+    state.settings.language.value === null &&
+    normalizeLocaleHint(navigator.languages) === undefined
+  );
+}

--- a/apps/desktop-renderer/src/onboarding/controller.ts
+++ b/apps/desktop-renderer/src/onboarding/controller.ts
@@ -13,10 +13,7 @@ import type {
   OnboardingLlmEndpointSelection,
   OnboardingLlmSelection,
 } from "./bridge";
-import {
-  CUSTOM_MODEL_SELECTION,
-  DESKTOP_CREDENTIAL_SLOTS,
-} from "./constants";
+import { CUSTOM_MODEL_SELECTION, DESKTOP_CREDENTIAL_SLOTS } from "./constants";
 import { handoffCredential, type CredentialDraftPort } from "./credentials";
 import type { SetupCommit } from "./lanes";
 import {

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -12,11 +12,7 @@ import {
   claudeCliIdentityLine,
   claudeCliPresentation,
 } from "../onboarding/credential-presentation";
-import type {
-  ChatGptStatus,
-  ClaudeCliStatus,
-  CredentialSlotStatus,
-} from "../onboarding/machine";
+import type { ChatGptStatus, ClaudeCliStatus, CredentialSlotStatus } from "../onboarding/machine";
 
 export type CredentialKind = "Provider API key" | "ChatGPT profile" | "Training account key";
 

--- a/apps/desktop-renderer/src/state/activity-analysis-slice.ts
+++ b/apps/desktop-renderer/src/state/activity-analysis-slice.ts
@@ -1,9 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { ActivityAnalysisSection } from "@enduragent/coach-contract";
-import {
-  EMPTY_RIDE_ANALYSIS,
-  type RideAnalysisViewState,
-} from "../activity-analysis/controller";
+import { EMPTY_RIDE_ANALYSIS, type RideAnalysisViewState } from "../activity-analysis/controller";
 import type { EnduragentState } from "./store";
 
 export interface RideAnalysisActions {

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -637,8 +637,7 @@ export function createPlanViewAdapter(input: {
         action: "close",
         sourceScenarioId: model.scenarioId,
         destinationScenarioId: model.scenarioId === "PL-S079" ? "PL-S004" : "PL-S001",
-        returnFocusId:
-          model.scenarioId === "PL-S079" ? "plan-replacement-trigger" : "start-plan",
+        returnFocusId: model.scenarioId === "PL-S079" ? "plan-replacement-trigger" : "start-plan",
       });
     },
     async submitCoach(message) {

--- a/apps/desktop-renderer/src/state/adapters/settings.ts
+++ b/apps/desktop-renderer/src/state/adapters/settings.ts
@@ -1,7 +1,4 @@
-import type {
-  AthleteSettingsState,
-  AthleteSettingsView,
-} from "../../settings/athlete-controller";
+import type { AthleteSettingsState, AthleteSettingsView } from "../../settings/athlete-controller";
 import type {
   CredentialSettingsState,
   CredentialSettingsView,
@@ -10,10 +7,7 @@ import type {
   ProviderModelSettingsState,
   ProviderModelSettingsView,
 } from "../../settings/provider-model-controller";
-import type {
-  SessionSettingsState,
-  SessionSettingsView,
-} from "../../settings/session-controller";
+import type { SessionSettingsState, SessionSettingsView } from "../../settings/session-controller";
 import {
   CLOSED_PANE,
   type AthleteSettingsPort,

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -1,11 +1,6 @@
 import { create } from "zustand";
 import type { StoredViewId } from "../app/views";
-import {
-  applyPalette,
-  resolveTheme,
-  type Appearance,
-  type ResolvedTheme,
-} from "@enduragent/ui";
+import { applyPalette, resolveTheme, type Appearance, type ResolvedTheme } from "@enduragent/ui";
 import { publishNativeAppearance } from "../theme/nativeAppearance";
 import { paletteById } from "@enduragent/ui";
 import {
@@ -15,19 +10,12 @@ import {
   writeStoredPaletteId,
 } from "../theme/preferences";
 import { createArchiveSlice, type ArchiveSlice } from "./archive-slice";
-import {
-  createActivityAnalysisSlice,
-  type ActivityAnalysisSlice,
-} from "./activity-analysis-slice";
+import { createActivityAnalysisSlice, type ActivityAnalysisSlice } from "./activity-analysis-slice";
 import { createChatSlice, type ChatSlice } from "./chat-slice";
 import { createOnboardingSlice, type OnboardingSlice } from "./onboarding-slice";
 import { createPlanSlice, type PlanSlice } from "./plan-slice";
 import { createRideImportSlice, type RideImportSlice } from "./ride-import-slice";
-import {
-  createSettingsSlice,
-  settingsMutationActive,
-  type SettingsSlice,
-} from "./settings-slice";
+import { createSettingsSlice, settingsMutationActive, type SettingsSlice } from "./settings-slice";
 import { createSyncSlice, type SyncSlice } from "./sync-slice";
 import { createTrainingSlice, type TrainingSlice } from "./training-slice";
 import { createTrainingExportSlice, type TrainingExportSlice } from "./training-export-slice";

--- a/apps/desktop-renderer/src/state/training-slice.ts
+++ b/apps/desktop-renderer/src/state/training-slice.ts
@@ -26,10 +26,7 @@ export interface TrainingSlice {
   closeRide: () => void;
 }
 
-function provesRideAbsent(
-  week: CompletedActivityWeek | null,
-  localDate: string,
-): boolean {
+function provesRideAbsent(week: CompletedActivityWeek | null, localDate: string): boolean {
   return (
     week !== null &&
     localDate >= week.window.start &&

--- a/apps/desktop-renderer/src/training-sync.ts
+++ b/apps/desktop-renderer/src/training-sync.ts
@@ -97,10 +97,7 @@ function isSameTrainingSyncState(left: TrainingSyncState, right: TrainingSyncSta
         right.status === "succeeded" &&
         right.operation === left.operation &&
         right.kind === left.kind &&
-        isSameRestrictionWindow(
-          right.droppedActivities.overall,
-          left.droppedActivities.overall,
-        ) &&
+        isSameRestrictionWindow(right.droppedActivities.overall, left.droppedActivities.overall) &&
         isSameRestrictionWindow(
           right.droppedActivities.recent7Days,
           left.droppedActivities.recent7Days,

--- a/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
@@ -25,13 +25,7 @@ import {
   type SetupLane,
 } from "../../onboarding/lanes";
 import { llmSelectionFromDraft, type LlmSelectionDraft } from "../../onboarding/selection";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@enduragent/ui";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@enduragent/ui";
 import {
   credentialChangesBlocked,
   repairRequiredCredential,

--- a/apps/desktop-renderer/src/ui/onboarding/IntakeRows.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/IntakeRows.tsx
@@ -1,12 +1,6 @@
 import type { ReactElement } from "react";
 import { Button } from "@enduragent/ui";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@enduragent/ui";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@enduragent/ui";
 import type { OnboardingActions, OnboardingSurfaceState } from "../../onboarding/controller";
 import { errorSection } from "../../onboarding/lanes";
 import { RETRY_INTAKE_SAVE_LABEL } from "./copy";

--- a/apps/desktop-renderer/src/ui/onboarding/LanguageGate.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/LanguageGate.tsx
@@ -1,0 +1,92 @@
+import type { LanguageTag } from "@enduragent/coach-contract";
+import { LANGUAGE_OPTIONS } from "@enduragent/i18n";
+import { LanguageProvider, useLanguageReady, usePhrasebook } from "@enduragent/i18n/react";
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@enduragent/ui";
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import { rendererLocale } from "../../language";
+import { useEnduragentStore } from "../../state/store";
+import { SetupCard } from "./SetupCard";
+
+const ITEMS = LANGUAGE_OPTIONS.map(({ tag, endonym }) => ({ value: tag, label: endonym }));
+
+export function LanguageGate(): ReactElement {
+  const [tag, setTag] = useState<LanguageTag>("en");
+
+  return (
+    <LanguageProvider tag={tag} locale={rendererLocale(tag)}>
+      <LanguageChoice tag={tag} onChange={setTag} />
+    </LanguageProvider>
+  );
+}
+
+function LanguageChoice(props: {
+  readonly tag: LanguageTag;
+  readonly onChange: (tag: LanguageTag) => void;
+}): ReactElement {
+  const { say, tag } = usePhrasebook();
+  const ready = useLanguageReady();
+  const status = useEnduragentStore((state) => state.settings.language.status);
+  const port = useEnduragentStore((state) => state.settingsPorts?.language ?? null);
+  const title = useRef<HTMLHeadingElement>(null);
+  const disabled = port === null || status === "loading" || status === "saving";
+
+  useEffect(() => {
+    title.current?.focus();
+  }, []);
+
+  return (
+    <main aria-labelledby="language-title" lang={tag}>
+      <div className="setup-panel absolute top-1/2 left-1/2 w-[min(420px,calc(100%-32px))] -translate-x-1/2 -translate-y-1/2">
+        <header className="mb-[22px] flex justify-center">
+          <h1
+            id="language-title"
+            ref={title}
+            tabIndex={-1}
+            className="text-center text-2xl leading-8 font-semibold tracking-tight outline-none"
+          >
+            {say("language.chooseTitle")}
+          </h1>
+        </header>
+        <SetupCard>
+          <div className="p-4">
+            <Select<LanguageTag>
+              items={ITEMS}
+              value={props.tag}
+              disabled={disabled}
+              onValueChange={(value) => {
+                if (value !== null) props.onChange(value);
+              }}
+            >
+              <SelectTrigger aria-label={say("settings.language.title")} className="w-full min-w-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ITEMS.map(({ value, label }) => (
+                  <SelectItem key={value} value={value} lang={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex justify-end border-t border-line p-4">
+            <Button
+              type="button"
+              disabled={disabled || !ready}
+              onClick={() => port?.set(props.tag)}
+            >
+              {say("language.continue")}
+            </Button>
+          </div>
+        </SetupCard>
+      </div>
+    </main>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/AppearanceControl.tsx
+++ b/apps/desktop-renderer/src/ui/settings/AppearanceControl.tsx
@@ -1,15 +1,16 @@
 import type { ReactElement } from "react";
+import { usePhrasebook } from "@enduragent/i18n/react";
 import { Button } from "@enduragent/ui";
 import { useEnduragentStore } from "../../state/store";
 import type { Appearance } from "@enduragent/ui";
 
-const OPTIONS: readonly { readonly value: Appearance; readonly label: string }[] = Object.freeze([
-  { value: "system", label: "System" },
-  { value: "light", label: "Light" },
-  { value: "dark", label: "Dark" },
-]);
-
 export function AppearanceControl(): ReactElement {
+  const { say } = usePhrasebook();
+  const options: readonly { readonly value: Appearance; readonly label: string }[] = [
+    { value: "system", label: say("settings.appearance.system") },
+    { value: "light", label: say("settings.appearance.light") },
+    { value: "dark", label: say("settings.appearance.dark") },
+  ];
   const appearance = useEnduragentStore((state) => state.appearance);
   const setAppearance = useEnduragentStore((state) => state.setAppearance);
 
@@ -17,9 +18,9 @@ export function AppearanceControl(): ReactElement {
     <div
       className="flex shrink-0 rounded-ctl border border-line bg-sunk p-0.5"
       role="group"
-      aria-label="Appearance"
+      aria-label={say("settings.appearance.title")}
     >
-      {OPTIONS.map((option) => (
+      {options.map((option) => (
         <Button
           key={option.value}
           type="button"

--- a/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
@@ -1,22 +1,13 @@
 import { useEffect, useRef, type ReactElement } from "react";
 import { Button } from "@enduragent/ui";
-import {
-  CUSTOM_MODEL_SELECTION,
-  ONBOARDING_LLM_PROVIDER_LABELS,
-} from "../../onboarding/constants";
+import { CUSTOM_MODEL_SELECTION, ONBOARDING_LLM_PROVIDER_LABELS } from "../../onboarding/constants";
 import type {
   ProviderModelFormState,
   ProviderModelSettingsState,
 } from "../../settings/provider-model-controller";
 import { settingsMutationActive } from "../../state/settings-slice";
 import { useEnduragentStore } from "../../state/store";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@enduragent/ui";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@enduragent/ui";
 import { COACH_SAVE_ERROR_COPY, COACH_VALIDATION_COPY } from "./copy";
 import { settingsStyles as styles } from "./styles";
 

--- a/apps/desktop-renderer/src/ui/settings/LanguageControl.tsx
+++ b/apps/desktop-renderer/src/ui/settings/LanguageControl.tsx
@@ -1,23 +1,24 @@
 import { LanguageTagSchema } from "@enduragent/coach-contract";
 import { LANGUAGE_OPTIONS } from "@enduragent/i18n";
+import { usePhrasebook } from "@enduragent/i18n/react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@enduragent/ui";
 import type { ReactElement } from "react";
 import { useEnduragentStore } from "../../state/store";
 import { settingsStyles as styles } from "./styles";
 
-const ITEMS = [
-  { value: "automatic", label: "Automatic" },
-  ...LANGUAGE_OPTIONS.map(({ tag, endonym }) => ({ value: tag, label: endonym })),
-];
-
 export function LanguageControl(): ReactElement {
+  const { say } = usePhrasebook();
+  const items = [
+    { value: "automatic", label: say("common.automatic") },
+    ...LANGUAGE_OPTIONS.map(({ tag, endonym }) => ({ value: tag, label: endonym })),
+  ];
   const language = useEnduragentStore((store) => store.settings.language);
   const port = useEnduragentStore((store) => store.settingsPorts?.language ?? null);
   const disabled = port === null || language.status === "loading" || language.status === "saving";
 
   return (
     <Select
-      items={ITEMS}
+      items={items}
       value={language.value ?? "automatic"}
       disabled={disabled}
       onValueChange={(value) => {
@@ -25,11 +26,11 @@ export function LanguageControl(): ReactElement {
         port?.set(value === "automatic" ? null : LanguageTagSchema.parse(value));
       }}
     >
-      <SelectTrigger className={styles.control} aria-label="Language">
+      <SelectTrigger className={styles.control} aria-label={say("settings.language.title")}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent align="end">
-        {ITEMS.map(({ value, label }) => (
+        {items.map(({ value, label }) => (
           <SelectItem key={value} value={value}>
             {label}
           </SelectItem>

--- a/apps/desktop-renderer/src/ui/settings/PreferencesSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/PreferencesSection.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { usePhrasebook } from "@enduragent/i18n/react";
 import { PLATFORM_COPY } from "../../platform-copy";
 import { useEnduragentStore } from "../../state/store";
 import { AppearanceControl } from "./AppearanceControl";
@@ -8,46 +9,51 @@ import { settingsStyles as styles } from "./styles";
 import { UnitsControl } from "./UnitsControl";
 
 export function PreferencesSection(): ReactElement {
+  const { say } = usePhrasebook();
   const units = useEnduragentStore((store) => store.settings.units);
   const language = useEnduragentStore((store) => store.settings.language);
 
   return (
     <>
-      <h2 className={styles.heading}>Preferences</h2>
-      <section className={styles.group} aria-label="Preferences">
+      <h2 className={styles.heading}>{say("settings.preferences")}</h2>
+      <section className={styles.group} aria-label={say("settings.preferences")}>
         <div className={styles.row}>
           <div className={styles.label}>
-            <div className={styles.rowTitle}>Language</div>
+            <div className={styles.rowTitle}>{say("settings.language.title")}</div>
             <div className={styles.rowDetail}>
               {language.status === "saving"
-                ? "Saving language…"
+                ? say("settings.language.saving")
                 : language.status === "unavailable"
-                  ? "Language preference unavailable"
+                  ? say("settings.language.unavailable")
                   : language.value === null
-                    ? `Automatic follows your ${PLATFORM_COPY.operatingSystem} language. The coach replies in the language you write in.`
-                    : "The app and the coach use this language."}
+                    ? say("settings.language.automaticDetail", {
+                        operatingSystem: PLATFORM_COPY.operatingSystem,
+                      })
+                    : say("settings.language.explicitDetail")}
             </div>
           </div>
           <LanguageControl />
         </div>
         <div className={styles.row}>
           <div className={styles.label}>
-            <div className={styles.rowTitle}>Units</div>
+            <div className={styles.rowTitle}>{say("settings.units.title")}</div>
             <div className={styles.rowDetail}>
               {units.status === "saving"
-                ? "Saving units…"
+                ? say("settings.units.saving")
                 : units.status === "unavailable"
-                  ? "Units preference unavailable"
-                  : "Distance and body mass follow this setting. Cycling power-to-weight remains W/kg."}
+                  ? say("settings.units.unavailable")
+                  : say("settings.units.detail")}
             </div>
           </div>
           <UnitsControl />
         </div>
         <div className={styles.row}>
           <div className={styles.label}>
-            <div className={styles.rowTitle}>Appearance</div>
+            <div className={styles.rowTitle}>{say("settings.appearance.title")}</div>
             <div className={styles.rowDetail}>
-              System follows your {PLATFORM_COPY.operatingSystem} light and dark setting
+              {say("settings.appearance.detail", {
+                operatingSystem: PLATFORM_COPY.operatingSystem,
+              })}
             </div>
           </div>
           <AppearanceControl />

--- a/apps/desktop-renderer/src/ui/settings/UnitsControl.tsx
+++ b/apps/desktop-renderer/src/ui/settings/UnitsControl.tsx
@@ -1,15 +1,15 @@
 import type { UnitsPreference } from "@enduragent/coach-contract";
 import type { ReactElement } from "react";
+import { usePhrasebook } from "@enduragent/i18n/react";
 import { Button } from "@enduragent/ui";
 import { useEnduragentStore } from "../../state/store";
 
-const OPTIONS: readonly { readonly value: UnitsPreference; readonly label: string }[] =
-  Object.freeze([
-    { value: "metric", label: "Metric" },
-    { value: "imperial", label: "Imperial" },
-  ]);
-
 export function UnitsControl(): ReactElement {
+  const { say } = usePhrasebook();
+  const options: readonly { readonly value: UnitsPreference; readonly label: string }[] = [
+    { value: "metric", label: say("settings.units.metric") },
+    { value: "imperial", label: say("settings.units.imperial") },
+  ];
   const units = useEnduragentStore((store) => store.settings.units);
   const port = useEnduragentStore((store) => store.settingsPorts?.units ?? null);
   const disabled = port === null || units.status === "loading" || units.status === "saving";
@@ -18,9 +18,9 @@ export function UnitsControl(): ReactElement {
     <div
       className="flex shrink-0 rounded-ctl border border-line bg-sunk p-0.5"
       role="group"
-      aria-label="Display units"
+      aria-label={say("settings.units.displayUnits")}
     >
-      {OPTIONS.map((option) => (
+      {options.map((option) => (
         <Button
           key={option.value}
           type="button"

--- a/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
@@ -1,13 +1,7 @@
 import type { WorkoutArchiveFormat } from "@enduragent/coach-contract";
 import { useId, useState, type ReactElement } from "react";
 import { Button } from "@enduragent/ui";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@enduragent/ui";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@enduragent/ui";
 import { useEnduragentStore } from "../../state/store";
 import {
   trainingExportStatusCopy,

--- a/apps/desktop-renderer/tests/app-appearance.test.tsx
+++ b/apps/desktop-renderer/tests/app-appearance.test.tsx
@@ -22,6 +22,8 @@ function background(): string {
 }
 
 beforeEach(() => {
+  vi.spyOn(navigator, "languages", "get").mockReturnValue(["en"]);
+  vi.spyOn(navigator, "language", "get").mockReturnValue("en-US");
   useEnduragentStore.setState({
     activeView: "chat",
     runtimeReady: true,
@@ -34,6 +36,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   useEnduragentStore.setState({
     activeView: "chat",
     chat: EMPTY_CHAT_SURFACE,
@@ -44,9 +47,10 @@ afterEach(() => {
 });
 
 describe("app appearance", () => {
-  it("re-stamps the palette when the operating system flips scheme under System", () => {
+  it("re-stamps the palette when the operating system flips scheme under System", async () => {
     const onReady = vi.fn();
     render(<App onReady={onReady} />);
+    await screen.findByLabelText("Coaching conversation");
     act(() => {
       useEnduragentStore.getState().setAppearance("system");
     });
@@ -72,8 +76,9 @@ describe("app appearance", () => {
     expect(background()).toBe(stamped("light"));
   });
 
-  it("stops listening to the operating system once the athlete pins an appearance", () => {
+  it("stops listening to the operating system once the athlete pins an appearance", async () => {
     render(<App onReady={vi.fn()} />);
+    await screen.findByLabelText("Coaching conversation");
     act(() => {
       useEnduragentStore.getState().setAppearance("system");
     });
@@ -91,8 +96,9 @@ describe("app appearance", () => {
     expect(background()).toBe(stamped("light"));
   });
 
-  it("drops the operating-system listener when the app unmounts", () => {
+  it("drops the operating-system listener when the app unmounts", async () => {
     const view = render(<App onReady={vi.fn()} />);
+    await screen.findByLabelText("Coaching conversation");
     expect(matchMediaListenerCount()).toBe(1);
 
     view.unmount();

--- a/apps/desktop-renderer/tests/card-nesting-guard.test.ts
+++ b/apps/desktop-renderer/tests/card-nesting-guard.test.ts
@@ -96,9 +96,7 @@ function importsCard(sourceFile: ts.SourceFile): boolean {
       CARD_MODULE.test(statement.moduleSpecifier.text) &&
       statement.importClause?.namedBindings !== undefined &&
       ts.isNamedImports(statement.importClause.namedBindings) &&
-      statement.importClause.namedBindings.elements.some(
-        (element) => element.name.text === "Card",
-      ),
+      statement.importClause.namedBindings.elements.some((element) => element.name.text === "Card"),
   );
 }
 
@@ -174,7 +172,13 @@ async function scanRenderer(): Promise<Violation[]> {
   const violations = await Promise.all(
     files.map(async (path) => {
       const source = await readFile(path, "utf8");
-      const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TSX);
+      const sourceFile = ts.createSourceFile(
+        path,
+        source,
+        ts.ScriptTarget.ESNext,
+        true,
+        ts.ScriptKind.TSX,
+      );
       return collectViolations(sourceFile, relative(sourceRoot, path).split(sep).join("/"));
     }),
   );

--- a/apps/desktop-renderer/tests/credential-presentation.test.ts
+++ b/apps/desktop-renderer/tests/credential-presentation.test.ts
@@ -70,7 +70,9 @@ describe("claude subscription status presentation", () => {
   it("withholds an identity for every unready state", () => {
     for (const state of CLAUDE_CLI_STATES) {
       if (state === "ready" || state === "ready-api-key") continue;
-      expect(claudeCliIdentityLine({ state, email: "athlete@example.test", plan: "Max" })).toBeNull();
+      expect(
+        claudeCliIdentityLine({ state, email: "athlete@example.test", plan: "Max" }),
+      ).toBeNull();
     }
   });
 

--- a/apps/desktop-renderer/tests/language-harness.tsx
+++ b/apps/desktop-renderer/tests/language-harness.tsx
@@ -1,0 +1,21 @@
+import { LanguageProvider } from "@enduragent/i18n/react";
+import { render, waitFor, type RenderResult } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { expect } from "vitest";
+import { rendererLocale, resolvedLanguageTag } from "../src/language";
+import { useEnduragentStore } from "../src/state/store";
+
+function TestLanguageProvider({ children }: { readonly children: ReactNode }): ReactElement {
+  const tag = useEnduragentStore(resolvedLanguageTag);
+  return (
+    <LanguageProvider tag={tag} locale={rendererLocale(tag)}>
+      {children}
+    </LanguageProvider>
+  );
+}
+
+export async function renderWithLanguage(element: ReactElement): Promise<RenderResult> {
+  const view = render(element, { wrapper: TestLanguageProvider });
+  await waitFor(() => expect(view.container.firstChild).not.toBeNull());
+  return view;
+}

--- a/apps/desktop-renderer/tests/language-provider.test.tsx
+++ b/apps/desktop-renderer/tests/language-provider.test.tsx
@@ -1,0 +1,97 @@
+import { LanguageProvider, useLanguageReady, usePhrasebook } from "@enduragent/i18n/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+
+function PhrasebookConsumer() {
+  const phrasebook = usePhrasebook();
+  const ready = useLanguageReady();
+  const [draft, setDraft] = useState("");
+  return (
+    <>
+      <p data-ready={ready}>{phrasebook.say("language.chooseTitle")}</p>
+      <output>{phrasebook.format.number(12345.5)}</output>
+      <input aria-label="Draft" value={draft} onChange={(event) => setDraft(event.target.value)} />
+    </>
+  );
+}
+
+describe("LanguageProvider", () => {
+  it("renders nothing until its first catalog is ready", async () => {
+    const { container } = render(
+      <LanguageProvider tag="en" locale="en-GB">
+        <PhrasebookConsumer />
+      </LanguageProvider>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(await screen.findByText("Choose your language")).toHaveAttribute("data-ready", "true");
+  });
+
+  it("keeps local drafts while replacing a loaded phrasebook and locale", async () => {
+    const { rerender } = render(
+      <LanguageProvider tag="en" locale="en-GB">
+        <PhrasebookConsumer />
+      </LanguageProvider>,
+    );
+    const draft = await screen.findByRole("textbox", { name: "Draft" });
+    await userEvent.type(draft, "Saved draft");
+
+    rerender(
+      <LanguageProvider tag="it" locale="it-IT">
+        <PhrasebookConsumer />
+      </LanguageProvider>,
+    );
+    expect(screen.getByRole("textbox", { name: "Draft" })).toBe(draft);
+    expect(screen.getByText("Choose your language")).toHaveAttribute("data-ready", "false");
+    expect(await screen.findByText("Scegli la tua lingua")).toHaveAttribute("data-ready", "true");
+    expect(draft).toHaveValue("Saved draft");
+    expect(screen.getByRole("status")).toHaveTextContent("12.345,5");
+
+    rerender(
+      <LanguageProvider tag="it" locale="en-GB">
+        <PhrasebookConsumer />
+      </LanguageProvider>,
+    );
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("12,345.5"));
+    expect(draft).toHaveValue("Saved draft");
+  });
+
+  it("isolates a nested highlighted language from the application language", async () => {
+    render(
+      <LanguageProvider tag="en" locale="en-GB">
+        <PhrasebookConsumer />
+        <LanguageProvider tag="ja" locale="ja-JP">
+          <PhrasebookConsumer />
+        </LanguageProvider>
+      </LanguageProvider>,
+    );
+
+    expect(await screen.findByText("Choose your language")).toBeVisible();
+    expect(await screen.findByText("言語を選んでください")).toBeVisible();
+  });
+
+  it("settles on the last requested language after rapid changes", async () => {
+    const { rerender } = render(
+      <LanguageProvider tag="en" locale="en-GB">
+        <PhrasebookConsumer />
+      </LanguageProvider>,
+    );
+    await screen.findByText("Choose your language");
+
+    rerender(
+      <LanguageProvider tag="it" locale="it-IT">
+        <PhrasebookConsumer />
+      </LanguageProvider>,
+    );
+    rerender(
+      <LanguageProvider tag="ja" locale="ja-JP">
+        <PhrasebookConsumer />
+      </LanguageProvider>,
+    );
+
+    expect(await screen.findByText("言語を選んでください")).toHaveAttribute("data-ready", "true");
+    expect(screen.queryByText("Scegli la tua lingua")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop-renderer/tests/language.test.ts
+++ b/apps/desktop-renderer/tests/language.test.ts
@@ -1,0 +1,68 @@
+import type { LanguageTag } from "@enduragent/coach-contract";
+import { describeLanguage } from "@enduragent/i18n";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { languageRequired, rendererLocale, resolvedLanguageTag } from "../src/language";
+import { READY_ONBOARDING } from "../src/state/onboarding-slice";
+import { EMPTY_SETTINGS_SURFACE } from "../src/state/settings-slice";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("renderer language", () => {
+  it.each([
+    { saved: "ja", languages: ["it-IT"], expected: "ja" },
+    { saved: null, languages: ["it-IT"], expected: "it" },
+    { saved: null, languages: ["uk"], expected: "en" },
+    { saved: null, languages: ["uk", "ja-JP"], expected: "ja" },
+    { saved: null, languages: [], expected: "en" },
+  ] satisfies { saved: LanguageTag | null; languages: string[]; expected: LanguageTag }[])(
+    "resolves $saved with $languages to $expected",
+    ({ saved, languages, expected }) => {
+      vi.stubGlobal("navigator", { languages });
+      expect(
+        resolvedLanguageTag({
+          settings: { ...EMPTY_SETTINGS_SURFACE, language: { status: "ready", value: saved } },
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("uses the OS fallback while the preference is loading", () => {
+    vi.stubGlobal("navigator", { languages: ["it-IT"] });
+    expect(
+      resolvedLanguageTag({
+        settings: { ...EMPTY_SETTINGS_SURFACE, language: { status: "loading", value: "ja" } },
+      }),
+    ).toBe("it");
+  });
+
+  it.each([
+    { status: "loading", value: null, languages: ["uk"], expected: false },
+    { status: "unavailable", value: null, languages: ["uk"], expected: false },
+    { status: "ready", value: null, languages: ["uk"], expected: true },
+    { status: "saving", value: null, languages: ["uk"], expected: true },
+    { status: "ready", value: "it", languages: ["uk"], expected: false },
+    { status: "ready", value: null, languages: ["it-IT"], expected: false },
+  ] as const)(
+    "requires the language screen only for a ready null preference and an unsupported OS ($status, $value, $languages)",
+    ({ status, value, languages, expected }) => {
+      vi.stubGlobal("navigator", { languages });
+      expect(
+        languageRequired({
+          onboarding: { ...READY_ONBOARDING, completionRequired: true },
+          settings: { ...EMPTY_SETTINGS_SURFACE, language: { status, value } },
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it.each([
+    ["en_us", "en-US"],
+    ["it-it", "it-IT"],
+    ["uk-UA", "uk-UA"],
+    ["", describeLanguage("ja").defaultLocale],
+    ["invalid locale", describeLanguage("ja").defaultLocale],
+  ])("normalizes locale %s to %s independently of the language", (language, expected) => {
+    vi.stubGlobal("navigator", { language });
+    expect(rendererLocale("ja")).toBe(expected);
+  });
+});

--- a/apps/desktop-renderer/tests/onboarding-harness.tsx
+++ b/apps/desktop-renderer/tests/onboarding-harness.tsx
@@ -165,11 +165,7 @@ const SETUP_OPTION_LABELS: Readonly<Record<string, Readonly<Record<string, strin
   },
 };
 
-export async function selectSetupOption(
-  user: UserEvent,
-  id: string,
-  value: string,
-): Promise<void> {
+export async function selectSetupOption(user: UserEvent, id: string, value: string): Promise<void> {
   const label = SETUP_OPTION_LABELS[id]?.[value] ?? value;
   await user.click(control(id));
   await user.click(await screen.findByRole("option", { name: label }));

--- a/apps/desktop-renderer/tests/onboarding-secret-boundary.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-secret-boundary.test.tsx
@@ -200,9 +200,7 @@ describe("mounted onboarding secret boundary", () => {
     const user = userEvent.setup();
     const gate = deferred();
     const rpc: unknown[] = [];
-    expectTypeOf<IntervalsCredentialMutationResult>().toEqualTypeOf<
-      ExpectedIntervalsCredentialMutationResult
-    >();
+    expectTypeOf<IntervalsCredentialMutationResult>().toEqualTypeOf<ExpectedIntervalsCredentialMutationResult>();
     const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
     bridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
     bridge.credentialStatuses.mockResolvedValue([

--- a/apps/desktop-renderer/tests/onboarding-settings-mutation-gate.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-settings-mutation-gate.test.tsx
@@ -4,12 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { onboardingCredentialMutationsBlocked } from "../src/boot";
 import { useEnduragentStore } from "../src/state/store";
 import { SetupPanel } from "../src/ui/onboarding/OnboardingWizard";
-import {
-  mountWizard,
-  primaryButton,
-  resetOnboardingStore,
-  testBridge,
-} from "./onboarding-harness";
+import { mountWizard, primaryButton, resetOnboardingStore, testBridge } from "./onboarding-harness";
 
 const SAVED_INTAKE = {
   swim_skill_floor: null,

--- a/apps/desktop-renderer/tests/provider-model-settings.test.ts
+++ b/apps/desktop-renderer/tests/provider-model-settings.test.ts
@@ -421,12 +421,10 @@ describe("provider and model settings controller", () => {
   it("closes Settings before opening Setup for credential recovery", async () => {
     const sequence: string[] = [];
     const { controller, subject } = createSubject({
-      apply: vi.fn(
-        async (): Promise<OnboardingLlmSelectionResult> => ({
-          status: "refused",
-          reason: "credential-required",
-        }),
-      ),
+      apply: vi.fn(async (): Promise<OnboardingLlmSelectionResult> => ({
+        status: "refused",
+        reason: "credential-required",
+      })),
       openSetup: () => sequence.push("setup"),
     });
     vi.mocked(subject.view.close).mockImplementation(() => sequence.push("close"));

--- a/apps/desktop-renderer/tests/settings-preferences.test.tsx
+++ b/apps/desktop-renderer/tests/settings-preferences.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsView } from "../src/ui/settings/SettingsView";
 import { useEnduragentStore } from "../src/state/store";
 import { PALETTES } from "@enduragent/ui";
 import { APPEARANCE_STORAGE_KEY, PALETTE_STORAGE_KEY } from "../src/theme/preferences";
 import { setPrefersDark } from "./matchmedia";
+import { renderWithLanguage } from "./language-harness";
 
 function resetStore(): void {
   useEnduragentStore.setState({ paletteId: "patrol", appearance: "system", theme: "light" });
@@ -13,11 +14,17 @@ function resetStore(): void {
 
 describe("settings preferences", () => {
   beforeEach(() => {
+    vi.spyOn(navigator, "languages", "get").mockReturnValue(["en"]);
+    vi.spyOn(navigator, "language", "get").mockReturnValue("en-US");
     resetStore();
   });
 
-  it("offers one swatch per palette and marks the active one", () => {
-    render(<SettingsView />);
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("offers one swatch per palette and marks the active one", async () => {
+    await renderWithLanguage(<SettingsView />);
 
     const swatches = screen.getAllByRole("button", { name: /^Use the .+ palette$/u });
     expect(swatches).toHaveLength(PALETTES.length);
@@ -34,7 +41,7 @@ describe("settings preferences", () => {
 
   it("applies and persists a palette choice", async () => {
     const user = userEvent.setup();
-    render(<SettingsView />);
+    await renderWithLanguage(<SettingsView />);
 
     await user.click(screen.getByRole("button", { name: "Use the Cobalt palette" }));
 
@@ -53,7 +60,7 @@ describe("settings preferences", () => {
 
   it("applies and persists an appearance choice", async () => {
     const user = userEvent.setup();
-    render(<SettingsView />);
+    await renderWithLanguage(<SettingsView />);
     const group = screen.getByRole("group", { name: "Appearance" });
 
     await user.click(screen.getByRole("button", { name: "Dark" }));
@@ -72,7 +79,7 @@ describe("settings preferences", () => {
 
   it("follows the system colour scheme when the appearance is System", async () => {
     const user = userEvent.setup();
-    render(<SettingsView />);
+    await renderWithLanguage(<SettingsView />);
 
     setPrefersDark(true);
     await user.click(screen.getByRole("button", { name: "System" }));

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -1,9 +1,13 @@
 import { LANGUAGE_OPTIONS } from "@enduragent/i18n";
 import type { CoachClient } from "@enduragent/coach-client";
-import type { RuntimeConfigSnapshot, SpendSummary } from "@enduragent/coach-contract";
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import type { LanguageTag, RuntimeConfigSnapshot, SpendSummary } from "@enduragent/coach-contract";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithLanguage as render } from "./language-harness";
+import { App } from "../src/app/App";
+import { createPhrasebook } from "@enduragent/i18n/messages";
+import { describeLanguage } from "@enduragent/i18n";
 import { Shell } from "../src/app/Shell";
 import type { DesktopCoachClientProvider } from "../src/coach-client";
 import type {
@@ -49,7 +53,7 @@ import { createTelegramSettingsAdapter } from "../src/state/adapters/telegram";
 import { createUpdateSettingsAdapter } from "../src/state/adapters/update";
 import { credentialDrafts } from "../src/state/credential-drafts";
 import { CLOSED_PANE, EMPTY_SETTINGS_SURFACE } from "../src/state/settings-slice";
-import { READY_ONBOARDING, setupReady } from "../src/state/onboarding-slice";
+import { CLOSED_ONBOARDING, READY_ONBOARDING, setupReady } from "../src/state/onboarding-slice";
 import { useEnduragentStore } from "../src/state/store";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice";
 import type { TrainingSyncDroppedActivities } from "../src/training-sync";
@@ -247,9 +251,10 @@ function createHarness(options: HarnessOptions = {}) {
     close: async () => {},
   };
 
-  const restartToUpdate = vi.fn(
-    async (): Promise<DesktopUpdateState> => ({ status: "installing", version: "9.9.9" }),
-  );
+  const restartToUpdate = vi.fn(async (): Promise<DesktopUpdateState> => ({
+    status: "installing",
+    version: "9.9.9",
+  }));
   const checkForUpdates = vi.fn(async (): Promise<DesktopUpdateState> => ({ status: "current" }));
   const applyLlmSelection = vi.fn(
     options.applyLlmSelection ??
@@ -479,6 +484,8 @@ function createHarness(options: HarnessOptions = {}) {
 let harness: ReturnType<typeof createHarness> | undefined;
 
 beforeEach(() => {
+  vi.spyOn(navigator, "languages", "get").mockReturnValue(["en"]);
+  vi.spyOn(navigator, "language", "get").mockReturnValue("en-GB");
   const configuration = llmConfiguration();
   const provider = configuration.providers[0]!;
   const statuses = [
@@ -536,6 +543,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   harness?.dispose();
   harness = undefined;
   useEnduragentStore.setState({
@@ -549,7 +557,7 @@ afterEach(() => {
 
 async function renderSettings(options: HarnessOptions = {}) {
   harness = createHarness(options);
-  render(<SettingsView />);
+  await render(<SettingsView />);
   await screen.findByRole("button", { name: "Save coach route" });
   await waitFor(() => {
     expect(useEnduragentStore.getState().settings.coach.status).toBe("ready");
@@ -560,7 +568,7 @@ async function renderSettings(options: HarnessOptions = {}) {
 }
 
 describe("training restriction repair", () => {
-  it("shows the repair card only while Strava restrictions exist", () => {
+  it("shows the repair card only while Strava restrictions exist", async () => {
     useEnduragentStore.setState({
       sync: toManualSyncViewState({
         status: "succeeded",
@@ -569,7 +577,7 @@ describe("training restriction repair", () => {
         droppedActivities: stravaDroppedActivities(),
       }),
     });
-    render(<SettingsView />);
+    await render(<SettingsView />);
 
     const settings = screen.getByRole("region", { name: "Settings" });
     const notice = settings.querySelector("#strava-restricted-activities");
@@ -598,7 +606,7 @@ describe("training restriction repair", () => {
 
   it("focuses the Settings heading when a pending request has no repair card", async () => {
     requestTrainingRestrictionFocus();
-    render(<SettingsView />);
+    await render(<SettingsView />);
 
     const heading = screen.getByRole("heading", { level: 1, name: "Settings" });
     await waitFor(() => {
@@ -606,8 +614,8 @@ describe("training restriction repair", () => {
     });
   });
 
-  it("leaves focus alone on an ordinary Settings mount", () => {
-    render(<SettingsView />);
+  it("leaves focus alone on an ordinary Settings mount", async () => {
+    await render(<SettingsView />);
 
     const heading = screen.getByRole("heading", { level: 1, name: "Settings" });
     expect(heading).not.toHaveFocus();
@@ -618,14 +626,12 @@ describe("settings setup inventory", () => {
   it("reloads a stale credential inventory before confirming an Intervals deletion", async () => {
     const user = userEvent.setup();
     let intervalsConnected = false;
-    const loadCredentialStatuses = vi.fn(
-      async (): Promise<readonly CredentialSlotStatus[]> => [
-        { slot: "anthropic", state: "configured", runtimeState: "active" },
-        ...(intervalsConnected
-          ? ([{ slot: "intervals-icu", state: "configured", runtimeState: "active" }] as const)
-          : []),
-      ],
-    );
+    const loadCredentialStatuses = vi.fn(async (): Promise<readonly CredentialSlotStatus[]> => [
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+      ...(intervalsConnected
+        ? ([{ slot: "intervals-icu", state: "configured", runtimeState: "active" }] as const)
+        : []),
+    ]);
     const bridge = testBridge(async () => ({ status: "configured", runtimeReady: true }));
     bridge.credentialStatuses.mockImplementation(loadCredentialStatuses);
     bridge.pasteIntervalsApiKeyFromClipboard.mockImplementation(async () => {
@@ -1060,7 +1066,7 @@ describe("settings lifecycle", () => {
           await resetContinuation.promise;
         },
       });
-      render(<Shell onReady={() => {}} />);
+      await render(<Shell onReady={() => {}} />);
       await screen.findByRole("button", { name: "Save coach route" });
 
       await user.click(screen.getByRole("button", { name: "Remove all credentials" }));
@@ -1141,7 +1147,7 @@ describe("settings lifecycle", () => {
 
   it("keeps the resident Telegram controller active when Settings unmounts and remounts", async () => {
     harness = createHarness();
-    const view = render(<SettingsView />);
+    const view = await render(<SettingsView />);
     await screen.findByRole("button", { name: "Save coach route" });
     await waitFor(() => {
       expect(useEnduragentStore.getState().settings.conversation.status).toBe("ready");
@@ -1167,7 +1173,7 @@ describe("settings lifecycle", () => {
     expect(harness.telegramController.state()).toBe(telegram);
     expect(harness.cancelTelegramPoll).not.toHaveBeenCalled();
 
-    render(<SettingsView />);
+    await render(<SettingsView />);
     await waitFor(() => {
       expect(useEnduragentStore.getState().settings.conversation.status).toBe("ready");
     });
@@ -1813,7 +1819,7 @@ describe("credential deletion", () => {
         reason: "storage-uncertain",
       }),
     });
-    const firstVisit = render(<SettingsView />);
+    const firstVisit = await render(<SettingsView />);
     await waitFor(() => {
       expect(useEnduragentStore.getState().settings.credentials.status).toBe("ready");
     });
@@ -1831,7 +1837,7 @@ describe("credential deletion", () => {
     });
     expect(setupReady(useEnduragentStore.getState())).toBe(false);
 
-    render(<SettingsView />);
+    await render(<SettingsView />);
     await waitFor(() => expect(loadCredentialStatuses).toHaveBeenCalledTimes(2));
     expect(useEnduragentStore.getState().settings.credentials).toMatchObject({
       status: "loading",
@@ -2161,9 +2167,7 @@ it("renders Language above Units with Automatic and registry endonyms", async ()
     useEnduragentStore.getState().patchSettings({ language: { status: "ready", value: null } }),
   );
   const preferences = screen.getByRole("region", { name: "Preferences" });
-  expect(
-    within(preferences).getByText(/^Automatic follows your macOS language/),
-  ).toBeVisible();
+  expect(within(preferences).getByText(/^Automatic follows your macOS language/)).toBeVisible();
   expect(
     [...preferences.querySelectorAll(".settings-row-title")].map((row) => row.textContent),
   ).toEqual(["Language", "Units", "Appearance"]);
@@ -2183,7 +2187,7 @@ it("renders Language above Units with Automatic and registry endonyms", async ()
   );
   expect(select).toHaveTextContent("Français");
   await userEvent.click(select);
-  await userEvent.click(await screen.findByRole("option", { name: "Automatic" }));
+  await userEvent.click(await screen.findByRole("option", { name: "Automatique" }));
   expect(port?.set).toHaveBeenLastCalledWith(null);
 });
 
@@ -2205,4 +2209,138 @@ it("disables Language while loading, saving, or unbound and preserves unavailabl
   expect(select).toHaveTextContent("日本語");
   act(() => useEnduragentStore.getState().bindSettingsPorts(null));
   expect(select).toBeDisabled();
+});
+
+describe("catalog preferences", () => {
+  it.each([
+    { value: "it", languages: ["en"], tag: "it" },
+    { value: null, languages: ["en"], tag: "en" },
+    { value: null, languages: ["it-IT"], tag: "it" },
+  ] satisfies { value: LanguageTag | null; languages: string[]; tag: LanguageTag }[])(
+    "renders $tag preferences with saved $value and OS $languages",
+    async ({ value, languages, tag }) => {
+      vi.spyOn(navigator, "languages", "get").mockReturnValue(languages);
+      useEnduragentStore.getState().patchSettings({ language: { status: "ready", value } });
+      await renderSettings();
+      const { say } = await createPhrasebook({ tag, locale: describeLanguage(tag).defaultLocale });
+      const preferences = within(screen.getByRole("region", { name: say("settings.preferences") }));
+      expect(preferences.getByText(say("settings.language.title"))).toBeVisible();
+      expect(preferences.getByText(say("settings.units.title"))).toBeVisible();
+      expect(preferences.getByText(say("settings.appearance.title"))).toBeVisible();
+      expect(preferences.getByRole("button", { name: say("settings.units.metric") })).toBeVisible();
+      expect(
+        preferences.getByRole("button", { name: say("settings.appearance.dark") }),
+      ).toBeVisible();
+      expect(preferences.getByRole("combobox")).toHaveTextContent(
+        value === null ? say("common.automatic") : describeLanguage(value).endonym,
+      );
+      expect(useEnduragentStore.getState().settings.language.value).toBe(value);
+      expect(useEnduragentStore.getState().settingsPorts?.language.set).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe("first launch language", () => {
+  it.each([
+    { disposition: "required", value: null, languages: ["uk"], shell: "language" },
+    { disposition: "required", value: null, languages: ["it"], shell: "gate" },
+    { disposition: "required", value: null, languages: ["it-IT"], shell: "gate" },
+    { disposition: "required", value: "ja", languages: ["uk"], shell: "gate" },
+    { disposition: "satisfied", value: null, languages: ["uk"], shell: "app" },
+    { disposition: "unknown", value: null, languages: ["uk"], shell: "unknown" },
+  ] satisfies {
+    disposition: "required" | "satisfied" | "unknown";
+    value: LanguageTag | null;
+    languages: string[];
+    shell: string;
+  }[])(
+    "shows $shell for $disposition, $value, $languages",
+    async ({ disposition, value, languages, shell }) => {
+      vi.spyOn(navigator, "languages", "get").mockReturnValue(languages);
+      useEnduragentStore.setState({
+        activeView: "chat",
+        onboarding:
+          disposition === "unknown"
+            ? CLOSED_ONBOARDING
+            : { ...READY_ONBOARDING, completionRequired: disposition === "required" },
+      });
+      useEnduragentStore.getState().patchSettings({ language: { status: "ready", value } });
+      harness = createHarness();
+      await render(<Shell onReady={() => {}} />);
+      expect(document.querySelector("[data-shell]")).toHaveAttribute("data-shell", shell);
+      if (shell === "language") {
+        expect(await screen.findByRole("heading", { name: "Choose your language" })).toBeVisible();
+        expect(screen.getByRole("combobox")).toHaveTextContent("English");
+        expect(screen.getAllByRole("button")).toHaveLength(1);
+        expect(screen.queryByText("Automatic")).toBeNull();
+      } else {
+        expect(screen.queryByRole("heading", { name: "Choose your language" })).toBeNull();
+      }
+      expect(useEnduragentStore.getState().settingsPorts?.language.set).not.toHaveBeenCalled();
+      expect(useEnduragentStore.getState().settings.language.value).toBe(value);
+    },
+  );
+
+  it.each(["ja", "it"] satisfies LanguageTag[])(
+    "previews and saves %s before showing setup",
+    async (tag) => {
+      vi.spyOn(navigator, "languages", "get").mockReturnValue(["uk"]);
+      useEnduragentStore.setState({
+        onboarding: { ...READY_ONBOARDING, completionRequired: true },
+      });
+      useEnduragentStore.getState().patchSettings({ language: { status: "ready", value: null } });
+      harness = createHarness();
+      const port = useEnduragentStore.getState().settingsPorts?.language;
+      if (port === undefined) throw new Error("Language port missing");
+      const saved = deferred<void>();
+      vi.mocked(port.set).mockImplementation((value) => {
+        useEnduragentStore
+          .getState()
+          .patchSettings({ language: { status: "saving", value: null } });
+        void saved.promise.then(() => {
+          useEnduragentStore.getState().patchSettings({ language: { status: "ready", value } });
+        });
+      });
+      await render(<App onReady={() => {}} />);
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole("combobox", { name: "Language" }));
+      expect((await screen.findAllByRole("option")).map((option) => option.textContent)).toEqual(
+        LANGUAGE_OPTIONS.map(({ endonym }) => endonym),
+      );
+      await user.click(screen.getByRole("option", { name: describeLanguage(tag).endonym }));
+      const { say } = await createPhrasebook({ tag, locale: describeLanguage(tag).defaultLocale });
+      expect(
+        await screen.findByRole("heading", { name: say("language.chooseTitle") }),
+      ).toBeVisible();
+      expect(port.set).not.toHaveBeenCalled();
+      const button = screen.getByRole("button", { name: say("language.continue") });
+      await user.click(button);
+      expect(port.set).toHaveBeenCalledExactlyOnceWith(tag);
+      expect(button).toBeDisabled();
+      expect(screen.getByRole("combobox")).toBeDisabled();
+      expect(document.querySelector("[data-shell]")).toHaveAttribute("data-shell", "language");
+      await act(async () => saved.resolve());
+      await waitFor(() =>
+        expect(document.querySelector("[data-shell]")).toHaveAttribute("data-shell", "gate"),
+      );
+      expect(document.querySelector('[data-setup-host="gate"]')).toBeVisible();
+      expect(useEnduragentStore.getState().settings.language.value).toBe(tag);
+      expect(document.documentElement.lang).toBe(tag);
+    },
+  );
+
+  it("updates the document language as the saved preference changes", async () => {
+    vi.spyOn(navigator, "languages", "get").mockReturnValue(["it-IT"]);
+    useEnduragentStore.getState().patchSettings({ language: { status: "loading", value: null } });
+    await render(<App onReady={() => {}} />);
+    expect(document.documentElement.lang).toBe("it");
+    act(() =>
+      useEnduragentStore.getState().patchSettings({ language: { status: "ready", value: "ja" } }),
+    );
+    expect(document.documentElement.lang).toBe("ja");
+    act(() =>
+      useEnduragentStore.getState().patchSettings({ language: { status: "ready", value: null } }),
+    );
+    expect(document.documentElement.lang).toBe("it");
+  });
 });

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -1,5 +1,5 @@
 import type { TrainingHistoryComputed } from "@enduragent/coach-contract";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { Shell } from "../src/app/Shell";
@@ -26,6 +26,7 @@ import {
   takeTrainingRestrictionFocusRequest,
 } from "../src/ui/settings/restriction-focus";
 import { emptyPlanLibrary, planReadModel } from "./plan-fixtures";
+import { renderWithLanguage } from "./language-harness";
 
 const REPAIR_REQUIRED_CREDENTIALS: CredentialSettingsState = {
   status: "ready",
@@ -256,6 +257,8 @@ describe("shell", () => {
   beforeAll(preloadLazyViews);
 
   beforeEach(() => {
+    vi.spyOn(navigator, "languages", "get").mockReturnValue(["en"]);
+    vi.spyOn(navigator, "language", "get").mockReturnValue("en-US");
     useEnduragentStore.setState({
       activeView: "chat",
       runtimeReady: true,
@@ -279,6 +282,7 @@ describe("shell", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     useEnduragentStore.setState({
       chat: EMPTY_CHAT_SURFACE,
       chatActions: null,
@@ -302,8 +306,8 @@ describe("shell", () => {
     resetChatStream();
   });
 
-  it("renders the sidebar and the chat region by default", () => {
-    render(<Shell onReady={() => {}} />);
+  it("renders the sidebar and the chat region by default", async () => {
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(screen.getByText("Enduragent")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New chat" })).toBeEnabled();
@@ -322,8 +326,8 @@ describe("shell", () => {
     expect(document.querySelector('[data-shell="app"]')).not.toBeNull();
   });
 
-  it("retires the training drawer, data spine and topbar strip", () => {
-    render(<Shell onReady={() => {}} />);
+  it("retires the training drawer, data spine and topbar strip", async () => {
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(document.querySelector('.drawer[aria-label="Training data"]')).toBeNull();
     expect(document.querySelector(".data-spine")).toBeNull();
@@ -331,10 +335,10 @@ describe("shell", () => {
     expect(document.querySelector(".setup-button")).toBeNull();
   });
 
-  it("signals boot readiness once", () => {
+  it("signals boot readiness once", async () => {
     const onReady = vi.fn<() => void>();
 
-    const { rerender } = render(<Shell onReady={onReady} />);
+    const { rerender } = await renderWithLanguage(<Shell onReady={onReady} />);
     rerender(<Shell onReady={onReady} />);
 
     expect(onReady).toHaveBeenCalledTimes(1);
@@ -342,7 +346,7 @@ describe("shell", () => {
 
   it("switches the main region between the registered views", async () => {
     const user = userEvent.setup();
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     await user.click(screen.getByRole("button", { name: "Past chats" }));
     expect(await screen.findByRole("region", { name: "Past chats" })).toBeInTheDocument();
@@ -387,7 +391,7 @@ describe("shell", () => {
 
   it("keeps focus on the Training navigation button while switching views", async () => {
     const user = userEvent.setup();
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
     const trainingButton = screen.getByRole("button", { name: "Training" });
 
     await user.click(trainingButton);
@@ -424,7 +428,7 @@ describe("shell", () => {
       }),
       syncActions: { request },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
     expect(screen.getByRole("region", { name: "Ride review" })).toBeInTheDocument();
 
     const remedy = screen.getByRole("link", {
@@ -465,7 +469,7 @@ describe("shell", () => {
       }),
       syncActions: { request },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     const settings = await screen.findByRole("region", { name: "Settings" });
     await user.click(screen.getByRole("link", { name: "60 hidden by Strava. How to fix this" }));
@@ -495,7 +499,7 @@ describe("shell", () => {
         droppedActivities: stravaDroppedActivities(),
       }),
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
     await screen.findByRole("region", { name: "Settings" });
 
     requestTrainingRestrictionFocus();
@@ -508,7 +512,7 @@ describe("shell", () => {
   it("keeps the chat surface mounted while another view is shown", async () => {
     const user = userEvent.setup();
     const onReady = vi.fn<() => void>();
-    render(<Shell onReady={onReady} />);
+    await renderWithLanguage(<Shell onReady={onReady} />);
     const thread = document.querySelector("div.thread");
     const noticeHost = document.querySelector("div.chat-notice-host");
 
@@ -521,9 +525,9 @@ describe("shell", () => {
     expect(onReady).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps a neutral shell while the setup decision is unknown", () => {
+  it("keeps a neutral shell while the setup decision is unknown", async () => {
     useEnduragentStore.setState({ onboarding: CLOSED_ONBOARDING });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(setupRequired(useEnduragentStore.getState())).toBe(false);
     expect(setupBlocked(useEnduragentStore.getState())).toBe(true);
@@ -536,12 +540,12 @@ describe("shell", () => {
     expect(document.querySelector("textarea#message")).toBeNull();
   });
 
-  it("keeps an initialized state without a committed setup load neutral", () => {
+  it("keeps an initialized state without a committed setup load neutral", async () => {
     useEnduragentStore.setState({
       activeView: "training",
       onboarding: { ...CLOSED_ONBOARDING, open: true, initialized: true, loading: false },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(document.querySelector('[data-shell="unknown"]')).not.toBeNull();
     expect(screen.getByRole("status")).toHaveTextContent("Checking setup…");
@@ -550,11 +554,11 @@ describe("shell", () => {
     expect(document.querySelector("textarea#message")).toBeNull();
   });
 
-  it("keeps the known app shell mounted while setup status refreshes", () => {
+  it("keeps the known app shell mounted while setup status refreshes", async () => {
     useEnduragentStore.setState({
       onboarding: { ...READY_ONBOARDING, loading: true },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(setupRequired(useEnduragentStore.getState())).toBe(false);
     expect(setupBlocked(useEnduragentStore.getState())).toBe(false);
@@ -565,11 +569,11 @@ describe("shell", () => {
     expect(screen.getByLabelText("Message your coach")).toBeEnabled();
   });
 
-  it("keeps the known app shell mounted when a refresh becomes unavailable", () => {
+  it("keeps the known app shell mounted when a refresh becomes unavailable", async () => {
     useEnduragentStore.setState({
       onboarding: { ...READY_ONBOARDING, loadUnavailable: true },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(document.querySelector('[data-shell="app"]')).not.toBeNull();
     expect(document.querySelector('[data-setup-host="gate"]')).toBeNull();
@@ -578,7 +582,7 @@ describe("shell", () => {
     expect(screen.getByLabelText("Message your coach")).toBeEnabled();
   });
 
-  it("routes an unavailable initial decision to the setup recovery gate", () => {
+  it("routes an unavailable initial decision to the setup recovery gate", async () => {
     useEnduragentStore.setState({
       onboarding: {
         ...CLOSED_ONBOARDING,
@@ -588,7 +592,7 @@ describe("shell", () => {
         loadUnavailable: true,
       },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(document.querySelector('[data-shell="gate"]')).not.toBeNull();
     expect(document.querySelector('[data-setup-host="gate"]')).not.toBeNull();
@@ -599,9 +603,9 @@ describe("shell", () => {
     expect(document.querySelector("textarea#message")).toBeNull();
   });
 
-  it("replaces the shell with the setup gate while setup is required", () => {
+  it("replaces the shell with the setup gate while setup is required", async () => {
     useEnduragentStore.setState({ onboarding: REQUIRED_ONBOARDING });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(setupRequired(useEnduragentStore.getState())).toBe(true);
     expect(setupBlocked(useEnduragentStore.getState())).toBe(true);
@@ -617,12 +621,12 @@ describe("shell", () => {
     expect(document.querySelector("textarea#message")).toBeNull();
   });
 
-  it("ignores the persisted destination while setup is required", () => {
+  it("ignores the persisted destination while setup is required", async () => {
     useEnduragentStore.setState({
       activeView: "training",
       onboarding: REQUIRED_ONBOARDING,
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(setupSurfaceOnScreen(useEnduragentStore.getState())).toBe(true);
     expect(screen.queryByRole("region", { name: "Training" })).toBeNull();
@@ -633,12 +637,12 @@ describe("shell", () => {
     expect(useEnduragentStore.getState().activeView).toBe("training");
   });
 
-  it("holds the gate even when the stored destination is Settings", () => {
+  it("holds the gate even when the stored destination is Settings", async () => {
     useEnduragentStore.setState({
       activeView: "settings",
       onboarding: REQUIRED_ONBOARDING,
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(screen.queryByRole("region", { name: "Settings" })).toBeNull();
     expect(document.querySelector('[data-setup-host="gate"]')).not.toBeNull();
@@ -679,7 +683,7 @@ describe("shell", () => {
         },
         onboardingActions: { finish } as unknown as OnboardingController,
       });
-      render(<Shell onReady={() => {}} />);
+      await renderWithLanguage(<Shell onReady={() => {}} />);
       const gate = document.querySelector('[data-setup-host="gate"]');
 
       await user.click(screen.getByRole("button", { name: "Start coaching" }));
@@ -693,9 +697,9 @@ describe("shell", () => {
     },
   );
 
-  it("offers no dismiss, skip or close control on the gate", () => {
+  it("offers no dismiss, skip or close control on the gate", async () => {
     useEnduragentStore.setState({ onboarding: REQUIRED_ONBOARDING });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     const gate = document.querySelector('[data-setup-host="gate"]');
     if (!(gate instanceof HTMLElement)) throw new TypeError("setup gate missing");
@@ -707,10 +711,10 @@ describe("shell", () => {
     expect(document.querySelector('[data-setup-host="gate"]')).not.toBeNull();
   });
 
-  it("holds the gate at three ready until setup completion is acknowledged", () => {
+  it("holds the gate at three ready until setup completion is acknowledged", async () => {
     const onReady = vi.fn<() => void>();
     useEnduragentStore.setState({ onboarding: REQUIRED_ONBOARDING });
-    render(<Shell onReady={onReady} />);
+    await renderWithLanguage(<Shell onReady={onReady} />);
 
     expect(document.querySelector('[data-setup-host="gate"]')).not.toBeNull();
 
@@ -738,7 +742,7 @@ describe("shell", () => {
     expect(onReady).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps credential repair reachable on the gate for a non-Intervals credential", () => {
+  it("keeps credential repair reachable on the gate for a non-Intervals credential", async () => {
     useEnduragentStore.setState({
       onboarding: READY_ONBOARDING,
       settings: {
@@ -746,7 +750,7 @@ describe("shell", () => {
         credentials: REPAIR_REQUIRED_CREDENTIALS,
       },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     const gate = document.querySelector('[data-setup-host="gate"]');
     expect(gate).not.toBeNull();
@@ -769,7 +773,7 @@ describe("shell", () => {
     });
   });
 
-  it("holds a repair-triggered gate after reconciliation until Start coaching", () => {
+  it("holds a repair-triggered gate after reconciliation until Start coaching", async () => {
     const requireCompletion = vi.fn(() => {
       useEnduragentStore.setState((state) => ({
         onboarding: { ...state.onboarding, completionRequired: true },
@@ -778,7 +782,7 @@ describe("shell", () => {
     useEnduragentStore.getState().bindOnboardingActions({
       requireCompletion,
     } as unknown as OnboardingController);
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     act(() => {
       useEnduragentStore.getState().patchSettings({
@@ -797,9 +801,9 @@ describe("shell", () => {
     expect(screen.queryByRole("navigation", { name: "Main navigation" })).toBeNull();
   });
 
-  it("reports onboarding startup as pending until the decision settles", () => {
+  it("reports onboarding startup as pending until the decision settles", async () => {
     useEnduragentStore.setState({ onboardingStartupSettled: false });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(document.querySelector('[data-onboarding="pending"]')).not.toBeNull();
 
@@ -809,9 +813,9 @@ describe("shell", () => {
     expect(document.querySelector('[data-onboarding="settled"]')).not.toBeNull();
   });
 
-  it("disables the new chat button until the chat controller is bound", () => {
+  it("disables the new chat button until the chat controller is bound", async () => {
     useEnduragentStore.setState({ chatActions: null });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     expect(screen.getByRole("button", { name: "New chat" })).toBeDisabled();
   });
@@ -820,7 +824,7 @@ describe("shell", () => {
     const user = userEvent.setup();
     const actions = stubActions();
     useEnduragentStore.setState({ chatActions: actions, activeView: "settings" });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     await user.click(screen.getByRole("button", { name: "New chat" }));
 
@@ -839,7 +843,7 @@ describe("shell", () => {
         resetPhase: "uncertain",
       },
     });
-    render(<Shell onReady={() => {}} />);
+    await renderWithLanguage(<Shell onReady={() => {}} />);
 
     const opener = screen.getByRole("button", { name: "New chat" });
     expect(opener).toBeEnabled();

--- a/apps/desktop-renderer/tests/telegram-settings.test.ts
+++ b/apps/desktop-renderer/tests/telegram-settings.test.ts
@@ -52,78 +52,68 @@ function setup(options: { readonly credentialMutationsBlocked?: () => boolean } 
   const release = vi.fn();
   const bridge = {
     status: vi.fn(async (): Promise<TelegramControlStatus> => DISABLED),
-    pasteTokenFromClipboard: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({
-        outcome: "applied" as const,
-        current: {
-          ...DISABLED,
-          bot: { state: "ready" as const, username: "synthetic_bot" },
-          credentialConfigured: true,
-        },
-      }),
-    ),
-    enable: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({ outcome: "applied", current: PAIRED }),
-    ),
-    disable: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({
-        outcome: "applied" as const,
-        current: {
-          ...PAIRED,
-          channel: { desiredState: "disabled" as const, state: "disabled" as const },
-        },
-      }),
-    ),
-    remove: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({ outcome: "applied", current: DISABLED }),
-    ),
-    reconcile: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({ outcome: "applied", current: DISABLED }),
-    ),
-    removeWebhook: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({
-        outcome: "applied" as const,
-        current: {
-          ...PAIRED,
-          pairing: { state: "unpaired" as const },
-          channel: { desiredState: "disabled" as const, state: "disabled" as const },
-        },
-      }),
-    ),
-    beginPairing: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({
-        outcome: "applied" as const,
-        current: AWAITING,
-      }),
-    ),
-    cancelPairing: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({
-        outcome: "applied" as const,
-        current: {
-          ...PAIRED,
-          pairing: { state: "unpaired" as const },
-          channel: { desiredState: "disabled" as const, state: "disabled" as const },
-        },
-      }),
-    ),
-    acknowledgeGapWarning: vi.fn(
-      async (): Promise<TelegramMutationResult> => ({ outcome: "applied", current: PAIRED }),
-    ),
+    pasteTokenFromClipboard: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied" as const,
+      current: {
+        ...DISABLED,
+        bot: { state: "ready" as const, username: "synthetic_bot" },
+        credentialConfigured: true,
+      },
+    })),
+    enable: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied",
+      current: PAIRED,
+    })),
+    disable: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied" as const,
+      current: {
+        ...PAIRED,
+        channel: { desiredState: "disabled" as const, state: "disabled" as const },
+      },
+    })),
+    remove: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied",
+      current: DISABLED,
+    })),
+    reconcile: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied",
+      current: DISABLED,
+    })),
+    removeWebhook: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied" as const,
+      current: {
+        ...PAIRED,
+        pairing: { state: "unpaired" as const },
+        channel: { desiredState: "disabled" as const, state: "disabled" as const },
+      },
+    })),
+    beginPairing: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied" as const,
+      current: AWAITING,
+    })),
+    cancelPairing: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied" as const,
+      current: {
+        ...PAIRED,
+        pairing: { state: "unpaired" as const },
+        channel: { desiredState: "disabled" as const, state: "disabled" as const },
+      },
+    })),
+    acknowledgeGapWarning: vi.fn(async (): Promise<TelegramMutationResult> => ({
+      outcome: "applied",
+      current: PAIRED,
+    })),
     listAllowedSenders: vi.fn(async (): Promise<TelegramAllowedSenders> => SENDERS),
-    addAllowedSender: vi.fn(
-      async (): Promise<TelegramAllowedSendersMutationResult> => ({
-        outcome: "applied",
-        current: {
-          senders: [...SENDERS.senders, { senderId: 202, role: "additional" }],
-        },
-      }),
-    ),
-    removeAllowedSender: vi.fn(
-      async (): Promise<TelegramAllowedSendersMutationResult> => ({
-        outcome: "applied",
-        current: SENDERS,
-      }),
-    ),
+    addAllowedSender: vi.fn(async (): Promise<TelegramAllowedSendersMutationResult> => ({
+      outcome: "applied",
+      current: {
+        senders: [...SENDERS.senders, { senderId: 202, role: "additional" }],
+      },
+    })),
+    removeAllowedSender: vi.fn(async (): Promise<TelegramAllowedSendersMutationResult> => ({
+      outcome: "applied",
+      current: SENDERS,
+    })),
   } satisfies TelegramSettingsBridge;
   const view: TelegramSettingsView = {
     bind: (next) => {

--- a/apps/desktop-renderer/tests/training-sync.test.ts
+++ b/apps/desktop-renderer/tests/training-sync.test.ts
@@ -25,7 +25,10 @@ const published: SyncRpcResult = {
   published: true,
   referenceSucceeded: true,
   requests: { store: 1, reference: 1, total: 2 },
-  droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+  droppedActivities: {
+    overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+    recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+  },
 };
 
 function deferred<T>(): {
@@ -149,13 +152,40 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 1,
       kind: "published",
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     });
   });
 
   it.each([
-    [true, true, { status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } }],
-    [false, true, { status: "succeeded", operation: 1, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } }],
+    [
+      true,
+      true,
+      {
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: {
+          overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+          recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+        },
+      },
+    ],
+    [
+      false,
+      true,
+      {
+        status: "succeeded",
+        operation: 1,
+        kind: "no-change",
+        droppedActivities: {
+          overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+          recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+        },
+      },
+    ],
     [true, false, { status: "failed", operation: 1, kind: "partial", retryable: true }],
     [false, false, { status: "failed", operation: 1, kind: "operation", retryable: true }],
   ] as const)(
@@ -366,7 +396,10 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 2,
       kind: "published",
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     });
   });
 
@@ -398,7 +431,10 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 2,
       kind: "published",
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     });
   });
 
@@ -582,7 +618,10 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 1,
       kind: "published",
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     });
   });
 
@@ -618,7 +657,10 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 2,
       kind: "published",
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     });
   });
 

--- a/packages/i18n/catalogs/da.json
+++ b/packages/i18n/catalogs/da.json
@@ -25,11 +25,15 @@
       "title": "Sprog",
       "unavailable": "Sprogindstilling er ikke tilgængelig"
     },
+    "preferences": "Præferencer",
     "units": {
       "detail": "Distance og kropsvægt følger denne indstilling. Forholdet mellem effekt og vægt i cykling vises fortsat i W/kg.",
+      "displayUnits": "Visningsenheder",
       "imperial": "Imperial",
       "metric": "Metrisk",
-      "title": "Enheder"
+      "saving": "Gemmer enheder…",
+      "title": "Enheder",
+      "unavailable": "Enhedspræference er ikke tilgængelig"
     }
   }
 }

--- a/packages/i18n/catalogs/da.meta.json
+++ b/packages/i18n/catalogs/da.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/de.json
+++ b/packages/i18n/catalogs/de.json
@@ -25,11 +25,15 @@
       "title": "Sprache",
       "unavailable": "Spracheinstellung nicht verfügbar"
     },
+    "preferences": "Einstellungen",
     "units": {
       "detail": "Distanz und Körpergewicht richten sich nach dieser Einstellung. Das Leistungsgewicht beim Radfahren bleibt in W/kg.",
+      "displayUnits": "Anzeigeeinheiten",
       "imperial": "Imperial",
       "metric": "Metrisch",
-      "title": "Einheiten"
+      "saving": "Einheiten werden gespeichert…",
+      "title": "Einheiten",
+      "unavailable": "Einheiten-Einstellung nicht verfügbar"
     }
   }
 }

--- a/packages/i18n/catalogs/de.meta.json
+++ b/packages/i18n/catalogs/de.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/en.json
+++ b/packages/i18n/catalogs/en.json
@@ -25,11 +25,15 @@
       "title": "Language",
       "unavailable": "Language preference unavailable"
     },
+    "preferences": "Preferences",
     "units": {
       "detail": "Distance and body mass follow this setting. Cycling power-to-weight remains W/kg.",
+      "displayUnits": "Display units",
       "imperial": "Imperial",
       "metric": "Metric",
-      "title": "Units"
+      "saving": "Saving units…",
+      "title": "Units",
+      "unavailable": "Units preference unavailable"
     }
   }
 }

--- a/packages/i18n/catalogs/es.json
+++ b/packages/i18n/catalogs/es.json
@@ -25,11 +25,15 @@
       "title": "Idioma",
       "unavailable": "Preferencia de idioma no disponible"
     },
+    "preferences": "Preferencias",
     "units": {
       "detail": "La distancia y la masa corporal siguen este ajuste. La relación potencia-peso en ciclismo se mantiene en W/kg.",
+      "displayUnits": "Unidades de visualización",
       "imperial": "Imperial",
       "metric": "Métrico",
-      "title": "Unidades"
+      "saving": "Guardando unidades…",
+      "title": "Unidades",
+      "unavailable": "Preferencia de unidades no disponible"
     }
   }
 }

--- a/packages/i18n/catalogs/es.meta.json
+++ b/packages/i18n/catalogs/es.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/fi.json
+++ b/packages/i18n/catalogs/fi.json
@@ -25,11 +25,15 @@
       "title": "Kieli",
       "unavailable": "Kieliasetus ei ole käytettävissä"
     },
+    "preferences": "Asetukset",
     "units": {
       "detail": "Matka ja kehonpaino noudattavat tätä asetusta. Pyöräilyn teho-painosuhteen yksikkö on edelleen W/kg.",
+      "displayUnits": "Näyttöyksiköt",
       "imperial": "Brittiläinen",
       "metric": "Metrinen",
-      "title": "Yksiköt"
+      "saving": "Tallennetaan yksiköitä…",
+      "title": "Yksiköt",
+      "unavailable": "Yksikköasetus ei ole käytettävissä"
     }
   }
 }

--- a/packages/i18n/catalogs/fi.meta.json
+++ b/packages/i18n/catalogs/fi.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/fr.json
+++ b/packages/i18n/catalogs/fr.json
@@ -25,11 +25,15 @@
       "title": "Langue",
       "unavailable": "Préférence de langue indisponible"
     },
+    "preferences": "Préférences",
     "units": {
       "detail": "La distance et la masse corporelle suivent ce réglage. Le rapport puissance-poids en cyclisme reste en W/kg.",
+      "displayUnits": "Unités d’affichage",
       "imperial": "Impérial",
       "metric": "Métrique",
-      "title": "Unités"
+      "saving": "Enregistrement des unités…",
+      "title": "Unités",
+      "unavailable": "Préférence d’unités indisponible"
     }
   }
 }

--- a/packages/i18n/catalogs/fr.meta.json
+++ b/packages/i18n/catalogs/fr.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/it.json
+++ b/packages/i18n/catalogs/it.json
@@ -25,11 +25,15 @@
       "title": "Lingua",
       "unavailable": "Preferenza della lingua non disponibile"
     },
+    "preferences": "Preferenze",
     "units": {
       "detail": "La distanza e la massa corporea seguono questa impostazione. Il rapporto potenza-peso nel ciclismo resta in W/kg.",
+      "displayUnits": "Unità di visualizzazione",
       "imperial": "Imperiale",
       "metric": "Metrico",
-      "title": "Unità"
+      "saving": "Salvataggio delle unità…",
+      "title": "Unità",
+      "unavailable": "Preferenza delle unità non disponibile"
     }
   }
 }

--- a/packages/i18n/catalogs/it.meta.json
+++ b/packages/i18n/catalogs/it.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/ja.json
+++ b/packages/i18n/catalogs/ja.json
@@ -25,11 +25,15 @@
       "title": "言語",
       "unavailable": "言語設定を利用できません"
     },
+    "preferences": "環境設定",
     "units": {
       "detail": "距離と体重はこの設定に従います。サイクリングのパワーウェイトレシオはW/kgのままです。",
+      "displayUnits": "表示単位",
       "imperial": "ヤード・ポンド法",
       "metric": "メートル法",
-      "title": "単位"
+      "saving": "単位を保存中…",
+      "title": "単位",
+      "unavailable": "単位設定を利用できません"
     }
   }
 }

--- a/packages/i18n/catalogs/ja.meta.json
+++ b/packages/i18n/catalogs/ja.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/ko.json
+++ b/packages/i18n/catalogs/ko.json
@@ -25,11 +25,15 @@
       "title": "언어",
       "unavailable": "언어 설정을 사용할 수 없습니다"
     },
+    "preferences": "환경설정",
     "units": {
       "detail": "거리와 체중은 이 설정을 따릅니다. 사이클링의 체중 대비 파워는 W/kg으로 유지됩니다.",
+      "displayUnits": "표시 단위",
       "imperial": "야드파운드법",
       "metric": "미터법",
-      "title": "단위"
+      "saving": "단위 저장 중…",
+      "title": "단위",
+      "unavailable": "단위 설정을 사용할 수 없습니다"
     }
   }
 }

--- a/packages/i18n/catalogs/ko.meta.json
+++ b/packages/i18n/catalogs/ko.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/nb.json
+++ b/packages/i18n/catalogs/nb.json
@@ -25,11 +25,15 @@
       "title": "Språk",
       "unavailable": "Språkinnstillingen er utilgjengelig"
     },
+    "preferences": "Innstillinger",
     "units": {
       "detail": "Distanse og kroppsvekt følger denne innstillingen. Forholdet mellom effekt og vekt i sykling vises fortsatt i W/kg.",
+      "displayUnits": "Visningsenheter",
       "imperial": "Britiske enheter",
       "metric": "Metrisk",
-      "title": "Enheter"
+      "saving": "Lagrer enheter…",
+      "title": "Enheter",
+      "unavailable": "Enhetsinnstillingen er ikke tilgjengelig"
     }
   }
 }

--- a/packages/i18n/catalogs/nb.meta.json
+++ b/packages/i18n/catalogs/nb.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/nl.json
+++ b/packages/i18n/catalogs/nl.json
@@ -25,11 +25,15 @@
       "title": "Taal",
       "unavailable": "Taalvoorkeur niet beschikbaar"
     },
+    "preferences": "Voorkeuren",
     "units": {
       "detail": "Afstand en lichaamsgewicht volgen deze instelling. De verhouding tussen vermogen en gewicht bij het fietsen blijft in W/kg.",
+      "displayUnits": "Weergave-eenheden",
       "imperial": "Imperiaal",
       "metric": "Metrisch",
-      "title": "Eenheden"
+      "saving": "Eenheden opslaan…",
+      "title": "Eenheden",
+      "unavailable": "Eenhedenvoorkeur niet beschikbaar"
     }
   }
 }

--- a/packages/i18n/catalogs/nl.meta.json
+++ b/packages/i18n/catalogs/nl.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/pl.json
+++ b/packages/i18n/catalogs/pl.json
@@ -25,11 +25,15 @@
       "title": "Język",
       "unavailable": "Ustawienie języka jest niedostępne"
     },
+    "preferences": "Preferencje",
     "units": {
       "detail": "Dystans i masa ciała są wyświetlane zgodnie z tym ustawieniem. Stosunek mocy do masy w kolarstwie pozostaje w W/kg.",
+      "displayUnits": "Jednostki wyświetlania",
       "imperial": "Imperialne",
       "metric": "Metryczne",
-      "title": "Jednostki"
+      "saving": "Zapisywanie jednostek…",
+      "title": "Jednostki",
+      "unavailable": "Preferencja jednostek niedostępna"
     }
   }
 }

--- a/packages/i18n/catalogs/pl.meta.json
+++ b/packages/i18n/catalogs/pl.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/pt-BR.json
+++ b/packages/i18n/catalogs/pt-BR.json
@@ -25,11 +25,15 @@
       "title": "Idioma",
       "unavailable": "Preferência de idioma indisponível"
     },
+    "preferences": "Preferências",
     "units": {
       "detail": "A distância e a massa corporal seguem esta configuração. A relação potência-peso no ciclismo continua em W/kg.",
+      "displayUnits": "Unidades de exibição",
       "imperial": "Imperial",
       "metric": "Métrico",
-      "title": "Unidades"
+      "saving": "Salvando unidades…",
+      "title": "Unidades",
+      "unavailable": "Preferência de unidades indisponível"
     }
   }
 }

--- a/packages/i18n/catalogs/pt-BR.meta.json
+++ b/packages/i18n/catalogs/pt-BR.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/pt-PT.json
+++ b/packages/i18n/catalogs/pt-PT.json
@@ -25,11 +25,15 @@
       "title": "Idioma",
       "unavailable": "Preferência de idioma indisponível"
     },
+    "preferences": "Preferências",
     "units": {
       "detail": "A distância e a massa corporal seguem esta definição. A relação potência-peso no ciclismo mantém-se em W/kg.",
+      "displayUnits": "Unidades de apresentação",
       "imperial": "Imperial",
       "metric": "Métrico",
-      "title": "Unidades"
+      "saving": "A guardar unidades…",
+      "title": "Unidades",
+      "unavailable": "Preferência de unidades indisponível"
     }
   }
 }

--- a/packages/i18n/catalogs/pt-PT.meta.json
+++ b/packages/i18n/catalogs/pt-PT.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/sv.json
+++ b/packages/i18n/catalogs/sv.json
@@ -25,11 +25,15 @@
       "title": "Språk",
       "unavailable": "Språkinställningen är inte tillgänglig"
     },
+    "preferences": "Inställningar",
     "units": {
       "detail": "Distans och kroppsvikt följer den här inställningen. Förhållandet mellan effekt och vikt vid cykling visas fortfarande i W/kg.",
+      "displayUnits": "Visningsenheter",
       "imperial": "Brittiska enheter",
       "metric": "Metriskt",
-      "title": "Enheter"
+      "saving": "Sparar enheter…",
+      "title": "Enheter",
+      "unavailable": "Enhetsinställningen är inte tillgänglig"
     }
   }
 }

--- a/packages/i18n/catalogs/sv.meta.json
+++ b/packages/i18n/catalogs/sv.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/zh-Hans.json
+++ b/packages/i18n/catalogs/zh-Hans.json
@@ -25,11 +25,15 @@
       "title": "语言",
       "unavailable": "语言偏好设置不可用"
     },
+    "preferences": "偏好设置",
     "units": {
       "detail": "距离和体重会遵循此设置。骑行功率体重比仍使用W/kg。",
+      "displayUnits": "显示单位",
       "imperial": "英制",
       "metric": "公制",
-      "title": "单位"
+      "saving": "正在保存单位…",
+      "title": "单位",
+      "unavailable": "单位偏好不可用"
     }
   }
 }

--- a/packages/i18n/catalogs/zh-Hans.meta.json
+++ b/packages/i18n/catalogs/zh-Hans.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/catalogs/zh-Hant.json
+++ b/packages/i18n/catalogs/zh-Hant.json
@@ -25,11 +25,15 @@
       "title": "語言",
       "unavailable": "無法使用語言偏好設定"
     },
+    "preferences": "偏好設定",
     "units": {
       "detail": "距離和體重會遵循此設定。自行車功率體重比仍使用W/kg。",
+      "displayUnits": "顯示單位",
       "imperial": "英制",
       "metric": "公制",
-      "title": "單位"
+      "saving": "正在儲存單位…",
+      "title": "單位",
+      "unavailable": "單位偏好無法使用"
     }
   }
 }

--- a/packages/i18n/catalogs/zh-Hant.meta.json
+++ b/packages/i18n/catalogs/zh-Hant.meta.json
@@ -68,8 +68,16 @@
       "sourceHash": "8356674617e3491f6829bb5bad117bcd371c0c2a8ab2c4e2c4731827590723f0",
       "translatedBy": "model"
     },
+    "settings.preferences": {
+      "sourceHash": "66962f72a08883733c35df6f82a049b929f9579f19c4bc083ac99bead602eab3",
+      "translatedBy": "model"
+    },
     "settings.units.detail": {
       "sourceHash": "afe796c5de44a9293493c9191bfa0f0f5d49d80026d6ec3cb73bf9c5333a9954",
+      "translatedBy": "model"
+    },
+    "settings.units.displayUnits": {
+      "sourceHash": "4ab38c5d62e3c820427b2db40ad4f31c76fb38cbdbbfab0c924fde87b4769990",
       "translatedBy": "model"
     },
     "settings.units.imperial": {
@@ -80,8 +88,16 @@
       "sourceHash": "2d275a74912cca2e02e6d41f9cae3a75ceef3ed0ef734eff3710e10eb7112228",
       "translatedBy": "model"
     },
+    "settings.units.saving": {
+      "sourceHash": "03ed41b4c22491ab7d50f07a0dcea5b58466b38d9f07db1c24fc474170d11c08",
+      "translatedBy": "model"
+    },
     "settings.units.title": {
       "sourceHash": "9fb6669a77ea48bb4c080ead0e145a11f0dea709af0d542f6ad87d27958a61a1",
+      "translatedBy": "model"
+    },
+    "settings.units.unavailable": {
+      "sourceHash": "32f3aee072558d15b378fb02c7efe88dd38ae2d4c0702f6463e76fa4fac2b5f6",
       "translatedBy": "model"
     }
   }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,6 +22,10 @@
     "./messages": {
       "types": "./dist/messages.d.ts",
       "default": "./dist/messages.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "default": "./dist/react.js"
     }
   },
   "scripts": {
@@ -36,9 +40,13 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "@types/react": "19.2.18",
     "tsup": "^8.4.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.11"
+  },
+  "peerDependencies": {
+    "react": "^19.2.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/i18n/src/catalog-keys.ts
+++ b/packages/i18n/src/catalog-keys.ts
@@ -16,7 +16,11 @@ export type CatalogKey =
   | "settings.language.saving"
   | "settings.language.title"
   | "settings.language.unavailable"
+  | "settings.preferences"
   | "settings.units.detail"
+  | "settings.units.displayUnits"
   | "settings.units.imperial"
   | "settings.units.metric"
-  | "settings.units.title";
+  | "settings.units.saving"
+  | "settings.units.title"
+  | "settings.units.unavailable";

--- a/packages/i18n/src/react.tsx
+++ b/packages/i18n/src/react.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { createPhrasebook, type Phrasebook } from "./messages.js";
+
+type LanguageProviderProps = Parameters<typeof createPhrasebook>[0] & {
+  readonly children: ReactNode;
+};
+
+type LanguageState =
+  | { readonly kind: "loading" }
+  | { readonly kind: "ready"; readonly phrasebook: Phrasebook }
+  | { readonly kind: "failed"; readonly error: unknown };
+
+const LanguageContext = createContext<{
+  readonly phrasebook: Phrasebook;
+  readonly ready: boolean;
+} | null>(null);
+
+export function LanguageProvider({ tag, locale, children }: LanguageProviderProps) {
+  const [state, setState] = useState<LanguageState>({ kind: "loading" });
+
+  useEffect(() => {
+    let active = true;
+    void createPhrasebook({ tag, locale }).then(
+      (phrasebook) => {
+        if (active) setState({ kind: "ready", phrasebook });
+      },
+      (error: unknown) => {
+        if (active) setState({ kind: "failed", error });
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [tag, locale]);
+
+  if (state.kind === "failed") throw state.error;
+  if (state.kind === "loading") return null;
+
+  return (
+    <LanguageContext.Provider
+      value={{
+        phrasebook: state.phrasebook,
+        ready: state.phrasebook.tag === tag && state.phrasebook.locale === locale,
+      }}
+    >
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function usePhrasebook(): Phrasebook {
+  const context = useContext(LanguageContext);
+  if (context === null) throw new Error("usePhrasebook requires a LanguageProvider");
+  return context.phrasebook;
+}
+
+export function useLanguageReady(): boolean {
+  return useContext(LanguageContext)?.ready ?? false;
+}

--- a/packages/i18n/tests/build.test.ts
+++ b/packages/i18n/tests/build.test.ts
@@ -57,7 +57,7 @@ function sources(file: URL): string[] {
 }
 
 describe("built package", () => {
-  it.each(["index.js", "node.js", "messages.js"])("ships the %s entry", (entry) => {
+  it.each(["index.js", "node.js", "messages.js", "react.js"])("ships the %s entry", (entry) => {
     expect(statSync(new URL(entry, dist)).isFile()).toBe(true);
   });
 

--- a/packages/i18n/tests/messages.test.ts
+++ b/packages/i18n/tests/messages.test.ts
@@ -78,7 +78,6 @@ it.each(LANGUAGE_OPTIONS)("loads the complete $tag catalog", async ({ tag }) => 
     );
   }
   expect(keys(catalog)).toEqual(keys(english));
-  expect(keys(catalog)).toHaveLength(21);
 });
 
 it("derives message and phrasebook keys from the English catalog", () => {

--- a/packages/i18n/tests/package-deps.test.ts
+++ b/packages/i18n/tests/package-deps.test.ts
@@ -92,10 +92,13 @@ describe("built i18n dependency boundaries", () => {
     ]);
   });
 
-  it("requires both built entries and permits i18next only from messages", () => {
-    expect(checkI18nBuiltDependencies(fixture)).toHaveLength(2);
+  it("requires all built entries and permits React only from the React entry", () => {
+    expect(checkI18nBuiltDependencies(fixture)).toHaveLength(3);
     write("packages/i18n/dist/index.js", "export const msg = () => null;");
     write("packages/i18n/dist/messages.js", 'import "i18next";');
+    write("packages/i18n/dist/react.js", 'import "react";');
+    write("packages/i18n/node_modules/react/package.json", '{"name":"react","exports":"./index.js"}');
+    write("packages/i18n/node_modules/react/index.js", "export const createContext = () => null;");
     write("packages/i18n/node_modules/i18next/package.json", '{"name":"i18next","exports":"./index.js"}');
     write("packages/i18n/node_modules/i18next/index.js", "export const createInstance = () => null;");
 

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "outDir": "dist",

--- a/packages/i18n/tsup.config.ts
+++ b/packages/i18n/tsup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", node: "src/node.ts", messages: "src/messages.ts" },
+  entry: {
+    index: "src/index.ts",
+    node: "src/node.ts",
+    messages: "src/messages.ts",
+    react: "src/react.tsx",
+  },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,9 @@ importers:
       i18next:
         specifier: ^25.10.10
         version: 25.10.10(typescript@6.0.3)
+      react:
+        specifier: ^19.2.0
+        version: 19.2.8
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -572,6 +575,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@types/react':
+        specifier: 19.2.18
+        version: 19.2.18
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.12)(supports-color@7.2.0)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)

--- a/tools/check-package-deps.ts
+++ b/tools/check-package-deps.ts
@@ -159,7 +159,7 @@ export const RULES: readonly PackageDepRule[] = [
     srcOnly: true,
     allowedWorkspace: ["@enduragent/coach-contract"],
     transitionalWorkspace: [],
-    allowedExternal: ["zod", "i18next"],
+    allowedExternal: ["zod", "i18next", "react"],
     forbidNode: false,
   },
   {
@@ -411,6 +411,7 @@ export function checkI18nBuiltDependencies(root: string): BuiltDependencyViolati
   return [
     { name: "index", forbiddenPackages: ["i18next", "react", "react-i18next"] },
     { name: "messages", forbiddenPackages: ["react", "react-i18next"] },
+    { name: "react", forbiddenPackages: ["react-i18next"] },
   ].flatMap(({ name, forbiddenPackages }) =>
     checkBuiltDependencyGraph({
       entry: join(root, "packages/i18n/dist", `${name}.js`),
@@ -832,7 +833,7 @@ export function main(argv: readonly string[]): number {
       `check-package-deps: ${result.scannedFileCount} source file(s) across the governed package graph clean.`,
     );
     if (existsSync(join(root, "packages/i18n"))) {
-      console.log("check-package-deps: i18n built index and messages dependency graphs clean.");
+      console.log("check-package-deps: i18n built index, messages, and react dependency graphs clean.");
     }
     return 0;
   }


### PR DESCRIPTION
Second child of the localization catalog epic.

- `@enduragent/i18n/react`: `LanguageProvider` and `usePhrasebook` over the per-language Phrasebook (no react-i18next; React is a peer dependency; the dependency walk keeps the common and messages entries React-free).
- Interface language = saved preference, else the OS language when it is one of the 17, else English. `document.documentElement.lang` follows it; retained English regions carry `lang="en"`.
- First launch: when setup is required, the preference is ready and null, and the OS language is unsupported, a centered language screen (title, one Select with English preselected, Continue) shows before Setup. Continue saves through the existing language port. A supported OS language shows nothing and writes nothing. The screen never renders while the preference RPC is still loading.
- Settings Preferences group, Language, Units, and Appearance controls read from the catalogs. Four keys added (`settings.preferences`, `settings.units.saving`, `settings.units.unavailable`, `settings.units.displayUnits`) and translated into the 16 catalogs with the translation skill; `check:catalogs` clean.
- English rendering unchanged: `pnpm check:ui-states` passes against the sealed v6 baselines.

Checks: root `pnpm check` green, renderer suite green (one pre-existing chat focus-trap test flakes under full-file load on the base branch too; passes 3/3 in isolation), i18n suite green. Verifier (codex astra, read-only): loading-flash blocker fixed with a status guard and a unit test; leftover English Preferences strings converted; scope note on adapting three existing tests accepted.

https://claude.ai/code/session_016sJNBpzjk93aLbK8VTwKW2