### PR TITLE
Serve desktop auto-update YAML without GitHub client redirects

### DIFF
--- a/.changeset/public-desktop-update-feed.md
+++ b/.changeset/public-desktop-update-feed.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Version 0.3.0 cannot update itself; download the latest macOS installer from https://enduragent.icu/download/mac, and later versions will check for updates again.
+
+Packaged `app-update.yml` now points at `https://updates.enduragent.icu/`, a Cloudflare Worker that follows GitHub Releases latest/download redirects on the server and returns YAML and artifacts with no `Location` header. GitHub remains the canonical publish target. Installed 0.3.0 builds still use the GitHub URL and cannot self-heal.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -166,6 +166,16 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
+      - name: Require the public updater feed
+        env:
+          PUBLIC_FEED: https://updates.enduragent.icu/
+        run: |
+          set -euo pipefail
+          yaml="${PUBLIC_FEED}latest-mac.yml"
+          headers=$(curl -fsSD - -o /dev/null "$yaml")
+          location=$(printf '%s' "$headers" | tr -d '\r' | awk 'tolower($1)=="location:" { print $2; exit }')
+          test -z "$location"
+          curl -fsS "$yaml" | grep -q '^version: '
       - name: Resolve signed baseline
         id: baseline
         env:
@@ -204,7 +214,7 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           ENDURAGENT_DEVELOPER_ID_IDENTITY: ${{ vars.ENDURAGENT_DEVELOPER_ID_IDENTITY }}
-          ENDURAGENT_DESKTOP_UPDATE_URL: https://github.com/yerzhansa/enduragent/releases/latest/download/
+          ENDURAGENT_DESKTOP_UPDATE_URL: https://updates.enduragent.icu/
           ENDURAGENT_MACOS_BASELINE_APP: ${{ steps.baseline.outputs.baseline_app }}
           APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -626,13 +636,26 @@ jobs:
       - name: Confirm production feed serves the release
         env:
           DESKTOP_VERSION: ${{ inputs.desktop_version }}
+          PUBLIC_FEED: https://updates.enduragent.icu/
         run: |
           set -euo pipefail
+          github_yaml="https://github.com/$GITHUB_REPOSITORY/releases/latest/download/latest-mac.yml"
+          public_yaml="${PUBLIC_FEED}latest-mac.yml"
+          github_dmg="https://github.com/$GITHUB_REPOSITORY/releases/latest/download/Enduragent-arm64.dmg"
+          public_dmg="${PUBLIC_FEED}Enduragent-arm64.dmg"
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            SERVED=$(curl -fsSL "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/latest-mac.yml" | sed -n 's/^version: //p' | head -1) || SERVED=''
-            if [ "$SERVED" = "$DESKTOP_VERSION" ] && \
-              curl -fsSIL "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/Enduragent-arm64.dmg" >/dev/null; then
-              echo "Production feed and stable DMG serve $SERVED"
+            GITHUB_SERVED=$(curl -fsSL "$github_yaml" | sed -n 's/^version: //p' | head -1) || GITHUB_SERVED=''
+            PUBLIC_HEADERS=$(curl -fsSD - -o /dev/null "$public_yaml") || PUBLIC_HEADERS=''
+            PUBLIC_LOCATION=$(printf '%s' "$PUBLIC_HEADERS" | tr -d '\r' | awk 'tolower($1)=="location:" { print $2; exit }')
+            PUBLIC_SERVED=$(curl -fsS "$public_yaml" | sed -n 's/^version: //p' | head -1) || PUBLIC_SERVED=''
+            PUBLIC_DMG_HEADERS=$(curl -fsSD - -o /dev/null --range 0-0 "$public_dmg") || PUBLIC_DMG_HEADERS=''
+            PUBLIC_DMG_LOCATION=$(printf '%s' "$PUBLIC_DMG_HEADERS" | tr -d '\r' | awk 'tolower($1)=="location:" { print $2; exit }')
+            if [ "$GITHUB_SERVED" = "$DESKTOP_VERSION" ] && \
+              [ "$PUBLIC_SERVED" = "$DESKTOP_VERSION" ] && \
+              [ -z "$PUBLIC_LOCATION" ] && \
+              [ -z "$PUBLIC_DMG_LOCATION" ] && \
+              curl -fsSIL "$github_dmg" >/dev/null; then
+              echo "GitHub and $PUBLIC_FEED serve $PUBLIC_SERVED without a client redirect"
               exit 0
             fi
             sleep 30

--- a/.github/workflows/desktop-update-feed.yml
+++ b/.github/workflows/desktop-update-feed.yml
@@ -1,0 +1,43 @@
+name: Desktop update feed
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - tools/desktop-update-feed.ts
+      - tools/desktop-update-feed.worker.ts
+      - tools/desktop-update-feed.wrangler.toml
+      - .github/workflows/desktop-update-feed.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ vars.ENABLE_DESKTOP_UPDATE_FEED == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: tools
+          command: deploy --config desktop-update-feed.wrangler.toml
+      - name: Confirm the public feed returns YAML without a redirect
+        run: |
+          set -euo pipefail
+          yaml=https://updates.enduragent.icu/latest-mac.yml
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            headers=$(curl -fsSD - -o /dev/null "$yaml") || headers=''
+            location=$(printf '%s' "$headers" | tr -d '\r' | awk 'tolower($1)=="location:" { print $2; exit }')
+            if [ -z "$location" ] && curl -fsS "$yaml" | grep -q '^version: '; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo '::error::Public updater feed did not serve YAML without a redirect'
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Changesets-driven and CI-automated. Contributors do **not** create tags or GitHu
 
 2. **Merge your PR to `main`.** `version-pr.yml` opens (or updates) a bot-managed "Version Packages" PR aggregating all pending changesets.
 3. **Merge the "Version Packages" PR when ready to ship.** It bumps only the packages listed by pending changesets. On merge, `version-pr.yml` tags and dispatches only public package versions that changed; if `apps/desktop/package.json` changed, it separately creates `enduragent-desktop@<SemVer>`, creates a draft release bound to the desktop changelog, and dispatches `desktop-release.yml` on that tag.
