### PR TITLE
fix(desktop): mention 0.4.0 in the update-feed release notes

### DIFF
--- a/.changeset/public-desktop-update-feed.md
+++ b/.changeset/public-desktop-update-feed.md
@@ -2,6 +2,6 @@
 "@enduragent/desktop": patch
 ---
 
-User-facing: Version 0.3.0 cannot update itself; download the latest macOS installer from https://enduragent.icu/download/mac, and later versions will check for updates again.
+User-facing: Versions 0.3.0 and 0.4.0 cannot update themselves. Download the latest macOS installer from https://enduragent.icu/download/mac. This version and later will check for updates again.
 
-Packaged `app-update.yml` now points at `https://updates.enduragent.icu/`, a Cloudflare Worker that follows GitHub Releases latest/download redirects on the server and returns YAML and artifacts with no `Location` header. GitHub remains the canonical publish target. Installed 0.3.0 builds still use the GitHub URL and cannot self-heal.
+Packaged `app-update.yml` now points at `https://updates.enduragent.icu/`, a Cloudflare Worker that follows GitHub Releases latest/download redirects on the server and returns YAML and artifacts with no `Location` header. GitHub remains the canonical publish target. Installed 0.3.0 and 0.4.0 builds still use the GitHub URL and cannot self-heal.


### PR DESCRIPTION
## Summary
- Desktop **0.4.1** is already queued on Version Packages [#1015](https://github.com/yerzhansa/enduragent/pull/1015).
- The pending changeset only warned 0.3.0 users. Installed **0.4.0** also cannot self-update to the Cloudflare feed.
- This updates the athlete-facing line before 1015 is merged, so the 0.4.1 GitHub Release notes are accurate.

## Test plan
- [ ] Version Packages #1015 regenerates with copy that names 0.3.0 and 0.4.0
- [ ] Do not merge #1015 in this PR