### PR TITLE
feat(ios): records, record log, union merge, hybrid clock

### DIFF
--- a/.changeset/ios-records.md
+++ b/.changeset/ios-records.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add the in-memory record log, union merge, hybrid clock, and identity helpers for the Enduragent iOS coach package. No athlete-facing change.

--- a/apps/ios/Packages/EnduragentCoach/Package.swift
+++ b/apps/ios/Packages/EnduragentCoach/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
 		.target(name: "EnduragentCoach"),
 		.testTarget(
 			name: "EnduragentCoachTests",
-			dependencies: ["EnduragentCoach"]
+			dependencies: ["EnduragentCoach"],
+			resources: [.copy("Fixtures")]
 		),
 	],
 	swiftLanguageModes: [.v6]

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Identity.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Identity.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 public struct ULID: Hashable, Sendable, RawRepresentable {
@@ -12,7 +13,19 @@ public struct ULID: Hashable, Sendable, RawRepresentable {
 	}
 
 	public static func generate(at now: Date) -> ULID {
-		fatalError("not implemented")
+		let alphabet = Array("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+		let ms = max(0, (now.timeIntervalSince1970 * 1000).rounded(.down))
+		var time = UInt64(ms)
+		var chars = [Character](repeating: "0", count: 26)
+		for index in (0..<10).reversed() {
+			chars[index] = alphabet[Int(time % 32)]
+			time /= 32
+		}
+		var rng = SystemRandomNumberGenerator()
+		for index in 10..<26 {
+			chars[index] = alphabet[Int(rng.next() % 32)]
+		}
+		return ULID(rawValue: String(chars))!
 	}
 }
 
@@ -92,7 +105,20 @@ public struct CivilDate: Hashable, Sendable, Comparable, ExpressibleByStringLite
 	}
 
 	public func adding(days: Int) -> CivilDate {
-		fatalError("not implemented")
+		var calendar = Calendar(identifier: .gregorian)
+		calendar.locale = Locale(identifier: "en_US_POSIX")
+		calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+		let parts = rawValue.split(separator: "-")
+		let components = DateComponents(
+			year: Int(parts[0]),
+			month: Int(parts[1]),
+			day: Int(parts[2])
+		)
+		let date = calendar.date(from: components)!
+		let shifted = calendar.date(byAdding: .day, value: days, to: date)!
+		let out = calendar.dateComponents([.year, .month, .day], from: shifted)
+		let formatted = String(format: "%04d-%02d-%02d", out.year!, out.month!, out.day!)
+		return CivilDate(rawValue: formatted)!
 	}
 }
 
