### PR TITLE
fix(i18n): fall back to English when an athlete's catalog cannot load

### DIFF
--- a/packages/core/src/channels/npm-telegram-host.ts
+++ b/packages/core/src/channels/npm-telegram-host.ts
@@ -148,26 +148,40 @@ export interface TelegramUpdateMessageSender {
   sendMessage(chatId: string, text: string): Promise<unknown>;
 }
 
+export type NotifyNpmTelegramUpdatePorts = {
+  readonly checkForUpdateWithDailyTelemetry: typeof checkForUpdateWithDailyTelemetry;
+  readonly getKnownTelegramChatIds: typeof getKnownTelegramChatIds;
+  readonly getLastNotifiedVersion: typeof getLastNotifiedVersion;
+  readonly setLastNotifiedVersion: typeof setLastNotifiedVersion;
+  readonly isManagedDeploy: typeof isManagedDeploy;
+};
+
 export async function notifyNpmTelegramUpdate(
   sender: TelegramUpdateMessageSender,
   dataDir: string,
   binary: BinaryConfig,
   language: CoachLanguage,
+  ports: Partial<NotifyNpmTelegramUpdatePorts> = {},
 ): Promise<void> {
+  const checkUpdate = ports.checkForUpdateWithDailyTelemetry ?? checkForUpdateWithDailyTelemetry;
+  const knownIds = ports.getKnownTelegramChatIds ?? getKnownTelegramChatIds;
+  const lastNotified = ports.getLastNotifiedVersion ?? getLastNotifiedVersion;
+  const rememberVersion = ports.setLastNotifiedVersion ?? setLastNotifiedVersion;
+  const managed = ports.isManagedDeploy ?? isManagedDeploy;
   try {
-    const info = await checkForUpdateWithDailyTelemetry(binary.binaryName, dataDir);
-    if (!info?.updateAvailable || getLastNotifiedVersion(dataDir) === info.latest) return;
+    const info = await checkUpdate(binary.binaryName, dataDir);
+    if (!info?.updateAvailable || lastNotified(dataDir) === info.latest) return;
 
     const allowed = loadAllowedSenders(dataDir);
     const allowSet = new Set(allowed.allowFrom);
-    const knownChats = getKnownTelegramChatIds(dataDir);
+    const knownChats = knownIds(dataDir);
     const chatIds =
       allowed.dmPolicy === "open" ? knownChats : knownChats.filter((id) => allowSet.has(id));
     let delivered = false;
     for (const chatId of chatIds) {
       try {
         const book = await language.phrasebookFor({ chatId: `telegram:${chatId}` });
-        const updateInstruction = isManagedDeploy(binary.binaryName)
+        const updateInstruction = managed(binary.binaryName)
           ? book.say(
               msg("telegram.update.managedInstruction", {
                 whatsnew: "/whatsnew",
@@ -193,6 +207,6 @@ export async function notifyNpmTelegramUpdate(
         delivered = true;
       } catch {}
     }
-    if (delivered) setLastNotifiedVersion(dataDir, info.latest);
+    if (delivered) rememberVersion(dataDir, info.latest);
   } catch {}
 }

--- a/packages/core/tests/operator-capture.test.ts
+++ b/packages/core/tests/operator-capture.test.ts
@@ -9,6 +9,25 @@ import {
   loadAllowedSenders,
 } from "../src/channels/allowed-senders.js";
 
+const grammyFake = vi.hoisted(() => ({
+  bot: undefined as ((token: string) => unknown) | undefined,
+  InputFile: class FakeInputFile {
+    constructor(
+      readonly data: Buffer,
+      readonly filename: string,
+    ) {}
+  },
+  GrammyError: class FakeGrammyError extends Error {},
+}));
+vi.mock("grammy", () => ({
+  Bot: function FakeBot(this: unknown, token: string) {
+    if (grammyFake.bot === undefined) throw new Error("Test bug: no fake bot queued");
+    return grammyFake.bot(token);
+  },
+  InputFile: grammyFake.InputFile,
+  GrammyError: grammyFake.GrammyError,
+}));
+
 // ─── Fake grammy Bot factory ─────────────────────────────────────────────────
 // Each test sets up its desired bot behavior by pushing onto these queues.
 
@@ -60,13 +79,11 @@ beforeEach(() => {
   delete process.env.CYCLING_COACH_OPERATOR_ID;
   nextBots = [];
   vi.resetModules();
-  vi.doMock("grammy", () => ({
-    Bot: function FakeBot(this: unknown, _token: string) {
-      const next = nextBots.shift();
-      if (!next) throw new Error("Test bug: no fake bot queued");
-      return next;
-    },
-  }));
+  grammyFake.bot = () => {
+    const next = nextBots.shift();
+    if (!next) throw new Error("Test bug: no fake bot queued");
+    return next;
+  };
 });
 
 afterEach(() => {
@@ -74,10 +91,10 @@ afterEach(() => {
   else process.env.CYCLING_COACH_OPERATOR_ID = savedEnv;
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
-  vi.doUnmock("grammy");
 });
 
 async function importHelper() {
+  vi.resetModules();
   return (await import("../src/channels/operator-capture.js")).captureAndPersistOperator;
 }
 

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -7,7 +7,23 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
 import { defaultPairingState, saveAllowedSenders } from "../src/channels/allowed-senders.js";
+import { notifyNpmTelegramUpdate } from "../src/channels/npm-telegram-host.js";
 import { GARMIN_DATA_ATTRIBUTION } from "../src/agent/garmin-attribution.js";
+
+const SAMPLE_UPDATE = {
+  current: "2026.5.5",
+  latest: "2026.5.10",
+  updateAvailable: true as const,
+};
+
+function sampleUpdatePorts(knownChatIds: string[]) {
+  return {
+    checkForUpdateWithDailyTelemetry: vi.fn(async () => SAMPLE_UPDATE),
+    getKnownTelegramChatIds: vi.fn(() => knownChatIds),
+    getLastNotifiedVersion: vi.fn(() => null),
+    setLastNotifiedVersion: vi.fn(),
+  };
+}
 
 const broadcastPhrasebook = await createPhrasebook({ tag: "en", locale: "en-GB" });
 function broadcastLanguage(): CoachLanguage {
@@ -77,8 +93,6 @@ afterEach(() => {
   }
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
-  vi.doUnmock("../src/updater.js");
-  vi.doUnmock("../src/channels/allowed-senders.js");
 });
 
 function seedSession(chatId: string): void {
@@ -363,30 +377,16 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       allowFrom: ["11111", "22222"],
       primaryOperator: "11111",
     }));
-    const setLastNotifiedVersion = vi.fn();
-    vi.doMock("../src/updater.js", async () => {
-      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
-      return {
-        ...real,
-        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
-          current: "2026.5.5",
-          latest: "2026.5.10",
-          updateAvailable: true,
-        })),
-        getKnownTelegramChatIds: vi.fn(() => ["11111", "22222"]),
-        getLastNotifiedVersion: vi.fn(() => null),
-        setLastNotifiedVersion,
-      };
-    });
-    const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
+    const ports = sampleUpdatePorts(["11111", "22222"]);
 
     await notifyNpmTelegramUpdate(
       { sendMessage: vi.fn(async () => Promise.reject(new Error("sealed"))) },
       dataDir,
       cyclingBinary,
       broadcastLanguage(),
+      ports,
     );
-    expect(setLastNotifiedVersion).not.toHaveBeenCalled();
+    expect(ports.setLastNotifiedVersion).not.toHaveBeenCalled();
 
     await notifyNpmTelegramUpdate(
       {
@@ -397,15 +397,16 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       dataDir,
       cyclingBinary,
       broadcastLanguage(),
+      ports,
     );
-    expect(setLastNotifiedVersion).toHaveBeenCalledOnce();
-    expect(setLastNotifiedVersion).toHaveBeenCalledWith(dataDir, "2026.5.10");
+    expect(ports.setLastNotifiedVersion).toHaveBeenCalledOnce();
+    expect(ports.setLastNotifiedVersion).toHaveBeenCalledWith(dataDir, "2026.5.10");
   });
 
   it("filters chat-ids to allowFrom subset (allowlist mode)", async () => {
-    seedSession("11111"); // allowed
-    seedSession("22222"); // allowed
-    seedSession("99999"); // stranger from before allowlist
+    seedSession("11111");
+    seedSession("22222");
+    seedSession("99999");
     saveAllowedSenders(dataDir, () => ({
       ...defaultPairingState(),
       dmPolicy: "allowlist",
@@ -413,33 +414,20 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       primaryOperator: "11111",
     }));
 
-    vi.doMock("../src/updater.js", async () => {
-      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
-      return {
-        ...real,
-        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
-          current: "2026.5.5",
-          latest: "2026.5.10",
-          updateAvailable: true,
-        })),
-        getKnownTelegramChatIds: vi.fn(() => ["11111", "22222", "99999"]),
-        getLastNotifiedVersion: vi.fn(() => null),
-        setLastNotifiedVersion: vi.fn(),
-      };
-    });
-
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
-    const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
+    await notifyNpmTelegramUpdate(
+      { sendMessage },
+      dataDir,
+      cyclingBinary,
+      broadcastLanguage(),
+      sampleUpdatePorts(["11111", "22222", "99999"]),
+    );
 
     const calledIds = sendMessage.mock.calls.map((c: unknown[]) => String(c[0])).sort();
     expect(calledIds).toEqual(["11111", "22222"]);
     expect(calledIds).not.toContain("99999");
   });
 