-4. **The matching release path runs.** `release.yml` publishes changed npm packages via OIDC and keeps their GitHub Releases non-latest. `desktop-release.yml` publishes no npm package; it signs and notarizes on macOS, independently verifies the signed envelope, publishes the exact four updater assets, and promotes the release to repository latest.
+4. **The matching release path runs.** `release.yml` publishes changed npm packages via OIDC and keeps their GitHub Releases non-latest. `desktop-release.yml` publishes no npm package; it signs and notarizes on macOS, independently verifies the signed envelope, publishes the exact four updater assets, and promotes the release to repository latest. Packaged update checks use `https://updates.enduragent.icu/`; GitHub Releases remains the canonical copy of those assets.
 
 Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is tagged. When a stub binary (`running-coach`, `duathlon-coach`) graduates by flipping `private: false`, it auto-tags on the next Version-PR merge.
 
@@ -170,13 +170,29 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 
 `tools/bump-binaries-to-calver.ts` runs after `changeset version`. It reads the committed pre-Changesets version and all occupied npm versions, then overrides binary versions with the next stable release number for the current UTC month. It rewrites only the new matching changelog header; historical entries are immutable.
 
+## Desktop update feed (operator)
+
+Packaged macOS and Windows update checks use the generic YAML feed at `https://updates.enduragent.icu/`. GitHub Releases remains the canonical copy of `latest-mac.yml`, `latest.yml`, and the artifacts. The Cloudflare Worker in `tools/desktop-update-feed.ts` follows GitHub's download redirects on the server and returns the bytes with no `Location` header.
+
+Do this before the first desktop release that bakes that feed URL:
+
+1. Put `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in this repository's Actions secrets (the same Cloudflare account that already serves `enduragent.icu` and `ping.enduragent.icu`).
+2. Set Actions variable `ENABLE_DESKTOP_UPDATE_FEED` to `true`.
+3. Merge to `main` so `.github/workflows/desktop-update-feed.yml` deploys `tools/desktop-update-feed.wrangler.toml`, or run that workflow with `workflow_dispatch`.
+4. Confirm `updates.enduragent.icu` is attached on that zone if deploy did not create the custom domain.
+5. Confirm `curl -fsS https://updates.enduragent.icu/latest-mac.yml` prints YAML starting with `version:` and that a headers-only GET shows no `Location`.
+
+`desktop-release.yml` refuses to notarize unless that public YAML is already reachable without a redirect. After promote it dual-checks GitHub `/releases/latest/download/latest-mac.yml` and the public feed, and fails if the public YAML still redirects or the versions differ. Installed 0.3.0 builds still point at GitHub and cannot self-update; those athletes install from https://enduragent.icu/download/mac.
+
+Keep publishing the macOS updater assets and the Windows envelope to the GitHub Release. The website `/download/mac` link may keep redirecting to GitHub; browsers can follow that chain.
+
 ## Windows release (operator)
 
 - Keep `desktop-release.yml` macOS-only and fully automatic.
 - Never make `desktop-release.yml` wait for Windows.
 - Use one GitHub release per desktop version.
 - Append Windows assets after the macOS release.
-- Append Windows assets only while `enduragent-desktop@<x.y.z>` is the repository's latest release. The updater feed is `/releases/latest/download/`, so Windows clients cannot discover assets on an older release.
+- Append Windows assets only while `enduragent-desktop@<x.y.z>` is the repository's latest release. The public updater feed proxies GitHub `/releases/latest/download/`, so Windows clients cannot discover assets on an older release.
 - Skip Windows for a version once a newer desktop release exists. Ship it with the next version instead.
 - State which platforms shipped in the release notes.
 - Build and sign in one `electron-builder` run on the operator's Windows VM inside an open SimplySign session.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ access; it does not add a desktop shortcut. Closing the main window hides it whi
 running in the tray; quit it explicitly from the tray menu.
 
 Uninstalling keeps your data in `%LOCALAPPDATA%\Enduragent`; remove that folder by hand to erase
-it. Windows update checks use the same generic GitHub release feed as macOS and switch on with the
+it. Windows update checks use the same public updater feed as macOS and switch on with the
 first signed release. Windows assets can arrive later than macOS, and Windows may lag or skip a
 version; release notes say which platforms shipped.
 
@@ -177,7 +177,7 @@ once per installation in any 24 hours. The request contains the product, version
 and a random installation UUID — no athlete data, messages, or credentials. Set
 `CYCLING_COACH_NO_UPDATE_CHECK=1` for the bot or `ENDURAGENT_NO_USAGE_PING=1` for Desktop to switch
 it off. Manual commands never initiate telemetry; Desktop update checks remain separate and go