@@ -105,11 +131,14 @@ public struct DateKey: Hashable, Sendable, Comparable {
 	}
 
 	public static func from(_ date: CivilDate) -> DateKey {
-		fatalError("not implemented")
+		DateKey(rawValue: Int(date.rawValue.replacingOccurrences(of: "-", with: ""))!)!
 	}
 
 	public var civil: CivilDate {
-		fatalError("not implemented")
+		let year = rawValue / 10_000
+		let month = (rawValue / 100) % 100
+		let day = rawValue % 100
+		return CivilDate(rawValue: String(format: "%04d-%02d-%02d", year, month, day))!
 	}
 
 	public static func < (lhs: DateKey, rhs: DateKey) -> Bool {
@@ -143,22 +172,137 @@ public enum JSONValue: Sendable, Equatable {
 	case object([String: JSONValue])
 
 	public static func parse(_ raw: String) throws -> JSONValue {
-		fatalError("not implemented")
+		guard let data = raw.data(using: .utf8) else {
+			throw DecodingError.dataCorrupted(
+				.init(codingPath: [], debugDescription: "invalid JSON")
+			)
+		}
+		let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+		return try JSONValue.fromJSONObject(object)
 	}
 
 	public func canonicalDigestInput() -> String {
-		fatalError("not implemented")
+		JSONValue.render(self, pretty: false, depth: 0)
+	}
+
+	private static func fromJSONObject(_ object: Any) throws -> JSONValue {
+		switch object {
+		case is NSNull:
+			return .null
+		case let number as NSNumber:
+			if CFGetTypeID(number) == CFBooleanGetTypeID() {
+				return .bool(number.boolValue)
+			}
+			return .number(number.doubleValue)
+		case let string as String:
+			return .string(string)
+		case let array as [Any]:
+			return .array(try array.map { try fromJSONObject($0) })
+		case let dictionary as [String: Any]:
+			var object: [String: JSONValue] = [:]
+			object.reserveCapacity(dictionary.count)
+			for (key, value) in dictionary {
+				object[key] = try fromJSONObject(value)
+			}
+			return .object(object)
+		default:
+			throw DecodingError.dataCorrupted(
+				.init(codingPath: [], debugDescription: "invalid JSON")
+			)
+		}
+	}
+
+	fileprivate static func render(_ value: JSONValue, pretty: Bool, depth: Int) -> String {
+		switch value {
+		case .null:
+			return "null"
+		case .bool(let flag):
+			return flag ? "true" : "false"
+		case .number(let number):
+			return encodeJSONNumber(number)
+		case .string(let string):
+			return encodeJSONString(string)
+		case .array(let items):
+			if items.isEmpty { return "[]" }
+			if !pretty {
+				return "[" + items.map { render($0, pretty: false, depth: 0) }.joined(separator: ",") + "]"
+			}
+			let pad = String(repeating: "  ", count: depth + 1)
+			let close = String(repeating: "  ", count: depth)
+			let inner = items.map { pad + render($0, pretty: true, depth: depth + 1) }.joined(separator: ",\n")
+			return "[\n\(inner)\n\(close)]"
+		case .object(let fields):
+			let keys = fields.keys.sorted()
+			if keys.isEmpty { return "{}" }
+			if !pretty {
+				return "{"
+					+ keys.map { encodeJSONString($0) + ":" + render(fields[$0]!, pretty: false, depth: 0) }
+					.joined(separator: ",")
+					+ "}"
+			}
+			let pad = String(repeating: "  ", count: depth + 1)
+			let close = String(repeating: "  ", count: depth)
+			let inner = keys.map {
+				pad + encodeJSONString($0) + ": " + render(fields[$0]!, pretty: true, depth: depth + 1)
+			}.joined(separator: ",\n")
+			return "{\n\(inner)\n\(close)}"
+		}
 	}
 }
 
 public func canonicalJSON(_ value: JSONValue) -> String {
-	fatalError("not implemented")
+	JSONValue.render(value, pretty: true, depth: 0)
 }
 
 public func sha256Hex(_ utf8: String) -> String {
-	fatalError("not implemented")
+	SHA256.hash(data: Data(utf8.utf8)).map { byte in
+		String(byte, radix: 16).leftPadHex
+	}.joined()
 }
 
 public func estimateTokens(_ text: String) -> Int {
-	fatalError("not implemented")
+	Int((Double(text.utf16.count) / 4.0 * 1.2).rounded(.up))
+}
+
+private extension String {
+	var leftPadHex: String { count == 1 ? "0" + self : self }
+}
+
+private func encodeJSONString(_ string: String) -> String {
+	var out = "\""
+	for scalar in string.unicodeScalars {
+		switch scalar.value {
+		case 0x22: out += "\\\""
+		case 0x5C: out += "\\\\"
+		case 0x08: out += "\\b"
+		case 0x0C: out += "\\f"
+		case 0x0A: out += "\\n"
+		case 0x0D: out += "\\r"
+		case 0x09: out += "\\t"
+		case 0x00..<0x20:
+			out += "\\u" + String(format: "%04x", scalar.value)
+		case 0x2028:
+			out += "\\u2028"
+		case 0x2029:
+			out += "\\u2029"
+		default:
+			out.append(Character(scalar))
+		}
+	}
+	out += "\""
+	return out
+}
+
+private func encodeJSONNumber(_ value: Double) -> String {
+	if !value.isFinite {
+		return "null"
+	}
+	if value == 0 {
+		return "0"
+	}
+	let maxSafe = 9_007_199_254_740_991.0
+	if abs(value) <= maxSafe, value.rounded(.towardZero) == value {
+		return String(Int64(value))
+	}
+	return String(value)
 }

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/HybridLogicalClock.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/HybridLogicalClock.swift
@@ -12,7 +12,13 @@ public struct HybridLogicalClock: Sendable, Hashable, Comparable {
 	}
 
 	public static func tick(now: Date, deviceId: DeviceID, last: HybridLogicalClock?) -> HybridLogicalClock {
-		fatalError("not implemented")
+		let nowMs = Int64((now.timeIntervalSince1970 * 1000).rounded(.down))
+		guard let last else {
+			return HybridLogicalClock(wallMs: nowMs, logical: 0, deviceId: deviceId)
+		}
+		let wallMs = max(nowMs, last.wallMs)
+		let logical: UInt32 = wallMs == last.wallMs ? last.logical + 1 : 0
+		return HybridLogicalClock(wallMs: wallMs, logical: logical, deviceId: deviceId)
 	}
 
 	public static func < (lhs: HybridLogicalClock, rhs: HybridLogicalClock) -> Bool {

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/RecordLog.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/RecordLog.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 
 public struct RecordQuery: Sendable, Equatable {
 	public var kinds: Set<RecordKind>
@@ -29,19 +30,68 @@ public protocol RecordLog: Sendable {
 	func fetch(_ query: RecordQuery) async throws -> [AthleteRecord]
 }
 
+public struct ForeignDeviceLocalRecord: Error, Sendable, Equatable {
+	public var recordDeviceId: DeviceID
+	public var logDeviceId: DeviceID
+
+	public init(recordDeviceId: DeviceID, logDeviceId: DeviceID) {
+		self.recordDeviceId = recordDeviceId
+		self.logDeviceId = logDeviceId
+	}
+}
+
 public final class InMemoryRecordLog: RecordLog, @unchecked Sendable {
 	public let deviceId: DeviceID
+	private let records = Mutex<[AthleteRecord]>([])
 
 	public init(deviceId: DeviceID = DeviceID()) {
 		self.deviceId = deviceId
 	}
 
 	public func append(_ record: AthleteRecord) async throws {
-		fatalError("not implemented")
+		if record.locality == .deviceLocal, record.deviceId != deviceId {
+			throw ForeignDeviceLocalRecord(recordDeviceId: record.deviceId, logDeviceId: deviceId)
+		}
+		records.withLock { $0.append(record) }
 	}
 
 	public func fetch(_ query: RecordQuery) async throws -> [AthleteRecord] {
-		fatalError("not implemented")
+		records.withLock { $0.filter { matches($0, query) } }
+	}
+
+	private func matches(_ record: AthleteRecord, _ query: RecordQuery) -> Bool {
+		guard query.kinds.contains(record.body.kind) else { return false }
+		if record.locality == .deviceLocal, record.deviceId != deviceId {
+			return false
+		}
+		if query.deviceLocalOnly, record.deviceId != deviceId {
+			return false
+		}
+		if let from = query.from, record.civilDate < from {
+			return false
+		}
+		if let to = query.to, record.civilDate > to {
+			return false
+		}
+		if let chatId = query.chatId {
+			guard let recordChatId = recordChatId(record.body), recordChatId == chatId else {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+private func recordChatId(_ body: RecordBody) -> ChatID? {
+	switch body {
+	case .userMessage(let body): return body.chatId
+	case .assistantMessage(let body): return body.chatId
+	case .windowStart(let body): return body.chatId
+	case .compactionSummary(let body): return body.chatId
+	case .pendingProposal(let body): return body.chatId
+	case .proposalCleared(let body): return body.chatId
+	case .flushPending(let body): return body.chatId
+	default: return nil
 	}
 }
 

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/UnionMerge.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/UnionMerge.swift
@@ -6,27 +6,77 @@ package enum UnionMerge {
 		chatId: ChatID,
 		deviceId: DeviceID
 	) -> [ChatMessage] {
-		fatalError("not implemented")
+		let ordered = inHLCOrder(records)
+		let cutoff = ordered.last { record in
+			guard record.deviceId == deviceId else { return false }
+			guard case .windowStart(let body) = record.body else { return false }
+			return body.chatId == chatId
+		}
+		let firstIncluded: ULID?
+		if case .windowStart(let body)? = cutoff?.body {
+			firstIncluded = body.firstIncludedUlid
+		} else {
+			firstIncluded = nil
+		}
+		return ordered.compactMap { record in
+			if let firstIncluded, record.ulid.rawValue < firstIncluded.rawValue {
+				return nil
+			}
+			switch record.body {
+			case .userMessage(let body) where body.chatId == chatId:
+				return ChatMessage(role: .user, text: body.athleteText, civilDate: record.civilDate)
+			case .assistantMessage(let body) where body.chatId == chatId:
+				return ChatMessage(role: .assistant, text: body.text, civilDate: record.civilDate)
+			default:
+				return nil
+			}
+		}
 	}
 
 	package static func sectionText(_ records: [AthleteRecord], name: SectionName) -> String? {
-		fatalError("not implemented")
+		inHLCOrder(records).reversed().compactMap { record -> String? in
+			guard case .memorySection(let body) = record.body, body.name == name else { return nil }
+			return body.content
+		}.first
 	}
 
 	package static func ledger(_ records: [AthleteRecord]) -> [LedgerEventBody] {
-		fatalError("not implemented")
+		var seen: Set<String> = []
+		var events: [LedgerEventBody] = []
+		for record in inHLCOrder(records) {
+			guard case .ledgerEvent(let body) = record.body else { continue }
+			let digest = ledgerDigest(date: record.civilDate, kind: body.kind, text: body.text)
+			if seen.insert(digest).inserted {
+				events.append(body)
+			}
+		}
+		return events
 	}
 
 	package static func ledgerDigest(date: CivilDate, kind: LedgerKind, text: String) -> String {
-		fatalError("not implemented")
+		ledgerDigest(date: date.rawValue, kind: kind.rawValue, text: text)
+	}
+
+	package static func ledgerDigest(date: String, kind: String, text: String) -> String {
+		let normalized = text.replacing(/^[\s]+|[\s]+$/, with: "").replacing(/\s+/, with: " ").lowercased()
+		let input = JSONValue.array([.string(date), .string(kind), .string(normalized)]).canonicalDigestInput()
+		return sha256Hex(input)
 	}
 
 	package static func planningDevice(_ records: [AthleteRecord]) -> PlanningDeviceBody? {
-		fatalError("not implemented")
+		inHLCOrder(records).reversed().compactMap { record -> PlanningDeviceBody? in
+			guard case .planningDevice(let body) = record.body else { return nil }
+			return body
+		}.first
 	}
 
 	package static func coachReplyLanguage(_ records: [AthleteRecord]) -> LanguageTag? {
-		fatalError("not implemented")
+		for record in inHLCOrder(records).reversed() {
+			if case .coachReplyLanguage(let body) = record.body {
+				return body.tag
+			}
+		}
+		return nil
 	}
 
 	package static func pendingProposal(
@@ -34,6 +84,23 @@ package enum UnionMerge {
 		chatId: ChatID,
 		now: Date
 	) -> ProposalBody? {
-		fatalError("not implemented")
+		let ordered = inHLCOrder(records)
+		var clearedAt: [Nonce: HybridLogicalClock] = [:]
+		for record in ordered {
+			if case .proposalCleared(let body) = record.body, body.chatId == chatId {
+				clearedAt[body.nonce] = record.hlc
+			}
+		}
+		for record in ordered.reversed() {
+			guard case .pendingProposal(let body) = record.body, body.chatId == chatId else { continue }
+			if body.expiresAt <= now { continue }
+			if let cleared = clearedAt[body.nonce], record.hlc < cleared { continue }
+			return body
+		}
+		return nil
 	}
+}
+
+private func inHLCOrder(_ records: [AthleteRecord]) -> [AthleteRecord] {
+	records.sorted { $0.hlc < $1.hlc }
 }

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/UnionMerge.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/UnionMerge.swift
@@ -54,12 +54,8 @@ package enum UnionMerge {
 	}
 
 	package static func ledgerDigest(date: CivilDate, kind: LedgerKind, text: String) -> String {
-		ledgerDigest(date: date.rawValue, kind: kind.rawValue, text: text)
-	}
-
-	package static func ledgerDigest(date: String, kind: String, text: String) -> String {
 		let normalized = text.replacing(/^[\s]+|[\s]+$/, with: "").replacing(/\s+/, with: " ").lowercased()
-		let input = JSONValue.array([.string(date), .string(kind), .string(normalized)]).canonicalDigestInput()
+		let input = JSONValue.array([.string(date.rawValue), .string(kind.rawValue), .string(normalized)]).canonicalDigestInput()
 		return sha256Hex(input)
 	}
 

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/ledger-digest-table.json
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/ledger-digest-table.json
@@ -1,82 +1,82 @@
 [
   {
     "date": "1998-06-13",
-    "kind": "athlete_note",
+    "kind": "decision",
     "text": "Ada Kovač wants Saturdays kept free for the group ride.",
-    "digestInput": "[\"1998-06-13\",\"athlete_note\",\"ada kovač wants saturdays kept free for the group ride.\"]",
-    "digest": "dcf2089e782fb1f9b09f65ad6ca4d355817c8e3ce947872e48f13f949bbd01aa",
+    "digestInput": "[\"1998-06-13\",\"decision\",\"ada kovač wants saturdays kept free for the group ride.\"]",
+    "digest": "39c83e1461510839e370367caac58cf8939edde0a166223261a09c933c76574f",
     "estimateTokens": 17
   },
   {
     "date": "1998-06-13",
-    "kind": "athlete_note",
+    "kind": "override",
     "text": "  Ada Kovač   wants Saturdays kept free for the group ride.  ",
-    "digestInput": "[\"1998-06-13\",\"athlete_note\",\"ada kovač wants saturdays kept free for the group ride.\"]",
-    "digest": "dcf2089e782fb1f9b09f65ad6ca4d355817c8e3ce947872e48f13f949bbd01aa",
+    "digestInput": "[\"1998-06-13\",\"override\",\"ada kovač wants saturdays kept free for the group ride.\"]",
+    "digest": "9b7e1d37db376fd46008f2397325b1e1afb6f8a0eb03c7bac52e70407d9e108a",
     "estimateTokens": 19
   },
   {
     "date": "1998-06-14",
-    "kind": "coach_decision",
+    "kind": "illness",
     "text": "Moved the threshold session to Tuesday because of the Monday travel day.",
-    "digestInput": "[\"1998-06-14\",\"coach_decision\",\"moved the threshold session to tuesday because of the monday travel day.\"]",
-    "digest": "e8d24db0ecfed80e4b440d958d615985c7b6697f4b6f01660f8e3d8454cf8cbb",
+    "digestInput": "[\"1998-06-14\",\"illness\",\"moved the threshold session to tuesday because of the monday travel day.\"]",
+    "digest": "c36e733275fec52faf2d26b220da99918efa9c275e7cb49995208415ebc1b124",
     "estimateTokens": 22
   },
   {
     "date": "1998-06-15",
-    "kind": "athlete_note",
+    "kind": "experiment",
     "text": "Fitness 42, Fatigue 49, Form −7 after the weekend.",
-    "digestInput": "[\"1998-06-15\",\"athlete_note\",\"fitness 42, fatigue 49, form −7 after the weekend.\"]",
-    "digest": "523e31694f8271ac66cdb313375111671ce8238b88ed546b744e79c7afbbd972",
+    "digestInput": "[\"1998-06-15\",\"experiment\",\"fitness 42, fatigue 49, form −7 after the weekend.\"]",
+    "digest": "11caa4b3178a4b1c58d4c6a031d69d43a0a1ac9bc8abfa92bd6b9d2761af9289",
     "estimateTokens": 15
   },
   {
     "date": "1998-06-16",
-    "kind": "athlete_note",
+    "kind": "outcome",
     "text": "Knee felt fine on the 3 × 12 min efforts.\nNo pain after.",
-    "digestInput": "[\"1998-06-16\",\"athlete_note\",\"knee felt fine on the 3 × 12 min efforts. no pain after.\"]",
-    "digest": "014591c17a19840a0780977884382a6fc92cd0f1ee9672adddbbde9d90abed3c",
+    "digestInput": "[\"1998-06-16\",\"outcome\",\"knee felt fine on the 3 × 12 min efforts. no pain after.\"]",
+    "digest": "a970a8047df2f0c835c8fee03be385aa7bce1e55d406cc6e7af693e37110010d",
     "estimateTokens": 17
   },
   {
     "date": "1998-06-17",
-    "kind": "coach_decision",
+    "kind": "decision",
     "text": "FTP stays at 250 W until the next test.",
-    "digestInput": "[\"1998-06-17\",\"coach_decision\",\"ftp stays at 250 w until the next test.\"]",
-    "digest": "c072782d7fe093495df89900aa3f94feb4cbbdaa4b81aa25b3bbfad122895edb",
+    "digestInput": "[\"1998-06-17\",\"decision\",\"ftp stays at 250 w until the next test.\"]",
+    "digest": "4c83c8d6e7b7ce37d5b6eddeb229104f09e7417a234cdc3dc9b5b60074f82d32",
     "estimateTokens": 12
   },
   {
     "date": "1998-06-18",
-    "kind": "athlete_note",
+    "kind": "override",
     "text": "Slept badly, 5 h. Skipped the openers.",
-    "digestInput": "[\"1998-06-18\",\"athlete_note\",\"slept badly, 5 h. skipped the openers.\"]",
-    "digest": "9eed4eb4c29deda3fb354c456e72502656e07841b1c811a4247385e786eba224",
+    "digestInput": "[\"1998-06-18\",\"override\",\"slept badly, 5 h. skipped the openers.\"]",
+    "digest": "fd3de89a95388ea683e6dbfe6b450199ab532f077379b3f58e929e154de6e436",
     "estimateTokens": 12
   },
   {
     "date": "1998-06-19",
-    "kind": "athlete_note",
+    "kind": "illness",
     "text": "Café stop in Škofja Loka, 4 h endurance ride.",
-    "digestInput": "[\"1998-06-19\",\"athlete_note\",\"café stop in škofja loka, 4 h endurance ride.\"]",
-    "digest": "040f909ea1e9c513109e9a289f78c3feb1d0cac973f20d8def6470d4ea35f725",
+    "digestInput": "[\"1998-06-19\",\"illness\",\"café stop in škofja loka, 4 h endurance ride.\"]",
+    "digest": "120d09f2907741e68682860f7a9d6a29eaa7d0c3783a725b7cb2dce86e73ec8c",
     "estimateTokens": 14
   },
   {
     "date": "1998-06-20",
-    "kind": "coach_decision",
+    "kind": "experiment",
     "text": "Race week: taper from Wednesday.",
-    "digestInput": "[\"1998-06-20\",\"coach_decision\",\"race week: taper from wednesday.\"]",
-    "digest": "64b81c884da33492c7369bd342e81cbd69a8be922c15a39907c9185950ade173",
+    "digestInput": "[\"1998-06-20\",\"experiment\",\"race week: taper from wednesday.\"]",
+    "digest": "f1f7c8302cc40993a9c10928f54f1edcb3bc9449ed7bb5fdf329973bddf674fc",
     "estimateTokens": 10
   },
   {
     "date": "1998-06-21",
-    "kind": "athlete_note",
+    "kind": "outcome",
     "text": "",
-    "digestInput": "[\"1998-06-21\",\"athlete_note\",\"\"]",
-    "digest": "0284bc34dfad2a8c8c911c27222a2a2595a985af44d43c9a50e8c0db676ad29b",
+    "digestInput": "[\"1998-06-21\",\"outcome\",\"\"]",
+    "digest": "72007d785525482ef3287435d493bfca2ac09e6d211876b37594a63b657d8dc6",
     "estimateTokens": 0
   }
 ]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/ledger-digest-table.json
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/ledger-digest-table.json
@@ -1,0 +1,82 @@
+[
+  {
+    "date": "1998-06-13",
+    "kind": "athlete_note",
+    "text": "Ada Kovač wants Saturdays kept free for the group ride.",
+    "digestInput": "[\"1998-06-13\",\"athlete_note\",\"ada kovač wants saturdays kept free for the group ride.\"]",
+    "digest": "dcf2089e782fb1f9b09f65ad6ca4d355817c8e3ce947872e48f13f949bbd01aa",
+    "estimateTokens": 17
+  },
+  {
+    "date": "1998-06-13",
+    "kind": "athlete_note",
+    "text": "  Ada Kovač   wants Saturdays kept free for the group ride.  ",
+    "digestInput": "[\"1998-06-13\",\"athlete_note\",\"ada kovač wants saturdays kept free for the group ride.\"]",
+    "digest": "dcf2089e782fb1f9b09f65ad6ca4d355817c8e3ce947872e48f13f949bbd01aa",
+    "estimateTokens": 19
+  },
+  {
+    "date": "1998-06-14",
+    "kind": "coach_decision",
+    "text": "Moved the threshold session to Tuesday because of the Monday travel day.",
+    "digestInput": "[\"1998-06-14\",\"coach_decision\",\"moved the threshold session to tuesday because of the monday travel day.\"]",
+    "digest": "e8d24db0ecfed80e4b440d958d615985c7b6697f4b6f01660f8e3d8454cf8cbb",
+    "estimateTokens": 22
+  },
+  {
+    "date": "1998-06-15",
+    "kind": "athlete_note",
+    "text": "Fitness 42, Fatigue 49, Form −7 after the weekend.",
+    "digestInput": "[\"1998-06-15\",\"athlete_note\",\"fitness 42, fatigue 49, form −7 after the weekend.\"]",
+    "digest": "523e31694f8271ac66cdb313375111671ce8238b88ed546b744e79c7afbbd972",
+    "estimateTokens": 15
+  },
+  {
+    "date": "1998-06-16",
+    "kind": "athlete_note",
+    "text": "Knee felt fine on the 3 × 12 min efforts.\nNo pain after.",
+    "digestInput": "[\"1998-06-16\",\"athlete_note\",\"knee felt fine on the 3 × 12 min efforts. no pain after.\"]",
+    "digest": "014591c17a19840a0780977884382a6fc92cd0f1ee9672adddbbde9d90abed3c",
+    "estimateTokens": 17
+  },
+  {
+    "date": "1998-06-17",
+    "kind": "coach_decision",
+    "text": "FTP stays at 250 W until the next test.",
+    "digestInput": "[\"1998-06-17\",\"coach_decision\",\"ftp stays at 250 w until the next test.\"]",
+    "digest": "c072782d7fe093495df89900aa3f94feb4cbbdaa4b81aa25b3bbfad122895edb",
+    "estimateTokens": 12
+  },
+  {
+    "date": "1998-06-18",
+    "kind": "athlete_note",
+    "text": "Slept badly, 5 h. Skipped the openers.",
+    "digestInput": "[\"1998-06-18\",\"athlete_note\",\"slept badly, 5 h. skipped the openers.\"]",
+    "digest": "9eed4eb4c29deda3fb354c456e72502656e07841b1c811a4247385e786eba224",
+    "estimateTokens": 12
+  },
+  {
+    "date": "1998-06-19",
+    "kind": "athlete_note",
+    "text": "Café stop in Škofja Loka, 4 h endurance ride.",
+    "digestInput": "[\"1998-06-19\",\"athlete_note\",\"café stop in škofja loka, 4 h endurance ride.\"]",
+    "digest": "040f909ea1e9c513109e9a289f78c3feb1d0cac973f20d8def6470d4ea35f725",
+    "estimateTokens": 14
+  },
+  {
+    "date": "1998-06-20",
+    "kind": "coach_decision",
+    "text": "Race week: taper from Wednesday.",
+    "digestInput": "[\"1998-06-20\",\"coach_decision\",\"race week: taper from wednesday.\"]",
+    "digest": "64b81c884da33492c7369bd342e81cbd69a8be922c15a39907c9185950ade173",
+    "estimateTokens": 10
+  },
+  {
+    "date": "1998-06-21",
+    "kind": "athlete_note",
+    "text": "",
+    "digestInput": "[\"1998-06-21\",\"athlete_note\",\"\"]",
+    "digest": "0284bc34dfad2a8c8c911c27222a2a2595a985af44d43c9a50e8c0db676ad29b",
+    "estimateTokens": 0
+  }
+]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/IdentityTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/IdentityTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct IdentityTests {
+	@Test func ulidLengthAndTimeOrder() {
+		let earlier = Date(timeIntervalSince1970: 899_164_800)
+		let later = Date(timeIntervalSince1970: 899_164_801)
+		let first = ULID.generate(at: earlier)
+		let second = ULID.generate(at: later)
+		#expect(first.rawValue.count == 26)
+		#expect(second.rawValue.count == 26)
+		#expect(ULID(rawValue: first.rawValue) == first)
+		#expect(first.rawValue < second.rawValue)
+		#expect(ulidTimestamp(first.rawValue) == UInt64((earlier.timeIntervalSince1970 * 1000).rounded(.down)))
+		#expect(ulidTimestamp(second.rawValue) == UInt64((later.timeIntervalSince1970 * 1000).rounded(.down)))
+	}
+
+	@Test func civilDateAndDateKeyRoundTripEveryDayOf1998() {
+		var date = CivilDate(rawValue: "1998-01-01")!
+		var count = 0
+		while date.rawValue.hasPrefix("1998") {
+			#expect(date.adding(days: 0) == date)
+			let key = DateKey.from(date)
+			#expect(key.civil == date)
+			let next = date.adding(days: 1)
+			if next.rawValue.hasPrefix("1998") {
+				#expect(date < next)
+			}
+			date = next
+			count += 1
+			#expect(count <= 366)
+		}
+		#expect(count == 365)
+		#expect(CivilDate(rawValue: "1998-12-31")!.adding(days: 1).rawValue == "1999-01-01")
+	}
+
+	@Test func jsonParseCanonicalSha256AndStringify() throws {
+		let parsed = try JSONValue.parse("{\"b\":1,\"a\":[true,null,\"x\"]}")
+		#expect(
+			canonicalJSON(parsed)
+				== """
+				{
+				  "a": [
+				    true,
+				    null,
+				    "x"
+				  ],
+				  "b": 1
+				}
+				"""
+		)
+		#expect(parsed.canonicalDigestInput() == "{\"a\":[true,null,\"x\"],\"b\":1}")
+		#expect(sha256Hex("hello") == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+		let quotes = JSONValue.array([.string("say \"hi\""), .string("a\\b"), .string("line\n")]).canonicalDigestInput()
+		#expect(quotes == "[\"say \\\"hi\\\"\",\"a\\\\b\",\"line\\n\"]")
+	}
+
+	@Test func estimateTokensMatchesDesktop() throws {
+		let rows = try loadLedgerDigestTable()
+		for row in rows {
+			#expect(estimateTokens(row.text) == row.estimateTokens)
+		}
+	}
+}
+
+private func ulidTimestamp(_ raw: String) -> UInt64 {
+	let alphabet = Array("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+	var value: UInt64 = 0
+	for character in raw.prefix(10) {
+		value = value * 32 + UInt64(alphabet.firstIndex(of: character)!)
+	}
+	return value
+}
+
+struct LedgerDigestRow: Codable, Equatable {
+	var date: String
+	var kind: String
+	var text: String
+	var digestInput: String
+	var digest: String
+	var estimateTokens: Int
+}
+
+func loadLedgerDigestTable() throws -> [LedgerDigestRow] {
+	guard
+		let url = Bundle.module.url(
+			forResource: "ledger-digest-table",
+			withExtension: "json",
+			subdirectory: "Fixtures"
+		)
+	else {
+		throw URLError(.fileDoesNotExist)
+	}
+	return try JSONDecoder().decode([LedgerDigestRow].self, from: Data(contentsOf: url))
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/RecordLogTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/RecordLogTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct RecordLogTests {
+	let amsterdam = IANATimeZone(identifier: "Europe/Amsterdam")!
+	let phoneA = DeviceID(rawValue: "phone-a")
+	let phoneB = DeviceID(rawValue: "phone-b")
+
+	@Test func deviceLocalAppendFromAnotherDeviceThrows() async throws {
+		let log = InMemoryRecordLog(deviceId: phoneA)
+		let foreign = record(
+			device: phoneB,
+			wall: 1,
+			body: .pendingProposal(sampleProposal(chatId: .main, nonce: Nonce(), expiresAt: Date()))
+		)
+		await #expect(throws: ForeignDeviceLocalRecord.self) {
+			try await log.append(foreign)
+		}
+		try await log.append(
+			record(
+				device: phoneA,
+				wall: 2,
+				body: .pendingProposal(sampleProposal(chatId: .main, nonce: Nonce(), expiresAt: Date()))
+			)
+		)
+		try await log.append(
+			record(device: phoneB, wall: 3, body: .userMessage(sampleUser(chatId: .main, text: "from b")))
+		)
+	}
+
+	@Test func fetchHonoursEveryQueryField() async throws {
+		let log = InMemoryRecordLog(deviceId: phoneA)
+		let otherChat = ChatID(rawValue: "other")!
+		try await log.append(
+			record(
+				device: phoneA,
+				wall: 10,
+				date: "1998-06-13",
+				body: .userMessage(sampleUser(chatId: .main, text: "main 13"))
+			)
+		)
+		try await log.append(
+			record(
+				device: phoneB,
+				wall: 11,
+				date: "1998-06-14",
+				body: .assistantMessage(sampleAssistant(chatId: .main, text: "reply 14"))
+			)
+		)
+		try await log.append(
+			record(
+				device: phoneA,
+				wall: 12,
+				date: "1998-06-15",
+				body: .userMessage(sampleUser(chatId: otherChat, text: "other 15"))
+			)
+		)
+		try await log.append(
+			record(
+				device: phoneA,
+				wall: 13,
+				date: "1998-06-14",
+				body: .pendingProposal(sampleProposal(chatId: .main, nonce: Nonce(), expiresAt: Date()))
+			)
+		)
+
+		let kinds = try await log.fetch(RecordQuery(kinds: [.userMessage, .assistantMessage]))
+		#expect(kinds.map { text(of: $0) } == ["main 13", "reply 14", "other 15"])
+
+		let mainOnly = try await log.fetch(RecordQuery(kinds: [.userMessage, .assistantMessage], chatId: .main))
+		#expect(mainOnly.map { text(of: $0) } == ["main 13", "reply 14"])
+
+		let mid = try await log.fetch(
+			RecordQuery(
+				kinds: [.userMessage, .assistantMessage],
+				from: "1998-06-14",
+				to: "1998-06-14"
+			)
+		)
+		#expect(mid.map { text(of: $0) } == ["reply 14"])
+
+		let inclusive = try await log.fetch(
+			RecordQuery(
+				kinds: [.userMessage, .assistantMessage],
+				from: "1998-06-13",
+				to: "1998-06-14"
+			)
+		)
+		#expect(inclusive.map { text(of: $0) } == ["main 13", "reply 14"])
+
+		let thisDevice = try await log.fetch(
+			RecordQuery(kinds: [.userMessage, .assistantMessage, .pendingProposal], deviceLocalOnly: true)
+		)
+		#expect(thisDevice.map(\.deviceId) == [phoneA, phoneA, phoneA])
+		#expect(Set(thisDevice.map(\.body.kind)) == [.userMessage, .pendingProposal])
+	}
+
+	@Test func hlcMonotonicUnderFrozenWallClock() {
+		let frozen = Date(timeIntervalSince1970: 899_164_800)
+		var last: HybridLogicalClock?
+		var ticks: [HybridLogicalClock] = []
+		for _ in 0..<5 {
+			let next = HybridLogicalClock.tick(now: frozen, deviceId: phoneA, last: last)
+			ticks.append(next)
+			last = next
+		}
+		#expect(ticks[0].logical == 0)
+		#expect(ticks.map(\.wallMs).allSatisfy { $0 == ticks[0].wallMs })
+		#expect(ticks.map(\.logical) == [0, 1, 2, 3, 4])
+		for index in 1..<ticks.count {
+			#expect(ticks[index - 1] < ticks[index])
+		}
+		let later = HybridLogicalClock.tick(
+			now: frozen.addingTimeInterval(1),
+			deviceId: phoneA,
+			last: ticks.last
+		)
+		#expect(later.wallMs > ticks.last!.wallMs)
+		#expect(later.logical == 0)
+		#expect(ticks.last! < later)
+	}
+
+	private func record(
+		device: DeviceID,
+		wall: Int64,
+		logical: UInt32 = 0,
+		date: CivilDate = "1998-06-13",
+		body: RecordBody
+	) -> AthleteRecord {
+		AthleteRecord(
+			ulid: ULID.generate(at: Date(timeIntervalSince1970: TimeInterval(wall))),
+			deviceId: device,
+			hlc: HybridLogicalClock(wallMs: wall, logical: logical, deviceId: device),
+			timeZone: amsterdam,
+			civilDate: date,
+			body: body
+		)
+	}
+
+	private func text(of record: AthleteRecord) -> String {
+		switch record.body {
+		case .userMessage(let body): return body.athleteText
+		case .assistantMessage(let body): return body.text
+		default: return ""
+		}
+	}
+}
+
+func sampleUser(chatId: ChatID, text: String) -> UserMessageBody {
+	UserMessageBody(chatId: chatId, athleteText: text, timedText: text, slash: nil)
+}
+
+func sampleAssistant(chatId: ChatID, text: String) -> AssistantMessageBody {
+	AssistantMessageBody(chatId: chatId, text: text, templateHash: "t", assembledHash: "a")
+}
+
+func sampleProposal(chatId: ChatID, nonce: Nonce, expiresAt: Date) -> ProposalBody {
+	ProposalBody(
+		chatId: chatId,
+		nonce: nonce,
+		tool: .intervalsCreateStrengthWorkout,
+		toolInput: .createStrengthWorkout(date: "1998-06-13", name: "Core", description: "20 min"),
+		summary: "Core session",
+		description: "Core · 20 min",
+		expiresAt: expiresAt
+	)
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/UnionMergeTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/UnionMergeTests.swift
@@ -192,33 +192,21 @@ import Testing
 		#expect(UnionMerge.coachReplyLanguage([italian, automatic]) == nil)
 	}
 
-	@Test func ledgerDigestUsesKindRawValue() {
-		let date: CivilDate = "1998-06-13"
-		let text = "Keep Saturdays free."
-		let fromKind = UnionMerge.ledgerDigest(date: date, kind: .decision, text: text)
-		let fromString = UnionMerge.ledgerDigest(date: date.rawValue, kind: LedgerKind.decision.rawValue, text: text)
-		#expect(fromKind == fromString)
-		#expect(fromKind.count == 64)
-	}
-
 	@Test func ledgerDigestMatchesDesktop() throws {
 		let rows = try loadLedgerDigestTable()
 		var computed: [LedgerDigestRow] = []
 		for row in rows {
+			let kind = try #require(LedgerKind(rawValue: row.kind))
+			let date = try #require(CivilDate(rawValue: row.date))
 			let normalized = row.text.replacing(/^[\s]+|[\s]+$/, with: "").replacing(/\s+/, with: " ").lowercased()
 			let digestInput = JSONValue.array([
 				.string(row.date),
 				.string(row.kind),
 				.string(normalized),
 			]).canonicalDigestInput()
-			let digest = UnionMerge.ledgerDigest(date: row.date, kind: row.kind, text: row.text)
-			#expect(digestInput == row.digestInput)
-			#expect(digest == row.digest)
+			let digest = UnionMerge.ledgerDigest(date: date, kind: kind, text: row.text)
 			#expect(Array(digestInput.utf8) == Array(row.digestInput.utf8))
 			#expect(Array(digest.utf8) == Array(row.digest.utf8))
-			if let kind = LedgerKind(rawValue: row.kind), let date = CivilDate(rawValue: row.date) {
-				#expect(UnionMerge.ledgerDigest(date: date, kind: kind, text: row.text) == row.digest)
-			}
 			computed.append(
 				LedgerDigestRow(
 					date: row.date,

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/UnionMergeTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/UnionMergeTests.swift
@@ -1,0 +1,275 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct UnionMergeTests {
+	let amsterdam = IANATimeZone(identifier: "Europe/Amsterdam")!
+	let phoneA = DeviceID(rawValue: "phone-a")
+	let phoneB = DeviceID(rawValue: "phone-b")
+
+	@Test func twoDeviceInterleave() {
+		let first = record(
+			device: phoneB,
+			wall: 100,
+			ulid: ulid(0),
+			body: .userMessage(sampleUser(chatId: .main, text: "from b"))
+		)
+		let second = record(
+			device: phoneA,
+			wall: 100,
+			logical: 1,
+			ulid: ulid(1),
+			body: .assistantMessage(sampleAssistant(chatId: .main, text: "from a"))
+		)
+		let third = record(
+			device: phoneB,
+			wall: 101,
+			ulid: ulid(2),
+			body: .userMessage(sampleUser(chatId: .main, text: "from b later"))
+		)
+		let messages = UnionMerge.conversation([third, first, second], chatId: .main, deviceId: phoneA)
+		#expect(messages.map(\.text) == ["from b", "from a", "from b later"])
+		#expect(messages.map(\.role) == [.user, .assistant, .user])
+	}
+
+	@Test func windowStartCut() {
+		let one = record(
+			device: phoneA,
+			wall: 1,
+			ulid: ulid(1),
+			body: .userMessage(sampleUser(chatId: .main, text: "old"))
+		)
+		let two = record(
+			device: phoneB,
+			wall: 2,
+			ulid: ulid(2),
+			body: .assistantMessage(sampleAssistant(chatId: .main, text: "also old"))
+		)
+		let kept = record(
+			device: phoneA,
+			wall: 3,
+			ulid: ulid(3),
+			body: .userMessage(sampleUser(chatId: .main, text: "kept"))
+		)
+		let reply = record(
+			device: phoneB,
+			wall: 4,
+			ulid: ulid(4),
+			body: .assistantMessage(sampleAssistant(chatId: .main, text: "kept reply"))
+		)
+		let window = record(
+			device: phoneA,
+			wall: 5,
+			ulid: ulid(5),
+			body: .windowStart(WindowStartBody(chatId: .main, firstIncludedUlid: kept.ulid))
+		)
+		let otherWindow = record(
+			device: phoneB,
+			wall: 6,
+			ulid: ulid(6),
+			body: .windowStart(WindowStartBody(chatId: .main, firstIncludedUlid: one.ulid))
+		)
+		let messages = UnionMerge.conversation(
+			[one, two, kept, reply, window, otherWindow],
+			chatId: .main,
+			deviceId: phoneA
+		)
+		#expect(messages.map(\.text) == ["kept", "kept reply"])
+	}
+
+	@Test func sectionHighestHLC() {
+		let earlier = record(
+			device: phoneA,
+			wall: 1,
+			ulid: ulid(1),
+			body: .memorySection(MemorySectionBody(name: .person, content: "Ada, older"))
+		)
+		let later = record(
+			device: phoneB,
+			wall: 2,
+			ulid: ulid(2),
+			body: .memorySection(MemorySectionBody(name: .person, content: "Ada Kovač"))
+		)
+		let other = record(
+			device: phoneA,
+			wall: 3,
+			ulid: ulid(3),
+			body: .memorySection(MemorySectionBody(name: .schedule, content: "Saturdays free"))
+		)
+		#expect(UnionMerge.sectionText([earlier, later, other], name: .person) == "Ada Kovač")
+		#expect(UnionMerge.sectionText([earlier, later, other], name: .schedule) == "Saturdays free")
+		#expect(UnionMerge.sectionText([earlier, later, other], name: .goals) == nil)
+	}
+
+	@Test func ledgerDedupeAcrossDevices() {
+		let first = record(
+			device: phoneA,
+			wall: 1,
+			date: "1998-06-13",
+			ulid: ulid(1),
+			body: .ledgerEvent(LedgerEventBody(kind: .decision, text: "Keep Saturdays free.", source: .chat))
+		)
+		let duplicate = record(
+			device: phoneB,
+			wall: 2,
+			date: "1998-06-13",
+			ulid: ulid(2),
+			body: .ledgerEvent(
+				LedgerEventBody(kind: .decision, text: "  Keep Saturdays   free.  ", source: .flush)
+			)
+		)
+		let extra = record(
+			device: phoneA,
+			wall: 3,
+			date: "1998-06-14",
+			ulid: ulid(3),
+			body: .ledgerEvent(LedgerEventBody(kind: .illness, text: "Knee niggle.", source: .chat))
+		)
+		let events = UnionMerge.ledger([duplicate, extra, first])
+		#expect(events.map(\.text) == ["Keep Saturdays free.", "Knee niggle."])
+		#expect(events.map(\.kind) == [.decision, .illness])
+	}
+
+	@Test func proposalClearedThenAbsent() {
+		let nonce = Nonce()
+		let now = Date(timeIntervalSince1970: 899_164_800)
+		let live = record(
+			device: phoneA,
+			wall: 1,
+			ulid: ulid(1),
+			body: .pendingProposal(sampleProposal(chatId: .main, nonce: nonce, expiresAt: now.addingTimeInterval(600)))
+		)
+		#expect(UnionMerge.pendingProposal([live], chatId: .main, now: now)?.nonce == nonce)
+		let cleared = record(
+			device: phoneA,
+			wall: 2,
+			ulid: ulid(2),
+			body: .proposalCleared(
+				ProposalClearedBody(chatId: .main, nonce: nonce, reason: .executed)
+			)
+		)
+		#expect(UnionMerge.pendingProposal([live, cleared], chatId: .main, now: now) == nil)
+		let expired = record(
+			device: phoneA,
+			wall: 3,
+			ulid: ulid(3),
+			body: .pendingProposal(sampleProposal(chatId: .main, nonce: Nonce(), expiresAt: now))
+		)
+		#expect(UnionMerge.pendingProposal([expired], chatId: .main, now: now) == nil)
+	}
+
+	@Test func planningDeviceAndReplyLanguageHighestHLC() {
+		let firstDevice = record(
+			device: phoneA,
+			wall: 1,
+			ulid: ulid(1),
+			body: .planningDevice(
+				PlanningDeviceBody(planningDeviceId: phoneA, planUlid: ulid(10), activatedAt: Date(timeIntervalSince1970: 10))
+			)
+		)
+		let secondDevice = record(
+			device: phoneB,
+			wall: 2,
+			ulid: ulid(2),
+			body: .planningDevice(
+				PlanningDeviceBody(planningDeviceId: phoneB, planUlid: ulid(11), activatedAt: Date(timeIntervalSince1970: 20))
+			)
+		)
+		#expect(UnionMerge.planningDevice([firstDevice, secondDevice])?.planningDeviceId == phoneB)
+		let italian = record(
+			device: phoneA,
+			wall: 3,
+			ulid: ulid(3),
+			body: .coachReplyLanguage(CoachReplyLanguageBody(tag: .it))
+		)
+		let automatic = record(
+			device: phoneB,
+			wall: 4,
+			ulid: ulid(4),
+			body: .coachReplyLanguage(CoachReplyLanguageBody(tag: nil))
+		)
+		#expect(UnionMerge.coachReplyLanguage([italian]) == .it)
+		#expect(UnionMerge.coachReplyLanguage([italian, automatic]) == nil)
+	}
+
+	@Test func ledgerDigestUsesKindRawValue() {
+		let date: CivilDate = "1998-06-13"
+		let text = "Keep Saturdays free."
+		let fromKind = UnionMerge.ledgerDigest(date: date, kind: .decision, text: text)
+		let fromString = UnionMerge.ledgerDigest(date: date.rawValue, kind: LedgerKind.decision.rawValue, text: text)
+		#expect(fromKind == fromString)
+		#expect(fromKind.count == 64)
+	}
+
+	@Test func ledgerDigestMatchesDesktop() throws {
+		let rows = try loadLedgerDigestTable()
+		var computed: [LedgerDigestRow] = []
+		for row in rows {
+			let normalized = row.text.replacing(/^[\s]+|[\s]+$/, with: "").replacing(/\s+/, with: " ").lowercased()
+			let digestInput = JSONValue.array([
+				.string(row.date),
+				.string(row.kind),
+				.string(normalized),
+			]).canonicalDigestInput()
+			let digest = UnionMerge.ledgerDigest(date: row.date, kind: row.kind, text: row.text)
+			#expect(digestInput == row.digestInput)
+			#expect(digest == row.digest)
+			#expect(Array(digestInput.utf8) == Array(row.digestInput.utf8))
+			#expect(Array(digest.utf8) == Array(row.digest.utf8))
+			if let kind = LedgerKind(rawValue: row.kind), let date = CivilDate(rawValue: row.date) {
+				#expect(UnionMerge.ledgerDigest(date: date, kind: kind, text: row.text) == row.digest)
+			}
+			computed.append(
+				LedgerDigestRow(
+					date: row.date,
+					kind: row.kind,
+					text: row.text,
+					digestInput: digestInput,
+					digest: digest,
+					estimateTokens: estimateTokens(row.text)
+				)
+			)
+		}
+		if let path = ProcessInfo.processInfo.environment["ENDURAGENT_DIGEST_OUT"], !path.isEmpty {
+			try encodeDigestTable(computed).write(toFile: path, atomically: true, encoding: .utf8)
+		}
+	}
+
+	private func record(
+		device: DeviceID,
+		wall: Int64,
+		logical: UInt32 = 0,
+		date: CivilDate = "1998-06-13",
+		ulid: ULID,
+		body: RecordBody
+	) -> AthleteRecord {
+		AthleteRecord(
+			ulid: ulid,
+			deviceId: device,
+			hlc: HybridLogicalClock(wallMs: wall, logical: logical, deviceId: device),
+			timeZone: amsterdam,
+			civilDate: date,
+			body: body
+		)
+	}
+
+	private func ulid(_ offset: Int) -> ULID {
+		ULID.generate(at: Date(timeIntervalSince1970: 899_164_800 + Double(offset)))
+	}
+}
+
+private func encodeDigestTable(_ rows: [LedgerDigestRow]) -> String {
+	let objects = rows.map { row in
+		let fields = [
+			("date", JSONValue.string(row.date).canonicalDigestInput()),
+			("kind", JSONValue.string(row.kind).canonicalDigestInput()),
+			("text", JSONValue.string(row.text).canonicalDigestInput()),
+			("digestInput", JSONValue.string(row.digestInput).canonicalDigestInput()),
+			("digest", JSONValue.string(row.digest).canonicalDigestInput()),
+			("estimateTokens", String(row.estimateTokens)),
+		]
+		let inner = fields.map { "    \"\($0.0)\": \($0.1)" }.joined(separator: ",\n")
+		return "  {\n\(inner)\n  }"
+	}
+	return "[\n" + objects.joined(separator: ",\n") + "\n]\n"
+}


### PR DESCRIPTION
## Why

Second child of the TestFlight 1 epic (#1019). Every later coach module writes through the record log, so the append-only records, the locality rule (device-local kinds never leave their device), the hybrid clock, and the union-merge folds land first, against an in-memory log. The SwiftData and CloudKit log in a later PR implements the same `RecordLog` contract these tests pin.

## Scope

- `Records/HybridLogicalClock.swift`: `tick(now:deviceId:last:)`.
- `Records/RecordLog.swift`: `InMemoryRecordLog.append` and `fetch`, new `ForeignDeviceLocalRecord` error.
- `Records/UnionMerge.swift`: conversation, section text, ledger with digest dedupe, planning device, coach reply language, pending proposal folds, `ledgerDigest`.
- `Identity.swift`: `ULID.generate`, `CivilDate.adding`, `DateKey`, `JSONValue.parse`, `canonicalJSON`, `sha256Hex`, `estimateTokens`.
- Tests: `RecordLogTests`, `UnionMergeTests`, `IdentityTests`, fixture `ledger-digest-table.json`.

Out of scope: SwiftData, CloudKit, `Coach.history`, `Memory`, `ProposalPolicy`.

## Tradeoffs

`ledgerDigest` takes `LedgerKind`, not a string, so a caller cannot hash a kind the desktop ledger does not have. The differential fixture was regenerated with real kinds to keep it that way.

## Blast Radius

Package-internal. No app screen, no network, no persistence yet. Fifteen tests replace the single skipped one.

## Verification

- `swift build`: zero warnings in Swift 6 mode.
- `swift test`: 15 tests in 4 suites passed.
- Differential: ten ledger rows hashed by the desktop `contentDigest` in `packages/engine/src/provenance.ts` (through the `appendEvent` normalization in `packages/core/src/memory/store.ts`) and by `estimateTokens` in `packages/engine/src/agent/token-utils.ts`; the Swift test recomputes every row and the two JSON tables are byte-identical (`diff` empty).
- CI `ios-package-tests` on this PR.

Known gaps the tests do not cover: JavaScript number formatting beyond safe integers, unpaired surrogates, and BOM whitespace. None occur in ledger text today.

Playbook: poteto-mode Feature, implementation delegated to Grok 4.6 xhigh, reviewed by the lead.