-  // The daily re-check calls notifyUpdate on a timer; the last-notified-version
-  // guard must make a second firing for the same version a no-op so athletes get
-  // at most one broadcast per release.
   it("does not re-broadcast an already-notified version on a second firing (idempotent)", async () => {
     seedSession("11111");
     saveAllowedSenders(dataDir, () => ({
@@ -449,28 +437,16 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       primaryOperator: "11111",
     }));
 
-    // Keep the REAL getLastNotifiedVersion / setLastNotifiedVersion so the
-    // guard actually persists to (and reads back from) the temp data dir.
-    vi.doMock("../src/updater.js", async () => {
-      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
-      return {
-        ...real,
-        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
-          current: "2026.5.5",
-          latest: "2026.5.10",
-          updateAvailable: true,
-        })),
-        getKnownTelegramChatIds: vi.fn(() => ["11111"]),
-      };
-    });
-
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
-    const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
     const sender = { sendMessage };
-    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, broadcastLanguage());
+    const ports = {
+      checkForUpdateWithDailyTelemetry: vi.fn(async () => SAMPLE_UPDATE),
+      getKnownTelegramChatIds: vi.fn(() => ["11111"]),
+    };
+    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, broadcastLanguage(), ports);
     expect(sendMessage).toHaveBeenCalledTimes(1);
 
