### PR TITLE
fix(engine): keep ChatGPT retries and failed trim flushes after review

### DIFF
--- a/.changeset/llm-turn-review-findings.md
+++ b/.changeset/llm-turn-review-findings.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/engine": patch
+"@enduragent/core": patch
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: If ChatGPT is still looking something up, a slow reply can retry instead of stopping on the first words. A memory save that fails during a long chat is retried after you reopen the app. Garmin labels stay on the facts they belong to.

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -89,6 +89,17 @@ export interface UnflushedResetArchive {
 }
 
 const RESET_ARCHIVE_REF_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z\.[a-f0-9]{64}$/;
+const PRECOMPACT_ARCHIVE_REF_PATTERN = /^precompact\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z$/;
+
+function pendingArchivePath(sessionPath: string, archiveRef: string): string | null {
+  if (RESET_ARCHIVE_REF_PATTERN.test(archiveRef)) {
+    return `${sessionPath}.reset.${archiveRef}`;
+  }
+  if (PRECOMPACT_ARCHIVE_REF_PATTERN.test(archiveRef)) {
+    return `${sessionPath}.${archiveRef}`;
+  }
+  return null;
+}
 
 const DURABLE_RESET_OPERATIONS = new WeakMap<
   ChatStore,
@@ -316,8 +327,8 @@ export class ChatStore {
       .sort();
     for (const marker of markers) {
       const archiveRef = marker.slice(prefix.length);
-      if (!RESET_ARCHIVE_REF_PATTERN.test(archiveRef)) continue;
-      const archivePath = `${path}.reset.${archiveRef}`;
+      const archivePath = pendingArchivePath(path, archiveRef);
+      if (archivePath === null) continue;
       if (!this.sessionExists(archivePath)) {
         this.unlinkSessionPath(marker);
         continue;
@@ -335,7 +346,7 @@ export class ChatStore {
   }
 
   markResetArchiveFlushed(chatId: string, archiveRef: string): void {
-    if (!RESET_ARCHIVE_REF_PATTERN.test(archiveRef)) {
+    if (pendingArchivePath(this.filePath(chatId), archiveRef) === null) {
       throw new TypeError("Reset archive reference is invalid.");
     }
     this.unlinkIfPresent(this.flushPendingPath(chatId, archiveRef));
@@ -1165,12 +1176,16 @@ export class ChatStore {
     return deleted;
   }
 
-  archivePreCompact(chatId: string): void {
+  archivePreCompact(chatId: string, options?: { readonly flushPending?: boolean }): void {
     const path = this.filePath(chatId);
     if (!this.sessionExists(path)) return;
 
     const ts = new Date().toISOString().replace(/:/g, "-");
-    this.copySessionPath(path, `${path}.precompact.${ts}`);
+    const archiveRef = `precompact.${ts}`;
+    this.copySessionPath(path, `${path}.${archiveRef}`);
+    if (options?.flushPending === true) {
+      this.appendSessionContent(this.flushPendingPath(chatId, archiveRef), "");
+    }
     this.pruneArchives(chatId, "precompact");
   }
 

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -160,9 +160,9 @@ export class ConversationStore implements ConversationStorePort {
     this.chatStore.overwriteHistory(chatId, messages);
   }
 
-  archivePreCompact(chatId: string): void {
+  archivePreCompact(chatId: string, options?: { readonly flushPending?: boolean }): void {
     this.recoverBeforeAccess(chatId);
-    this.chatStore.archivePreCompact(chatId);
+    this.chatStore.archivePreCompact(chatId, options);
   }
 
   appendCompletedTurn(input: TranscriptCompletedTurnInput): void {

--- a/packages/core/tests/chat-store.test.ts
+++ b/packages/core/tests/chat-store.test.ts
@@ -509,6 +509,29 @@ describe("ChatStore durable reset — private race-checked targets", () => {
     );
   });
 
+  it("marks a precompact archive flush-pending and serves it until flushed", () => {
+    const store = new ChatStore(dataDir);
+    store.appendTurn("trim", "synthetic older user", "synthetic older coach", LINEAGE);
+    store.archivePreCompact("trim", { flushPending: true });
+
+    const archives = listPrecompactArchives("trim");
+    expect(archives).toHaveLength(1);
+    const archiveRef = archives[0].slice("trim.jsonl.".length);
+    expect(archiveRef.startsWith("precompact.")).toBe(true);
+    expect(existsSync(join(sessionsDir, `trim.jsonl.flush-pending.${archiveRef}`))).toBe(true);
+
+    const loaded = store.loadUnflushedResetArchive("trim");
+    expect(loaded?.archiveRef).toBe(archiveRef);
+    expect(loaded?.messages.map((m) => m.content)).toEqual([
+      "synthetic older user",
+      "synthetic older coach",
+    ]);
+
+    store.markResetArchiveFlushed("trim", archiveRef);
+    expect(existsSync(join(sessionsDir, `trim.jsonl.flush-pending.${archiveRef}`))).toBe(false);
+    expect(store.loadUnflushedResetArchive("trim")).toBeNull();
+  });
+
   it("drops a flush-pending marker whose archive is gone", () => {
     const store = new ChatStore(dataDir);
     store.appendTurn("orphan", "synthetic user", "synthetic coach", LINEAGE);

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -394,12 +394,6 @@ export class CoachAgent {
   private lastFlushMessageCount = new Map<string, number>();
   private pendingFlushMessages = new Map<string, ModelMessage[]>();
   private readonly confirmationGate: boolean;
-  // The prompt-template hash is derived from constructor-stable inputs (soul,
-  // skills, tool schemas, model, and the compile-time rule-block set), so it is
-  // computed once on first use and reused for every turn of the process.
-  private templateHash?: string;
-  private desktopTemplateHash?: string;
-  private planTemplateHash?: string;
   private readonly activeChatTurns = new Map<
     string,
     { readonly turnId: string; readonly controller: AbortController }
@@ -590,13 +584,7 @@ export class CoachAgent {
   }
 
   private templateHashForChat(chatId: string, tools: ToolSet): string {
-    const current = chatId.startsWith("plan:")
-      ? this.planTemplateHash
-      : chatId === "desktop"
-        ? this.desktopTemplateHash
-        : this.templateHash;
-    if (current !== undefined) return current;
-    const value = computeTemplateHash({
+    return computeTemplateHash({
       soul: chatId.startsWith("plan:") ? PLAN_COACH_AUTHORITY_RULES : this.sport.soul,
       skills: chatId.startsWith("plan:") ? {} : this.sport.skills,
       ruleBlocks: chatId.startsWith("plan:")
@@ -607,10 +595,6 @@ export class CoachAgent {
       toolSchemas: tools,
       model: this.config.llm.model,
     });
-    if (chatId.startsWith("plan:")) this.planTemplateHash = value;
-    else if (chatId === "desktop") this.desktopTemplateHash = value;
-    else this.templateHash = value;
-    return value;
   }
 
   private runWithWriteProvenance<T>(provenance: SourceProvenance, fn: () => T): T {
@@ -786,7 +770,7 @@ export class CoachAgent {
       return;
     }
     await this.flushMemory(window, trigger, budget);
-    this.markFlushed(chatId, history.length);
+    this.markFlushed(chatId, history.length + currentTurn.length);
   }
 
   settle(chatId?: string): Promise<void> {
@@ -1042,14 +1026,23 @@ export class CoachAgent {
 
         let recoveryFlushQueued = false;
         const unflushed = this.chatStore.loadUnflushedResetArchive(chatId);
-        if (unflushed !== null) {
-          const markFlushed = () =>
-            this.chatStore.markResetArchiveFlushed(chatId, unflushed.archiveRef);
-          if (unflushed.messages.length === 0) {
-            markFlushed();
+        const ramPending = this.pendingFlushMessages.get(chatId) ?? [];
+        if (unflushed !== null || ramPending.length > 0) {
+          const markDiskFlushed = (): void => {
+            if (unflushed !== null) {
+              this.chatStore.markResetArchiveFlushed(chatId, unflushed.archiveRef);
+            }
+          };
+          if (unflushed !== null && unflushed.messages.length === 0 && ramPending.length === 0) {
+            markDiskFlushed();
           } else {
             recoveryFlushQueued = true;
-            this.queueFlush(chatId, unflushed.messages, "stale-reset", markFlushed);
+            this.queueFlush(
+              chatId,
+              ramPending.length > 0 ? [] : (unflushed?.messages ?? []),
+              "stale-reset",
+              markDiskFlushed,
+            );
           }
         }
 
@@ -1079,11 +1072,13 @@ export class CoachAgent {
         let summaryMsg: ModelMessage | undefined;
         let requeued: ModelMessage[] = [];
         if (dropped.length > 0) {
+          let trimFlushFailed = false;
           if (!flushedThisTurn) {
             flushedThisTurn = true;
             try {
               await this.flushNewMessages(chatId, history, "trim", turnBudget);
             } catch (err) {
+              trimFlushFailed = true;
               this.log.warn(
                 "Pre-compaction memory flush failed; the dropped messages stay queued for the next flush",
                 err,
@@ -1105,7 +1100,7 @@ export class CoachAgent {
             summaryMsg = makeSummaryMessage(summary, summaryProvenance);
             requeued = unsummarized;
             const compacted = [summaryMsg, ...requeued, ...kept];
-            this.chatStore.archivePreCompact(chatId);
+            this.chatStore.archivePreCompact(chatId, { flushPending: trimFlushFailed });
             this.chatStore.overwriteHistory(chatId, compacted);
             this.deferUnflushed(chatId, history, compacted.length);
           } catch (err) {
@@ -1363,7 +1358,7 @@ export class CoachAgent {
               }
               if (chatId.startsWith("plan:")) assertPlanCoachReplyAuthority(effectiveText);
 
-              const templateHash = this.templateHashForChat(chatId, this.toolsForChat(chatId));
+              const templateHash = this.templateHashForChat(chatId, turnTools);
               const assembledHash = computeAssembledHash(systemPrompt, providerMessages);
 
               const lineage: ChatLineage = {
@@ -1658,7 +1653,7 @@ export class CoachAgent {
               providerUserMessage,
               turn?.nativeMedia ?? [],
             );
-            const templateHash = this.templateHashForChat(chatId, this.toolsForChat(chatId));
+            const templateHash = this.templateHashForChat(chatId, turnTools);
             try {
               this.chatStore.appendTurn(chatId, userMessageWithTime, streamedText, {
                 templateHash,

--- a/packages/engine/src/agent/codex-bridge.ts
+++ b/packages/engine/src/agent/codex-bridge.ts
@@ -304,7 +304,9 @@ export async function codexGenerateText(
 
   for (let step = 0; step < limit; step++) {
     let result: CodexResponsesResult;
+    const stepDeltas: string[] = [];
     while (true) {
+      stepDeltas.length = 0;
       try {
         result = await codexResponses({
           modelId,
@@ -314,7 +316,11 @@ export async function codexGenerateText(
           accessToken,
           sessionId: cacheKey,
           signal,
-          onTextDelta,
+          onTextDelta: onTextDelta
+            ? (delta) => {
+                stepDeltas.push(delta);
+              }
+            : undefined,
         });
         break;
       } catch (err) {
@@ -348,7 +354,15 @@ export async function codexGenerateText(
     convo.push({ role: "assistant", content: assistantContent } as ModelMessage);
 
     const calls = result.toolCalls;
-    if (calls.length === 0 || result.stopReason !== "toolUse") break;
+    const toolStep = calls.length > 0 && result.stopReason === "toolUse";
+    if (!toolStep && onTextDelta) {
+      if (stepDeltas.length > 0) {
+        for (const delta of stepDeltas) onTextDelta(delta);
+      } else if (result.text) {
+        onTextDelta(result.text);
+      }
+    }
+    if (!toolStep) break;
     if (!tools) break;
 
     const results = isAdmissibleCoachDecisionBatch(calls)

--- a/packages/engine/src/agent/memory-flush.ts
+++ b/packages/engine/src/agent/memory-flush.ts
@@ -69,19 +69,10 @@ write, so include ALL current facts for that section, not just new ones.
 Use the ledger_append tool to record dated events (decisions, overrides,
 illness, experiment outcomes); ledger entries are appended, never replaced.`;
 
-function renderCurrentMemory(memory: MemoryStorePort): {
-  text: string;
-  provenance: SourceProvenance;
-} {
-  const current = memory.getContextWithProvenance?.() ?? {
-    text: memory.getContext(),
-    provenance: EMPTY_PROVENANCE,
-  };
+function renderCurrentMemory(memory: MemoryStorePort): string {
+  const current = memory.getContextWithProvenance?.() ?? { text: memory.getContext() };
   const text = current.text || "No athlete data stored yet.";
-  return {
-    text: wrapAthleteContextFence({ text, maxChars: ATHLETE_CONTEXT_MAX_CHARS }),
-    provenance: current.text ? current.provenance : EMPTY_PROVENANCE,
-  };
+  return wrapAthleteContextFence({ text, maxChars: ATHLETE_CONTEXT_MAX_CHARS });
 }
 
 function buildFlushUserPrompt(
@@ -144,7 +135,7 @@ ${currentMemory}`;
 function createFlushMemoryWriteTool(
   memory: MemoryStorePort,
   sections: readonly MemorySectionSpec[],
-  provenance: () => SourceProvenance,
+  provenanceFor: (section: string) => SourceProvenance,
   onWrite: () => void,
 ) {
   const sectionNames = sections.map((s) => s.name) as [string, ...string[]];
@@ -157,7 +148,7 @@ function createFlushMemoryWriteTool(
       }),
     ),
     execute: async (input: { section: string; content: string }) => {
-      memory.writeSection(input.section, input.content, "flush", provenance());
+      memory.writeSection(input.section, input.content, "flush", provenanceFor(input.section));
       onWrite();
       return { saved: true };
     },
@@ -224,10 +215,7 @@ export async function runMemoryFlush(params: {
   let writes = 0;
   let ledgerAppends = 0;
   const currentMemory = renderCurrentMemory(params.memory);
-  const visibleProvenance = unionProvenance(
-    provenanceOfMessages(params.messages),
-    currentMemory.provenance,
-  );
+  const conversationProvenance = provenanceOfMessages(params.messages);
   const beforeChars = new Map(
     params.memorySections.map((s) => [s.name, (params.memory.readSection(s.name) ?? "").length]),
   );
@@ -235,7 +223,11 @@ export async function runMemoryFlush(params: {
     memory_write: createFlushMemoryWriteTool(
       params.memory,
       params.memorySections,
-      () => visibleProvenance,
+      (section) =>
+        unionProvenance(
+          conversationProvenance,
+          params.memory.provenanceForSection?.(section) ?? EMPTY_PROVENANCE,
+        ),
       () => {
         writes++;
       },
@@ -243,7 +235,7 @@ export async function runMemoryFlush(params: {
     ledger_append: createLedgerAppendTool(
       params.memory,
       "flush",
-      () => visibleProvenance,
+      () => conversationProvenance,
       () => {
         ledgerAppends++;
       },
@@ -259,7 +251,7 @@ export async function runMemoryFlush(params: {
         role: "user" as const,
         content: buildFlushUserPrompt(
           params.memorySections,
-          currentMemory.text,
+          currentMemory,
           todayInTZ(params.tz ?? "UTC"),
         ),
       },

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -166,7 +166,7 @@ export interface ChatStorePort {
     chatId: string,
   ): { readonly archiveRef: string; readonly messages: ModelMessage[] } | null;
   markResetArchiveFlushed(chatId: string, archiveRef: string): void;
-  archivePreCompact(chatId: string): void;
+  archivePreCompact(chatId: string, options?: { readonly flushPending?: boolean }): void;
   getChatQueue?(chatId: string): ChatQueueSnapshot;
   enqueueChatMessage?(
     chatId: string,

--- a/packages/engine/tests/athlete-snapshot-wiring.test.ts
+++ b/packages/engine/tests/athlete-snapshot-wiring.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import type { ToolSet } from "ai";
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cyclingSport } from "@enduragent/sport-cycling";
@@ -189,4 +189,64 @@ describe("memory_read registration follows the non-injected sections", () => {
       "Read only stored sections that Athlete Context does not show, plus today's notes and plan state.",
     );
   });
+
+  it("persists the template hash of the tools sent this turn", async () => {
+    const emptyDir = makeDataDir();
+    const notesDir = makeDataDir();
+    new Memory(notesDir).writeSection("notes", "prefers hill repeats");
+    await runTurn(emptyDir, undefined, "chat-hash");
+    await runTurn(notesDir, undefined, "chat-hash");
+    expect(lastTemplateHash(emptyDir, "chat-hash")).not.toBe(lastTemplateHash(notesDir, "chat-hash"));
+  });
+
+  it("recomputes the template hash when memory_read appears on a later turn of the same agent", async () => {
+    const dataDir = makeDataDir();
+    const base = baseAgentConfig(dataDir);
+    let tools: ToolSet = {};
+    const ports: EngineHostPorts = {
+      ...base,
+      platform: { ...base.platform, athleteData: undefined },
+      transcriptWriter: { appendCompletedTurn: () => undefined },
+      modelTransportDecorator: () => ({
+        generate: async (request) => {
+          tools = request.options.tools ?? {};
+          const usage = {
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            inputTokenDetails: { noCacheTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+            outputTokenDetails: { textTokens: 0, reasoningTokens: 0 },
+          };
+          return {
+            text: "ok",
+            toolCalls: [],
+            finishReason: "stop",
+            usage,
+            totalUsage: usage,
+            steps: 1,
+          };
+        },
+      }),
+    };
+    const agent = new CoachAgent(cyclingSport, ports);
+    await agent.chat("chat-hash", "first");
+    expect(tools).not.toHaveProperty("memory_read");
+    const hashWithout = lastTemplateHash(dataDir, "chat-hash");
+    new Memory(dataDir).writeSection("notes", "prefers hill repeats");
+    await agent.chat("chat-hash", "second");
+    expect(tools).toHaveProperty("memory_read");
+    expect(lastTemplateHash(dataDir, "chat-hash")).not.toBe(hashWithout);
+  });
 });
+
+function lastTemplateHash(dataDir: string, chatId: string): string {
+  const lines = readFileSync(join(dataDir, "sessions", `${chatId}.jsonl`), "utf8")
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0);
+  const last = JSON.parse(lines[lines.length - 1] ?? "{}") as { templateHash?: string };
+  if (typeof last.templateHash !== "string") {
+    throw new Error("session line is missing templateHash");
+  }
+  return last.templateHash;
+}

--- a/packages/engine/tests/codex-bridge.test.ts
+++ b/packages/engine/tests/codex-bridge.test.ts
@@ -634,7 +634,7 @@ describe("codex-bridge", () => {
     expect(JSON.stringify(toolMsg!.content)).toContain("logged 60");
   });
 
-  it("forwards opts.onTextDelta to every step's request", async () => {
+  it("forwards opts.onTextDelta only for the terminal step", async () => {
     const tools = {
       log_ride: {
         description: "log a ride",
@@ -668,7 +668,7 @@ describe("codex-bridge", () => {
       onTextDelta: (delta) => deltas.push(delta),
     });
 
-    expect(deltas).toEqual(["Checking", "Logged ", "60 min."]);
+    expect(deltas).toEqual(["Logged ", "60 min."]);
     expect(result.text).toBe("Logged 60 min.");
   });
 

--- a/packages/engine/tests/flush-delta.test.ts
+++ b/packages/engine/tests/flush-delta.test.ts
@@ -192,16 +192,67 @@ describe("memory flush sends only what changed since the last successful flush",
     ).toHaveLength(1);
 
     expect(await agent.chat("trim", "again")).toBe("trim-reply");
+    await drain("trim");
     expect(complete.mock.calls.filter(isCompaction)).toHaveLength(1);
-    expect(flushCalls(complete)).toHaveLength(2);
+    expect(flushCalls(complete).some((flush) => flush.includes("TRIM-0 "))).toBe(true);
+    expect(flushCalls(complete).some((flush) => flush.includes("TRIM-29 "))).toBe(true);
 
     await expect(agent.resetSession("trim")).resolves.toEqual({ memoryFlushed: true });
+    const lastFlush = flushCalls(complete).at(-1) ?? "";
+    expect(lastFlush).not.toContain("TRIM-0 ");
+    expect(lastFlush).toContain("hello");
+    expect(lastFlush).toContain("again");
+    expect(lastFlush).not.toContain("## Coach Stance");
+  });
+
+  it("a failed trim flush still reaches a new process through the precompact pending marker", async () => {
+    const failing = vi.fn(async (params: Call) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) throw new Error("boom");
+      if (sys.includes(COMPACTION_MARKER)) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("trim-reply");
+    });
+    const first = await setupAgent(failing, 120_000);
+    seedSession("trim-restart", markedLines("TRIM", 30));
+    expect(await first.chat("trim-restart", "hello")).toBe("trim-reply");
+    expect(
+      readdirSync(join(dataDir, "sessions")).some((f) =>
+        f.startsWith("trim-restart.jsonl.flush-pending.precompact."),
+      ),
+    ).toBe(true);
+
+    vi.resetModules();
+    const recovered = routeByPrompt("again-reply");
+    const second = await setupAgent(recovered, 120_000);
+    expect(await second.chat("trim-restart", "again")).toBe("again-reply");
+    await drain("trim-restart");
+    expect(flushCalls(recovered).some((flush) => flush.includes("TRIM-0 "))).toBe(true);
+  });
+
+  it("an overflow-recovery flush does not resend the in-progress user line on the next flush", async () => {
+    let mainTurns = 0;
+    const complete = vi.fn(async (params: Call) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.includes(COMPACTION_MARKER)) return mkAssistant(FIVE_SECTION_SUMMARY);
+      mainTurns++;
+      if (mainTurns === 1) {
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      return mkAssistant("recovered");
+    });
+    const agent = await setupAgent(complete, 80_000);
+    expect(await agent.chat("overflow-watermark", "hello-unique-xyz")).toBe("recovered");
+    await drain("overflow-watermark");
+    expect(flushCalls(complete)).toHaveLength(1);
+    expect(flushCalls(complete)[0]).toContain("hello-unique-xyz");
+
+    await expect(agent.resetSession("overflow-watermark")).resolves.toEqual({
+      memoryFlushed: true,
+    });
     const flushes = flushCalls(complete);
-    expect(flushes).toHaveLength(3);
-    expect(flushes[2]).toContain("TRIM-0 ");
-    expect(flushes[2]).toContain("TRIM-29 ");
-    expect(flushes[2]).toContain("hello");
-    expect(flushes[2]).toContain("again");
-    expect(flushes[2]).not.toContain("## Coach Stance");
+    expect(flushes).toHaveLength(2);
+    expect(flushes[1]).not.toContain("hello-unique-xyz");
+    expect(flushes[1]).toContain("recovered");
   });
 });

--- a/packages/engine/tests/memory-flush-outcome.test.ts
+++ b/packages/engine/tests/memory-flush-outcome.test.ts
@@ -173,6 +173,39 @@ describe("runMemoryFlush outcome detection", () => {
     expect(memory.getContextWithProvenance().provenance.garmin).toBe(true);
   });
 
+  it("does not copy Garmin provenance from another section onto a different write", async () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "Garmin-derived goal", "chat-tool", {
+      garmin: true,
+      nonGarmin: false,
+      unknown: false,
+    });
+    const llm = drivenLLM([""], async (tools) => {
+      await tools.memory_write.execute!(
+        { section: "medical-history", content: "Asthma, mild" },
+        {} as never,
+      );
+    });
+
+    await runMemoryFlush({
+      llm,
+      messages: TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+
+    expect(memory.provenanceForSection("goals")).toEqual({
+      garmin: true,
+      nonGarmin: false,
+      unknown: false,
+    });
+    expect(memory.provenanceForSection("medical-history")).toEqual({
+      garmin: false,
+      nonGarmin: false,
+      unknown: true,
+    });
+  });
+
   it("does not infer Garmin provenance from Garmin-looking text in a write", async () => {
     const memory = new Memory(dataDir);
     const llm = drivenLLM([""], async (tools) => {

--- a/packages/engine/tests/timeout-compaction-threshold.test.ts
+++ b/packages/engine/tests/timeout-compaction-threshold.test.ts
@@ -153,4 +153,90 @@ describe("timeout compaction threshold on a 1M-token window", () => {
     expect(mainTurns).toBe(2);
     expect(reply).toBe("recovered");
   });
+
+  it("still compact-retries a timeout after a tool-step preamble streamed", async () => {
+    const seen: Array<{ system: string; messages: ModelMessage[] }> = [];
+    let mainTurns = 0;
+    const complete = vi.fn(
+      async (params: {
+        system?: string;
+        messages: ModelMessage[];
+        onTextDelta?: (delta: string) => void;
+      }) => {
+        const sys = params.system ?? "";
+        if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+        mainTurns++;
+        seen.push({ system: sys, messages: params.messages });
+        if (mainTurns === 1) {
+          params.onTextDelta?.("Checking");
+          return {
+            text: "Checking",
+            toolCalls: [{ id: "c1", name: "missing_tool", arguments: {} }],
+            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+            stopReason: "toolUse" as const,
+          };
+        }
+        if (mainTurns === 2) throw timeoutError();
+        return mkAssistant("recovered");
+      },
+    );
+    const summarize = vi.fn(async (params: { messages: ModelMessage[] }) => ({
+      messages: params.messages.slice(-2),
+    }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, summarize);
+
+    const probeReply = await agent.chat("probe", "hi");
+    expect(probeReply).toBe("recovered");
+    const systemTokens = estimateTokens(seen[0].system);
+    seen.length = 0;
+    mainTurns = 0;
+
+    seedSession("timeout-preamble", Math.floor(0.7 * EFFECTIVE_BUDGET) - systemTokens);
+    const reply = await agent.chat("timeout-preamble", "hello");
+
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(mainTurns).toBe(3);
+    expect(reply).toBe("recovered");
+  });
+
+  it("still compact-retries a timeout that follows a live preamble on the same request", async () => {
+    const seen: Array<{ system: string; messages: ModelMessage[] }> = [];
+    let mainTurns = 0;
+    const complete = vi.fn(
+      async (params: {
+        system?: string;
+        messages: ModelMessage[];
+        onTextDelta?: (delta: string) => void;
+      }) => {
+        const sys = params.system ?? "";
+        if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+        mainTurns++;
+        seen.push({ system: sys, messages: params.messages });
+        if (mainTurns === 1) {
+          params.onTextDelta?.("Checking");
+          throw timeoutError();
+        }
+        return mkAssistant("recovered");
+      },
+    );
+    const summarize = vi.fn(async (params: { messages: ModelMessage[] }) => ({
+      messages: params.messages.slice(-2),
+    }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete, summarize);
+
+    const probeReply = await agent.chat("probe", "hi");
+    expect(probeReply).toBe("recovered");
+    const systemTokens = estimateTokens(seen[0].system);
+    seen.length = 0;
+    mainTurns = 0;
+
+    seedSession("timeout-live-preamble", Math.floor(0.7 * EFFECTIVE_BUDGET) - systemTokens);
+    const reply = await agent.chat("timeout-live-preamble", "hello");
+
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(mainTurns).toBe(2);
+    expect(reply).toBe("recovered");
+  });
 });


### PR DESCRIPTION
## Why

The llm-turn-efficiency review found six defects in the ChatGPT streaming and memory-flush path. A tool-step preamble counted as a delivered reply, so a timeout could not compact and retry. A failed trim flush then marked the compacted session as flushed, so a crash dropped those messages. This PR fixes those two, and the four warnings that shared the same turn.

## Scope

- `codexGenerateText` forwards `onTextDelta` only after a non-tool step.
- `ChatStore.archivePreCompact` can write a flush-pending marker. `loadUnflushedResetArchive` loads it on the next process.
- `flushNewMessages` watermarks `history.length + currentTurn.length`.
- `runMemoryFlush` unions provenance per section, not the whole memory file.
- `templateHashForChat` hashes the toolset sent this turn and does not cache across turns.

Out of scope: Reviewer B's archive pruning, snapshot timeout, and issue #1000.

## Tradeoffs

Terminal ChatGPT text arrives in a burst after the last step, not token by token during that step. That is the cost of not counting a tool preamble as delivered text.

## Blast Radius

Athletes on ChatGPT sign-in get retries after a tool lookup. A memory save that fails during a long chat is retried after restart. Garmin labels stay on the section they belong to. Session lineage hashes change when `memory_read` appears or disappears.

## Verification

- Nine new or updated tests failed on the epic tip, then passed after the fix.
- `pnpm --filter @enduragent/engine exec vitest run tests/codex-bridge.test.ts tests/timeout-compaction-threshold.test.ts tests/flush-delta.test.ts tests/memory-flush-outcome.test.ts tests/athlete-snapshot-wiring.test.ts tests/flush-dedupe-per-turn.test.ts tests/coach-agent-streaming.test.ts tests/flush-retry-degradation.test.ts tests/reset-flush-guard.test.ts tests/soft-threshold-flush.test.ts` → 110 passed.
- `pnpm --filter @enduragent/core exec vitest run tests/chat-store.test.ts tests/conversation-store.test.ts` → 87 passed.
- `pnpm check` → green.