### PR TITLE
fix(desktop): keep live Chat below Plan creation answers

### DIFF
--- a/.changeset/plan-creation-chat-header.md
+++ b/.changeset/plan-creation-chat-header.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Chat keeps the newest message in view while a plan is being created. Status and Discard live in the Chat header.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ workers/
 .DS_Store
 .idea/
 .obsidian/
+.cursor/
+.nvmrc
 /scripts/
 .claude
 .codex/

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -188,6 +188,7 @@ function conversationTimelineWithDiscardEvents(
   historicalItems: readonly ChatTranscriptItemView[],
   liveItems: readonly ChatTranscriptItemView[],
   events: readonly PlanCreationDiscardEvent[],
+  planCreationItems: readonly ChatTranscriptItemView[],
 ): readonly ChatTranscriptItemView[] {
   const appended = new Set<string>();
   const timeline: ChatTranscriptItemView[] = [];
@@ -206,6 +207,7 @@ function conversationTimelineWithDiscardEvents(
   };
   appendItems(historicalItems);
   appendEvents(null);
+  timeline.push(...planCreationItems);
   appendItems(liveItems);
   for (const event of events) {
     if (appended.has(event.eventId)) continue;
@@ -297,19 +299,18 @@ export function createChatViewAdapter(input: {
       .filter((delivery) => delivery.state !== "cancelled")
       .map((delivery) => ({ kind: "planning-request", delivery }));
     const planCreation = controls?.planCreation;
+    const planActivated = planCreation?.notice === "Plan activated locally.";
+    const planCreationItems: readonly ChatTranscriptItemView[] =
+      planCreation?.loaded === true && (planCreation.value !== null || planActivated)
+        ? [{ kind: "plan-creation", model: planCreation.value }]
+        : [];
     const conversationItems = conversationTimelineWithDiscardEvents(
       historicalItems,
       liveItems,
       planCreation?.discardEvents ?? [],
+      planCreationItems,
     );
-    const planActivated = planCreation?.notice === "Plan activated locally.";
-    const timeline = [
-      ...conversationItems,
-      ...planningItems,
-      ...(planCreation?.loaded === true && (planCreation.value !== null || planActivated)
-        ? ([{ kind: "plan-creation", model: planCreation.value }] as const)
-        : []),
-    ];
+    const timeline = [...conversationItems, ...planningItems];
     const decisionBlocksWork =
       decision?.value?.status === "unanswered" ||
       (decision?.value?.status === "answered" && decision.value.continuation.status === "pending");

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -33,6 +33,7 @@ import {
   PlanCreationDiscardDialog,
   PlanCreationDock,
 } from "./PlanCreationCards";
+import { PlanCreationHeaderActions, PlanCreationSubtitle } from "./PlanCreationHeader";
 
 const CHAT_DISCLAIMER =
   "Not medical advice, and not a substitute for a doctor or a certified coach.";
@@ -161,42 +162,48 @@ export function ChatView(): ReactElement {
       ref={surface}
       className="chat-surface grid min-h-0 min-w-0 flex-1 grid-rows-[52px_minmax(0,1fr)] bg-bg"
     >
-      <header className="flex items-center justify-between border-b border-line px-[calc(var(--inset)*3)] max-md:px-[calc(var(--inset)*2)]">
-        <h1 className="m-0 text-sm font-semibold">Chat</h1>
-        {compact ? (
-          <Dialog open={contextDrawerOpen} onOpenChange={setContextDrawerOpen}>
-            <DialogTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label={contextExpanded ? "Hide training context" : "Show training context"}
-                />
-              }
+      <header className="flex min-w-0 items-center justify-between gap-4 border-b border-line px-[calc(var(--inset)*3)] max-md:px-[calc(var(--inset)*2)]">
+        <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
+          <h1 className="m-0 shrink-0 text-sm font-semibold">Chat</h1>
+          <PlanCreationSubtitle />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <PlanCreationHeaderActions />
+          {compact ? (
+            <Dialog open={contextDrawerOpen} onOpenChange={setContextDrawerOpen}>
+              <DialogTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={contextExpanded ? "Hide training context" : "Show training context"}
+                  />
+                }
+              >
+                <PanelRightOpen />
+              </DialogTrigger>
+              <DialogContent className="top-0 right-0 left-auto h-full max-h-none w-[min(320px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 content-start overflow-auto [scrollbar-width:none] rounded-none rounded-l-card border-y-0 border-r-0 p-0">
+                <DialogTitle className="sr-only">Training context</DialogTitle>
+                <DialogDescription className="sr-only">
+                  Training data available to Coach.
+                </DialogDescription>
+                <TrainingContextPanel className="h-full border-l-0 pt-12" />
+              </DialogContent>
+            </Dialog>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={contextExpanded ? "Hide training context" : "Show training context"}
+              aria-expanded={contextExpanded}
+              onClick={toggleContext}
             >
-              <PanelRightOpen />
-            </DialogTrigger>
-            <DialogContent className="top-0 right-0 left-auto h-full max-h-none w-[min(320px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 content-start overflow-auto [scrollbar-width:none] rounded-none rounded-l-card border-y-0 border-r-0 p-0">
-              <DialogTitle className="sr-only">Training context</DialogTitle>
-              <DialogDescription className="sr-only">
-                Training data available to Coach.
-              </DialogDescription>
-              <TrainingContextPanel className="h-full border-l-0 pt-12" />
-            </DialogContent>
-          </Dialog>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={contextExpanded ? "Hide training context" : "Show training context"}
-            aria-expanded={contextExpanded}
-            onClick={toggleContext}
-          >
-            {contextExpanded ? <PanelRightClose /> : <PanelRightOpen />}
-          </Button>
-        )}
+              {contextExpanded ? <PanelRightClose /> : <PanelRightOpen />}
+            </Button>
+          )}
+        </div>
       </header>
       <div
         className={`chat-layout row-start-2 grid min-h-0 min-w-0 ${contextOpen && !compact ? "grid-cols-[minmax(0,1fr)_252px]" : "grid-cols-[minmax(0,1fr)]"}`}

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationCards.tsx
@@ -314,13 +314,13 @@ function PlanCreationConversationContent(props: {
             </div>
           </CardContent>
         </Card>
-        <PlanCreationSummary model={model} answersOnly />
+        <PlanCreationSummary model={model} />
       </section>
     );
   return (
     <>
       {editingKey !== null || model.openQuestion !== null ? (
-        <PlanCreationSummary model={model} answersOnly />
+        <PlanCreationSummary model={model} />
       ) : null}
       <PlanCreationDraftCards
         model={model}

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationHeader.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationHeader.tsx
@@ -1,0 +1,112 @@
+import type { PlanCreationCardModel } from "@enduragent/coach-contract";
+import { useEffect, useRef, type ReactElement } from "react";
+import { Button } from "@enduragent/ui";
+import { useEnduragentStore } from "../../state/store";
+import { commitmentSummaryId } from "./PlanCreationDraftCards";
+import { creationProgressCopy } from "./plan-creation-progress";
+
+function usePlanCreationChrome(): {
+  readonly model: PlanCreationCardModel;
+  readonly title: string;
+  readonly status: "Paused" | "In progress";
+  readonly summary: string;
+  readonly buildDraft: boolean;
+  readonly canContinue: boolean;
+} | null {
+  const model = useEnduragentStore((state) => state.chat.planCreation);
+  const paused = useEnduragentStore((state) => state.chat.planCreationPaused);
+  const library = useEnduragentStore((state) => state.planLibrary.value);
+  if (model === null) return null;
+  const copy = creationProgressCopy({
+    model,
+    paused,
+    libraryLoaded: library !== null,
+    activePlanName: library?.active?.name ?? null,
+  });
+  return {
+    model,
+    ...copy,
+    buildDraft: model.readiness === "ready" && model.draft === null,
+    canContinue: paused && model.openQuestion !== null,
+  };
+}
+
+export function PlanCreationSubtitle(): ReactElement | null {
+  const chrome = usePlanCreationChrome();
+  if (chrome === null) return null;
+  return (
+    <p
+      className="m-0 min-w-0 truncate text-xs leading-4 text-ink-2"
+      title={`Plan creation · ${chrome.title} · ${chrome.status} · ${chrome.summary}`}
+    >
+      <span data-parity="progress.eyebrow">Plan creation</span>
+      {" · "}
+      <span data-parity="progress.title">{chrome.title}</span>
+      {" · "}
+      <span data-parity="progress.status">{chrome.status}</span>
+      {" · "}
+      <span data-parity="progress.summary">{chrome.summary}</span>
+    </p>
+  );
+}
+
+export function PlanCreationHeaderActions(): ReactElement | null {
+  const chrome = usePlanCreationChrome();
+  const actions = useEnduragentStore((state) => state.chatActions);
+  const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
+  const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
+  const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
+  const discardButton = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (focusRequest?.target === "discard") {
+      queueMicrotask(() => discardButton.current?.focus());
+    }
+  }, [focusRequest?.revision, focusRequest?.target]);
+  if (chrome === null) return null;
+  return (
+    <div className="flex items-center gap-2" data-parity="progress.actions">
+      <Button
+        ref={discardButton}
+        type="button"
+        size="xs"
+        variant="destructive"
+        className="border-[color-mix(in_srgb,var(--danger)_52%,var(--line))] bg-transparent"
+        data-plan-creation-discard={chrome.model.creationId}
+        aria-haspopup="dialog"
+        disabled={busy || actions === null}
+        onClick={() => actions?.openPlanCreationDiscard()}
+      >
+        Discard
+      </Button>
+      {chrome.buildDraft ? (
+        <Button
+          type="button"
+          size="xs"
+          disabled={
+            actions === null ||
+            busy ||
+            editingKey !== null ||
+            chrome.model.pendingCommitment !== null
+          }
+          aria-describedby={
+            chrome.model.pendingCommitment === null ? undefined : commitmentSummaryId(chrome.model)
+          }
+          onClick={() => actions?.buildPlanCreationDraft()}
+        >
+          Build Draft
+        </Button>
+      ) : null}
+      {chrome.canContinue ? (
+        <Button
+          type="button"
+          size="xs"
+          variant="default"
+          disabled={actions === null || busy}
+          onClick={() => actions?.continuePlanCreation()}
+        >
+          Continue
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanCreationSummary.tsx
@@ -1,167 +1,62 @@
 import type { PlanCreationCardModel } from "@enduragent/coach-contract";
-import { useEffect, useRef, type ReactElement } from "react";
+import type { ReactElement } from "react";
 import { Check } from "lucide-react";
 import { Button } from "@enduragent/ui";
-import { Card, CardContent } from "@enduragent/ui";
-import { creationTitle } from "../../plan/creation-title";
 import { useEnduragentStore } from "../../state/store";
-
-import { commitmentSummaryId, resolvedAnswerSummaries } from "./PlanCreationDraftCards";
+import { resolvedAnswerSummaries } from "./PlanCreationDraftCards";
 
 export function PlanCreationSummary(props: {
   readonly model: PlanCreationCardModel;
-  readonly answersOnly?: boolean;
-}): ReactElement {
+}): ReactElement | null {
   const actions = useEnduragentStore((state) => state.chatActions);
-  const library = useEnduragentStore((state) => state.planLibrary.value);
-  const paused = useEnduragentStore((state) => state.chat.planCreationPaused);
   const busy = useEnduragentStore((state) => state.chat.planCreationBusy);
   const editingKey = useEnduragentStore((state) => state.chat.planCreationEditingKey);
-  const focusRequest = useEnduragentStore((state) => state.chat.planCreationFocusRequest);
-  const discardButton = useRef<HTMLButtonElement>(null);
   const summaries = resolvedAnswerSummaries(props.model.answeredSummaries);
-  const ready = props.model.readiness === "ready";
-  const canContinue = paused && props.model.openQuestion !== null;
-  const total =
-    props.model.openQuestion?.step.total ??
-    props.model.answeredSummaries[0]?.question.step.total ??
-    props.model.answeredSummaries.length;
-  useEffect(() => {
-    if (focusRequest?.target === "discard") {
-      queueMicrotask(() => discardButton.current?.focus());
-    }
-  }, [focusRequest?.revision, focusRequest?.target]);
+  if (summaries.length === 0) return null;
   return (
-    <section className="grid min-w-0 gap-4" aria-label="Plan Creation progress">
-      {summaries.length === 0 ? null : (
-        <ul className="m-0 grid list-none gap-2 p-0" role="list">
-          {summaries.map((summary) => (
-            <li
-              key={summary.answerKey}
-              className="grid min-w-0 grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)_auto] items-center gap-row rounded-card border border-line bg-surface px-ctl-px py-3 text-sm"
-              data-parity="summary.row"
-              aria-label={`${summary.title} answer`}
-            >
-              <span className="grid size-8 place-items-center rounded-full bg-[color-mix(in_srgb,var(--ok)_16%,var(--surface))] text-ok">
-                <Check className="size-4" aria-hidden="true" />
-              </span>
-              <div className="min-w-0">
-                <p
-                  className="m-0 mb-[calc(var(--inset)/2)] text-xs font-semibold uppercase tracking-wide text-ink-2"
-                  data-parity="summary.eyebrow"
-                >
-                  Answer recorded
-                </p>
-                <strong
-                  className="block min-w-0 break-words font-medium"
-                  data-parity="summary.label"
-                >
-                  {summary.detail}
-                </strong>
-                <p
-                  className="m-0 mt-[calc(var(--inset)/2)] text-xs text-ink-2"
-                  data-parity="summary.detail"
-                >
-                  {summary.title} ·{" "}
-                  {summary.source.kind === "athlete" ? "your answer" : summary.source.label}
-                </p>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="xs"
-                className="gap-inset border-line bg-surface"
-                data-parity="summary.edit"
-                aria-label={`Edit ${summary.title}`}
-                disabled={actions === null || busy || editingKey !== null}
-                onClick={() => actions?.editPlanCreation(summary.answerKey)}
-              >
-                Edit
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
-      {props.answersOnly ? null : (
-        <Card size="sm" className="block min-w-0 gap-0 py-0" data-parity="progress.card">
-          <CardContent className="p-4">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <p
-                  className="mt-0 mb-1 text-xs font-semibold uppercase tracking-wide text-ink-2"
-                  data-parity="progress.eyebrow"
-                >
-                  Plan creation
-                </p>
-                <strong
-                  className="block text-base font-semibold leading-6"
-                  data-parity="progress.title"
-                >
-                  {creationTitle(props.model)}
-                </strong>
-              </div>
-              <div className="flex items-center gap-inset self-start">
-                <span
-                  className="inline-flex items-center gap-[calc(var(--row-inset)/2)] rounded-full bg-sunk px-2 py-0.75 text-xs font-normal leading-4 text-ink-2"
-                  data-parity="progress.status"
-                >
-                  {paused ? "Paused" : "In progress"}
-                </span>
-              </div>
-            </div>
+    <ul className="m-0 grid list-none gap-2 p-0" role="list">
+      {summaries.map((summary) => (
+        <li
+          key={summary.answerKey}
+          className="grid min-w-0 grid-cols-[var(--ctl-h-sm)_minmax(0,1fr)_auto] items-center gap-row rounded-card border border-line bg-surface px-ctl-px py-3 text-sm"
+          data-parity="summary.row"
+          aria-label={`${summary.title} answer`}
+        >
+          <span className="grid size-8 place-items-center rounded-full bg-[color-mix(in_srgb,var(--ok)_16%,var(--surface))] text-ok">
+            <Check className="size-4" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
             <p
-              className="mt-inset mb-0 text-sm leading-5 text-ink-2"
-              data-parity="progress.summary"
+              className="m-0 mb-[calc(var(--inset)/2)] text-xs font-semibold uppercase tracking-wide text-ink-2"
+              data-parity="summary.eyebrow"
             >
-              {ready
-                ? "The essentials are complete."
-                : `${summaries.length} of ${total} answered.${library === null ? "" : ` ${library.active ? `${library.active.name} keeps running.` : "No Plan is active."}`}`}
+              Answer recorded
             </p>
-            <div className="mt-4 flex flex-wrap gap-inset" data-parity="progress.actions">
-              <Button
-                ref={discardButton}
-                type="button"
-                variant="destructive"
-                className="border-[color-mix(in_srgb,var(--danger)_52%,var(--line))] bg-transparent"
-                data-plan-creation-discard={props.model.creationId}
-                aria-haspopup="dialog"
-                disabled={busy || actions === null}
-                onClick={() => actions?.openPlanCreationDiscard()}
-              >
-                Discard
-              </Button>
-              {ready && props.model.draft === null ? (
-                <Button
-                  disabled={
-                    actions === null ||
-                    busy ||
-                    editingKey !== null ||
-                    props.model.pendingCommitment !== null
-                  }
-                  aria-describedby={
-                    props.model.pendingCommitment === null
-                      ? undefined
-                      : commitmentSummaryId(props.model)
-                  }
-                  onClick={() => actions?.buildPlanCreationDraft()}
-                >
-                  Build Draft
-                </Button>
-              ) : null}
-              {canContinue ? (
-                <Button
-                  type="button"
-                  variant="default"
-                  disabled={actions === null || busy}
-                  onClick={() => actions?.continuePlanCreation()}
-                >
-                  Continue
-                </Button>
-              ) : null}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-    </section>
+            <strong className="block min-w-0 break-words font-medium" data-parity="summary.label">
+              {summary.detail}
+            </strong>
+            <p
+              className="m-0 mt-[calc(var(--inset)/2)] text-xs text-ink-2"
+              data-parity="summary.detail"
+            >
+              {summary.title} ·{" "}
+              {summary.source.kind === "athlete" ? "your answer" : summary.source.label}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            className="gap-inset border-line bg-surface"
+            data-parity="summary.edit"
+            aria-label={`Edit ${summary.title}`}
+            disabled={actions === null || busy || editingKey !== null}
+            onClick={() => actions?.editPlanCreation(summary.answerKey)}
+          >
+            Edit
+          </Button>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/apps/desktop-renderer/src/ui/chat/plan-creation-progress.ts
+++ b/apps/desktop-renderer/src/ui/chat/plan-creation-progress.ts
@@ -1,0 +1,35 @@
+import type { PlanCreationCardModel } from "@enduragent/coach-contract";
+import { creationTitle } from "../../plan/creation-title";
+import { resolvedAnswerSummaries } from "./PlanCreationDraftCards";
+
+export function creationProgressCopy(input: {
+  readonly model: PlanCreationCardModel;
+  readonly paused: boolean;
+  readonly libraryLoaded: boolean;
+  readonly activePlanName: string | null;
+}): {
+  readonly title: string;
+  readonly status: "Paused" | "In progress";
+  readonly summary: string;
+} {
+  const summaries = resolvedAnswerSummaries(input.model.answeredSummaries);
+  const total =
+    input.model.openQuestion?.step.total ??
+    input.model.answeredSummaries[0]?.question.step.total ??
+    input.model.answeredSummaries.length;
+  const summary =
+    input.model.readiness === "ready"
+      ? "The essentials are complete."
+      : `${summaries.length} of ${total} answered.${
+          input.libraryLoaded
+            ? input.activePlanName === null
+              ? " No Plan is active."
+              : ` ${input.activePlanName} keeps running.`
+            : ""
+        }`;
+  return {
+    title: creationTitle(input.model),
+    status: input.paused ? "Paused" : "In progress",
+    summary,
+  };
+}

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -606,8 +606,74 @@ describe("chat view adapter", () => {
 
     expect(published.at(-1)?.timeline).toMatchObject([
       { kind: "plan-creation-discard", eventId: "01J00000000000000000000000" },
-      { kind: "message", message: { text: "Later Chat message" } },
       { kind: "plan-creation", model: nextModel },
+      { kind: "message", message: { text: "Later Chat message" } },
+    ]);
+  });
+
+  it("places live Chat after Plan creation and keeps hydrated messages above it", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    const model: PlanCreationCardModel = {
+      draft: null,
+      draftStale: false,
+      calendarWindow: null,
+      pendingCommitment: null,
+      creationId: "01J00000000000000000000001",
+      version: 1,
+      status: "in-progress",
+      readiness: "incomplete",
+      answeredSummaries: [],
+      openQuestion: null,
+    };
+
+    adapter.view.render(
+      submitted("PING two"),
+      controls({
+        hydration: {
+          status: "ready",
+          hasEarlier: false,
+          revision: 1,
+          change: "initial",
+          entries: [
+            {
+              kind: "turn",
+              turnId: "turn-history",
+              completedAt: "1998-03-03T12:00:00.000Z",
+              athleteText: "I want a new plan.",
+              coachText: "A few questions first.",
+            },
+          ],
+        },
+        planCreation: {
+          value: model,
+          loaded: true,
+          busy: false,
+          error: null,
+          paused: false,
+          editingKey: null,
+          focusRevision: 0,
+          discardConfirmationOpen: false,
+          activateConfirmationOpen: false,
+          activePlanKnowledge: { kind: "unknown" },
+          discardEvents: [],
+          notice: null,
+          focusRequest: null,
+        },
+      }),
+    );
+
+    expect(published.at(-1)?.timeline.map((item) => item.kind)).toEqual([
+      "message",
+      "message",
+      "plan-creation",
+      "message",
+    ]);
+    expect(published.at(-1)?.timeline).toMatchObject([
+      { kind: "message", message: { text: "I want a new plan.", historical: true } },
+      { kind: "message", message: { text: "A few questions first.", historical: true } },
+      { kind: "plan-creation", model },
+      { kind: "message", message: { text: "PING two", historical: false } },
     ]);
   });
 

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -586,17 +586,19 @@ describe("chat surface", () => {
         changesPaused: null,
         changes: [],
       };
+      const model = planCreationModel(goalQuestion("What are you preparing for?"));
       useEnduragentStore.setState({
         planLibrary:
           state === "unloaded"
             ? { status: "loading", value: null }
             : { status: "ready", value: library },
       });
-      render(
-        <PlanCreationSummary
-          model={planCreationModel(goalQuestion("What are you preparing for?"))}
-        />,
-      );
+      render(<Harness />);
+      setChat({
+        planCreation: model,
+        planCreationLoaded: true,
+        timeline: [{ kind: "plan-creation", model }],
+      });
       const tail =
         state === "unloaded"
           ? ""
@@ -606,6 +608,51 @@ describe("chat surface", () => {
       expect(screen.getByText(`0 of 9 answered.${tail}`, { exact: true })).toBeVisible();
     },
   );
+
+  it("keeps a live Chat message after Plan creation answers and out of the progress card", () => {
+    const model = planCreationModel(null, {
+      readiness: "incomplete",
+      answeredSummaries: [
+        {
+          answerKey: "restriction",
+          title: "Training Restriction",
+          detail: "No training restrictions",
+          question: restrictionQuestion("What Training Restriction should this Plan respect?"),
+          answer: { kind: "restriction", restriction: { kind: "none" } },
+        },
+      ],
+    });
+    const ping: ChatMessageView = {
+      id: "ping-two",
+      role: "athlete",
+      delivery: "complete",
+      historical: false,
+      text: "PING two",
+    };
+    render(<Harness />);
+    setChat({
+      planCreation: model,
+      planCreationLoaded: true,
+      planCreationPaused: true,
+      sendDisabled: false,
+      inputDisabled: false,
+      messages: [ping],
+      timeline: [
+        { kind: "plan-creation", model },
+        { kind: "message", message: ping },
+      ],
+    });
+    const conversation = screen.getByRole("main", { name: "Coaching conversation" });
+    const answer = conversation.querySelector("[data-parity='summary.row']");
+    const message = conversation.querySelector("[data-message-id='ping-two']");
+    expect(answer).not.toBeNull();
+    expect(message).not.toBeNull();
+    expect(
+      answer!.compareDocumentPosition(message!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(conversation.querySelector("[data-parity='progress.card']")).toBeNull();
+    expect(screen.getByRole("button", { name: "Discard" }).closest("header")).not.toBeNull();
+  });
 
   it("preserves and focuses the draft after enqueue failure and clears only after acknowledgment", async () => {
     const user = userEvent.setup();
@@ -3151,9 +3198,10 @@ describe("chat surface", () => {
       expect(
         screen.getByText("Endurance ride limited to 60 minutes by your confirmed limits."),
       ).toBeVisible();
-      const discard = screen.getByRole("button", { name: "Discard" });
-      const edit = screen.getByRole("button", { name: "Edit answers" });
-      const activate = screen.getByRole("button", { name: "Activate Plan" });
+      const review = screen.getByRole("region", { name: "Plan Draft review" });
+      const discard = within(review).getByRole("button", { name: "Discard" });
+      const edit = within(review).getByRole("button", { name: "Edit answers" });
+      const activate = within(review).getByRole("button", { name: "Activate Plan" });
       expect(activate).toBeEnabled();
       await userEvent.click(activate);
       expect(actions.openPlanCreationActivate).toHaveBeenCalledOnce();

--- a/apps/desktop-renderer/tests/plan-change-cards.test.tsx
+++ b/apps/desktop-renderer/tests/plan-change-cards.test.tsx
@@ -558,7 +558,8 @@ describe("Plan Change cards", () => {
     patchChange({ open: false, planId: null });
     render(<ChatView />);
     expect(screen.getByRole("region", { name: "Plan Changes" })).toBeVisible();
-    expect(screen.getByRole("region", { name: "Plan Creation progress" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Discard" })).toBeVisible();
+    expect(screen.getByText("Paused", { exact: true })).toBeVisible();
     expect(screen.getByText("Your separate Plan creation is still open.")).toBeVisible();
     expect(screen.getByText("Training changes need your confirmation.")).toBeVisible();
     const composer = screen.getByRole("combobox", { name: "Message your coach" });

--- a/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
+++ b/apps/desktop/tests/e2e/plan-creation-slice2.spec.ts
@@ -128,7 +128,7 @@ async function relaunch(scenario: Scenario, playwright: Playwright): Promise<voi
     width: scenario.width,
     height: scenario.height,
   });
-  await expect(scenario.page.getByRole("region", { name: "Plan Creation progress" })).toBeVisible();
+  await expect(scenario.page.getByRole("button", { name: "Discard" })).toBeVisible();
   await test.info().attach("relaunch-timing", {
     body: JSON.stringify({
       event: "relaunch-to-restored-progress",
@@ -291,13 +291,14 @@ test("completes the Fitness Goal with an authored success answer", async ({ play
   const scenario = await launch(playwright);
   try {
     await completeFitnessGoal(scenario);
-    const progress = scenario.page.getByRole("region", { name: "Plan Creation progress" });
     await expect(
-      progress.getByText("The essentials are complete.", {
+      scenario.page.getByText("The essentials are complete.", {
         exact: true,
       }),
     ).toBeVisible();
-    await expect(progress.getByRole("button", { name: "Build Draft", exact: true })).toBeVisible();
+    await expect(
+      scenario.page.getByRole("button", { name: "Build Draft", exact: true }),
+    ).toBeVisible();
     await expect(scenario.page.getByRole("button", { name: "Send message" })).toBeEnabled();
     const answers = await scenario.backend.answers();
     expect(answers.map((answer) => answer.answer_key)).toEqual([


### PR DESCRIPTION
## Why

During Plan creation, Chat put the Plan creation block after every live message. Follow-latest scrolls to the bottom of the conversation, so a send landed above a tall stack of Answer recorded rows and the old progress card. The working spinner flashed and the athlete thought the message was dropped. The message was never dropped.

This change puts Plan creation status and Discard in the Chat header. Answer recorded rows and Draft review stay in the transcript, above live Chat.

## Scope

- `conversationTimelineWithDiscardEvents` takes `planCreationItems` and inserts them after hydrated history and after `afterMessageId === null` discards, before live messages.
- `PlanCreationHeader` and `creationProgressCopy` own the muted subtitle and Discard, Build Draft, and Continue.
- `PlanCreationSummary` is answers only. The pane no longer renders `data-parity="progress.card"`.
- `.gitignore` now ignores `.cursor/` and `.nvmrc`.
- Out of scope: `CHAT_FOLLOW_LATEST_THRESHOLD`, optimistic composer clear, and retargeting follow-latest to the last message node.

## Tradeoffs

Rejected portaling the progress card into the header. The header owns chrome. The transcript keeps answers.

## Blast Radius

Athletes in Plan creation see status in the Chat header. Draft review Discard and Plan library Discard stay on their own controls. Renderer tests and Plan creation e2e cover the new selectors.

## Verification

- `pnpm check` green.
- `pnpm exec vitest run --project renderer-dom` on `chat-adapter`, `chat-surface`, and `plan-change-cards`: 216 passed.
- Desktop fixture with 9 seeded answers, send `PING two`. Last `[data-message-id]` sits after the answer rows and inside `main.conversation` (message top 643, host 52–673). Discard is in the header. `progress.card` count is 0.