### PR TITLE
fix(desktop): preserve consistent card gaps above composer

### DIFF
--- a/.changeset/cold-tires-tickle.md
+++ b/.changeset/cold-tires-tickle.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Cards above the message box no longer leave extra space above the composer.

--- a/.changeset/cold-tires-tickle.md
+++ b/.changeset/cold-tires-tickle.md
@@ -2,4 +2,4 @@
 "@enduragent/desktop": patch
 ---
 
-User-facing: Cards above the message box no longer leave extra space above the composer.
+User-facing: Cards above the message box now keep a consistent gap, so questions, attachments, and queued messages stay visually separate from the composer.

--- a/apps/desktop-renderer/src/ui/chat/AttachmentPanel.tsx
+++ b/apps/desktop-renderer/src/ui/chat/AttachmentPanel.tsx
@@ -313,7 +313,7 @@ export function AttachmentPanel(): ReactElement | null {
     return null;
   }
   return (
-    <AttachmentList aria-live="polite">
+    <AttachmentList className="mb-row gap-row" aria-live="polite">
       {surface.attachmentBusy ? (
         <div className="flex items-center gap-3 rounded-card border border-line-2 bg-surface p-4 text-sm text-ink-2">
           <LoaderCircle

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -203,7 +203,7 @@ export function ChatView(): ReactElement {
       >
         <div className="chat-reading-column grid min-h-0 min-w-0 px-6 max-md:px-4 grid-rows-[minmax(0,1fr)_auto] has-[[data-parity='question.card']]:grid-rows-[minmax(calc(var(--ctl-h-lg)*4),1fr)_minmax(0,auto)]">
           <main
-            className="conversation overflow-auto [scrollbar-width:none] pt-[calc(var(--inset)*4)] pb-[calc(var(--inset)*3)] [overflow-anchor:none] max-md:pt-5.5"
+            className="conversation overflow-auto [scrollbar-width:none] pt-[calc(var(--inset)*4)] [overflow-anchor:none] max-md:pt-5.5"
             aria-label="Coaching conversation"
             data-chat-status={status}
             ref={conversation}
@@ -216,7 +216,7 @@ export function ChatView(): ReactElement {
             </div>
           </main>
           <div className="composer-wrap z-2 mx-auto grid w-full max-w-[720px] max-h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] pb-3.5">
-            <div className="composer-projections min-h-0 overflow-y-auto [scrollbar-width:none] overscroll-contain empty:hidden">
+            <div className="composer-projections [&>:last-child]:mb-0 min-h-0 overflow-y-auto [scrollbar-width:none] overscroll-contain empty:hidden">
               <div className="chat-notice-host empty:hidden">
                 <p
                   className="new-conversation-status m-0 text-sm text-ink-2 not-empty:px-3.5 not-empty:pb-inset"

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -203,7 +203,7 @@ export function ChatView(): ReactElement {
       >
         <div className="chat-reading-column grid min-h-0 min-w-0 px-6 max-md:px-4 grid-rows-[minmax(0,1fr)_auto] has-[[data-parity='question.card']]:grid-rows-[minmax(calc(var(--ctl-h-lg)*4),1fr)_minmax(0,auto)]">
           <main
-            className="conversation overflow-auto [scrollbar-width:none] pt-[calc(var(--inset)*4)] [overflow-anchor:none] max-md:pt-5.5"
+            className="conversation overflow-auto [scrollbar-width:none] pt-[calc(var(--inset)*4)] pb-row [overflow-anchor:none] max-md:pt-5.5"
             aria-label="Coaching conversation"
             data-chat-status={status}
             ref={conversation}
@@ -216,7 +216,7 @@ export function ChatView(): ReactElement {
             </div>
           </main>
           <div className="composer-wrap z-2 mx-auto grid w-full max-w-[720px] max-h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] pb-3.5">
-            <div className="composer-projections [&>:last-child]:mb-0 min-h-0 overflow-y-auto [scrollbar-width:none] overscroll-contain empty:hidden">
+            <div className="composer-projections min-h-0 overflow-y-auto [scrollbar-width:none] overscroll-contain empty:hidden">
               <div className="chat-notice-host empty:hidden">
                 <p
                   className="new-conversation-status m-0 text-sm text-ink-2 not-empty:px-3.5 not-empty:pb-inset"
@@ -229,7 +229,7 @@ export function ChatView(): ReactElement {
                 <Notice />
                 <RetryBar />
               </div>
-              <div className="mb-inset grid gap-inset empty:hidden">
+              <div className="mb-row grid gap-row empty:hidden">
                 <CoachDecisionPanel onCustomOpenChange={setCustomDecisionOpen} />
                 <PlanCreationDock onEditorOpenChange={setPlanEditorOpen} />
               </div>

--- a/apps/desktop-renderer/src/ui/chat/QueuedMessages.tsx
+++ b/apps/desktop-renderer/src/ui/chat/QueuedMessages.tsx
@@ -17,6 +17,7 @@ export function QueuedMessages(): ReactElement | null {
 
   return (
     <QueuedMessageList
+      className="mb-row"
       title="Queued messages"
       count={queued.length}
       announcement={queueLabel}

--- a/apps/desktop-renderer/src/ui/chat/SpendNotice.tsx
+++ b/apps/desktop-renderer/src/ui/chat/SpendNotice.tsx
@@ -8,7 +8,7 @@ export function SpendNotice(): ReactElement {
   return (
     <Card
       id="spend-cap-warning"
-      className="relative mb-2.5 gap-0 overflow-hidden py-2.5 pr-3 pl-[15px] shadow-elev-1 before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-danger before:content-['']"
+      className="relative mb-row gap-0 overflow-hidden py-2.5 pr-3 pl-[15px] shadow-elev-1 before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-danger before:content-['']"
       role="status"
       aria-live="polite"
       hidden={warning === null}


### PR DESCRIPTION
Cards above the composer now use the shared row spacing for their bottom gap. This covers conversation cards, docked questions, attachments and import/error panels, queued messages, and spend notices. The composer retains zero top padding, and the transcript and composer retain equal widths.

Includes an athlete-facing changeset. Matching prototype card states receive the same spacing token.

Validation: all 118 chat tests pass; dependencies, renderer, and desktop build successfully. Eight desktop tests pass for chat and Plan question/commitment flows. Geometry checks measure the 10px card gap in wide/compact light/dark commitment states and on queued-message and attachment/error stacks. Required OpenAI Codex review is clean. One completed correction batch follows the operator's clarification that cards need bottom spacing.