-    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, broadcastLanguage());
+    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, broadcastLanguage(), ports);
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
@@ -485,24 +461,14 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     }));
     process.env.CYCLING_COACH_DM_POLICY = "open";
 
-    vi.doMock("../src/updater.js", async () => {
-      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
-      return {
-        ...real,
-        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
-          current: "2026.5.5",
-          latest: "2026.5.10",
-          updateAvailable: true,
-        })),
-        getKnownTelegramChatIds: vi.fn(() => ["11111", "99999"]),
-        getLastNotifiedVersion: vi.fn(() => null),
-        setLastNotifiedVersion: vi.fn(),
-      };
-    });
-
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
-    const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
+    await notifyNpmTelegramUpdate(
+      { sendMessage },
+      dataDir,
+      cyclingBinary,
+      broadcastLanguage(),
+      sampleUpdatePorts(["11111", "99999"]),
+    );
 
     const calledIds = sendMessage.mock.calls.map((c: unknown[]) => String(c[0])).sort();
     expect(calledIds).toEqual(["11111", "99999"]);
@@ -511,24 +477,14 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
   it("does NOT broadcast in default-pairing mode (no allowed senders → empty filter)", async () => {
     seedSession("99999");
 
-    vi.doMock("../src/updater.js", async () => {
-      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
-      return {
-        ...real,
-        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
-          current: "2026.5.5",
-          latest: "2026.5.10",
-          updateAvailable: true,
-        })),
-        getKnownTelegramChatIds: vi.fn(() => ["99999"]),
-        getLastNotifiedVersion: vi.fn(() => null),
-        setLastNotifiedVersion: vi.fn(),
-      };
-    });
-
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
-    const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
+    await notifyNpmTelegramUpdate(
+      { sendMessage },
+      dataDir,
+      cyclingBinary,
+      broadcastLanguage(),
+      sampleUpdatePorts(["99999"]),
+    );
 
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -543,24 +499,14 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     }));
     process.env.CYCLING_COACH_MANAGED_DEPLOY = "1";
 
-    vi.doMock("../src/updater.js", async () => {
-      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
-      return {
-        ...real,
-        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
-          current: "2026.5.5",
-          latest: "2026.5.10",
-          updateAvailable: true,
-        })),
-        getKnownTelegramChatIds: vi.fn(() => ["11111"]),
-        getLastNotifiedVersion: vi.fn(() => null),
-        setLastNotifiedVersion: vi.fn(),
-      };
-    });
-
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
-    const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
+    await notifyNpmTelegramUpdate(
+      { sendMessage },
+      dataDir,
+      cyclingBinary,
+      broadcastLanguage(),
+      sampleUpdatePorts(["11111"]),
+    );
 
     const message = sendMessage.mock.calls[0]?.[1] ?? "";
     expect(message).toContain("Update available: 2026.5.5");

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -1,4 +1,6 @@
 import { createNpmCoachLanguage } from "../src/language-preference.js";
+import { LANGUAGE_OPTIONS, type CoachLanguage } from "@enduragent/i18n";
+import { createPhrasebook } from "@enduragent/i18n/messages";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -6,6 +8,40 @@ import { join } from "node:path";
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
 import { defaultPairingState, saveAllowedSenders } from "../src/channels/allowed-senders.js";
 import { GARMIN_DATA_ATTRIBUTION } from "../src/agent/garmin-attribution.js";
+
+const broadcastPhrasebook = await createPhrasebook({ tag: "en", locale: "en-GB" });
+function broadcastLanguage(): CoachLanguage {
+  return {
+    options: LANGUAGE_OPTIONS,
+    resolveFor: async () => ({ language: "en", source: "default", locale: "en-GB" }),
+    phrasebookFor: async () => broadcastPhrasebook,
+    current: async () => ({
+      value: null,
+      origin: "unset",
+      resolved: { language: "en", source: "default", locale: "en-GB" },
+    }),
+    set: async () => ({ value: null, origin: "unset" }),
+  };
+}
+
+const grammyFake = vi.hoisted(() => ({
+  bot: undefined as ((token: string) => unknown) | undefined,
+  InputFile: class FakeInputFile {
+    constructor(
+      readonly data: Buffer,
+      readonly filename: string,
+    ) {}
+  },
+  GrammyError: class FakeGrammyError extends Error {},
+}));
+vi.mock("grammy", () => ({
+  Bot: function FakeBot(this: unknown, token: string) {
+    if (grammyFake.bot === undefined) throw new Error("Test bug: no fake bot queued");
+    return grammyFake.bot(token);
+  },
+  InputFile: grammyFake.InputFile,
+  GrammyError: grammyFake.GrammyError,
+}));
 
 type TestApiCall = (method: string, payload: unknown, signal?: AbortSignal) => Promise<unknown>;
 type TestApiTransformer = (
@@ -41,7 +77,6 @@ afterEach(() => {
   }
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
-  vi.doUnmock("grammy");
   vi.doUnmock("../src/updater.js");
   vi.doUnmock("../src/channels/allowed-senders.js");
 });
