### PR TITLE
fix(desktop): dock pending commitment checks above the composer

### DIFF
--- a/.changeset/pending-commitment-dock.md
+++ b/.changeset/pending-commitment-dock.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: When the coach could not use a typed commitment, the card asking you to answer again or skip stays above the message box until you deal with it.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -205,7 +205,7 @@ export interface ChatViewControls {
     readonly discardEvents: readonly PlanCreationDiscardEvent[];
     readonly notice: string | null;
     readonly focusRequest: {
-      readonly target: "discard" | "activate" | "edit" | "start" | "continue" | "change";
+      readonly target: "discard" | "activate" | "edit" | "start" | "continue" | "change" | "composer";
       readonly libraryTarget?: "continue" | "change";
       readonly revision: number;
     } | null;
@@ -431,7 +431,7 @@ export function createChatController(input: {
   let planCreationDiscardEvents: readonly PlanCreationDiscardEvent[] = [];
   let planCreationNotice: string | null = null;
   let planCreationFocusRequest: {
-    readonly target: "discard" | "activate" | "edit" | "start" | "continue" | "change";
+    readonly target: "discard" | "activate" | "edit" | "start" | "continue" | "change" | "composer";
     readonly libraryTarget?: "continue" | "change";
     readonly revision: number;
   } | null = null;
@@ -1118,12 +1118,12 @@ export function createChatController(input: {
 
   const installPlanCreation = (
     next: PlanCreationCardModel | null,
-    focusTarget?: "discard" | "activate" | "edit" | "start" | "continue" | "change",
+    focusTarget?: "discard" | "activate" | "edit" | "start" | "continue" | "change" | "composer",
   ): void => {
     const previous = planCreation;
     let actionFocusRequested = false;
     const requestActionFocus = (
-      target: "discard" | "activate" | "edit" | "start" | "continue" | "change",
+      target: "discard" | "activate" | "edit" | "start" | "continue" | "change" | "composer",
     ): void => {
       requestPlanCreationFocus(target);
       actionFocusRequested = true;
@@ -1183,7 +1183,7 @@ export function createChatController(input: {
       .filter((message) => message.role === "athlete" || message.text.length > 0)
       .at(-1)?.id ?? null;
   const requestPlanCreationFocus = (
-    target: "discard" | "activate" | "edit" | "start" | "continue" | "change",
+    target: "discard" | "activate" | "edit" | "start" | "continue" | "change" | "composer",
   ): void => {
     planCreationFocusRequest = {
       ...(target === "start" || planCreationFocusRequest?.libraryTarget === undefined
@@ -1886,6 +1886,13 @@ export function createChatController(input: {
       });
       pendingPlanCreationCommand = null;
       installPlanCreation(result.planCreation);
+      if (
+        result.status !== "rejected" &&
+        (answer.kind === "commitments-confirm" || answer.kind === "commitments-cancel") &&
+        planCreation?.pendingCommitment === null &&
+        planCreation.openQuestion === null
+      )
+        requestPlanCreationFocus("composer");
       if (result.status === "rejected") {
         if (
           submittedEditingKey !== null &&

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -328,6 +328,10 @@ export function createChatViewAdapter(input: {
           planCreation.value.openQuestion?.kind === "commitments-question"
         ) &&
         (planCreationEditingKey !== null || planCreation.value.openQuestion !== null));
+    const pendingCommitmentDocked =
+      !planCreationPaused &&
+      planCreation?.value?.pendingCommitment != null &&
+      planCreationEditingKey === null;
     const decisionLoading = controls?.decisionLoading === true;
     const decisionLoadError = controls?.queueLoadError ?? controls?.decisionLoadError ?? null;
     const decisionUnavailable = decisionLoading || decisionLoadError !== null;
@@ -392,11 +396,14 @@ export function createChatViewAdapter(input: {
         decisionBlocksWork ||
         decisionUnavailable ||
         attachmentUnavailable ||
-        planCreationBlocksWork,
-      inputDisabled: workBlocked || planCreationBlocksWork,
-      composerPlaceholder: planCreationBlocksWork
-        ? "Finish the Plan question above"
-        : "Message your coach",
+        planCreationBlocksWork ||
+        pendingCommitmentDocked,
+      inputDisabled: workBlocked || planCreationBlocksWork || pendingCommitmentDocked,
+      composerPlaceholder: pendingCommitmentDocked
+        ? "Finish the correction above"
+        : planCreationBlocksWork
+          ? "Finish the Plan question above"
+          : "Message your coach",
       newConversationUnavailable: newConversationUnavailable || decisionUnavailable,
       resetPhase: state.session.resetPhase,
       resetCount: state.session.resetCount,

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -85,7 +85,7 @@ export interface ChatSurfaceState {
   readonly planCreationActivateConfirmationOpen: boolean;
   readonly planCreationActivePlanKnowledge: ActivePlanKnowledge;
   readonly planCreationFocusRequest: {
-    readonly target: "discard" | "activate" | "start" | "continue" | "change" | "edit";
+    readonly target: "discard" | "activate" | "start" | "continue" | "change" | "edit" | "composer";
     readonly libraryTarget?: "continue" | "change";
     readonly revision: number;
   } | null;

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -201,7 +201,7 @@ export function ChatView(): ReactElement {
       <div
         className={`chat-layout row-start-2 grid min-h-0 min-w-0 ${contextOpen && !compact ? "grid-cols-[minmax(0,1fr)_252px]" : "grid-cols-[minmax(0,1fr)]"}`}
       >
-        <div className="chat-reading-column grid min-h-0 min-w-0 px-6 max-md:px-4 grid-rows-[minmax(0,1fr)_auto] has-[[data-parity='question.card']]:grid-rows-[minmax(calc(var(--ctl-h-lg)*4),1fr)_minmax(0,auto)]">
+        <div className="chat-reading-column grid min-h-0 min-w-0 px-6 max-md:px-4 grid-rows-[minmax(0,1fr)_auto] has-[[data-plan-creation-dock]]:grid-rows-[minmax(calc(var(--ctl-h-lg)*4),1fr)_minmax(0,auto)]">
           <main
             className="conversation overflow-auto [scrollbar-width:none] pt-[calc(var(--inset)*4)] pb-[calc(var(--inset)*3)] [overflow-anchor:none] max-md:pt-5.5"
             aria-label="Coaching conversation"

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -53,6 +53,7 @@ export function Composer(props: {
   const chatSendDisabled = useEnduragentStore((state) => state.chat.sendDisabled);
   const chatInputDisabled = useEnduragentStore((state) => state.chat.inputDisabled);
   const chatPlaceholder = useEnduragentStore((state) => state.chat.composerPlaceholder);
+  const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
   const chatStatus = useEnduragentStore((state) => state.chat.status);
   const actions = useEnduragentStore((state) => state.chatActions);
   const chatReady = useEnduragentStore(setupReady);
@@ -64,6 +65,12 @@ export function Composer(props: {
   const status = props.surface?.status ?? chatStatus;
   const canChat = props.surface === undefined ? chatReady : true;
   const inputId = props.inputId ?? "message";
+  useEffect(() => {
+    if (focusRequest?.target !== "composer" || props.surface !== undefined) return;
+    queueMicrotask(() => {
+      if (textarea.current?.disabled === false) textarea.current.focus();
+    });
+  }, [focusRequest?.revision, focusRequest?.target, props.surface]);
 
   const matches = useMemo(
     () => (props.surface?.allowSlashCommands === false ? [] : filterSlashCommands(draft)),

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -227,7 +227,15 @@ export function PlanCreationDock(props: {
   }, [focusRequest?.revision, focusRequest?.target]);
   if (!loaded) return null;
   if (model === null) return null;
-  if (paused || (editingKey === null && model.openQuestion === null)) return null;
+  if (paused) return null;
+  if (editingKey === null && model.pendingCommitment !== null) {
+    return (
+      <section aria-label="Plan creation dock" data-plan-creation-dock>
+        <PlanCreationCommitmentCard model={model} />
+      </section>
+    );
+  }
+  if (editingKey === null && model.openQuestion === null) return null;
   const editedSummary =
     editingKey === null
       ? null
@@ -235,27 +243,29 @@ export function PlanCreationDock(props: {
   const question = editedSummary?.question ?? model.openQuestion;
   if (question === null) return null;
   return (
-    <PlanCreationQuestionCard
-      key={`${model.creationId}:${model.version}:${editingKey ?? question.kind}`}
-      question={question}
-      currentAnswer={
-        question.kind === "commitments-question" && model.pendingCommitment !== null
-          ? {
-              kind: "commitments",
-              commitments: { kind: "interpreted", text: model.pendingCommitment.text },
-            }
-          : (editedSummary?.answer ?? null)
-      }
-      commitmentStatus={model.pendingCommitment?.status}
-      editing={editingKey !== null}
-      busy={busy}
-      error={model.pendingCommitment === null ? error : null}
-      focusRevision={focusRevision}
-      onAnswer={(answer) => actions?.answerPlanCreation(answer)}
-      onLater={() => actions?.pausePlanCreation()}
-      onCancel={() => actions?.cancelPlanCreationEdit()}
-      onEditorOpenChange={props.onEditorOpenChange}
-    />
+    <section aria-label="Plan creation dock" data-plan-creation-dock>
+      <PlanCreationQuestionCard
+        key={`${model.creationId}:${model.version}:${editingKey ?? question.kind}`}
+        question={question}
+        currentAnswer={
+          question.kind === "commitments-question" && model.pendingCommitment !== null
+            ? {
+                kind: "commitments",
+                commitments: { kind: "interpreted", text: model.pendingCommitment.text },
+              }
+            : (editedSummary?.answer ?? null)
+        }
+        commitmentStatus={model.pendingCommitment?.status}
+        editing={editingKey !== null}
+        busy={busy}
+        error={error}
+        focusRevision={focusRevision}
+        onAnswer={(answer) => actions?.answerPlanCreation(answer)}
+        onLater={() => actions?.pausePlanCreation()}
+        onCancel={() => actions?.cancelPlanCreationEdit()}
+        onEditorOpenChange={props.onEditorOpenChange}
+      />
+    </section>
   );
 }
 
@@ -266,9 +276,7 @@ export function PlanCreationConversation(props: {
   return (
     <section className="grid min-w-0 gap-4" aria-label="Plan creation">
       <Notice inPlanCreation />
-      {props.model.draft === null ? null : <PlanCreationCommitmentCard model={props.model} />}
       <PlanCreationConversationContent model={props.model} />
-      {props.model.draft === null ? <PlanCreationCommitmentCard model={props.model} /> : null}
     </section>
   );
 }

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationDraftCards.tsx
@@ -5,7 +5,7 @@ import type {
   PlanCreationDraft,
   PlanCreationCommitmentRule,
 } from "@enduragent/coach-contract";
-import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import { useEffect, useRef, type ReactElement, type ReactNode, type Ref } from "react";
 import { Button } from "@enduragent/ui";
 import { Fact, PlanCard } from "../plan/plan-card";
 import { useEnduragentStore } from "../../state/store";
@@ -47,6 +47,17 @@ function AnswerFacts(props: {
   );
 }
 
+export function resolvedAnswerSummaries(
+  summaries: readonly PlanCreationAnswerSummary[],
+): PlanCreationAnswerSummary[] {
+  return summaries.filter(
+    ({ answer }) =>
+      answer.kind !== "commitments" ||
+      answer.commitments.kind !== "interpreted" ||
+      answer.commitments.status === "confirmed",
+  );
+}
+
 function ReviewCard(props: {
   readonly eyebrow?: string;
   readonly title: string;
@@ -54,6 +65,8 @@ function ReviewCard(props: {
   readonly summary?: string;
   readonly summaryId?: string;
   readonly "aria-label"?: string;
+  readonly headingRef?: Ref<HTMLHeadingElement>;
+  readonly headingTabIndex?: number;
   readonly children: ReactNode;
 }): ReactElement {
   return <PlanCard {...props} aria-label={props["aria-label"] ?? props.title} />;
@@ -94,7 +107,7 @@ export function PlanCreationDraftCards(props: {
       {stale ? (
         <ReviewCard title="Changed answers">
           <div role="table" className="border-t border-line" aria-label="Changed answers">
-            <AnswerFacts summaries={props.model.answeredSummaries} current />
+            <AnswerFacts summaries={resolvedAnswerSummaries(props.model.answeredSummaries)} current />
           </div>
         </ReviewCard>
       ) : null}
@@ -244,9 +257,6 @@ export function PlanCreationDraftCards(props: {
   );
 }
 
-export const pendingCommitmentSummary =
-  "Your last confirmed limits remain effective. Draft building and activation wait for this correction.";
-
 export function commitmentSummaryId(model: PlanCreationCardModel): string {
   return `commitment-summary-${model.creationId}`;
 }
@@ -271,34 +281,43 @@ export function PlanCreationCommitmentCard(props: {
   const actions = useEnduragentStore((state) => state.chatActions);
   const error = useEnduragentStore((state) => state.chat.planCreationError);
   const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
-  const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
+  const focusRevision = useEnduragentStore((state) => state.chat.planCreationFocusRevision);
+  const heading = useRef<HTMLHeadingElement>(null);
   const pending = props.model.pendingCommitment;
+  const pendingText = pending?.text ?? null;
+  useEffect(() => {
+    if (pendingText !== null) heading.current?.focus();
+  }, [focusRevision, pendingText]);
   if (pending === null) return null;
   const disabled = busy || actions === null;
+  const clarify = pending.status === "clarify";
+  const resolve = (): void => {
+    void actions?.answerPlanCreation({
+      kind: clarify ? "commitments-cancel" : "commitments-confirm",
+    });
+  };
   return (
     <ReviewCard
-      eyebrow="Schedule correction"
-      title={pending.status === "clarify" ? "Clarify your commitment" : "Confirm these limits"}
-      status="Not yet confirmed"
-      summary={pendingCommitmentSummary}
+      eyebrow="Plan creation · Commitments"
+      title={clarify ? "I could not use that answer" : "Did I read this right?"}
+      summary={
+        clarify
+          ? "Tell me again in a different way, with weekdays, time limits, or exact dates."
+          : "I understood your note as this limit. Confirm it and your other confirmed limits stay as they are."
+      }
       summaryId={commitmentSummaryId(props.model)}
+      headingRef={heading}
+      headingTabIndex={-1}
     >
-      <div role="table" className="border-t border-line" aria-label="Schedule correction">
-        <Fact label="Submitted">{pending.text}</Fact>
-        {pending.rules.map((rule, index) => (
-          <Fact key={index} label="Interpreted limit">
-            {commitmentRuleText(rule)}
-          </Fact>
-        ))}
-        {pending.unparsed.length === 0 ? null : (
-          <Fact label="Not understood">
-            <ul className="m-0 grid list-none gap-1 p-0">
-              {pending.unparsed.map((fragment, index) => (
-                <li key={index}>{fragment}</li>
-              ))}
-            </ul>
-          </Fact>
-        )}
+      <div role="table" className="border-t border-line" aria-label="Commitments">
+        <Fact label="You wrote">{pending.text}</Fact>
+        {clarify
+          ? null
+          : pending.rules.map((rule, index) => (
+              <Fact key={index} label="I understood">
+                {commitmentRuleText(rule)}
+              </Fact>
+            ))}
       </div>
       {error === null ? null : (
         <p role="alert" className="m-0 text-xs text-danger">
@@ -310,26 +329,16 @@ export function PlanCreationCommitmentCard(props: {
           variant="outline"
           className="border-line bg-surface"
           disabled={disabled}
-          onClick={() => actions?.answerPlanCreation({ kind: "commitments-cancel" })}
+          onClick={clarify ? resolve : () => actions?.editPlanCreation("commitments")}
         >
-          Cancel correction
+          {clarify ? "Skip for now" : "Change it"}
         </Button>
         <Button
-          variant="outline"
-          className="border-line bg-surface"
-          disabled={disabled || editingKey !== null}
-          onClick={() => actions?.editPlanCreation("commitments")}
+          disabled={disabled}
+          onClick={clarify ? () => actions?.editPlanCreation("commitments") : resolve}
         >
-          Clarify
+          {clarify ? "Answer" : "Confirm"}
         </Button>
-        {pending.status === "confirm" ? (
-          <Button
-            disabled={disabled}
-            onClick={() => actions?.answerPlanCreation({ kind: "commitments-confirm" })}
-          >
-            Confirm limits
-          </Button>
-        ) : null}
       </div>
     </ReviewCard>
   );

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from "@enduragent/ui";
 import { creationTitle } from "../../plan/creation-title";
 import { useEnduragentStore } from "../../state/store";
 
-import { commitmentSummaryId } from "./PlanCreationDraftCards";
+import { commitmentSummaryId, resolvedAnswerSummaries } from "./PlanCreationDraftCards";
 
 export function PlanCreationSummary(props: {
   readonly model: PlanCreationCardModel;
@@ -19,6 +19,7 @@ export function PlanCreationSummary(props: {
   const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
   const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
   const discardButton = useRef<HTMLButtonElement>(null);
+  const summaries = resolvedAnswerSummaries(props.model.answeredSummaries);
   const ready = props.model.readiness === "ready";
   const canContinue = paused && props.model.openQuestion !== null;
   const total =
@@ -32,9 +33,9 @@ export function PlanCreationSummary(props: {
   }, [focusRequest?.revision, focusRequest?.target]);
   return (
     <section className="grid min-w-0 gap-4" aria-label="Plan Creation progress">
-      {props.model.answeredSummaries.length === 0 ? null : (
+      {summaries.length === 0 ? null : (
         <ul className="m-0 grid list-none gap-2 p-0" role="list">
-          {props.model.answeredSummaries.map((summary) => (
+          {summaries.map((summary) => (
             <li
               key={summary.answerKey}
               className="grid min-w-0 grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)_auto] items-center gap-row rounded-card border border-line bg-surface px-ctl-px py-3 text-sm"
@@ -114,7 +115,7 @@ export function PlanCreationSummary(props: {
             >
               {ready
                 ? "The essentials are complete."
-                : `${props.model.answeredSummaries.length} of ${total} answered.${library === null ? "" : ` ${library.active ? `${library.active.name} keeps running.` : "No Plan is active."}`}`}
+                : `${summaries.length} of ${total} answered.${library === null ? "" : ` ${library.active ? `${library.active.name} keeps running.` : "No Plan is active."}`}`}
             </p>
             <div className="mt-4 flex flex-wrap gap-inset" data-parity="progress.actions">
               <Button

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -366,6 +366,59 @@ describe("chat view adapter", () => {
     });
   });
 
+  it("blocks the composer while an unresolved typed commitment is docked", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    const pending = {
+      text: "Some evenings are busy",
+      status: "clarify" as const,
+      rules: [],
+      unparsed: ["Some evenings are busy"],
+    };
+    const planCreation = (editingKey: "commitments" | null, paused = false) => ({
+      value: {
+        draft: null,
+        draftStale: false,
+        calendarWindow: null,
+        pendingCommitment: pending,
+        creationId: "01J00000000000000000000000",
+        version: 1,
+        status: "in-progress" as const,
+        readiness: "ready" as const,
+        answeredSummaries: [],
+        openQuestion: null,
+      },
+      loaded: true,
+      busy: false,
+      error: null,
+      paused,
+      editingKey,
+      focusRevision: 1,
+      discardConfirmationOpen: false,
+      activateConfirmationOpen: false,
+      activePlanKnowledge: { kind: "unknown" as const },
+      discardEvents: [],
+      notice: null,
+      focusRequest: null,
+    });
+    adapter.view.render(EMPTY_CHAT_STATE, controls({ planCreation: planCreation(null) }));
+    expect(published.at(-1)).toMatchObject({
+      sendDisabled: true,
+      inputDisabled: true,
+      composerPlaceholder: "Finish the correction above",
+    });
+    adapter.view.render(EMPTY_CHAT_STATE, controls({ planCreation: planCreation("commitments") }));
+    expect(published.at(-1)).toMatchObject({
+      inputDisabled: false,
+      composerPlaceholder: "Message your coach",
+    });
+    adapter.view.render(EMPTY_CHAT_STATE, controls({ planCreation: planCreation(null, true) }));
+    expect(published.at(-1)).toMatchObject({
+      inputDisabled: false,
+      composerPlaceholder: "Message your coach",
+    });
+  });
+
   it("blocks work during activation and retains its completed transcript notice once", () => {
     const published: ChatSurfaceState[] = [];
     const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -3122,9 +3122,53 @@ describe("chat controller", () => {
         expect.objectContaining({ answer: { kind } }),
       );
       expect(controls.at(-1)?.planCreation?.value?.pendingCommitment).toBeNull();
+      expect(controls.at(-1)?.planCreation?.focusRequest).toMatchObject({ target: "composer" });
       controller.dispose();
     },
   );
+
+  it("leaves focus with the next question when a resolved correction reopens one", async () => {
+    const question: NonNullable<PlanCreationCardModel["openQuestion"]> = {
+      kind: "plan-length-question",
+      step: { current: 2, total: 9 },
+      prompt: "How long should this Fitness Plan be?",
+      options: [{ weeks: 4, label: "4 weeks", detail: "A short block." }],
+    };
+    const card: PlanCreationCardModel = {
+      creationId: "01J00000000000000000000000",
+      version: 10,
+      status: "in-progress",
+      readiness: "incomplete",
+      answeredSummaries: [],
+      openQuestion: null,
+      draft: null,
+      calendarWindow: null,
+      draftStale: false,
+      pendingCommitment: {
+        text: "Some evenings are busy",
+        rules: [],
+        status: "clarify",
+        unparsed: ["Some evenings are busy"],
+      },
+    };
+    const answerPlanCreation = vi
+      .fn<(request: PlanCreationAnswerRpcParams) => Promise<PlanCreationAnswerRpcResult>>()
+      .mockResolvedValue({
+        status: "answered",
+        planCreation: { ...card, version: 11, pendingCommitment: null, openQuestion: question },
+      });
+    const { controller, controls } = subject(
+      client(replies(), {
+        listPlanningRequests: async () => ({ deliveries: [], planCreation: card }),
+        answerPlanCreation,
+      }),
+    );
+    await controller.start();
+    await controller.answerPlanCreation({ kind: "commitments-cancel" });
+    expect(controls.at(-1)?.planCreation?.value?.openQuestion?.kind).toBe("plan-length-question");
+    expect(controls.at(-1)?.planCreation?.focusRequest?.target).not.toBe("composer");
+    controller.dispose();
+  });
 
   it("rereads pending correction and displays the daemon explanation after rejected Draft build", async () => {
     const card: PlanCreationCardModel = {

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -3269,10 +3269,13 @@ describe("chat surface", () => {
         setChat({
           planCreationLoaded: true,
           planCreation: model,
+          inputDisabled: true,
+          sendDisabled: true,
+          composerPlaceholder: "Finish the correction above",
           timeline: [{ kind: "plan-creation", model }],
         });
         render(<Harness />);
-        const correction = screen.getByRole("region", { name: "Confirm these limits" });
+        const correction = screen.getByRole("region", { name: "Did I read this right?" });
         for (const text of [
           "Wed · at most 45 min",
           "Sat · unavailable",
@@ -3281,9 +3284,9 @@ describe("chat surface", () => {
         ]) {
           expect(within(correction).getByText(text)).toBeVisible();
         }
-        expect(
-          within(correction).getAllByRole("rowheader", { name: "Interpreted limit" }),
-        ).toHaveLength(4);
+        expect(within(correction).getAllByRole("rowheader", { name: "I understood" })).toHaveLength(
+          4,
+        );
         const blocked = screen.getByRole("button", {
           name:
             stage === "question"
@@ -3294,16 +3297,38 @@ describe("chat surface", () => {
         });
         expect(blocked).toBeDisabled();
         expect(blocked).toHaveAccessibleDescription(
-          "Your last confirmed limits remain effective. Draft building and activation wait for this correction.",
+          "I understood your note as this limit. Confirm it and your other confirmed limits stay as they are.",
         );
-        await userEvent.click(within(correction).getByRole("button", { name: "Confirm limits" }));
+        const dock = screen.getByRole("region", { name: "Plan creation dock" });
+        expect(dock).toContainElement(correction);
+        expect(
+          within(screen.getByRole("region", { name: "Plan creation" })).queryByRole("region", {
+            name: "Did I read this right?",
+          }),
+        ).toBeNull();
+        expect(composer()).toBeDisabled();
+        expect(composer()).toHaveAttribute("placeholder", "Finish the correction above");
+        expect(
+          within(correction)
+            .getAllByRole("button")
+            .map((button) => button.textContent),
+        ).toEqual(["Change it", "Confirm"]);
+        await userEvent.click(within(correction).getByRole("button", { name: "Change it" }));
+        expect(actions.editPlanCreation).toHaveBeenLastCalledWith("commitments");
+        vi.mocked(actions.answerPlanCreation).mockImplementation(async () => {
+          setChat({
+            planCreation: { ...model, pendingCommitment: null },
+            planCreationFocusRequest: { target: "composer", revision: 1 },
+            inputDisabled: false,
+            sendDisabled: false,
+            composerPlaceholder: "Message your coach",
+          });
+        });
+        await userEvent.click(within(correction).getByRole("button", { name: "Confirm" }));
         expect(actions.answerPlanCreation).toHaveBeenLastCalledWith({
           kind: "commitments-confirm",
         });
-        await userEvent.click(
-          within(correction).getByRole("button", { name: "Cancel correction" }),
-        );
-        expect(actions.answerPlanCreation).toHaveBeenLastCalledWith({ kind: "commitments-cancel" });
+        await waitFor(() => expect(composer()).toHaveFocus());
       },
     );
 
@@ -3324,18 +3349,47 @@ describe("chat surface", () => {
       setChat({
         planCreationLoaded: true,
         planCreation: model,
+        inputDisabled: true,
+        sendDisabled: true,
+        composerPlaceholder: "Finish the correction above",
         timeline: [{ kind: "plan-creation", model }],
       });
       render(<Harness />);
-      const correction = screen.getByRole("region", { name: "Clarify your commitment" });
-      const progress = screen.getByRole("region", { name: "Plan Creation progress" });
+      const correction = screen.getByRole("region", { name: "I could not use that answer" });
+      expect(screen.getByRole("region", { name: "Plan creation dock" })).toContainElement(
+        correction,
+      );
       expect(
-        progress.compareDocumentPosition(correction) & Node.DOCUMENT_POSITION_FOLLOWING,
-      ).not.toBe(0);
-      expect(within(correction).getByRole("rowheader", { name: "Not understood" })).toBeVisible();
-      expect(within(correction).queryByRole("button", { name: "Confirm limits" })).toBeNull();
+        within(screen.getByRole("region", { name: "Plan creation" })).queryByRole("region", {
+          name: "I could not use that answer",
+        }),
+      ).toBeNull();
+      expect(within(correction).getAllByRole("row")).toHaveLength(1);
+      expect(within(correction).getByRole("rowheader", { name: "You wrote" })).toBeVisible();
+      expect(within(correction).getByText("Plan creation · Commitments")).toBeVisible();
+      expect(correction.querySelector("[data-plan-card-status]")).toBeNull();
+      expect(
+        within(correction).getByText(
+          "Tell me again in a different way, with weekdays, time limits, or exact dates.",
+        ),
+      ).toBeVisible();
+      expect(
+        within(correction)
+          .getAllByRole("button")
+          .map((button) => button.textContent),
+      ).toEqual(["Skip for now", "Answer"]);
+      expect(screen.queryByRole("textbox", { name: "Commitments or time off" })).toBeNull();
+      expect(composer()).toBeDisabled();
+      expect(composer()).toHaveAttribute("placeholder", "Finish the correction above");
+      vi.mocked(actions.editPlanCreation).mockImplementation(() => {
+        setChat({ planCreationEditingKey: "commitments" });
+      });
+      await userEvent.click(within(correction).getByRole("button", { name: "Answer" }));
+      expect(actions.editPlanCreation).toHaveBeenLastCalledWith("commitments");
+      expect(screen.queryByRole("region", { name: "I could not use that answer" })).toBeNull();
       const editor = screen.getByRole("textbox", { name: "Commitments or time off" });
       expect(editor).toHaveValue("Some evenings are busy");
+      await waitFor(() => expect(editor).toHaveFocus());
       expect(editor).toHaveAccessibleDescription(
         "Give the weekday and exact limit, or the exact time-off dates.",
       );
@@ -3347,6 +3401,245 @@ describe("chat surface", () => {
         commitments: { kind: "interpreted", text: "Wed 45 min" },
       });
     });
+
+    it("shows a failed correction in the active editor and preserves the answer for retry", async () => {
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(
+          commitmentsQuestion("Any fixed commitments or time off?", "Add scheduling details"),
+        ),
+        pendingCommitment: {
+          text: "Some evenings are busy",
+          rules: [],
+          status: "clarify",
+          unparsed: ["Some evenings are busy"],
+        },
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        planCreationEditingKey: "commitments",
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      vi.mocked(actions.answerPlanCreation).mockImplementation(async () => {
+        setChat({ planCreationError: "Could not save that answer. Try again." });
+      });
+      render(<Harness />);
+      const editor = screen.getByRole("textbox", { name: "Commitments or time off" });
+      await userEvent.clear(editor);
+      await userEvent.type(editor, "Wed 45 min");
+      await userEvent.click(screen.getByRole("button", { name: "Review interpretation" }));
+      const dock = screen.getByRole("region", { name: "Plan creation dock" });
+      expect(within(dock).getByRole("alert")).toHaveTextContent(
+        "Could not save that answer. Try again.",
+      );
+      expect(editor).toHaveValue("Wed 45 min");
+      await userEvent.click(screen.getByRole("button", { name: "Review interpretation" }));
+      expect(actions.answerPlanCreation).toHaveBeenCalledTimes(2);
+      expect(actions.answerPlanCreation).toHaveBeenLastCalledWith({
+        kind: "commitments",
+        commitments: { kind: "interpreted", text: "Wed 45 min" },
+      });
+    });
+
+    it("replaces a pending confirmation with the commitments editor", async () => {
+      const question = commitmentsQuestion(
+        "Any fixed commitments or time off?",
+        "Add scheduling details",
+      );
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(question),
+        pendingCommitment: {
+          text: "Wednesday at most 45 minutes",
+          rules: [{ kind: "weekday-duration", day: 3, minutes: 45 }],
+          status: "confirm",
+          unparsed: [],
+        },
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      vi.mocked(actions.editPlanCreation).mockImplementation(() => {
+        setChat({ planCreationEditingKey: "commitments" });
+      });
+      render(<Harness />);
+      const dock = screen.getByRole("region", { name: "Plan creation dock" });
+      expect(within(dock).getAllByRole("region")).toHaveLength(1);
+      expect(screen.queryByText(question.prompt)).toBeNull();
+      await userEvent.click(within(dock).getByRole("button", { name: "Change it" }));
+      const editor = screen.getByRole("textbox", { name: "Commitments or time off" });
+      expect(editor).toHaveValue("Wednesday at most 45 minutes");
+      await waitFor(() => expect(editor).toHaveFocus());
+      expect(screen.queryByRole("region", { name: "Did I read this right?" })).toBeNull();
+      expect(document.querySelector("#message")).toBeNull();
+    });
+
+    it("returns focus to the composer and enables building after skipping a pending answer", async () => {
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null),
+        pendingCommitment: {
+          text: "Some evenings are busy",
+          rules: [],
+          status: "clarify",
+          unparsed: ["Some evenings are busy"],
+        },
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      vi.mocked(actions.answerPlanCreation).mockImplementation(async () => {
+        const resolved = { ...model, pendingCommitment: null };
+        setChat({
+          planCreation: resolved,
+          planCreationFocusRequest: { target: "composer", revision: 1 },
+          timeline: [{ kind: "plan-creation", model: resolved }],
+        });
+      });
+      render(<Harness />);
+      expect(screen.getByRole("button", { name: "Build Draft" })).toBeDisabled();
+      await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+      expect(actions.answerPlanCreation).toHaveBeenLastCalledWith({ kind: "commitments-cancel" });
+      await waitFor(() => expect(composer()).toHaveFocus());
+      expect(composer()).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Build Draft" })).toBeEnabled();
+    });
+
+    it("focuses the docked check card when a typed commitment could not be used", () => {
+      const model: PlanCreationCardModel = {
+        ...planCreationModel(null),
+        readiness: "ready",
+        pendingCommitment: {
+          text: "Some evenings are busy",
+          status: "clarify",
+          rules: [],
+          unparsed: ["Some evenings are busy"],
+        },
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        planCreationFocusRevision: 1,
+        inputDisabled: true,
+        sendDisabled: true,
+        composerPlaceholder: "Finish the correction above",
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+      expect(screen.getByRole("heading", { name: "I could not use that answer" })).toHaveFocus();
+    });
+
+    it("keeps an unresolved typed commitment out of the Changed answers card", () => {
+      const original = planCreationModel(null, { readiness: "ready" });
+      const unresolved = {
+        answerKey: "commitments",
+        title: "Commitments",
+        detail: "Some evenings are busy",
+        question: commitmentsQuestion(
+          "Any fixed commitments or time off?",
+          "Add scheduling details",
+        ),
+        source: { kind: "athlete" },
+        answer: {
+          kind: "commitments",
+          commitments: {
+            kind: "interpreted",
+            text: "Some evenings are busy",
+            status: "clarify",
+            rules: [],
+          },
+        },
+      } satisfies PlanCreationCardModel["answeredSummaries"][number];
+      const model: PlanCreationCardModel = {
+        ...original,
+        version: 3,
+        status: "review",
+        draft: planCreationDraft(original.answeredSummaries),
+        draftStale: true,
+        answeredSummaries: [...original.answeredSummaries, unresolved],
+        pendingCommitment: {
+          text: "Some evenings are busy",
+          status: "clarify",
+          rules: [],
+          unparsed: ["Some evenings are busy"],
+        },
+      };
+      setChat({
+        planCreationLoaded: true,
+        planCreation: model,
+        inputDisabled: true,
+        sendDisabled: true,
+        composerPlaceholder: "Finish the correction above",
+        timeline: [{ kind: "plan-creation", model }],
+      });
+      render(<Harness />);
+      const transcript = screen.getByRole("region", { name: "Plan creation" });
+      expect(within(transcript).queryByText("Some evenings are busy")).toBeNull();
+      expect(
+        within(screen.getByRole("region", { name: "Plan creation dock" })).getByText(
+          "Some evenings are busy",
+        ),
+      ).toBeVisible();
+    });
+
+    it.each(["confirmed", "unresolved"] as const)(
+      "hides an unresolved commitments summary row and keeps a %s one",
+      (source) => {
+        const question = commitmentsQuestion(
+          "Any fixed commitments or time off?",
+          "Add scheduling details",
+        );
+        const confirmed = {
+          answerKey: "commitments",
+          title: "Commitments",
+          detail: "Friday off",
+          question,
+          source: { kind: "athlete" },
+          answer: {
+            kind: "commitments",
+            commitments: {
+              kind: "interpreted",
+              text: "Friday off",
+              status: "confirmed",
+              rules: [{ kind: "weekday-unavailable", day: 5 }],
+            },
+          },
+        } satisfies PlanCreationCardModel["answeredSummaries"][number];
+        const unresolved = {
+          ...confirmed,
+          detail: "Some evenings are busy",
+          answer: {
+            kind: "commitments",
+            commitments: {
+              kind: "interpreted",
+              text: "Some evenings are busy",
+              status: "clarify",
+              rules: [],
+            },
+          },
+        } satisfies PlanCreationCardModel["answeredSummaries"][number];
+        const model: PlanCreationCardModel = {
+          ...planCreationModel(null),
+          answeredSummaries: [source === "confirmed" ? confirmed : unresolved],
+          pendingCommitment: {
+            text: "Some evenings are busy",
+            status: "clarify",
+            rules: [],
+            unparsed: ["Some evenings are busy"],
+          },
+        };
+        render(<PlanCreationSummary model={model} />);
+        expect(screen.queryByText("Some evenings are busy")).toBeNull();
+        if (source === "unresolved")
+          expect(screen.queryByRole("listitem", { name: "Commitments answer" })).toBeNull();
+        else
+          expect(screen.getByRole("listitem", { name: "Commitments answer" })).toHaveTextContent(
+            "Friday off",
+          );
+      },
+    );
 
     it("keeps fixed Workout dates and pinned status visible during Draft review", () => {
       const draft = planCreationDraft();

--- a/apps/desktop/tests/e2e/plan-creation-commitments.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-commitments.spec.ts
@@ -9,7 +9,7 @@ import { PlanCreationBackend } from "../helpers/plan-creation-backend.js";
 const commitments = "Wednesday at most 45 minutes";
 const ambiguousCommitment = "Keep my evenings free";
 const pendingSummary =
-  "Your last confirmed limits remain effective. Draft building and activation wait for this correction.";
+  "I understood your note as this limit. Confirm it and your other confirmed limits stay as they are.";
 const previews = fileURLToPath(new URL("./previews/plan-creation-commitments/", import.meta.url));
 
 type Playwright = PlaywrightWorkerArgs["playwright"];
@@ -51,6 +51,33 @@ async function capture(page: Page, name: string): Promise<void> {
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
 }
 
+async function expectAboveComposer(
+  page: Page,
+  correction: ReturnType<Page["getByRole"]>,
+): Promise<void> {
+  const name = (await correction.getAttribute("aria-label")) ?? "";
+  await expect(
+    page
+      .getByRole("region", { name: "Plan creation dock", exact: true })
+      .getByRole("region", { name, exact: true }),
+  ).toHaveCount(1);
+  await expect(
+    page
+      .getByRole("region", { name: "Plan creation", exact: true })
+      .getByRole("region", { name, exact: true }),
+  ).toHaveCount(0);
+  await expect(page.locator("#message")).toBeDisabled();
+  await expect(page.locator("#message")).toHaveAttribute(
+    "placeholder",
+    "Finish the correction above",
+  );
+  const cardBox = await correction.boundingBox();
+  const composerBox = await page.locator("#message").boundingBox();
+  if (cardBox === null || composerBox === null)
+    throw new TypeError("Correction or composer is unavailable");
+  expect(cardBox.y + cardBox.height).toBeLessThanOrEqual(composerBox.y);
+}
+
 async function card(backend: PlanCreationBackend) {
   const model = await backend.card();
   if (model === null) throw new TypeError("Plan Creation is unavailable");
@@ -77,13 +104,29 @@ for (const appearance of [
     test.setTimeout(180_000);
     const scratch = await mkdtemp(join(tmpdir(), "plan-commitments-"));
     const backend = new PlanCreationBackend(join(scratch, "store.db"), false, true);
+    let failNextAnswer = false;
     let fixture: RunningDesktopFixture | undefined;
     let browser: Browser | undefined;
     try {
       await backend.open();
-      await backend.seedTrainingCreation({ kind: "interpreted", text: commitments });
+      await backend.seedTrainingCreation({ kind: "interpreted", text: ambiguousCommitment });
       fixture = await launchDesktopFixture({
-        script: backend.script,
+        script: {
+          ...backend.script,
+          onRequest: (request) => {
+            if (
+              failNextAnswer &&
+              typeof request === "object" &&
+              request !== null &&
+              "method" in request &&
+              request.method === "plan_creation.answer"
+            ) {
+              failNextAnswer = false;
+              throw new Error("Synthetic answer failure");
+            }
+            return backend.script.onRequest(request);
+          },
+        },
         token: "d".repeat(43),
         width: appearance.width,
         height: 1000,
@@ -99,14 +142,20 @@ for (const appearance of [
       const screenshot = (name: string) =>
         capture(page, `${name}-${appearance.width}-${appearance.colorScheme}`);
       const build = page.getByRole("button", { name: "Build Draft", exact: true });
-      await expect(
-        page.getByRole("heading", { name: "Confirm these limits", exact: true }),
-      ).toBeVisible();
+      const initialCorrection = page.getByRole("region", {
+        name: "I could not use that answer",
+        exact: true,
+      });
+      await expect(initialCorrection).toBeVisible();
+      await expectAboveComposer(page, initialCorrection);
       await expect(build).toBeDisabled();
-      await expect(build).toHaveAccessibleDescription(pendingSummary);
+      await expect(build).toHaveAccessibleDescription(
+        "Tell me again in a different way, with weekdays, time limits, or exact dates.",
+      );
       await screenshot("pending-before-draft");
-      await page.getByRole("button", { name: "Cancel correction", exact: true }).click();
+      await page.getByRole("button", { name: "Skip for now", exact: true }).click();
       await expect(build).toBeEnabled();
+      await expect(page.locator("#message")).toBeFocused();
       await build.click();
       await expect(page.getByRole("button", { name: "Activate Plan", exact: true })).toBeEnabled();
       const original = await card(backend);
@@ -121,16 +170,22 @@ for (const appearance of [
       await editCommitments(page);
       await page.locator('[data-parity="custom.textarea"]').fill(commitments);
       await page.getByRole("button", { name: "Review interpretation", exact: true }).click();
-      const confirmation = page.getByRole("region", { name: "Confirm these limits", exact: true });
+      const confirmation = page.getByRole("region", {
+        name: "Did I read this right?",
+        exact: true,
+      });
       await expect(confirmation).toBeVisible();
-      await expect(confirmation.getByText("Schedule correction", { exact: true })).toBeVisible();
-      await expect(confirmation.getByText("Not yet confirmed", { exact: true })).toBeVisible();
       await expect(
-        confirmation.getByRole("row", { name: `Submitted ${commitments}`, exact: true }),
+        confirmation.getByText("Plan creation · Commitments", { exact: true }),
+      ).toBeVisible();
+      await expect(confirmation.locator("[data-plan-card-status]")).toHaveCount(0);
+      await expectAboveComposer(page, confirmation);
+      await expect(
+        confirmation.getByRole("row", { name: `You wrote ${commitments}`, exact: true }),
       ).toBeVisible();
       await expect(
         confirmation.getByRole("row", {
-          name: "Interpreted limit Wed · at most 45 min",
+          name: "I understood Wed · at most 45 min",
           exact: true,
         }),
       ).toBeVisible();
@@ -153,13 +208,14 @@ for (const appearance of [
       browser = connected.browser;
       page = connected.page;
       await expect(
-        page.getByRole("heading", { name: "Confirm these limits", exact: true }),
+        page.getByRole("heading", { name: "Did I read this right?", exact: true }),
       ).toBeVisible();
       expect(await card(backend)).toEqual(pending);
       await expect(page.getByRole("button", { name: "Activate Plan", exact: true })).toBeDisabled();
       await screenshot("pending-restored");
-      await page.getByRole("button", { name: "Confirm limits", exact: true }).click();
+      await page.getByRole("button", { name: "Confirm", exact: true }).click();
       await expect.poll(async () => (await backend.card())?.pendingCommitment).toBeNull();
+      await expect(page.locator("#message")).toBeFocused();
       expect(await card(backend)).toMatchObject({ draft: original.draft, draftStale: true });
       await page.getByRole("button", { name: "Rebuild Draft", exact: true }).click();
       await expect(page.getByRole("button", { name: "Activate Plan", exact: true })).toBeEnabled();
@@ -192,19 +248,23 @@ for (const appearance of [
       await page.locator('[data-parity="custom.textarea"]').fill(ambiguousCommitment);
       await page.getByRole("button", { name: "Review interpretation", exact: true }).click();
       const clarification = page.getByRole("region", {
-        name: "Clarify your commitment",
+        name: "I could not use that answer",
         exact: true,
       });
       await expect(clarification).toBeVisible();
-      await expect(clarification.getByText("Not understood", { exact: true })).toBeVisible();
       await expect(
-        clarification.getByRole("button", { name: "Confirm limits", exact: true }),
-      ).toHaveCount(0);
+        clarification.getByRole("row", { name: `You wrote ${ambiguousCommitment}`, exact: true }),
+      ).toBeVisible();
+      await expect(clarification.getByRole("row")).toHaveCount(1);
+      await expectAboveComposer(page, clarification);
+      await expect(clarification.getByRole("button", { name: "Confirm", exact: true })).toHaveCount(
+        0,
+      );
       await expect(page.getByRole("button", { name: "Activate Plan", exact: true })).toBeDisabled();
       expect((await card(backend)).draft).toEqual(rebuilt.draft);
       await clarification.scrollIntoViewIfNeeded();
       await screenshot("clarify-pending");
-      await page.getByRole("button", { name: "Clarify", exact: true }).click();
+      await page.getByRole("button", { name: "Answer", exact: true }).click();
       await expect(page.locator('[data-parity="custom.textarea"]')).toHaveValue(
         ambiguousCommitment,
       );
@@ -214,7 +274,25 @@ for (const appearance of [
         }),
       ).toBeVisible();
       await screenshot("clarify-editor");
+      failNextAnswer = true;
+      await page.locator('[data-parity="custom.textarea"]').fill("Some evenings are busy");
+      await page.getByRole("button", { name: "Review interpretation", exact: true }).click();
+      await expect(
+        page.getByRole("region", { name: "Plan creation dock", exact: true }).getByRole("alert"),
+      ).toHaveText("Plan Creation couldn’t save that. Try again.");
+      await expect(page.locator('[data-parity="custom.textarea"]')).toHaveValue(
+        "Some evenings are busy",
+      );
+      await screenshot("clarify-editor-error");
+      await page.getByRole("button", { name: "Review interpretation", exact: true }).click();
+      await expect(clarification).toBeVisible();
+      await expect(
+        clarification.getByText("Some evenings are busy", { exact: true }),
+      ).toBeVisible();
+      await page.getByRole("button", { name: "Answer", exact: true }).click();
       await page.getByRole("button", { name: "Back to answers", exact: true }).click();
+      await page.getByRole("button", { name: "Skip for now", exact: true }).click();
+      await expect(page.locator("#message")).toBeFocused();
       const clarificationBeforeChat = await card(backend);
       await page
         .getByRole("combobox", { name: "Message your coach" })
@@ -226,16 +304,25 @@ for (const appearance of [
           .getByText("Keep the effort conversational and finish feeling fresh.", { exact: true }),
       ).toBeVisible();
       expect(await card(backend)).toEqual(clarificationBeforeChat);
-      await page.getByRole("combobox", { name: "Message your coach" }).fill("Saturday unavailable");
-      await page.getByRole("button", { name: "Send message" }).click();
+      await editCommitments(page);
+      await page.locator('[data-parity="custom.textarea"]').fill("Saturday unavailable");
+      await page.getByRole("button", { name: "Review interpretation", exact: true }).click();
       await expect(
-        page.getByRole("heading", { name: "Confirm these limits", exact: true }),
+        page.getByRole("heading", { name: "Did I read this right?", exact: true }),
       ).toBeVisible();
       await expect
         .poll(async () => (await backend.card())?.pendingCommitment?.text)
         .toBe("Saturday unavailable");
-      await page.getByRole("button", { name: "Cancel correction", exact: true }).click();
+      await page.getByRole("button", { name: "Change it", exact: true }).click();
+      await expect(page.locator('[data-parity="custom.textarea"]')).toBeFocused();
+      await page.locator('[data-parity="custom.textarea"]').fill(ambiguousCommitment);
+      await page.getByRole("button", { name: "Review interpretation", exact: true }).click();
+      await page
+        .getByRole("region", { name: "I could not use that answer", exact: true })
+        .getByRole("button", { name: "Skip for now", exact: true })
+        .click();
       await expect.poll(async () => (await backend.card())?.pendingCommitment).toBeNull();
+      await expect(page.locator("#message")).toBeFocused();
       expect(await card(backend)).toMatchObject({
         draft: rebuilt.draft,
         draftStale: false,

--- a/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
@@ -535,7 +535,7 @@ for (const appearance of [
         .getByRole("button", { name: "Review interpretation", exact: true })
         .click();
       await expect(
-        scenario.page.getByRole("heading", { name: "Confirm these limits", exact: true }),
+        scenario.page.getByRole("heading", { name: "Did I read this right?", exact: true }),
       ).toBeVisible();
       const pending = await waitForVersion(scenario.backend, 6);
       expect(pending.pendingCommitment).toEqual({
@@ -546,7 +546,7 @@ for (const appearance of [
       });
       expect(pending.answeredSummaries).toHaveLength(5);
       expect(await scenario.backend.answers()).toHaveLength(5);
-      await scenario.page.getByRole("button", { name: "Confirm limits", exact: true }).click();
+      await scenario.page.getByRole("button", { name: "Confirm", exact: true }).click();
       const confirmed = await waitForVersion(scenario.backend, 7);
       expect(confirmed.pendingCommitment).toBeNull();
       expect(confirmed.answeredSummaries).toHaveLength(5);


### PR DESCRIPTION
Typed commitments that need clarification or confirmation now stay above the message box. The card uses coach-voice copy and keeps the message box disabled until the athlete answers or skips.

Unresolved answers stay out of the answer summary and changed-answer list. Resolving a check focuses the next question or the message box. Failed correction submissions show an alert in the active editor and preserve the text for retry.

The approved card has one submitted-answer row, interpreted-limit rows only when confirmation is possible, and two actions. Existing commitment interpretation remains unchanged.

Verification:

- Root build, package checks, root TypeScript check, lint, and repository gates passed. The checks that require local IPC passed after rerunning outside the socket-restricted sandbox.
- Chat surface and adapter tests passed, 161 tests. Controller and adapter checks passed, 154 tests.
- The renderer suite covered 771 tests. Three tests exceeded their five-second limit under concurrent local load and passed on isolated retries.
- All four commitments desktop flows passed at wide and compact widths in light and dark, including failure, retry, confirmation, cancellation, relaunch, and focus restoration.
- The prototype comparison ran in all four layout and theme cells. Content and action order match; production typography, primitive geometry, and responsive layouts account for retained visual differences.
- The isolated OpenAI review completed with no actionable findings. Two correction cycles completed.
- The full desktop E2E suite passed: 128 tests in 13.6 minutes.

https://claude.ai/code/session_01Q7jtJyv9VVvEJByQbXoSGF
