### PR TITLE
fix(desktop): align chat content and composer spacing

### DIFF
--- a/.changeset/sour-actors-reply.md
+++ b/.changeset/sour-actors-reply.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Chat content now lines up with the message box, with no extra padding above the composer.

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -201,21 +201,21 @@ export function ChatView(): ReactElement {
       <div
         className={`chat-layout row-start-2 grid min-h-0 min-w-0 ${contextOpen && !compact ? "grid-cols-[minmax(0,1fr)_252px]" : "grid-cols-[minmax(0,1fr)]"}`}
       >
-        <div className="chat-reading-column grid min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto] has-[[data-parity='question.card']]:grid-rows-[minmax(calc(var(--ctl-h-lg)*4),1fr)_minmax(0,auto)]">
+        <div className="chat-reading-column grid min-h-0 min-w-0 px-6 max-md:px-4 grid-rows-[minmax(0,1fr)_auto] has-[[data-parity='question.card']]:grid-rows-[minmax(calc(var(--ctl-h-lg)*4),1fr)_minmax(0,auto)]">
           <main
             className="conversation overflow-auto [scrollbar-width:none] pt-[calc(var(--inset)*4)] pb-[calc(var(--inset)*3)] [overflow-anchor:none] max-md:pt-5.5"
             aria-label="Coaching conversation"
             data-chat-status={status}
             ref={conversation}
           >
-            <div className="thread mx-auto w-[min(720px,calc(100%-48px))] max-md:w-[calc(100%-32px)]">
+            <div className="thread mx-auto w-full max-w-[720px]">
               <Transcript />
               <PlanChangeCards />
               <CoachProgress />
               <FirstSyncCard />
             </div>
           </main>
-          <div className="composer-wrap z-2 grid max-h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] px-[max(24px,calc((100%-720px)/2))] pt-7 pb-3.5 max-md:px-[calc(var(--inset)*2)]">
+          <div className="composer-wrap z-2 mx-auto grid w-full max-w-[720px] max-h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] pb-3.5">
             <div className="composer-projections min-h-0 overflow-y-auto [scrollbar-width:none] overscroll-contain empty:hidden">
               <div className="chat-notice-host empty:hidden">
                 <p


### PR DESCRIPTION
Chat had unnecessary space above the message box and independently calculated content widths. Remove the top padding and give the transcript and composer shared horizontal insets and the same maximum width, keeping their edges aligned at wide and compact sizes.

The operator requested this spacing adjustment and matching prototype updates. Includes an athlete-facing changeset.

Validation: all 118 chat surface tests pass; fixture privacy check passes; dependencies, renderer, and desktop build successfully. Isolated desktop checks pass for streaming, draft preservation across navigation, zero composer top padding, and equal transcript/composer edges at wide and compact widths in both themes. Required OpenAI Codex autoreview is clean; zero correction cycles.