@@ -71,20 +106,7 @@ function installTelegramBotMock() {
     }),
     catch: vi.fn(),
   };
-  class FakeInputFile {
-    constructor(
-      readonly data: Buffer,
-      readonly filename: string,
-    ) {}
-  }
-  class FakeGrammyError extends Error {}
-  vi.doMock("grammy", () => ({
-    Bot: function FakeBot() {
-      return bot;
-    },
-    InputFile: FakeInputFile,
-    GrammyError: FakeGrammyError,
-  }));
+  grammyFake.bot = () => bot;
   return { bot, commandHandlers, onHandlers };
 }
 
@@ -159,12 +181,7 @@ describe("createTelegramBot — webhook ownership", () => {
       }),
       stop: vi.fn(async () => undefined),
     };
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     const agent = {
       chat: vi.fn(),
       resetSession: vi.fn(),
@@ -206,12 +223,7 @@ describe("createTelegramBot — webhook ownership", () => {
       start: vi.fn(async () => undefined),
       stop: vi.fn(async () => undefined),
     };
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     const onPollingSuccess = vi.fn();
     const onPollingFailure = vi.fn();
     await createTestTelegramBot(
@@ -372,7 +384,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       { sendMessage: vi.fn(async () => Promise.reject(new Error("sealed"))) },
       dataDir,
       cyclingBinary,
-      createNpmCoachLanguage(dataDir),
+      broadcastLanguage(),
     );
     expect(setLastNotifiedVersion).not.toHaveBeenCalled();
 
@@ -384,7 +396,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       },
       dataDir,
       cyclingBinary,
-      createNpmCoachLanguage(dataDir),
+      broadcastLanguage(),
     );
     expect(setLastNotifiedVersion).toHaveBeenCalledOnce();
     expect(setLastNotifiedVersion).toHaveBeenCalledWith(dataDir, "2026.5.10");
@@ -418,12 +430,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
 
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate(
-      { sendMessage },
-      dataDir,
-      cyclingBinary,
-      createNpmCoachLanguage(dataDir),
-    );
+    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
 
     const calledIds = sendMessage.mock.calls.map((c: unknown[]) => String(c[0])).sort();
     expect(calledIds).toEqual(["11111", "22222"]);
@@ -460,10 +467,10 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
     const sender = { sendMessage };
-    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, createNpmCoachLanguage(dataDir));
+    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, broadcastLanguage());
     expect(sendMessage).toHaveBeenCalledTimes(1);
 
-    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, createNpmCoachLanguage(dataDir));
+    await notifyNpmTelegramUpdate(sender, dataDir, cyclingBinary, broadcastLanguage());
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
@@ -495,12 +502,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
 
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate(
-      { sendMessage },
-      dataDir,
-      cyclingBinary,
-      createNpmCoachLanguage(dataDir),
-    );
+    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
 
     const calledIds = sendMessage.mock.calls.map((c: unknown[]) => String(c[0])).sort();
     expect(calledIds).toEqual(["11111", "99999"]);
@@ -526,12 +528,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
 
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate(
-      { sendMessage },
-      dataDir,
-      cyclingBinary,
-      createNpmCoachLanguage(dataDir),
-    );
+    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
 
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -563,12 +560,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
 
     const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const { notifyNpmTelegramUpdate } = await import("../src/channels/npm-telegram-host.js");
-    await notifyNpmTelegramUpdate(
-      { sendMessage },
-      dataDir,
-      cyclingBinary,
-      createNpmCoachLanguage(dataDir),
-    );
+    await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary, broadcastLanguage());
 
     const message = sendMessage.mock.calls[0]?.[1] ?? "";
     expect(message).toContain("Update available: 2026.5.5");
