### PR TITLE
feat(ios): OpenRouter transport, SSE parser, and fake replay

### DIFF
--- a/.changeset/ios-openrouter-transport.md
+++ b/.changeset/ios-openrouter-transport.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add the iOS OpenRouter transport, SSE parser, and fake model transport. No athlete-facing change.

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Testing/Fakes.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Testing/Fakes.swift
@@ -9,6 +9,7 @@ public enum ScriptedEvent: Sendable, Equatable {
 public final class FakeModelTransport: ModelTransport, @unchecked Sendable {
 	public var script: [ScriptedEvent]
 	public private(set) var requests: [CompletionRequest]
+	private let lock = NSLock()
 
 	public init() {
 		self.script = []
@@ -16,7 +17,56 @@ public final class FakeModelTransport: ModelTransport, @unchecked Sendable {
 	}
 
 	public func stream(_ request: CompletionRequest) -> AsyncThrowingStream<TransportEvent, Error> {
-		fatalError("not implemented")
+		let events: [TransportEvent]
+		do {
+			events = try nextBatch(for: request)
+		} catch {
+			return AsyncThrowingStream { continuation in
+				continuation.finish(throwing: error)
+			}
+		}
+		return AsyncThrowingStream { continuation in
+			for event in events {
+				continuation.yield(event)
+			}
+			continuation.finish()
+		}
+	}
+
+	private func nextBatch(for request: CompletionRequest) throws -> [TransportEvent] {
+		lock.lock()
+		defer { lock.unlock() }
+		requests.append(request)
+		var events: [TransportEvent] = []
+		while !script.isEmpty {
+			let event = script.removeFirst()
+			switch event {
+			case .text(let text):
+				events.append(.textDelta(text))
+			case .toolCall(let name, let arguments):
+				guard let toolName = ToolName(rawValue: name) else {
+					throw OpenRouterParseError.unknownTool(name)
+				}
+				events.append(
+					.toolCall(
+						WireToolCall(
+							id: UUID().uuidString,
+							name: toolName,
+							arguments: arguments
+						)
+					)
+				)
+			case .finish(let reason):
+				events.append(
+					.finished(
+						reason: reason,
+						usage: Usage(inputTokens: 0, outputTokens: 0, cost: nil)
+					)
+				)
+				return events
+			}
+		}
+		return events
 	}
 }
 

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Transport/ModelTransport.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Transport/ModelTransport.swift
@@ -67,18 +67,199 @@ public protocol ModelTransport: Sendable {
 	func stream(_ request: CompletionRequest) -> AsyncThrowingStream<TransportEvent, Error>
 }
 
+public struct ProviderAuthError: Error, Equatable, Sendable {
+	public var statusCode: Int
+	public var body: String
+
+	public init(statusCode: Int, body: String) {
+		self.statusCode = statusCode
+		self.body = body
+	}
+}
+
+public struct UnknownFinishReasonError: Error, Equatable, Sendable {
+	public var reason: String
+
+	public init(reason: String) {
+		self.reason = reason
+	}
+}
+
+public struct OpenRouterHTTPError: Error, Equatable, Sendable {
+	public var statusCode: Int
+	public var body: String
+
+	public init(statusCode: Int, body: String) {
+		self.statusCode = statusCode
+		self.body = body
+	}
+}
+
 public struct OpenRouterTransport: ModelTransport {
+	private let apiKey: String
+	private let baseURL: URL
+	private let makeSession: @Sendable (TimeInterval) -> URLSession
+
 	public init(apiKey: String, baseURL: URL = URL(string: "https://openrouter.ai/api/v1")!) {
-		fatalError("not implemented")
+		self.init(apiKey: apiKey, baseURL: baseURL, makeSession: Self.makeDefaultSession)
+	}
+
+	package init(
+		apiKey: String,
+		baseURL: URL = URL(string: "https://openrouter.ai/api/v1")!,
+		makeSession: @escaping @Sendable (TimeInterval) -> URLSession
+	) {
+		self.apiKey = apiKey
+		self.baseURL = baseURL
+		self.makeSession = makeSession
 	}
 
 	public func stream(_ request: CompletionRequest) -> AsyncThrowingStream<TransportEvent, Error> {
-		fatalError("not implemented")
+		AsyncThrowingStream { continuation in
+			let task = Task {
+				let session = makeSession(OpenRouterHTTP.timeInterval(from: request.deadline))
+				defer { session.finishTasksAndInvalidate() }
+				do {
+					let urlRequest = try OpenRouterHTTP.urlRequest(
+						apiKey: apiKey,
+						baseURL: baseURL,
+						request: request
+					)
+					let (bytes, response) = try await session.bytes(for: urlRequest)
+					guard let http = response as? HTTPURLResponse else {
+						throw URLError(.badServerResponse)
+					}
+					if http.statusCode == 401 {
+						throw ProviderAuthError(
+							statusCode: 401,
+							body: try await OpenRouterHTTP.utf8String(from: bytes)
+						)
+					}
+					if http.statusCode != 200 {
+						throw OpenRouterHTTPError(
+							statusCode: http.statusCode,
+							body: try await OpenRouterHTTP.utf8String(from: bytes)
+						)
+					}
+					try await OpenRouterSSEParser.parse(lines: bytes.lines) { event in
+						continuation.yield(event)
+					}
+					continuation.finish()
+				} catch {
+					continuation.finish(throwing: error)
+				}
+			}
+			continuation.onTermination = { _ in
+				task.cancel()
+			}
+		}
+	}
+
+	private static let makeDefaultSession: @Sendable (TimeInterval) -> URLSession = { timeout in
+		let configuration = URLSessionConfiguration.ephemeral
+		configuration.timeoutIntervalForRequest = timeout
+		return URLSession(configuration: configuration)
 	}
 }
 
 public enum OpenRouterHTTP {
 	public static func body(for request: CompletionRequest) -> JSONValue {
-		fatalError("not implemented")
+		var object: [String: JSONValue] = [
+			"model": .string(request.model),
+			"messages": .array(request.messages.map(encode(message:))),
+			"stream": .bool(request.stream),
+			"usage": .object(["include": .bool(request.includeUsage)]),
+		]
+		if !request.tools.isEmpty {
+			object["tools"] = .array(request.tools.map(encode(tool:)))
+			object["tool_choice"] = .string("auto")
+		}
+		return .object(object)
+	}
+
+	package static func urlRequest(
+		apiKey: String,
+		baseURL: URL,
+		request: CompletionRequest
+	) throws -> URLRequest {
+		var urlRequest = URLRequest(url: baseURL.appending(path: "chat/completions"))
+		urlRequest.httpMethod = "POST"
+		urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+		urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		urlRequest.httpBody = try OpenRouterJSON.data(from: body(for: request))
+		return urlRequest
+	}
+
+	package static func timeInterval(from duration: Duration) -> TimeInterval {
+		let components = duration.components
+		return TimeInterval(components.seconds)
+			+ TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+	}
+
+	package static func utf8String(from bytes: URLSession.AsyncBytes) async throws -> String {
+		var data = Data()
+		for try await byte in bytes {
+			data.append(byte)
+		}
+		return String(decoding: data, as: UTF8.self)
+	}
+
+	private static func encode(message: WireMessage) -> JSONValue {
+		var object: [String: JSONValue] = [
+			"role": .string(message.role.rawValue),
+			"content": .string(message.content),
+		]
+		if !message.toolCalls.isEmpty {
+			object["tool_calls"] = .array(message.toolCalls.map(encode(toolCall:)))
+		}
+		if let toolCallId = message.toolCallId {
+			object["tool_call_id"] = .string(toolCallId)
+		}
+		return .object(object)
+	}
+
+	private static func encode(toolCall: WireToolCall) -> JSONValue {
+		.object([
+			"id": .string(toolCall.id),
+			"type": .string("function"),
+			"function": .object([
+				"name": .string(toolCall.name.rawValue),
+				"arguments": .string(toolCall.arguments),
+			]),
+		])
+	}
+
+	private static func encode(tool: ToolSchema) -> JSONValue {
+		.object([
+			"type": .string("function"),
+			"function": .object([
+				"name": .string(tool.name.rawValue),
+				"description": .string(tool.description),
+				"parameters": tool.parameters,
+			]),
+		])
+	}
+}
+
+package enum OpenRouterJSON {
+	package static func data(from value: JSONValue) throws -> Data {
+		try JSONSerialization.data(withJSONObject: jsonObject(from: value))
+	}
+
+	package static func jsonObject(from value: JSONValue) -> Any {
+		switch value {
+		case .null:
+			return NSNull()
+		case .bool(let value):
+			return value
+		case .number(let value):
+			return value
+		case .string(let value):
+			return value
+		case .array(let values):
+			return values.map(jsonObject(from:))
+		case .object(let values):
+			return values.mapValues(jsonObject(from:))
+		}
 	}
 }

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Transport/OpenRouterSSEParser.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Transport/OpenRouterSSEParser.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+package enum OpenRouterSSEParser {
+	package static func events(from text: String) -> AsyncThrowingStream<TransportEvent, Error> {
+		AsyncThrowingStream { continuation in
+			do {
+				var state = ParseState()
+				for line in splitLines(text) {
+					for event in try state.consume(line: line) {
+						continuation.yield(event)
+					}
+					if state.isComplete {
+						break
+					}
+				}
+				if !state.isComplete {
+					for event in try state.finish() {
+						continuation.yield(event)
+					}
+				}
+				continuation.finish()
+			} catch {
+				continuation.finish(throwing: error)
+			}
+		}
+	}
+
+	package static func parse<S: AsyncSequence>(
+		lines: S,
+		yield: @Sendable (TransportEvent) -> Void
+	) async throws where S.Element == String {
+		var state = ParseState()
+		for try await line in lines {
+			try Task.checkCancellation()
+			for event in try state.consume(line: line) {
+				yield(event)
+			}
+			if state.isComplete {
+				return
+			}
+		}
+		if !state.isComplete {
+			for event in try state.finish() {
+				yield(event)
+			}
+		}
+	}
+}
+
+private func splitLines(_ text: String) -> [String] {
+	text.split(separator: "\n", omittingEmptySubsequences: false).map { line in
+		if line.last == "\r" {
+			return String(line.dropLast())
+		}
+		return String(line)
+	}
+}
+
+private struct ParseState {
+	private var partials: [Int: PartialToolCall] = [:]
+	private var lastFinishReason: String?
+	private var usageSteps: [UsageStep] = []
+	private var finished = false
+	var isComplete: Bool { finished }
+
+	mutating func consume(line: String) throws -> [TransportEvent] {
+		if line.isEmpty {
+			return []
+		}
+		if line.hasPrefix(":") {
+			return [.heartbeat]
+		}
+		guard line.hasPrefix("data:") else {
+			return []
+		}
+		var payload = String(line.dropFirst(5))
+		if payload.first == " " {
+			payload.removeFirst()
+		}
+		if payload == "[DONE]" {
+			return try finish()
+		}
+		if payload.isEmpty {
+			return []
+		}
+		return try consume(json: payload)
+	}
+
+	mutating func finish() throws -> [TransportEvent] {
+		if finished {
+			return []
+		}
+		finished = true
+		var events = try emitToolCalls()
+		switch lastFinishReason {
+		case "stop":
+			events.append(.finished(reason: .stop, usage: summedUsage()))
+		case "tool_calls", "tool-calls":
+			events.append(.finished(reason: .toolCalls, usage: summedUsage()))
+		case "length":
+			events.append(.finished(reason: .length, usage: summedUsage()))
+		case let value?:
+			throw UnknownFinishReasonError(reason: value)
+		case nil:
+			throw UnknownFinishReasonError(reason: "")
+		}
+		return events
+	}
+
+	private mutating func consume(json payload: String) throws -> [TransportEvent] {
+		guard let data = payload.data(using: .utf8) else {
+			throw OpenRouterParseError.malformedSSE
+		}
+		let raw: Any
+		do {
+			raw = try JSONSerialization.jsonObject(with: data)
+		} catch {
+			throw OpenRouterParseError.malformedSSE
+		}
+		guard let object = raw as? [String: Any] else {
+			throw OpenRouterParseError.malformedSSE
+		}
+		if let usage = object["usage"] as? [String: Any] {
+			usageSteps.append(UsageStep(usage))
+		}
+		guard let choices = object["choices"] as? [Any],
+			let choice = choices.first as? [String: Any]
+		else {
+			return [.heartbeat]
+		}
+		if let reason = choice["finish_reason"] as? String {
+			lastFinishReason = reason
+		}
+		let delta = choice["delta"] as? [String: Any] ?? [:]
+		var events: [TransportEvent] = []
+		var emitted = false
+		if let content = delta["content"] as? String, !content.isEmpty {
+			events.append(.textDelta(content))
+			emitted = true
+		}
+		if let toolCalls = delta["tool_calls"] as? [Any], !toolCalls.isEmpty {
+			try merge(toolCalls: toolCalls)
+			events.append(.heartbeat)
+			emitted = true
+		}
+		if !emitted {
+			events.append(.heartbeat)
+		}
+		return events
+	}
+
+	private mutating func merge(toolCalls: [Any]) throws {
+		for item in toolCalls {
+			guard let fragment = item as? [String: Any] else {
+				throw OpenRouterParseError.malformedSSE
+			}
+			let index = intValue(fragment["index"]) ?? 0
+			var partial = partials[index] ?? PartialToolCall()
+			if let id = fragment["id"] as? String, !id.isEmpty {
+				partial.id = id
+			}
+			if let function = fragment["function"] as? [String: Any] {
+				if let name = function["name"] as? String, !name.isEmpty {
+					partial.name = name
+				}
+				if let arguments = function["arguments"] as? String {
+					partial.arguments += arguments
+				}
+			}
+			partials[index] = partial
+		}
+	}
+
+	private mutating func emitToolCalls() throws -> [TransportEvent] {
+		let ordered = partials.keys.sorted().compactMap { partials[$0] }
+		partials.removeAll()
+		return try ordered.map { partial in
+			guard let name = ToolName(rawValue: partial.name) else {
+				throw OpenRouterParseError.unknownTool(partial.name)
+			}
+			return .toolCall(
+				WireToolCall(
+					id: partial.id,
+					name: name,
+					arguments: partial.arguments
+				)
+			)
+		}
+	}
+
+	private func summedUsage() -> Usage {
+		let input = usageSteps.reduce(0) { $0 + $1.inputTokens }
+		let output = usageSteps.reduce(0) { $0 + $1.outputTokens }
+		let costs = usageSteps.map(\.cost)
+		let cost: Double?
+		if !usageSteps.isEmpty, costs.allSatisfy({ $0 != nil }) {
+			cost = costs.compactMap { $0 }.reduce(0, +)
+		} else {
+			cost = nil
+		}
+		return Usage(inputTokens: input, outputTokens: output, cost: cost)
+	}
+}
+
+private struct PartialToolCall {
+	var id = ""
+	var name = ""
+	var arguments = ""
+}
+
+private struct UsageStep {
+	var inputTokens: Int
+	var outputTokens: Int
+	var cost: Double?
+
+	init(_ usage: [String: Any]) {
+		inputTokens = intValue(usage["prompt_tokens"]) ?? 0
+		outputTokens = intValue(usage["completion_tokens"]) ?? 0
+		if let number = usage["cost"] as? NSNumber,
+			CFGetTypeID(number) != CFBooleanGetTypeID()
+		{
+			let value = number.doubleValue
+			cost = value.isFinite && value >= 0 ? value : nil
+		} else {
+			cost = nil
+		}
+	}
+}
+
+private func intValue(_ raw: Any?) -> Int? {
+	if let value = raw as? Int {
+		return value
+	}
+	if let value = raw as? NSNumber, CFGetTypeID(value) != CFBooleanGetTypeID() {
+		return value.intValue
+	}
+	return nil
+}
+
+package enum OpenRouterParseError: Error, Equatable, Sendable {
+	case malformedSSE
+	case unknownTool(String)
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/FakeModelTransportTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/FakeModelTransportTests.swift
@@ -1,0 +1,97 @@
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct FakeModelTransportTests {
+	@Test func streamReplaysScriptAcrossTwoRequests() async throws {
+		let transport = FakeModelTransport()
+		transport.script = [
+			.text("Ada rode Saturday."),
+			.finish(reason: .stop),
+			.toolCall(name: "intervals_fetch_athlete", arguments: "{}"),
+			.finish(reason: .toolCalls),
+		]
+		let firstRequest = CompletionRequest.openRouter(
+			messages: [
+				WireMessage(role: .user, content: "How was 1998-06-13?", toolCalls: [], toolCallId: nil),
+			],
+			tools: [],
+			deadline: .seconds(600)
+		)
+		let secondRequest = CompletionRequest.openRouter(
+			messages: [
+				WireMessage(role: .user, content: "Fetch the athlete.", toolCalls: [], toolCallId: nil),
+			],
+			tools: [
+				ToolSchema(
+					name: .intervalsFetchAthlete,
+					description: "Fetch the athlete profile.",
+					parameters: .object(["type": .string("object")])
+				),
+			],
+			deadline: .seconds(600)
+		)
+
+		let first = try await collect(transport.stream(firstRequest))
+		#expect(first == [
+			.textDelta("Ada rode Saturday."),
+			.finished(reason: .stop, usage: Usage(inputTokens: 0, outputTokens: 0, cost: nil)),
+		])
+
+		let second = try await collect(transport.stream(secondRequest))
+		#expect(second.count == 2)
+		guard case .toolCall(let call) = second.first else {
+			Issue.record("expected tool call")
+			return
+		}
+		#expect(!call.id.isEmpty)
+		#expect(call.name == .intervalsFetchAthlete)
+		#expect(call.arguments == "{}")
+		#expect(second.last == .finished(reason: .toolCalls, usage: Usage(inputTokens: 0, outputTokens: 0, cost: nil)))
+
+		#expect(transport.requests == [firstRequest, secondRequest])
+		#expect(transport.script.isEmpty)
+	}
+
+	@Test func streamStopsAtEachFinish() async throws {
+		let transport = FakeModelTransport()
+		transport.script = [
+			.text("one"),
+			.finish(reason: .stop),
+			.text("two"),
+			.finish(reason: .length),
+		]
+		let request = CompletionRequest.openRouter(
+			messages: [
+				WireMessage(role: .user, content: "Hi Ada", toolCalls: [], toolCallId: nil),
+			],
+			tools: [],
+			deadline: .seconds(30)
+		)
+		let first = try await collect(transport.stream(request))
+		#expect(textDeltas(in: first) == ["one"])
+		let second = try await collect(transport.stream(request))
+		#expect(textDeltas(in: second) == ["two"])
+		guard case .finished(let reason, _) = second.last else {
+			Issue.record("expected finished")
+			return
+		}
+		#expect(reason == .length)
+	}
+}
+
+private func collect(_ stream: AsyncThrowingStream<TransportEvent, Error>) async throws -> [TransportEvent] {
+	var events: [TransportEvent] = []
+	for try await event in stream {
+		events.append(event)
+	}
+	return events
+}
+
+private func textDeltas(in events: [TransportEvent]) -> [String] {
+	events.compactMap { event in
+		if case .textDelta(let text) = event {
+			return text
+		}
+		return nil
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-finish-length.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-finish-length.sse
@@ -1,0 +1,5 @@
+data: {"id":"gen-1998-ada-length","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"Ada's June 1998 block "},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-length","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"was cut short."},"finish_reason":"length"}],"usage":{"prompt_tokens":40,"completion_tokens":20,"total_tokens":60,"cost":0.5}}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-finish-unknown.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-finish-unknown.sse
@@ -1,0 +1,3 @@
+data: {"id":"gen-1998-ada-unknown","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"Stopped."},"finish_reason":"content_filter"}]}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-parallel-tool-calls.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-parallel-tool-calls.sse
@@ -1,0 +1,9 @@
+data: {"id":"gen-1998-ada-parallel","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_ada_athlete","type":"function","function":{"name":"intervals_fetch_athlete","arguments":"{"}}]},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-parallel","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_ada_wellness","type":"function","function":{"name":"intervals_fetch_wellness","arguments":"{"}}]},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-parallel","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-parallel","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\"oldest\":\"1998-06-01\",\"newest\":\"1998-06-13\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":22,"completion_tokens":16,"total_tokens":38,"cost":0.25}}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-reasoning-keepalive.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-reasoning-keepalive.sse
@@ -1,0 +1,9 @@
+: keep-alive
+
+data: {"id":"gen-1998-ada-reason","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"Ada rode on Saturday 1998-06-13."},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-reason","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":""},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-reason","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"Rest on Sunday."},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15,"cost":0.25}}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-text-usage.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-text-usage.sse
@@ -1,0 +1,7 @@
+data: {"id":"gen-1998-ada-text","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"Your week "},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-text","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"looked strong, Ada."},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-text","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":24,"completion_tokens":8,"total_tokens":32,"cost":0.25}}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-tool-call-fragments.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-tool-call-fragments.sse
@@ -1,0 +1,9 @@
+data: {"id":"gen-1998-ada-tool","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_ada_week","type":"function","function":{"name":"intervals_fetch_activities","arguments":""}}]},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-tool","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-tool","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"days\":"}}]},"finish_reason":null}]}
+
+data: {"id":"gen-1998-ada-tool","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":18,"completion_tokens":12,"total_tokens":30,"cost":0.5}}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-unauthorized.json
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-unauthorized.json
@@ -1,0 +1,1 @@
+{"error":{"message":"User not found.","code":401}}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-usage-partial-cost.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-usage-partial-cost.sse
@@ -1,0 +1,5 @@
+data: {"id":"gen-1998-ada-partial","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}],"usage":{"prompt_tokens":4,"completion_tokens":1,"cost":0.25}}
+
+data: {"id":"gen-1998-ada-partial","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":" Ada"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2}}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-usage-sum.sse
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/openrouter-usage-sum.sse
@@ -1,0 +1,5 @@
+data: {"id":"gen-1998-ada-sum","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi "},"finish_reason":null}],"usage":{"prompt_tokens":10,"completion_tokens":1,"cost":0.25}}
+
+data: {"id":"gen-1998-ada-sum","object":"chat.completion.chunk","created":883612800,"model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"Ada"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"cost":0.5}}
+
+data: [DONE]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/OpenRouterLiveTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/OpenRouterLiveTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct OpenRouterLiveTests {
+	@Test(.enabled(if: ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil))
+	func streamsOneTurn() async throws {
+		let apiKey = try #require(ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"])
+		let request = CompletionRequest.openRouter(
+			messages: [
+				WireMessage(
+					role: .user,
+					content: "Reply with the single word pong.",
+					toolCalls: [],
+					toolCallId: nil
+				),
+			],
+			tools: [
+				ToolSchema(
+					name: .intervalsFetchAthlete,
+					description: "Fetch the athlete profile.",
+					parameters: .object([
+						"type": .string("object"),
+						"properties": .object([:]),
+					])
+				),
+			],
+			deadline: .seconds(60)
+		)
+		let urlRequest = try OpenRouterHTTP.urlRequest(
+			apiKey: apiKey,
+			baseURL: URL(string: "https://openrouter.ai/api/v1")!,
+			request: request
+		)
+		let configuration = URLSessionConfiguration.ephemeral
+		configuration.timeoutIntervalForRequest = OpenRouterHTTP.timeInterval(from: request.deadline)
+		let session = URLSession(configuration: configuration)
+		defer { session.finishTasksAndInvalidate() }
+		let (bytes, response) = try await session.bytes(for: urlRequest)
+		let http = try #require(response as? HTTPURLResponse)
+		if http.statusCode == 401 {
+			throw ProviderAuthError(
+				statusCode: 401,
+				body: try await OpenRouterHTTP.utf8String(from: bytes)
+			)
+		}
+		#expect(http.statusCode == 200)
+		var lines: [String] = []
+		var sawCacheDiscount = false
+		var sawCachedTokens = false
+		var provider: String?
+		for try await line in bytes.lines {
+			lines.append(line)
+			let flags = cacheFlags(in: line)
+			sawCacheDiscount = sawCacheDiscount || flags.discount
+			sawCachedTokens = sawCachedTokens || flags.cachedTokens
+			if provider == nil {
+				provider = providerField(in: line)
+			}
+		}
+		var events: [TransportEvent] = []
+		for try await event in OpenRouterSSEParser.events(from: lines.joined(separator: "\n")) {
+			events.append(event)
+		}
+		#expect(!events.isEmpty)
+		if case .finished(_, let usage) = events.last {
+			#expect(usage.inputTokens > 0)
+		} else {
+			Issue.record("expected finished")
+		}
+		if let path = ProcessInfo.processInfo.environment["ENDURAGENT_LIVE_OUT"], !path.isEmpty {
+			var payload: [String: Any] = [
+				"events": events.map(json(event:)),
+				"sawCacheDiscount": sawCacheDiscount,
+				"sawCachedTokens": sawCachedTokens,
+			]
+			if let provider {
+				payload["provider"] = provider
+			}
+			let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+			try data.write(to: URL(fileURLWithPath: path))
+		}
+	}
+}
+
+private func cacheFlags(in line: String) -> (discount: Bool, cachedTokens: Bool) {
+	guard let object = jsonObject(fromSSELine: line) else {
+		return (false, false)
+	}
+	return inspectCache(object)
+}
+
+private func providerField(in line: String) -> String? {
+	guard let object = jsonObject(fromSSELine: line) else {
+		return nil
+	}
+	return object["provider"] as? String
+}
+
+private func jsonObject(fromSSELine line: String) -> [String: Any]? {
+	guard line.hasPrefix("data:") else {
+		return nil
+	}
+	var payload = String(line.dropFirst(5))
+	if payload.first == " " {
+		payload.removeFirst()
+	}
+	guard payload != "[DONE]",
+		let data = payload.data(using: .utf8),
+		let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+	else {
+		return nil
+	}
+	return object
+}
+
+private func inspectCache(_ value: Any) -> (discount: Bool, cachedTokens: Bool) {
+	if let object = value as? [String: Any] {
+		var discount = object["cache_discount"] != nil
+		var cachedTokens = false
+		if let details = object["prompt_tokens_details"] as? [String: Any],
+			details["cached_tokens"] != nil
+		{
+			cachedTokens = true
+		}
+		for nested in object.values {
+			let inner = inspectCache(nested)
+			discount = discount || inner.discount
+			cachedTokens = cachedTokens || inner.cachedTokens
+		}
+		return (discount, cachedTokens)
+	}
+	if let array = value as? [Any] {
+		var discount = false
+		var cachedTokens = false
+		for nested in array {
+			let inner = inspectCache(nested)
+			discount = discount || inner.discount
+			cachedTokens = cachedTokens || inner.cachedTokens
+		}
+		return (discount, cachedTokens)
+	}
+	return (false, false)
+}
+
+private func json(event: TransportEvent) -> [String: Any] {
+	switch event {
+	case .textDelta(let text):
+		return ["type": "textDelta", "text": text]
+	case .toolCall(let call):
+		return [
+			"type": "toolCall",
+			"id": call.id,
+			"name": call.name.rawValue,
+			"arguments": call.arguments,
+		]
+	case .heartbeat:
+		return ["type": "heartbeat"]
+	case .finished(let reason, let usage):
+		var payload: [String: Any] = [
+			"type": "finished",
+			"reason": reason.rawValue,
+			"usage": [
+				"inputTokens": usage.inputTokens,
+				"outputTokens": usage.outputTokens,
+			],
+		]
+		if let cost = usage.cost {
+			var usageObject = payload["usage"] as? [String: Any] ?? [:]
+			usageObject["cost"] = cost
+			payload["usage"] = usageObject
+		}
+		return payload
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/OpenRouterTransportTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/OpenRouterTransportTests.swift
@@ -1,0 +1,428 @@
+import Foundation
+import Synchronization
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct OpenRouterTransportTests {
+	@Test func bodyOmitsTemperatureAndIncludesUsage() throws {
+		let body = OpenRouterHTTP.body(for: sampleRequest(tools: true))
+		let object = try objectValue(body)
+		#expect(object["temperature"] == nil)
+		#expect(object["model"] == .string("deepseek/deepseek-v4-flash"))
+		#expect(object["stream"] == .bool(true))
+		#expect(object["usage"] == .object(["include": .bool(true)]))
+		#expect(object["tool_choice"] == .string("auto"))
+		let tools = try arrayValue(object["tools"])
+		#expect(tools.count == 1)
+		let tool = try objectValue(tools[0])
+		#expect(tool["type"] == .string("function"))
+		let function = try objectValue(tool["function"])
+		#expect(function["name"] == .string("intervals_fetch_athlete"))
+		#expect(function["description"] == .string("Fetch the athlete profile."))
+		#expect(function["parameters"] == .object(["type": .string("object")]))
+		let messages = try arrayValue(object["messages"])
+		#expect(messages.count == 4)
+		let assistant = try objectValue(messages[2])
+		#expect(assistant["role"] == .string("assistant"))
+		let toolCalls = try arrayValue(assistant["tool_calls"])
+		let call = try objectValue(toolCalls[0])
+		#expect(call["id"] == .string("call_ada_1"))
+		#expect(call["type"] == .string("function"))
+		let callFunction = try objectValue(call["function"])
+		#expect(callFunction["name"] == .string("intervals_fetch_athlete"))
+		#expect(callFunction["arguments"] == .string("{}"))
+		let toolMessage = try objectValue(messages[3])
+		#expect(toolMessage["role"] == .string("tool"))
+		#expect(toolMessage["tool_call_id"] == .string("call_ada_1"))
+		#expect(toolMessage["content"] == .string("{\"name\":\"Ada Kovač\"}"))
+	}
+
+	@Test func bodyOmitsToolsWhenEmpty() throws {
+		let body = OpenRouterHTTP.body(for: sampleRequest(tools: false))
+		let object = try objectValue(body)
+		#expect(object["tools"] == nil)
+		#expect(object["tool_choice"] == nil)
+		#expect(object["temperature"] == nil)
+	}
+
+	@Test func parserConcatenatesFragmentedToolCallArguments() async throws {
+		let events = try await parseFixture("openrouter-tool-call-fragments")
+		let calls = toolCalls(in: events)
+		#expect(calls.count == 1)
+		#expect(calls[0].id == "call_ada_week")
+		#expect(calls[0].name == .intervalsFetchActivities)
+		#expect(calls[0].arguments == "{\"days\":7}")
+		guard case .finished(let reason, let usage) = events.last else {
+			Issue.record("expected finished")
+			return
+		}
+		#expect(reason == .toolCalls)
+		#expect(usage.inputTokens == 18)
+		#expect(usage.outputTokens == 12)
+		#expect(usage.cost == 0.5)
+	}
+
+	@Test func parserYieldsParallelToolCallsByIndex() async throws {
+		let events = try await parseFixture("openrouter-parallel-tool-calls")
+		let calls = toolCalls(in: events)
+		#expect(calls.count == 2)
+		#expect(calls[0].id == "call_ada_athlete")
+		#expect(calls[0].name == .intervalsFetchAthlete)
+		#expect(calls[0].arguments == "{}")
+		#expect(calls[1].id == "call_ada_wellness")
+		#expect(calls[1].name == .intervalsFetchWellness)
+		#expect(calls[1].arguments == "{\"oldest\":\"1998-06-01\",\"newest\":\"1998-06-13\"}")
+	}
+
+	@Test func parserYieldsTextUsageAndNoTemperatureLeak() async throws {
+		let events = try await parseFixture("openrouter-text-usage")
+		#expect(textDeltas(in: events) == ["Your week ", "looked strong, Ada."])
+		guard case .finished(let reason, let usage) = events.last else {
+			Issue.record("expected finished")
+			return
+		}
+		#expect(reason == .stop)
+		#expect(usage.inputTokens == 24)
+		#expect(usage.outputTokens == 8)
+		#expect(usage.cost == 0.25)
+	}
+
+	@Test func parserTreatsReasoningAndKeepAlivesAsHeartbeats() async throws {
+		let events = try await parseFixture("openrouter-reasoning-keepalive")
+		#expect(events.filter { $0 == .heartbeat }.count >= 3)
+		#expect(textDeltas(in: events) == ["Rest on Sunday."])
+		guard case .finished(let reason, _) = events.last else {
+			Issue.record("expected finished")
+			return
+		}
+		#expect(reason == .stop)
+	}
+
+	@Test func parserMapsLengthFinishReason() async throws {
+		let events = try await parseFixture("openrouter-finish-length")
+		guard case .finished(let reason, let usage) = events.last else {
+			Issue.record("expected finished")
+			return
+		}
+		#expect(reason == .length)
+		#expect(usage.inputTokens == 40)
+		#expect(usage.outputTokens == 20)
+	}
+
+	@Test func parserThrowsOnUnknownFinishReason() async {
+		await #expect(throws: UnknownFinishReasonError.self) {
+			_ = try await parseFixture("openrouter-finish-unknown")
+		}
+	}
+
+	@Test func parserSumsUsageAndCostAcrossSteps() async throws {
+		let events = try await parseFixture("openrouter-usage-sum")
+		guard case .finished(_, let usage) = events.last else {
+			Issue.record("expected finished")
+			return
+		}
+		#expect(usage.inputTokens == 20)
+		#expect(usage.outputTokens == 3)
+		#expect(usage.cost == 0.75)
+	}
+
+	@Test func parserOmitsCostWhenAnyStepLacksIt() async throws {
+		let events = try await parseFixture("openrouter-usage-partial-cost")
+		guard case .finished(_, let usage) = events.last else {
+			Issue.record("expected finished")
+			return
+		}
+		#expect(usage.inputTokens == 8)
+		#expect(usage.outputTokens == 3)
+		#expect(usage.cost == nil)
+	}
+
+	@Suite(.serialized)
+	struct HTTP {
+		@Test func streamPostsOnceWithBearerAndNoReferer() async throws {
+			let sse = try fixture("openrouter-text-usage", ext: "sse")
+			let state = HTTPCapture()
+			let transport = stubbedTransport()
+			let events = try await OpenRouterURLStub.withHandler({ request in
+				state.record(request)
+				return .ok(sse)
+			}) {
+				try await collect(transport.stream(sampleRequest(tools: false)))
+			}
+			#expect(state.posts == 1)
+			let request = try #require(state.request)
+			#expect(request.httpMethod == "POST")
+			#expect(request.url?.absoluteString == "https://openrouter.test/api/v1/chat/completions")
+			#expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-key")
+			#expect(request.value(forHTTPHeaderField: "HTTP-Referer") == nil)
+			#expect(request.value(forHTTPHeaderField: "Referer") == nil)
+			#expect(request.value(forHTTPHeaderField: "X-OpenRouter-Title") == nil)
+			let bodyData = try #require(httpBody(from: request))
+			let body = try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+			#expect(body?["temperature"] == nil)
+			#expect(body?["stream"] as? Bool == true)
+			#expect(textDeltas(in: events) == ["Your week ", "looked strong, Ada."])
+		}
+
+		@Test func streamUsesDeadlineAsRequestTimeout() async throws {
+			let sse = try fixture("openrouter-text-usage", ext: "sse")
+			let state = TimeoutCapture()
+			let transport = OpenRouterTransport(
+				apiKey: "test-key",
+				baseURL: URL(string: "https://openrouter.test/api/v1")!
+			) { value in
+				state.value = value
+				let configuration = URLSessionConfiguration.ephemeral
+				configuration.timeoutIntervalForRequest = value
+				configuration.protocolClasses = [OpenRouterURLStub.self]
+				return URLSession(configuration: configuration)
+			}
+			try await OpenRouterURLStub.withHandler({ _ in .ok(sse) }) {
+				_ = try await collect(
+					transport.stream(
+						CompletionRequest.openRouter(
+							messages: [
+								WireMessage(role: .user, content: "Hi Ada", toolCalls: [], toolCallId: nil),
+							],
+							tools: [],
+							deadline: .seconds(45)
+						)
+					)
+				)
+			}
+			#expect(state.value == 45)
+		}
+
+		@Test func streamSurfaces401AsProviderAuthError() async throws {
+			let body = try fixture("openrouter-unauthorized", ext: "json")
+			let state = HTTPCapture()
+			let transport = stubbedTransport()
+			do {
+				_ = try await OpenRouterURLStub.withHandler({ request in
+					state.record(request)
+					return OpenRouterURLStub.Response(
+						statusCode: 401,
+						headers: ["Content-Type": "application/json"],
+						body: Data(body.utf8)
+					)
+				}) {
+					try await collect(transport.stream(sampleRequest(tools: false)))
+				}
+				Issue.record("expected provider auth error")
+			} catch let error as ProviderAuthError {
+				#expect(error.statusCode == 401)
+				#expect(error.body.contains("User not found."))
+			}
+			#expect(state.posts == 1)
+		}
+	}
+}
+
+private final class HTTPCapture: Sendable {
+	private let state = Mutex<(request: URLRequest?, count: Int)>((nil, 0))
+
+	var request: URLRequest? {
+		state.withLock { $0.request }
+	}
+
+	var posts: Int {
+		state.withLock { $0.count }
+	}
+
+	func record(_ request: URLRequest) {
+		state.withLock { snapshot in
+			snapshot.request = request
+			snapshot.count += 1
+		}
+	}
+}
+
+private final class TimeoutCapture: Sendable {
+	private let stored = Mutex<TimeInterval?>(nil)
+
+	var value: TimeInterval? {
+		get { stored.withLock { $0 } }
+		set { stored.withLock { $0 = newValue } }
+	}
+}
+
+private func sampleRequest(tools: Bool) -> CompletionRequest {
+	CompletionRequest.openRouter(
+		messages: [
+			WireMessage(role: .system, content: "You are Ada Kovač's coach.", toolCalls: [], toolCallId: nil),
+			WireMessage(role: .user, content: "How did 1998-06-13 look?", toolCalls: [], toolCallId: nil),
+			WireMessage(
+				role: .assistant,
+				content: "",
+				toolCalls: [
+					WireToolCall(id: "call_ada_1", name: .intervalsFetchAthlete, arguments: "{}"),
+				],
+				toolCallId: nil
+			),
+			WireMessage(
+				role: .tool,
+				content: "{\"name\":\"Ada Kovač\"}",
+				toolCalls: [],
+				toolCallId: "call_ada_1"
+			),
+		],
+		tools: tools
+			? [
+				ToolSchema(
+					name: .intervalsFetchAthlete,
+					description: "Fetch the athlete profile.",
+					parameters: .object(["type": .string("object")])
+				),
+			]
+			: [],
+		deadline: .seconds(600)
+	)
+}
+
+private func parseFixture(_ name: String) async throws -> [TransportEvent] {
+	try await collect(OpenRouterSSEParser.events(from: fixture(name, ext: "sse")))
+}
+
+private func collect(_ stream: AsyncThrowingStream<TransportEvent, Error>) async throws -> [TransportEvent] {
+	var events: [TransportEvent] = []
+	for try await event in stream {
+		events.append(event)
+	}
+	return events
+}
+
+private func fixture(_ name: String, ext: String) throws -> String {
+	let url = try #require(
+		Bundle.module.url(forResource: name, withExtension: ext, subdirectory: "Fixtures")
+			?? Bundle.module.url(forResource: name, withExtension: ext)
+	)
+	return try String(contentsOf: url, encoding: .utf8)
+}
+
+private func objectValue(_ value: JSONValue?) throws -> [String: JSONValue] {
+	guard case .object(let object) = value else {
+		throw OpenRouterParseError.malformedSSE
+	}
+	return object
+}
+
+private func arrayValue(_ value: JSONValue?) throws -> [JSONValue] {
+	guard case .array(let items) = value else {
+		throw OpenRouterParseError.malformedSSE
+	}
+	return items
+}
+
+private func textDeltas(in events: [TransportEvent]) -> [String] {
+	events.compactMap { event in
+		if case .textDelta(let text) = event {
+			return text
+		}
+		return nil
+	}
+}
+
+private func toolCalls(in events: [TransportEvent]) -> [WireToolCall] {
+	events.compactMap { event in
+		if case .toolCall(let call) = event {
+			return call
+		}
+		return nil
+	}
+}
+
+private func httpBody(from request: URLRequest) -> Data? {
+	if let body = request.httpBody {
+		return body
+	}
+	guard let stream = request.httpBodyStream else {
+		return nil
+	}
+	stream.open()
+	defer { stream.close() }
+	let bufferSize = 1024
+	let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+	defer { buffer.deallocate() }
+	var data = Data()
+	while stream.hasBytesAvailable {
+		let read = stream.read(buffer, maxLength: bufferSize)
+		if read <= 0 {
+			break
+		}
+		data.append(buffer, count: read)
+	}
+	return data
+}
+
+private func stubbedTransport() -> OpenRouterTransport {
+	OpenRouterTransport(
+		apiKey: "test-key",
+		baseURL: URL(string: "https://openrouter.test/api/v1")!
+	) { timeout in
+		let configuration = URLSessionConfiguration.ephemeral
+		configuration.timeoutIntervalForRequest = timeout
+		configuration.protocolClasses = [OpenRouterURLStub.self]
+		return URLSession(configuration: configuration)
+	}
+}
+
+private final class OpenRouterURLStub: URLProtocol, @unchecked Sendable {
+	struct Response: Sendable {
+		var statusCode: Int
+		var headers: [String: String]
+		var body: Data
+
+		static func ok(_ sse: String) -> Response {
+			Response(
+				statusCode: 200,
+				headers: ["Content-Type": "text/event-stream"],
+				body: Data(sse.utf8)
+			)
+		}
+	}
+
+	private static let handler = Mutex<(@Sendable (URLRequest) -> Response)?>(nil)
+
+	static func withHandler<T: Sendable>(
+		_ handler: @escaping @Sendable (URLRequest) -> Response,
+		perform: () async throws -> T
+	) async throws -> T {
+		let previous = Self.handler.withLock { current in
+			let previous = current
+			current = handler
+			return previous
+		}
+		defer {
+			Self.handler.withLock { $0 = previous }
+		}
+		return try await perform()
+	}
+
+	override class func canInit(with request: URLRequest) -> Bool { true }
+	override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+	override func startLoading() {
+		let handler = Self.handler.withLock { $0 }
+		guard let handler else {
+			client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+			return
+		}
+		let response = handler(request)
+		guard let url = request.url,
+			let http = HTTPURLResponse(
+				url: url,
+				statusCode: response.statusCode,
+				httpVersion: "HTTP/1.1",
+				headerFields: response.headers
+			)
+		else {
+			client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+			return
+		}
+		client?.urlProtocol(self, didReceive: http, cacheStoragePolicy: .notAllowed)
+		client?.urlProtocol(self, didLoad: response.body)
+		client?.urlProtocolDidFinishLoading(self)
+	}
+
+	override func stopLoading() {}
+}


### PR DESCRIPTION
## Why

The phone talks to the model through OpenRouter's streaming chat completions. This PR lands the transport, the SSE parser, and the scripted fake the package tests use, so the turn loop in the next PR has a real and a fake transport behind one `ModelTransport` protocol.

## Scope

- `Transport/ModelTransport.swift`: `OpenRouterHTTP.body(for:)` (model, messages, `stream: true`, `usage.include: true`, tools with `tool_choice: "auto"`, no `temperature`), `OpenRouterTransport.stream` (one attempt, per-request timeout from `deadline`, `Authorization: Bearer`), `ProviderAuthError` for 401.
- `Transport/OpenRouterSSEParser.swift`: text deltas, fragmented and parallel tool calls keyed by index, heartbeats for reasoning and keep-alives, `finish_reason` mapping with a thrown error for unknown values, `usage.cost` summed only when every step reports it.
- `Testing/Fakes.swift`: `FakeModelTransport.stream` replays the script up to each `.finish` and records requests.
- Tests: eight SSE fixtures, 401 through a `URLProtocol` stub, fake replay, and a key-gated live case `OpenRouterLiveTests.streamsOneTurn` that skips without `OPENROUTER_API_KEY`.

Out of scope: watchdog, turn budget, retry classification beyond 401, tool execution, `cache_control` breakpoints.

## Tradeoffs

Request bodies are serialized with `JSONSerialization`, not the package's canonical encoder. The wire does not need canonical bytes, and prompt caching keys on message content.

## Blast Radius

Package-internal. No app screen. The live test only runs when a key is in the environment and is never run in CI.

## Verification

- `swift build`: zero warnings in Swift 6 mode.
- `swift test` after rebasing on the records PR: 31 tests in 8 suites passed (live test skipped).
- The live OpenRouter run with a capped key, and whether DeepSeek streams report cached tokens, is recorded after merge as this ticket's live proof; the ticket stays open until then.

Playbook: poteto-mode Feature, implementation delegated to Grok 4.6 xhigh, reviewed by the lead.
