### PR TITLE
fix(ci): let Desktop update feed install Wrangler on GitHub runners

### DIFF
--- a/.github/workflows/desktop-update-feed.yml
+++ b/.github/workflows/desktop-update-feed.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: tools
-          command: deploy --config desktop-update-feed.wrangler.toml
+          workingDirectory: ${{ runner.temp }}
+          command: deploy --config ${{ github.workspace }}/tools/desktop-update-feed.wrangler.toml
       - name: Confirm the public feed returns YAML without a redirect
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- GitHub Actions `Desktop update feed` failed after #1014 because `wrangler-action` ran `npm i wrangler@4` under `tools/`, npm walked up to the repo `package.json`, and `devEngines` rejected the runner's Node 22.
- Install and deploy from `${{ runner.temp }}` instead, with `--config` pointed at `tools/desktop-update-feed.wrangler.toml`, so npm never sees those engines.
- The public feed is already live from the local deploy; this only unblocks CI redeploys.

## Test plan
- [ ] `Desktop update feed` workflow_dispatch on this branch (or after merge to `main`) gets past Wrangler install
- [ ] Job curls `https://updates.enduragent.icu/latest-mac.yml` and sees `version:` with no `Location`
- [ ] Do not run `desktop-release.yml`