@@ -609,11 +601,7 @@ describe("createTelegramBot — startup diagnostic + no security broadcast", () 
       catch: vi.fn(),
     };
 
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-    }));
+    grammyFake.bot = () => bot;
 
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const agent = {
@@ -676,11 +664,7 @@ describe("createTelegramBot — startup diagnostic + no security broadcast", () 
       on: vi.fn(),
       catch: vi.fn(),
     };
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-    }));
+    grammyFake.bot = () => bot;
 
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const agent = {

--- a/packages/core/tests/telegram-coalescing.test.ts
+++ b/packages/core/tests/telegram-coalescing.test.ts
@@ -10,6 +10,25 @@ import type {
   TelegramOperationsCapabilities,
 } from "../src/channels/telegram-host.js";
 
+const grammyFake = vi.hoisted(() => ({
+  bot: undefined as ((token: string) => unknown) | undefined,
+  InputFile: class FakeInputFile {
+    constructor(
+      readonly data: Buffer,
+      readonly filename: string,
+    ) {}
+  },
+  GrammyError: class FakeGrammyError extends Error {},
+}));
+vi.mock("grammy", () => ({
+  Bot: function FakeBot(this: unknown, token: string) {
+    if (grammyFake.bot === undefined) throw new Error("Test bug: no fake bot queued");
+    return grammyFake.bot(token);
+  },
+  InputFile: grammyFake.InputFile,
+  GrammyError: grammyFake.GrammyError,
+}));
+
 let dataDir: string;
 
 beforeEach(() => {
@@ -23,7 +42,6 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
-  vi.doUnmock("grammy");
 });
 
 interface FakeBot {
@@ -71,12 +89,7 @@ async function buildBot(
     stop: vi.fn(async () => undefined),
     catch: vi.fn(),
   };
-  vi.doMock("grammy", () => ({
-    Bot: function FakeBot() {
-      return bot;
-    },
-    InputFile: class {},
-  }));
+  grammyFake.bot = () => bot;
 
   const engine: StubEngine = {
     chat: vi.fn(async () => ({ text: "ok" })),
@@ -105,6 +118,8 @@ async function buildBot(
       updateNotice: vi.fn(async () => "Update from Desktop."),
     },
   };
+
+  vi.resetModules();
 
   const { createTelegramBot } = await import("../src/channels/telegram.js");
   const { drainPending } = createTelegramBot({

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -19,6 +19,25 @@ import { createTurnContext } from "../../engine/src/agent/turn-context.js";
 import { COACH_EVENT_TAG } from "../src/agent/event-provenance.js";
 import type { IntervalsClient } from "intervals-icu-api";
 
+const grammyFake = vi.hoisted(() => ({
+  bot: undefined as ((token: string) => unknown) | undefined,
+  InputFile: class FakeInputFile {
+    constructor(
+      readonly data: Buffer,
+      readonly filename: string,
+    ) {}
+  },
+  GrammyError: class FakeGrammyError extends Error {},
+}));
+vi.mock("grammy", () => ({
+  Bot: function FakeBot(this: unknown, token: string) {
+    if (grammyFake.bot === undefined) throw new Error("Test bug: no fake bot queued");
+    return grammyFake.bot(token);
+  },
+  InputFile: grammyFake.InputFile,
+  GrammyError: grammyFake.GrammyError,
+}));
+
 let dataDir: string;
 
 beforeEach(() => {
@@ -32,7 +51,6 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
-  vi.doUnmock("grammy");
   vi.doUnmock("@grammyjs/auto-retry");
   vi.doUnmock("../src/updater.js");
   vi.doUnmock("../src/channels/telegram-update-offsets.js");
@@ -95,12 +113,7 @@ async function buildBot(opts?: {
     stop: vi.fn(opts?.stop ?? (async () => undefined)),
     catch: vi.fn(),
   };
-  vi.doMock("grammy", () => ({
-    Bot: function FakeBot() {
-      return bot;
-    },
-    InputFile: class {},
-  }));
+  grammyFake.bot = () => bot;
   const autoRetry = vi.fn((options: unknown) => ({ options }));
   vi.doMock("@grammyjs/auto-retry", () => ({ autoRetry }));
 

--- a/packages/core/tests/telegram-generation-lifecycle.test.ts
+++ b/packages/core/tests/telegram-generation-lifecycle.test.ts
@@ -9,6 +9,25 @@ import { defaultPairingState, saveAllowedSenders } from "../src/channels/allowed
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
 import type { CreateTelegramChannelInput } from "../src/channels/telegram.js";
 
+const grammyFake = vi.hoisted(() => ({
+  bot: undefined as ((token: string) => unknown) | undefined,
+  InputFile: class FakeInputFile {
+    constructor(
+      readonly data: Buffer,
+      readonly filename: string,
+    ) {}
+  },
+  GrammyError: class FakeGrammyError extends Error {},
+}));
+vi.mock("grammy", () => ({
+  Bot: function FakeBot(this: unknown, token: string) {
+    if (grammyFake.bot === undefined) throw new Error("Test bug: no fake bot queued");
+    return grammyFake.bot(token);
+  },
+  InputFile: grammyFake.InputFile,
+  GrammyError: grammyFake.GrammyError,
+}));
+
 type Middleware = (ctx: unknown, next: () => Promise<void>) => Promise<void>;
 type ApiCall = (
   method: string,
@@ -117,7 +136,6 @@ afterEach(() => {
   vi.useRealTimers();
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
-  vi.doUnmock("grammy");
   vi.doUnmock("@grammyjs/auto-retry");
   vi.doUnmock("../src/logging/index.js");
 });
@@ -130,12 +148,7 @@ describe("Telegram polling generation release", () => {
       markStarted = resolve;
     });
     const bot = createComposingBot();
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry:
         () =>
@@ -201,12 +214,7 @@ describe("Telegram polling generation release", () => {
       return pairing.promise;
     });
     const bot = createComposingBot();
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -267,12 +275,7 @@ describe("Telegram polling generation release", () => {
         return Promise.resolve({ ok: true, result: true });
       },
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -305,12 +308,7 @@ describe("Telegram polling generation release", () => {
   it("tracks each polling start through settlement and refuses direct sends after stop", async () => {
     const polling = deferred<void>();
     const bot = createComposingBot({ start: () => polling.promise });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -347,12 +345,7 @@ describe("Telegram polling generation release", () => {
       rawApi: (method) =>
         method === "setMyCommands" ? commands.promise : Promise.resolve({ ok: true, result: true }),
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -397,12 +390,7 @@ describe("Telegram polling generation release", () => {
       rawApi: (method) =>
         method === "sendMessage" ? send.promise : Promise.resolve({ ok: true, result: true }),
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -433,12 +421,7 @@ describe("Telegram polling generation release", () => {
       rawApi: (method) =>
         method === "sendChatAction" ? typing.promise : Promise.resolve({ ok: true, result: true }),
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -487,12 +470,7 @@ describe("Telegram polling generation release", () => {
       rawApi: (method) =>
         method === "sendMessage" ? reply.promise : Promise.resolve({ ok: true, result: true }),
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -559,12 +537,7 @@ describe("Telegram polling generation release", () => {
         return callApi("getUpdates", { offset: 8, timeout: 0 }).then(() => undefined);
       },
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry:
         () =>
@@ -613,12 +586,7 @@ describe("Telegram polling generation release", () => {
       },
       isRunning: () => running,
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -657,12 +625,7 @@ describe("Telegram polling generation release", () => {
       stop: (callApi) => callApi("getUpdates", { offset: 8, timeout: 0 }).then(() => undefined),
       isRunning: () => true,
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -687,12 +650,7 @@ describe("Telegram polling generation release", () => {
         return attempts === 1 ? Promise.reject({ error_code: 429 }) : finalAttempt.promise;
       },
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry:
         () => async (previous: ApiCall, method: string, payload: Record<string, unknown>) => {
@@ -736,12 +694,7 @@ describe("Telegram polling generation release", () => {
           ? secondGenerationSend.promise
           : Promise.resolve({ ok: true, result: true }),
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -786,12 +739,7 @@ describe("Telegram polling generation release", () => {
           ? generationWork.promise
           : Promise.resolve({ ok: true, result: true }),
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -871,12 +819,7 @@ describe("Telegram polling generation release", () => {
         throw new Error("private stop failure");
       },
     });
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),
@@ -947,12 +890,7 @@ describe("Telegram polling generation release", () => {
       };
     });
     const bot = createComposingBot();
-    vi.doMock("grammy", () => ({
-      Bot: function FakeBot() {
-        return bot;
-      },
-      InputFile: class {},
-    }));
+    grammyFake.bot = () => bot;
     vi.doMock("@grammyjs/auto-retry", () => ({
       autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
         previous(method, payload),

--- a/packages/core/tests/telegram-nonblocking.test.ts
+++ b/packages/core/tests/telegram-nonblocking.test.ts
@@ -5,6 +5,25 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
 
+const grammyFake = vi.hoisted(() => ({
+  bot: undefined as ((token: string) => unknown) | undefined,
+  InputFile: class FakeInputFile {
+    constructor(
+      readonly data: Buffer,
+      readonly filename: string,
+    ) {}
+  },
+  GrammyError: class FakeGrammyError extends Error {},
+}));
+vi.mock("grammy", () => ({
+  Bot: function FakeBot(this: unknown, token: string) {
+    if (grammyFake.bot === undefined) throw new Error("Test bug: no fake bot queued");
+    return grammyFake.bot(token);
+  },
+  InputFile: grammyFake.InputFile,
+  GrammyError: grammyFake.GrammyError,
+}));
+
 let dataDir: string;
 
 beforeEach(() => {
@@ -17,7 +36,6 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
-  vi.doUnmock("grammy");
 });
 
 interface FakeBot {
@@ -67,12 +85,7 @@ async function buildBot(opts?: { reference?: StubReference }): Promise<BuildBotR
     stop: vi.fn(async () => undefined),
     catch: vi.fn(),
   };
-  vi.doMock("grammy", () => ({
-    Bot: function FakeBot() {
-      return bot;
-    },
-    InputFile: class {},
-  }));
+  grammyFake.bot = () => bot;
 
   const agent: StubAgent = {
     chat: vi.fn(),
@@ -80,6 +93,8 @@ async function buildBot(opts?: { reference?: StubReference }): Promise<BuildBotR
     resetSession: vi.fn(),
     getAthleteState: vi.fn(),
   };
+
+  vi.resetModules();
 
   const [{ createTelegramBot, CHAT_COALESCE_MS }, { createNpmTelegramHost }] = await Promise.all([
     import("../src/channels/telegram.js"),

--- a/packages/core/tests/telegram-start-reset-failure.test.ts
+++ b/packages/core/tests/telegram-start-reset-failure.test.ts
@@ -4,6 +4,25 @@ import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+const grammyFake = vi.hoisted(() => ({
+  bot: undefined as ((token: string) => unknown) | undefined,
+  InputFile: class FakeInputFile {
+    constructor(
+      readonly data: Buffer,
+      readonly filename: string,
+    ) {}
+  },
+  GrammyError: class FakeGrammyError extends Error {},
+}));
+vi.mock("grammy", () => ({
+  Bot: function FakeBot(this: unknown, token: string) {
+    if (grammyFake.bot === undefined) throw new Error("Test bug: no fake bot queued");
+    return grammyFake.bot(token);
+  },
+  InputFile: grammyFake.InputFile,
+  GrammyError: grammyFake.GrammyError,
+}));
+
 let dataDir: string;
 
 beforeEach(() => {
@@ -15,7 +34,6 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
-  vi.doUnmock("grammy");
 });
 
 const RESET_FAILURE_REPLY =
@@ -33,12 +51,7 @@ async function buildStartHandler(resetSession: ReturnType<typeof vi.fn>) {
     on: vi.fn(),
     catch: vi.fn(),
   };
-  vi.doMock("grammy", () => ({
-    Bot: function FakeBot() {
-      return bot;
-    },
-    InputFile: class {},
-  }));
+  grammyFake.bot = () => bot;
   vi.spyOn(console, "error").mockImplementation(() => {});
   const engine = {
     resetSession,

--- a/packages/i18n/src/coach-language.ts
+++ b/packages/i18n/src/coach-language.ts
@@ -1,6 +1,6 @@
 import type { LanguageTag } from "@enduragent/coach-contract";
 import { detectMessageLanguage } from "./detect-message-language.js";
-import { LANGUAGE_OPTIONS, type LanguageDescription } from "./registry.js";
+import { LANGUAGE_OPTIONS, describeLanguage, type LanguageDescription } from "./registry.js";
 import { resolveLanguage, type LanguageResolution, type SurfaceHint } from "./resolve.js";
 import type { Phrasebook } from "./messages.js";
 
@@ -40,6 +40,17 @@ export function createCoachLanguage(input: {
   readonly phrasebooks: PhrasebookLoader;
 }): CoachLanguage {
   const phrasebooks = new Map<string, Promise<Phrasebook>>();
+  const load = (tag: LanguageTag, locale: string): Promise<Phrasebook> => {
+    const key = JSON.stringify([tag, locale]);
+    const cached = phrasebooks.get(key);
+    if (cached !== undefined) return cached;
+    const pending = input.phrasebooks({ tag, locale });
+    phrasebooks.set(key, pending);
+    void pending.catch(() => {
+      if (phrasebooks.get(key) === pending) phrasebooks.delete(key);
+    });
+    return pending;
+  };
   const language: CoachLanguage = {
     options: LANGUAGE_OPTIONS,
     async resolveFor({ athleteText, surfaceHint }) {
@@ -54,16 +65,17 @@ export function createCoachLanguage(input: {
       });
     },
     async phrasebookFor(request) {
-      const { language: tag, locale } = await language.resolveFor(request);
-      const key = JSON.stringify([tag, locale]);
-      const cached = phrasebooks.get(key);
-      if (cached !== undefined) return cached;
-      const pending = input.phrasebooks({ tag, locale });
-      phrasebooks.set(key, pending);
-      void pending.catch(() => {
-        if (phrasebooks.get(key) === pending) phrasebooks.delete(key);
-      });
-      return pending;
+      const resolved = await language.resolveFor(request).catch(() => ({
+        language: "en" as LanguageTag,
+        locale: describeLanguage("en").defaultLocale,
+      }));
+      const { language: tag, locale } = resolved;
+      try {
+        return await load(tag, locale);
+      } catch (error) {
+        if (tag === "en") throw error;
+        return load("en", describeLanguage("en").defaultLocale);
+      }
     },
     async current() {
       const saved = await input.store.read();

--- a/packages/i18n/src/messages.ts
+++ b/packages/i18n/src/messages.ts
@@ -2,6 +2,7 @@ import { createInstance } from "i18next";
 import type { LanguageTag } from "@enduragent/coach-contract";
 import type { CatalogKey } from "./catalog-keys.js";
 import type { Message } from "./message.js";
+import englishCatalog from "../catalogs/en.json" with { type: "json" };
 
 export type { CatalogKey } from "./catalog-keys.js";
 export type Catalog = { readonly [key: string]: string | Catalog };
@@ -38,9 +39,16 @@ export interface Phrasebook {
 }
 
 export async function loadCatalog(tag: LanguageTag): Promise<Catalog> {
+  if (tag === "en") return englishCatalog;
+  try {
+    return await importCatalog(tag);
+  } catch {
+    return englishCatalog;
+  }
+}
+
+async function importCatalog(tag: Exclude<LanguageTag, "en">): Promise<Catalog> {
   switch (tag) {
-    case "en":
-      return (await import("../catalogs/en.json", { with: { type: "json" } })).default;
     case "es":
       return (await import("../catalogs/es.json", { with: { type: "json" } })).default;
     case "fr":

--- a/packages/i18n/tests/build.test.ts
+++ b/packages/i18n/tests/build.test.ts
@@ -61,24 +61,33 @@ describe("built package", () => {
     expect(statSync(new URL(entry, dist)).isFile()).toBe(true);
   });
 
-  it("keeps the eager translator graph below 16 KiB without catalog modules", () => {
+  it("keeps only the English catalog in the eager translator graph", () => {
     const eager = eagerMessagesGraph();
-    expect(eager.flatMap(sources).filter((source) => source.includes("catalogs/"))).toEqual([]);
-    expect(eager.reduce((bytes, file) => bytes + statSync(file).size, 0)).toBeLessThan(16 * 1024);
+    const eagerCatalogs = eager
+      .flatMap(sources)
+      .filter((source) => source.includes("catalogs/"))
+      .map((source) => source.split("/").at(-1));
+    expect(eagerCatalogs).toEqual(["en.json"]);
+    const englishBytes = statSync(new URL("../catalogs/en.json", import.meta.url)).size;
+    expect(eager.reduce((bytes, file) => bytes + statSync(file).size, 0)).toBeLessThan(
+      englishBytes + 16 * 1024,
+    );
   });
 
-  it("emits a separate dynamically imported module for each of the 17 catalogs", () => {
+  it("emits a separate dynamically imported module for each of the 16 translated catalogs", () => {
     const eager = eagerMessagesGraph();
     const lazy = eager.flatMap((file) => imports(file).lazy);
-    expect(lazy).toHaveLength(17);
-    expect(new Set(lazy.map((file) => file.href)).size).toBe(17);
+    expect(lazy).toHaveLength(16);
+    expect(new Set(lazy.map((file) => file.href)).size).toBe(16);
     expect(lazy.some((file) => eager.some((loaded) => loaded.href === file.href))).toBe(false);
     const catalogSources = lazy.flatMap((file) => {
       expect(statSync(file).isFile()).toBe(true);
       return sources(file).filter((source) => source.includes("catalogs/"));
     });
     expect(catalogSources.map((source) => source.split("/").at(-1)).sort()).toEqual(
-      LANGUAGE_OPTIONS.map(({ tag }) => `${tag}.json`).sort(),
+      LANGUAGE_OPTIONS.filter(({ tag }) => tag !== "en")
+        .map(({ tag }) => `${tag}.json`)
+        .sort(),
     );
   });
 

--- a/packages/i18n/tests/coach-language.test.ts
+++ b/packages/i18n/tests/coach-language.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { LanguageTag } from "@enduragent/coach-contract";
 import {
   createCoachLanguage,
@@ -132,5 +132,24 @@ it("reads fresh preferences for current state and each turn, including Automatic
     language: "fr",
     source: "surface",
     locale: "fr-FR",
+  });
+});
+
+describe("phrasebook resilience", () => {
+  it("falls back to English when the athlete's catalog cannot load", async () => {
+    const language = createCoachLanguage({
+      store: {
+        read: async () => ({ value: "it" as const, origin: "stored" as const }),
+        write: async () => ({ value: "it" as const, origin: "stored" as const }),
+      },
+      surface: { language: undefined, locale: undefined },
+      phrasebooks: async ({ tag, locale }) => {
+        if (tag !== "en") throw new Error("catalog unavailable");
+        return createPhrasebook({ tag, locale });
+      },
+    });
+    const book = await language.phrasebookFor({});
+    expect(book.tag).toBe("en");
+    expect(book.say("common.cancel")).toBe("Cancel");
   });
 });

--- a/packages/i18n/tests/messages-fallback.test.ts
+++ b/packages/i18n/tests/messages-fallback.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createPhrasebook } from "../src/messages.js";
 
 vi.mock("../catalogs/it.json", () => ({ default: { common: { cancel: "Annulla" } } }));
@@ -10,4 +10,17 @@ it("falls back to the English catalog when a translated key is absent", async ()
   expect(book.say("settings.language.automaticDetail", { operatingSystem: "macOS" })).toBe(
     "Automatic follows your macOS language. The coach replies in the language you write in.",
   );
+});
+
+describe("catalog chunk failure", () => {
+  it("degrades a language whose catalog chunk cannot load to English", async () => {
+    vi.resetModules();
+    vi.doMock("../catalogs/it.json", () => {
+      throw new Error("chunk unavailable");
+    });
+    const { createPhrasebook } = await import("../src/messages.js");
+    const italian = await createPhrasebook({ tag: "it", locale: "it-IT" });
+    expect(italian.say("common.cancel")).toBe("Cancel");
+    vi.doUnmock("../catalogs/it.json");
+  });
 });


### PR DESCRIPTION
Reliability fix for the localization epic, needed before the remaining children can go green.

Production changes:
- `phrasebookFor` falls back to the English phrasebook when resolving or loading the athlete's catalog fails. Previously a failed load propagated and the caller's silent catch dropped the message entirely, so an update notice or reply could vanish rather than arrive in English.
- The English catalog is a static import in `@enduragent/i18n/messages` (every phrasebook needs it as the fallback anyway), and a translated catalog whose chunk fails to load degrades to English.

Test changes:
- Seven Telegram test files register their fake bot through one hoisted `vi.mock("grammy")` with a mutable factory instead of calling `vi.doMock` per test. The old pattern raced with `vi.resetModules()`: under load the module under test could bind the real grammy, and the test then failed with `message:text handler not registered` or `Cannot read properties of undefined`. This is what failed CI on the docs-only PR #1006.
- The broadcast tests pass a stub language door instead of building one from a module imported before `resetModules`.
- The i18n build test expects the English catalog in the eager graph and 16 lazy chunks.

Checks: `packages/core` + `packages/i18n` suites 3103 passed with 4 workers, i18n 233, type check clean.

Known residual: `telegram-bot.test.ts > notifyUpdate > records the release only after at least one configured destination succeeds` still flakes about one run in three when that file runs alongside the other Telegram files with a single worker. It passes alone and passes with 4 workers. The cause is the file's own `vi.doMock("../src/updater.js")` plus `vi.resetModules()` pattern, not the language path (it still flakes with the door fully stubbed). Two hoisted-mock rewrites of the updater mock broke other tests in the file and were reverted.

https://claude.ai/code/session_016sJNBpzjk93aLbK8VTwKW2