-directly to GitHub.
+to `https://updates.enduragent.icu/`.
 
 Full policy: [enduragent.icu/privacy.html](https://enduragent.icu/privacy.html).
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -2,17 +2,17 @@
 
 ## Releases and updates
 
-The desktop app uses its own SemVer from `apps/desktop/package.json` and releases under `enduragent-desktop@<version>`; desktop releases never publish or bump the npm package. The protected macOS workflow signs with Developer ID, notarizes with Apple, verifies the DMG, ZIP, blockmap, and `latest-mac.yml`, runs the signed update round trip, and makes the tested release the updater feed only after those checks pass.
+The desktop app uses its own SemVer from `apps/desktop/package.json` and releases under `enduragent-desktop@<version>`; desktop releases never publish or bump the npm package. The protected macOS workflow signs with Developer ID, notarizes with Apple, verifies the DMG, ZIP, blockmap, and `latest-mac.yml`, runs the signed update round trip, and makes the tested release the updater feed only after those checks pass. Packaged update checks use `https://updates.enduragent.icu/`, which serves the GitHub Release artifacts without sending the client through GitHub's download redirects.
 
 Official releases send a separate installation heartbeat to `ping.enduragent.icu` at startup and
 on a daily timer, limited to one attempt per installation in any 24-hour period. It contains only
 the fixed product label `enduragent-desktop`, a random persisted installation UUID, the app
 version, and the platform channel; set
-`ENDURAGENT_NO_USAGE_PING=1` before launch to disable it without disabling GitHub update checks.
+`ENDURAGENT_NO_USAGE_PING=1` before launch to disable it without disabling update checks.
 
 ## Windows
 
-Windows targets Windows 11 x64 with the per-user, one-click `Enduragent-<version>-x64.exe` installer, its `.blockmap`, and `latest.yml`; the installer requests no elevation, adds a Start Menu shortcut but no desktop shortcut, and ships only with an Authenticode signature from `<PUBLISHER_NAME>`, although SmartScreen can still prompt while a new publisher identity builds reputation. Windows assets are appended to the existing desktop release, may lag or skip a version, and never hold the macOS release; update checks use the same generic GitHub release feed and switch on with the first signed release. Closing the main window keeps the app running in the tray until it is explicitly quit, while uninstalling retains `%LOCALAPPDATA%\Enduragent` for the athlete to remove by hand. Follow the operator runbook in `CONTRIBUTING.md`.
+Windows targets Windows 11 x64 with the per-user, one-click `Enduragent-<version>-x64.exe` installer, its `.blockmap`, and `latest.yml`; the installer requests no elevation, adds a Start Menu shortcut but no desktop shortcut, and ships only with an Authenticode signature from `<PUBLISHER_NAME>`, although SmartScreen can still prompt while a new publisher identity builds reputation. Windows assets are appended to the existing desktop release, may lag or skip a version, and never hold the macOS release; update checks use the same public updater feed and switch on with the first signed release. Closing the main window keeps the app running in the tray until it is explicitly quit, while uninstalling retains `%LOCALAPPDATA%\Enduragent` for the athlete to remove by hand. Follow the operator runbook in `CONTRIBUTING.md`.
 
 ## Open at Login and uninstalling
 

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import { createPackage, uncache } from "@electron/asar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse, stringify } from "yaml";
+import { DESKTOP_FEED_URL } from "../../../tools/desktop-update-feed.js";
 import {
   inspectMacosReleaseApplication,
   safeMacosReleaseVerificationMessage,
@@ -254,7 +255,7 @@ async function signedIdentityFixture() {
         join(application, "Contents/Resources/app-update.yml"),
         [
           "provider: generic",
-          "url: https://github.com/yerzhansa/enduragent/releases/latest/download/",
+          "url: " + DESKTOP_FEED_URL,
           "channel: latest",
           "updaterCacheDirName: '@enduragentdesktop-updater'",
           "",
@@ -399,7 +400,7 @@ describe.skipIf(process.platform === "win32")("macOS signed identity continuity"
     expect(inspected).toEqual({
       version,
       enduragentDesktopRelease: true,
-      feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+      feedUrl: DESKTOP_FEED_URL,
       bundleIdentifier: "icu.enduragent.desktop",
       teamIdentifier: "FA494ACVTF",
       designatedRequirementSha256: createHash("sha256")
@@ -609,7 +610,7 @@ describe.skipIf(process.platform === "win32")("macOS signed identity continuity"
       }),
     ).resolves.toMatchObject({
       enduragentDesktopRelease: true,
-      feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+      feedUrl: DESKTOP_FEED_URL,
     });
     expect(executeFile).toHaveBeenCalledWith(
       "/usr/bin/ditto",

--- a/apps/desktop/tests/upload-windows-release.test.ts
+++ b/apps/desktop/tests/upload-windows-release.test.ts
@@ -12,6 +12,7 @@ import {
   windowsReleaseArtifactNames,
   windowsUpdaterMetadataDigest,
 } from "../scripts/windows-release-plan.mjs";
+import { DESKTOP_FEED_URL } from "../../../tools/desktop-update-feed.js";
 
 const version = "0.1.5";
 const commit = "a".repeat(40);
@@ -47,7 +48,7 @@ beforeEach(async () => {
     metadata: Buffer.from("metadata"),
   };
   const appUpdateMetadata = serializeWindowsReleaseUpdaterMetadata(
-    "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+    DESKTOP_FEED_URL,
     publisherDn,
   );
   const paths = {

--- a/apps/desktop/tests/windows-authenticode.test.ts
+++ b/apps/desktop/tests/windows-authenticode.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stringify } from "yaml";
+import { DESKTOP_FEED_URL } from "../../../tools/desktop-update-feed.js";
 import {
   createWindowsAuthenticodeVerifyMode,
   decideWindowsAuthenticode,
@@ -25,7 +26,7 @@ const version = "0.1.5";
 const publisherDn = "CN=Enduragent Test Publisher, O=Enduragent Test";
 const thumbprint = "a".repeat(40);
 const commit = "c".repeat(40);
-const feedUrl = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
+const feedUrl = DESKTOP_FEED_URL;
 const updaterMetadata = serializeWindowsReleaseUpdaterMetadata(feedUrl, publisherDn);
 const updaterMetadataSha256 = windowsUpdaterMetadataDigest(updaterMetadata);
 const scriptPath = resolve(

--- a/apps/desktop/tests/windows-release-artifacts.test.ts
+++ b/apps/desktop/tests/windows-release-artifacts.test.ts
@@ -14,11 +14,12 @@ import {
   windowsReleaseArtifactNames,
   windowsUpdaterMetadataDigest,
 } from "../scripts/windows-release-plan.mjs";
+import { DESKTOP_FEED_URL } from "../../../tools/desktop-update-feed.js";
 
 const version = "0.1.5";
 const commit = "a".repeat(40);
 const publisherDn = "CN=Enduragent Test";
-const feedUrl = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
+const feedUrl = DESKTOP_FEED_URL;
 const releaseDate = "2026-08-25T00:00:00.000Z";
 const script = resolve(
   dirname(fileURLToPath(import.meta.url)),

--- a/apps/desktop/tests/windows-release-plan.test.ts
+++ b/apps/desktop/tests/windows-release-plan.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parse, stringify } from "yaml";
 import { createWindowsDevelopmentPackagePlan } from "../scripts/windows-development-package-plan.mjs";
+import { DESKTOP_FEED_URL } from "../../../tools/desktop-update-feed.js";
 import { createWindowsPackagePlan } from "../scripts/windows-package-plan.mjs";
 import {
   WINDOWS_AUTHENTICODE_PENDING,
@@ -20,7 +21,7 @@ import {
   windowsUpdaterMetadataDigest,
 } from "../scripts/windows-release-plan.mjs";
 
-const feedUrl = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
+const feedUrl = DESKTOP_FEED_URL;
 const commit = "a".repeat(40);
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 

--- a/apps/desktop/tests/windows-updater-round-trip.test.ts
+++ b/apps/desktop/tests/windows-updater-round-trip.test.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import { gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { stringify } from "yaml";
+import { DESKTOP_FEED_URL } from "../../../tools/desktop-update-feed.js";
 import {
   safeWindowsUpdaterRoundTripMessage,
   verifyWindowsUpdaterRoundTrip,
@@ -35,7 +36,7 @@ function blockmapFor(installer: Buffer, chunkSize = 16): Buffer {
 }
 const releaseDate = "2026-08-25T00:00:00.000Z";
 const preflight: WindowsUpdaterPreflight = {
-  feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+  feedUrl: DESKTOP_FEED_URL,
   channel: "latest",
   publisherName: "CN=Operator Name, O=Open Source Developer, C=KZ",
   disableWebInstaller: true,

--- a/guides/privacy.md
+++ b/guides/privacy.md
@@ -32,8 +32,9 @@ launch to disable it; disabled and unofficial builds create no heartbeat state.
 The heartbeat endpoint stores those four fields, a count, and the time the request was received for
 up to three months so the project can estimate active installations. Like any HTTPS service, its
 hosting provider can receive ordinary network metadata such as an IP address and user agent. The
-Desktop updater remains separate: it checks the public GitHub release feed directly and never
-depends on the heartbeat endpoint.
+Desktop updater remains separate: it checks `https://updates.enduragent.icu/` for the latest
+GitHub release artifacts and never depends on the heartbeat endpoint. That host can receive the
+same ordinary network metadata as the heartbeat endpoint.
 
 Desktop does not fetch release notes in the background. Choosing **What’s new** explicitly contacts
 `registry.npmjs.org` for the latest published version and the GitHub Releases API for that exact

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -10,6 +10,7 @@ import {
   DESKTOP_MANIFEST,
   DESKTOP_PROVISIONAL_RELEASE_BODY,
   DESKTOP_STABLE_DMG_NAME,
+  GITHUB_DESKTOP_RELEASE_FEED_URL,
   GithubClient,
   activateDesktopRelease,
   compensateDesktopRelease,
@@ -549,6 +550,63 @@ describe("GitHub desktop release transaction", () => {
         "https://github.com/other/repository/releases/download/tag/latest-mac.yml",
       ),
     ).rejects.toThrow("outside the bound repository");
+    await expect(client.anonymousBytes(`${DESKTOP_FEED_URL}latest-mac.yml`)).rejects.toThrow(
+      "outside the bound repository",
+    );
+  });
+
+  it("reads latest metadata from the public feed without following redirects", async () => {
+    const yaml = Buffer.from("version: 0.1.7\n");
+    const digest = createHash("sha256").update(yaml).digest("hex");
+    let feedRedirect: RequestInit["redirect"];
+    const client = new GithubClient("yerzhansa/enduragent", "token", async (input, init = {}) => {
+      const url = String(input);
+      if (url.endsWith("/releases/latest")) {
+        return Response.json({
+          id: 123,
+          tag_name: "enduragent-desktop@0.1.7",
+          draft: false,
+          prerelease: false,
+          assets: [
+            {
+              id: 1,
+              name: "latest-mac.yml",
+              size: yaml.length,
+              digest: `sha256:${digest}`,
+              state: "uploaded",
+              url: "https://api.github.com/repos/yerzhansa/enduragent/releases/assets/1",
+              browser_download_url:
+                "https://github.com/yerzhansa/enduragent/releases/download/enduragent-desktop@0.1.7/latest-mac.yml",
+            },
+          ],
+          upload_url:
+            "https://uploads.github.com/repos/yerzhansa/enduragent/releases/123/assets{?name,label}",
+          body: "body",
+        });
+      }
+      if (url === `${DESKTOP_FEED_URL}latest-mac.yml`) {
+        feedRedirect = init.redirect;
+        expect(new Headers(init.headers).get("Authorization")).toBeNull();
+        return new Response(yaml);
+      }
+      return new Response(null, { status: 599 });
+    });
+    await expect(client.latest()).resolves.toEqual({
+      id: 123,
+      tag: "enduragent-desktop@0.1.7",
+      metadataSha256: digest,
+    });
+    expect(feedRedirect).toBe("error");
+  });
+
+  it("refuses a public feed that still redirects", async () => {
+    const client = new GithubClient("yerzhansa/enduragent", "token", async () => {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: `${GITHUB_DESKTOP_RELEASE_FEED_URL}latest-mac.yml` },
+      });
+    });
+    await expect(client.publicFeedMetadataBytes()).rejects.toThrow("public updater feed redirected");
   });
 
   it("uses injected deadlines for metadata requests without exposing secrets or URLs", async () => {

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -5,8 +5,9 @@ import { link, lstat, mkdir, readFile, readdir, writeFile } from "node:fs/promis
 import { basename, relative, resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
+import { DESKTOP_FEED_URL, GITHUB_DESKTOP_RELEASE_FEED_URL } from "./desktop-update-feed.js";
 
-export const DESKTOP_FEED_URL = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
+export { DESKTOP_FEED_URL, GITHUB_DESKTOP_RELEASE_FEED_URL };
 export const DESKTOP_MANIFEST = "desktop-release-manifest.json";
 export const DESKTOP_RELEASE_SCHEMA_VERSION = 3 as const;
 export const DESKTOP_PROVISIONAL_RELEASE_BODY =
@@ -1129,6 +1130,38 @@ export class GithubClient {
     );
   }
 
+  async publicFeedMetadataBytes(deadlineAt?: number): Promise<Buffer> {
+    const target = new URL("latest-mac.yml", DESKTOP_FEED_URL);
+    if (target.href !== `${DESKTOP_FEED_URL}latest-mac.yml`) {
+      throw new TypeError("public updater feed URL is invalid");
+    }
+    return this.#bounded(
+      "public updater feed transfer",
+      this.#timing.assetTransferTimeoutMs,
+      async (signal) => {
+        const response = await this.#fetch(target, {
+          headers: { Accept: "application/octet-stream" },
+          redirect: "error",
+          signal,
+        });
+        if (response.status >= 300 && response.status < 400) {
+          await response.body?.cancel();
+          throw new TypeError("public updater feed redirected");
+        }
+        if (!response.ok) {
+          await response.arrayBuffer();
+          throw new TypeError(`public updater feed download failed (${response.status})`);
+        }
+        if (response.headers.get("location") !== null) {
+          await response.body?.cancel();
+          throw new TypeError("public updater feed redirected");
+        }
+        return Buffer.from(await response.arrayBuffer());
+      },
+      deadlineAt,
+    );
+  }
+
   release(id: string | number, deadlineAt?: number): Promise<GithubRelease> {
     return this.request(`/repos/${this.#repository}/releases/${id}`, {}, deadlineAt);
   }
@@ -1185,7 +1218,7 @@ export class GithubClient {
       if (metadata.state !== "uploaded" || !match || metadata.size <= 0) {
         throw new TypeError("repository latest metadata digest is invalid");
       }
-      const feedBytes = await this.anonymousBytes(`${DESKTOP_FEED_URL}latest-mac.yml`, deadlineAt);
+      const feedBytes = await this.publicFeedMetadataBytes(deadlineAt);
       metadataSha256 = sha256(feedBytes);
       if (feedBytes.length !== metadata.size || metadataSha256 !== match[1]) {
         throw new TypeError("repository latest and updater feed digest differ");

--- a/tools/desktop-update-feed.test.ts
+++ b/tools/desktop-update-feed.test.ts
@@ -1,0 +1,214 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_FEED_URL,
+  GITHUB_DESKTOP_RELEASE_FEED_URL,
+  desktopUpdateFeedObjectName,
+  githubDesktopReleaseObjectUrl,
+  handleDesktopUpdateFeedRequest,
+} from "./desktop-update-feed.js";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const yamlBody = "version: 0.4.0\npath: Enduragent-0.4.0-arm64.zip\n";
+const githubLatest = `${GITHUB_DESKTOP_RELEASE_FEED_URL}latest-mac.yml`;
+const githubTagged =
+  "https://github.com/yerzhansa/enduragent/releases/download/enduragent-desktop@0.4.0/latest-mac.yml";
+const jwtBlob = "https://release-assets.githubusercontent.com/github-production-release-asset/1?jwt=x";
+
+function request(path: string, init?: RequestInit): Request {
+  return new Request(new URL(path, DESKTOP_FEED_URL), init);
+}
+
+function githubFetch(handlers: Record<string, () => Response>): typeof fetch {
+  return async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const handler = handlers[url];
+    if (handler === undefined) return new Response(`unmocked ${url}`, { status: 599 });
+    return handler();
+  };
+}
+
+describe("desktop update feed objects", () => {
+  it("accepts channel files and versioned Mac and Windows artifacts", () => {
+    expect(desktopUpdateFeedObjectName("/latest-mac.yml")).toBe("latest-mac.yml");
+    expect(desktopUpdateFeedObjectName("/latest.yml")).toBe("latest.yml");
+    expect(desktopUpdateFeedObjectName("/Enduragent-arm64.dmg")).toBe("Enduragent-arm64.dmg");
+    expect(desktopUpdateFeedObjectName("/Enduragent-0.4.0-arm64.zip")).toBe(
+      "Enduragent-0.4.0-arm64.zip",
+    );
+    expect(desktopUpdateFeedObjectName("/Enduragent-0.4.0-arm64.zip.blockmap")).toBe(
+      "Enduragent-0.4.0-arm64.zip.blockmap",
+    );
+    expect(desktopUpdateFeedObjectName("/Enduragent-0.4.0-x64.exe")).toBe("Enduragent-0.4.0-x64.exe");
+  });
+
+  it("rejects traversal, encoded hosts, and unknown names", () => {
+    expect(desktopUpdateFeedObjectName("/../latest-mac.yml")).toBeUndefined();
+    expect(desktopUpdateFeedObjectName("//latest-mac.yml")).toBeUndefined();
+    expect(desktopUpdateFeedObjectName("/latest-mac.yml/")).toBeUndefined();
+    expect(desktopUpdateFeedObjectName("/enduragent-desktop@0.4.0/latest-mac.yml")).toBeUndefined();
+    expect(desktopUpdateFeedObjectName("/secret.txt")).toBeUndefined();
+  });
+
+  it("builds the GitHub latest-download URL for an allowed object", () => {
+    expect(githubDesktopReleaseObjectUrl("latest-mac.yml")).toBe(githubLatest);
+  });
+});
+
+describe("desktop update feed handler", () => {
+  it("returns GitHub YAML bytes to the client without a redirect", async () => {
+    const fetchImpl = githubFetch({
+      [githubLatest]: () =>
+        new Response(null, { status: 302, headers: { Location: githubTagged } }),
+      [githubTagged]: () => new Response(null, { status: 302, headers: { Location: jwtBlob } }),
+      [jwtBlob]: () =>
+        new Response(yamlBody, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/octet-stream",
+            "Set-Cookie": "session=1",
+            Location: "https://evil.example/",
+          },
+        }),
+    });
+    const response = await handleDesktopUpdateFeedRequest(
+      request("latest-mac.yml?noCache=abc"),
+      { fetch: fetchImpl },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("application/octet-stream");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe(yamlBody);
+  });
+
+  it("forwards a Range GET and returns 206 without leaking GitHub cookies", async () => {
+    const zipLatest = `${GITHUB_DESKTOP_RELEASE_FEED_URL}Enduragent-0.4.0-arm64.zip`;
+    const zipTagged =
+      "https://github.com/yerzhansa/enduragent/releases/download/enduragent-desktop@0.4.0/Enduragent-0.4.0-arm64.zip";
+    const zipBlob = "https://release-assets.githubusercontent.com/zip?jwt=y";
+    const seen: string[] = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const headers = new Headers(init?.headers);
+      seen.push(`${init?.method ?? "GET"} ${url} range=${headers.get("range") ?? ""}`);
+      if (url === zipLatest || url === zipTagged) {
+        const location = url === zipLatest ? zipTagged : zipBlob;
+        return new Response(null, { status: 302, headers: { Location: location } });
+      }
+      if (url === zipBlob) {
+        expect(headers.get("range")).toBe("bytes=0-3");
+        return new Response("abcd", {
+          status: 206,
+          headers: {
+            "Content-Range": "bytes 0-3/10",
+            "Accept-Ranges": "bytes",
+            "Set-Cookie": "session=1",
+          },
+        });
+      }
+      return new Response(null, { status: 599 });
+    };
+    const response = await handleDesktopUpdateFeedRequest(
+      request("Enduragent-0.4.0-arm64.zip", { headers: { Range: "bytes=0-3" } }),
+      { fetch: fetchImpl },
+    );
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 0-3/10");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(await response.text()).toBe("abcd");
+    expect(seen).toEqual([
+      `GET ${zipLatest} range=bytes=0-3`,
+      `GET ${zipTagged} range=bytes=0-3`,
+      `GET ${zipBlob} range=bytes=0-3`,
+    ]);
+  });
+
+  it("returns 404 for an unknown object and 405 for POST", async () => {
+    const missing = await handleDesktopUpdateFeedRequest(request("notes.txt"), {
+      fetch: githubFetch({}),
+    });
+    expect(missing.status).toBe(404);
+    const posted = await handleDesktopUpdateFeedRequest(request("latest-mac.yml", { method: "POST" }), {
+      fetch: githubFetch({}),
+    });
+    expect(posted.status).toBe(405);
+    expect(posted.headers.get("allow")).toBe("GET, HEAD");
+  });
+
+  it("returns GitHub YAML on HEAD without a body or Location", async () => {
+    const fetchImpl = githubFetch({
+      [githubLatest]: () =>
+        new Response(null, { status: 302, headers: { Location: githubTagged } }),
+      [githubTagged]: () => new Response(null, { status: 302, headers: { Location: jwtBlob } }),
+      [jwtBlob]: () =>
+        new Response(yamlBody, {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+    });
+    const response = await handleDesktopUpdateFeedRequest(
+      request("latest-mac.yml", { method: "HEAD" }),
+      { fetch: fetchImpl },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(await response.text()).toBe("");
+  });
+
+  it("returns 502 when GitHub redirects off githubusercontent hosts", async () => {
+    const fetchImpl = githubFetch({
+      [githubLatest]: () =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://evil.example/latest-mac.yml" },
+        }),
+    });
+    const response = await handleDesktopUpdateFeedRequest(request("latest-mac.yml"), {
+      fetch: fetchImpl,
+    });
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe("");
+  });
+});
+
+describe("desktop update feed wiring", () => {
+  it("keeps the packaged feed URL in the macOS release workflow", () => {
+    const workflow = readFileSync(
+      join(repositoryRoot, ".github/workflows/desktop-release.yml"),
+      "utf8",
+    );
+    expect(workflow).toContain(`ENDURAGENT_DESKTOP_UPDATE_URL: ${DESKTOP_FEED_URL}`);
+    expect(workflow).toContain("Require the public updater feed");
+    expect(workflow).toContain(`${DESKTOP_FEED_URL}latest-mac.yml`);
+    expect(workflow).toContain(`${DESKTOP_FEED_URL}Enduragent-arm64.dmg`);
+    expect(workflow).toContain(
+      "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/latest-mac.yml",
+    );
+    expect(workflow).not.toContain('curl -fsSL "$public_yaml"');
+    expect(workflow).not.toContain('curl -fsSIL "${PUBLIC_FEED}');
+  });
+
+  it("deploys the public feed Worker with pinned actions and a custom hostname", () => {
+    const workflow = readFileSync(
+      join(repositoryRoot, ".github/workflows/desktop-update-feed.yml"),
+      "utf8",
+    );
+    const wrangler = readFileSync(
+      join(repositoryRoot, "tools/desktop-update-feed.wrangler.toml"),
+      "utf8",
+    );
+    expect(workflow).toContain("vars.ENABLE_DESKTOP_UPDATE_FEED == 'true'");
+    expect(workflow).toContain("actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0");
+    expect(workflow).toContain(
+      "cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0",
+    );
+    expect(workflow).toContain(`${DESKTOP_FEED_URL}latest-mac.yml`);
+    expect(workflow).not.toContain("curl -fsSL");
+    expect(wrangler).toContain('pattern = "updates.enduragent.icu"');
+    expect(wrangler).toContain("custom_domain = true");
+  });
+});

--- a/tools/desktop-update-feed.test.ts
+++ b/tools/desktop-update-feed.test.ts
@@ -182,9 +182,10 @@ describe("desktop update feed wiring", () => {
       "utf8",
     );
     expect(workflow).toContain(`ENDURAGENT_DESKTOP_UPDATE_URL: ${DESKTOP_FEED_URL}`);
+    expect(workflow).toContain(`PUBLIC_FEED: ${DESKTOP_FEED_URL}`);
     expect(workflow).toContain("Require the public updater feed");
-    expect(workflow).toContain(`${DESKTOP_FEED_URL}latest-mac.yml`);
-    expect(workflow).toContain(`${DESKTOP_FEED_URL}Enduragent-arm64.dmg`);
+    expect(workflow).toContain('${PUBLIC_FEED}latest-mac.yml');
+    expect(workflow).toContain('${PUBLIC_FEED}Enduragent-arm64.dmg');
     expect(workflow).toContain(
       "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/latest-mac.yml",
     );

--- a/tools/desktop-update-feed.ts
+++ b/tools/desktop-update-feed.ts
@@ -1,0 +1,136 @@
+export const GITHUB_DESKTOP_RELEASE_FEED_URL =
+  "https://github.com/yerzhansa/enduragent/releases/latest/download/" as const;
+export const DESKTOP_FEED_URL = "https://updates.enduragent.icu/" as const;
+
+const FEED_OBJECT =
+  /^(?:latest(?:-mac)?\.yml|Enduragent-(?:arm64|\d+\.\d+\.\d+-arm64)\.dmg|Enduragent-\d+\.\d+\.\d+-arm64\.zip(?:\.blockmap)?|Enduragent-\d+\.\d+\.\d+-x64\.exe(?:\.blockmap)?)$/u;
+
+const MAX_REDIRECTS = 10;
+const USER_AGENT = "EnduragentDesktopUpdateFeed/1";
+const YAML_CACHE = "public, max-age=60";
+const VERSIONED_CACHE = "public, max-age=31536000, immutable";
+const ALIAS_CACHE = "public, max-age=60";
+const FORWARDED_REQUEST_HEADERS = ["range", "if-none-match", "if-modified-since"] as const;
+const FORWARDED_RESPONSE_HEADERS = [
+  "content-type",
+  "content-length",
+  "content-range",
+  "accept-ranges",
+  "etag",
+  "last-modified",
+] as const;
+
+export interface DesktopUpdateFeedFetch {
+  (input: string | URL | Request, init?: RequestInit): Promise<Response>;
+}
+
+export function desktopUpdateFeedObjectName(pathname: string): string | undefined {
+  if (!pathname.startsWith("/") || pathname.includes("\\") || pathname.includes("\0")) {
+    return undefined;
+  }
+  if (pathname.includes("//") || pathname.includes("..") || pathname.includes("@")) {
+    return undefined;
+  }
+  const name = pathname.slice(1);
+  if (name.length === 0 || name.includes("/") || !FEED_OBJECT.test(name)) return undefined;
+  return name;
+}
+
+export function githubDesktopReleaseObjectUrl(name: string): string {
+  if (desktopUpdateFeedObjectName(`/${name}`) !== name) {
+    throw new TypeError("desktop update feed object is invalid");
+  }
+  return `${GITHUB_DESKTOP_RELEASE_FEED_URL}${name}`;
+}
+
+function allowedUpstream(url: URL): boolean {
+  if (url.protocol !== "https:" || url.username !== "" || url.password !== "") return false;
+  const host = url.hostname.toLowerCase();
+  return host === "github.com" || host.endsWith(".githubusercontent.com");
+}
+
+function cacheControlFor(name: string): string {
+  if (name === "latest-mac.yml" || name === "latest.yml" || name === "Enduragent-arm64.dmg") {
+    return name.endsWith(".yml") ? YAML_CACHE : ALIAS_CACHE;
+  }
+  return VERSIONED_CACHE;
+}
+
+function copyRequestHeaders(source: Headers): Headers {
+  const headers = new Headers();
+  headers.set("User-Agent", USER_AGENT);
+  for (const name of FORWARDED_REQUEST_HEADERS) {
+    const value = source.get(name);
+    if (value !== null && value !== "") headers.set(name, value);
+  }
+  return headers;
+}
+
+function publicHeaders(objectName: string, upstream: Headers): Headers {
+  const headers = new Headers();
+  for (const headerName of FORWARDED_RESPONSE_HEADERS) {
+    const value = upstream.get(headerName);
+    if (value !== null && value !== "") headers.set(headerName, value);
+  }
+  headers.set("Cache-Control", cacheControlFor(objectName));
+  return headers;
+}
+
+export async function handleDesktopUpdateFeedRequest(
+  request: Request,
+  dependencies: { readonly fetch?: DesktopUpdateFeedFetch } = {},
+): Promise<Response> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response(null, { status: 405, headers: { Allow: "GET, HEAD" } });
+  }
+  const name = desktopUpdateFeedObjectName(new URL(request.url).pathname);
+  if (name === undefined) return new Response(null, { status: 404 });
+  const fetchImpl = dependencies.fetch ?? globalThis.fetch;
+  let upstreamUrl = githubDesktopReleaseObjectUrl(name);
+  const outbound = copyRequestHeaders(request.headers);
+  for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect += 1) {
+    let parsed: URL;
+    try {
+      parsed = new URL(upstreamUrl);
+    } catch {
+      return new Response(null, { status: 502 });
+    }
+    if (!allowedUpstream(parsed)) return new Response(null, { status: 502 });
+    const upstream = await fetchImpl(parsed, {
+      method: request.method,
+      headers: outbound,
+      redirect: "manual",
+    });
+    if (upstream.status >= 300 && upstream.status < 400) {
+      const location = upstream.headers.get("location");
+      await upstream.body?.cancel();
+      if (location === null || location === "") return new Response(null, { status: 502 });
+      try {
+        upstreamUrl = new URL(location, parsed).href;
+      } catch {
+        return new Response(null, { status: 502 });
+      }
+      continue;
+    }
+    if (upstream.status === 404) {
+      await upstream.body?.cancel();
+      return new Response(null, { status: 404 });
+    }
+    if (upstream.status !== 200 && upstream.status !== 206 && upstream.status !== 304) {
+      await upstream.body?.cancel();
+      return new Response(null, { status: 502 });
+    }
+    if (request.method === "HEAD") {
+      await upstream.body?.cancel();
+      return new Response(null, {
+        status: upstream.status,
+        headers: publicHeaders(name, upstream.headers),
+      });
+    }
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: publicHeaders(name, upstream.headers),
+    });
+  }
+  return new Response(null, { status: 502 });
+}

--- a/tools/desktop-update-feed.worker.ts
+++ b/tools/desktop-update-feed.worker.ts
@@ -1,0 +1,7 @@
+import { handleDesktopUpdateFeedRequest } from "./desktop-update-feed.js";
+
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleDesktopUpdateFeedRequest(request);
+  },
+};

--- a/tools/desktop-update-feed.wrangler.toml
+++ b/tools/desktop-update-feed.wrangler.toml
@@ -1,0 +1,8 @@
+name = "enduragent-desktop-updates"
+main = "desktop-update-feed.worker.ts"
+compatibility_date = "2026-01-15"
+workers_dev = true
+
+[[routes]]
+pattern = "updates.enduragent.icu"
+custom_domain = true

--- a/tools/probe-desktop-update-feed.ts
+++ b/tools/probe-desktop-update-feed.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env tsx
+
+import { DESKTOP_FEED_URL, handleDesktopUpdateFeedRequest } from "./desktop-update-feed.js";
+
+const response = await handleDesktopUpdateFeedRequest(
+  new Request(`${DESKTOP_FEED_URL}latest-mac.yml?noCache=probe`),
+);
+const body = await response.text();
+const location = response.headers.get("location");
+if (response.status !== 200 || location !== null || !/^version: /mu.test(body)) {
+  process.stderr.write(
+    `desktop update feed probe failed status=${response.status} location=${location ?? ""} body=${body.slice(0, 200)}\n`,
+  );
+  process.exit(1);
+}
+process.stdout.write(body);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Packaged 0.3.0 Settings update checks fail (`Update check failed. Try again`) because Electron’s generic updater cannot complete GitHub’s `latest/download` → unencoded `@` tag → JWT blob redirect chain.

This change keeps electron-updater YAML (`latest-mac.yml` / `latest.yml`) and still publishes those files on GitHub Releases. New builds bake `https://updates.enduragent.icu/` as the generic feed. A Cloudflare Worker follows GitHub redirects on the server and returns the bytes with no `Location` header.

**Installed 0.3.0 cannot self-update.** Those athletes reinstall from https://enduragent.icu/download/mac. Website `/download/mac` can keep redirecting to GitHub; browsers can follow that chain.

## Operator (required before the next desktop release)

1. Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` to this repo’s Actions secrets.
2. Set `ENABLE_DESKTOP_UPDATE_FEED=true`.
3. Deploy `.github/workflows/desktop-update-feed.yml` (push to `main` after merge, or `workflow_dispatch`).
4. Confirm `curl -fsS https://updates.enduragent.icu/latest-mac.yml` returns YAML starting with `version:` and a headers-only GET has no `Location`.

`desktop-release.yml` refuses to notarize until that public YAML is live without a redirect, then dual-checks GitHub and the public feed after promote.

## Test plan

- `pnpm exec vitest run --project workspace tools/desktop-update-feed.test.ts tools/desktop-release-github.test.ts tools/desktop-release-transaction.test.ts` plus the desktop artifact tests that pin `DESKTOP_FEED_URL`: **313 passed** (1 skipped) after the workflow-string assertion fix.
- `pnpm exec tsx tools/probe-desktop-update-feed.ts` against live GitHub through the handler (not a deployed Worker): **200, no Location, `version: 0.4.0`**.
- Packaged macOS Settings check is **not** reproduced here (no Electron dist on this Linux VM).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b5c9d58-e837-5165-83a5-21c3bd1157cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b5c9d58-e837-5165-83a5-21c3bd1157cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

