### PR TITLE
fix(desktop): show Coach working status without a card

### DIFF
--- a/.changeset/chat-working-inline-status.md
+++ b/.changeset/chat-working-inline-status.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: While the coach is writing a reply, Chat shows a spinner and Coach is working… without a box around it.

--- a/apps/desktop-renderer/src/ui/chat/Notice.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Notice.tsx
@@ -1,5 +1,6 @@
+import { LoaderCircle } from "lucide-react";
 import type { ReactElement } from "react";
-import { Button, ProgressDisplay } from "@enduragent/ui";
+import { Button } from "@enduragent/ui";
 import { useEnduragentStore } from "../../state/store";
 
 export function Notice(props: { readonly inPlanCreation?: boolean }): ReactElement | null {
@@ -28,14 +29,18 @@ export function CoachProgress(): ReactElement | null {
   const progress = useEnduragentStore((state) => state.chat.coachProgress ?? null);
   if (progress === null) return null;
   return (
-    <ProgressDisplay
-      className="coach-progress mt-row rounded-card border border-line bg-surface p-ctl-px"
+    <div
+      className="coach-progress mt-row flex items-center gap-inset text-sm leading-5 text-ink"
       role="status"
       aria-live="polite"
       aria-busy="true"
-      label={progress}
-      value={{ kind: "indeterminate" }}
-    />
+    >
+      <LoaderCircle
+        className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none"
+        aria-hidden="true"
+      />
+      <span>{progress}</span>
+    </div>
   );
 }
 

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -1980,16 +1980,16 @@ describe("chat surface", () => {
     });
 
     it("renders Coach progress after the transcript instead of above the composer", () => {
-      setChat({ status: "streaming", coachProgress: "Checking your training data…" });
+      setChat({ status: "streaming", coachProgress: "Coach is working…" });
       render(<Harness />);
 
       const progress = document.querySelector(".coach-progress");
       if (!(progress instanceof HTMLElement)) throw new TypeError("progress missing");
-      expect(progress).toHaveTextContent("Checking your training data…");
+      expect(progress).toHaveTextContent("Coach is working…");
       expect(progress).toHaveAttribute("aria-busy", "true");
-      expect(
-        screen.getByRole("progressbar", { name: "Checking your training data…" }),
-      ).not.toHaveAttribute("value");
+      expect(progress.querySelector(".animate-spin")).not.toBeNull();
+      expect(progress.className).not.toMatch(/rounded-card|border|bg-surface|p-ctl-px/);
+      expect(screen.queryByRole("progressbar")).toBeNull();
       expect(progress.closest(".thread")).not.toBeNull();
       expect(progress.closest(".composer-wrap")).toBeNull();
     });

--- a/apps/desktop/tests/e2e/chat-core.spec.ts
+++ b/apps/desktop/tests/e2e/chat-core.spec.ts
@@ -17,6 +17,12 @@ test("streams a coach response through the visible Chat surface", async ({ chatD
   const athleteArticle = transcript.getByText("Your message", { exact: true }).locator("..");
   await expect(athleteArticle.getByText(prompt, { exact: true })).toBeVisible();
   await expect(page.getByText("Coach is working…", { exact: true })).toBeVisible();
+  const working = page.locator(".coach-progress");
+  await expect(working).toBeVisible();
+  await expect(working.locator("svg.animate-spin")).toBeVisible();
+  await expect(working).not.toHaveClass(/rounded-card/);
+  await expect(working).not.toHaveClass(/bg-surface/);
+  await expect(working.getByRole("progressbar")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Stop responding" })).toBeVisible();
 
   coach.emitText(firstDelta);


### PR DESCRIPTION
## Summary
- While the coach is writing a reply, Chat now shows a spinner and **Coach is working…** without a card, border, or progress track.
- Renderer and Chat e2e coverage assert that in-flight wait stays inline in the transcript, not boxed above the composer.

## Test plan
- [ ] Send a Chat message and confirm the wait is spinner + copy only, with no card behind it.
- [ ] Confirm the streamed reply still replaces that wait, and Stop still appears while a turn is in flight.
- [ ] `pnpm --filter @enduragent/desktop-renderer exec vitest run tests/chat-surface.test.tsx`