### PR TITLE
feat(ios): workout serializer and confirmation gate

### DIFF
--- a/.changeset/ios-serializer-confirmation-gate.md
+++ b/.changeset/ios-serializer-confirmation-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add the intervals.icu workout serializer and confirmation gate to the Enduragent iOS coach package. No npm or desktop release target yet.

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Coach.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Coach.swift
@@ -72,21 +72,7 @@ public actor Coach {
 		let records = (try? await store.fetch(
 			RecordQuery(kinds: [.pendingProposal, .proposalCleared], chatId: chatId, deviceLocalOnly: true)
 		)) ?? []
-		let ordered = records.sorted { $0.hlc < $1.hlc }
-		var current: ProposalBody?
-		for record in ordered {
-			switch record.body {
-			case .pendingProposal(let body) where body.chatId == chatId:
-				current = body
-			case .proposalCleared(let body) where body.chatId == chatId:
-				if current?.nonce == body.nonce {
-					current = nil
-				}
-			default:
-				break
-			}
-		}
-		guard let current, current.expiresAt > clock.now else {
+		guard let current = UnionMerge.pendingProposal(records, chatId: chatId, now: clock.now) else {
 			return nil
 		}
 		return PendingProposal(
@@ -99,13 +85,37 @@ public actor Coach {
 	}
 
 	public func confirm(chatId: ChatID, nonce: Nonce) async throws -> ConfirmOutcome {
-		_ = chatId
-		_ = nonce
 		_ = sport
 		_ = transport
 		_ = intervals
-		_ = tools
-		return .none
+		let tools = self.tools
+		do {
+			let lookup = try await ProposalPolicy.take(
+				chatId: chatId,
+				nonce: nonce,
+				store: store,
+				clock: clock,
+				run: { input in
+					try await tools.rebuildConfirmed(input)
+				}
+			)
+			switch lookup {
+			case .found(let body):
+				return .executed(summary: body.summary)
+			case .expired:
+				return .expired
+			case .mismatch:
+				return .mismatch
+			case .none:
+				return .none
+			}
+		} catch let error as IntervalsError {
+			return .refused(message: error.details)
+		} catch let error as InvalidWorkout {
+			return .refused(message: error.message)
+		} catch {
+			return .failed(message: "\(error)")
+		}
 	}
 
 	public func setCoachReplyLanguage(_ tag: LanguageTag?) async {

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Confirmation/PendingProposal.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Confirmation/PendingProposal.swift
@@ -32,6 +32,7 @@ package enum ProposalLookup: Sendable, Equatable {
 
 package enum ProposalPolicy {
 	package static let ttl: Duration = TurnPolicy.proposalTTL
+	package static let ttlSeconds: TimeInterval = 10 * 60
 
 	package static func propose(
 		chatId: ChatID,
@@ -43,7 +44,39 @@ package enum ProposalPolicy {
 		store: any RecordLog,
 		clock: any Clock
 	) async throws -> PendingProposal {
-		fatalError("not implemented")
+		let records = try await store.fetch(
+			RecordQuery(kinds: [.pendingProposal, .proposalCleared], chatId: chatId, deviceLocalOnly: true)
+		)
+		var last = records.map(\.hlc).max()
+		if let live = UnionMerge.pendingProposal(records, chatId: chatId, now: now) {
+			try await append(
+				.proposalCleared(
+					ProposalClearedBody(chatId: chatId, nonce: live.nonce, reason: .replaced)
+				),
+				store: store,
+				clock: clock,
+				last: &last
+			)
+		}
+		let nonce = Nonce()
+		let expiresAt = now.addingTimeInterval(ttlSeconds)
+		let body = ProposalBody(
+			chatId: chatId,
+			nonce: nonce,
+			tool: tool,
+			toolInput: input,
+			summary: summary,
+			description: description,
+			expiresAt: expiresAt
+		)
+		try await append(.pendingProposal(body), store: store, clock: clock, last: &last)
+		return PendingProposal(
+			chatId: chatId,
+			nonce: nonce,
+			summary: summary,
+			description: description,
+			expiresAt: expiresAt
+		)
 	}
 
 	package static func take(
@@ -53,6 +86,93 @@ package enum ProposalPolicy {
 		clock: any Clock,
 		run: @Sendable (GatedToolInput) async throws -> JSONValue
 	) async throws -> ProposalLookup {
-		fatalError("not implemented")
+		let records = try await store.fetch(
+			RecordQuery(kinds: [.pendingProposal, .proposalCleared], chatId: chatId, deviceLocalOnly: true)
+		)
+		let now = clock.now
+		if let live = UnionMerge.pendingProposal(records, chatId: chatId, now: now) {
+			if live.nonce != nonce {
+				return .mismatch
+			}
+			var last = records.map(\.hlc).max()
+			try await append(
+				.proposalCleared(
+					ProposalClearedBody(chatId: chatId, nonce: nonce, reason: .executed)
+				),
+				store: store,
+				clock: clock,
+				last: &last
+			)
+			_ = try await run(live.toolInput)
+			return .found(live)
+		}
+		if latestUncleared(records, chatId: chatId) != nil {
+			return .expired
+		}
+		return .none
+	}
+
+	package static func summary(for input: GatedToolInput) -> String {
+		switch input {
+		case .createWorkout(let date, let workout):
+			return "Create workout \"\(workout.name)\" on \(date.rawValue)"
+		case .createStrengthWorkout(let date, let name, _):
+			return "Create strength workout \"\(name)\" on \(date.rawValue)"
+		case .deleteWorkout:
+			return "Delete a workout"
+		case .updateWorkout(let update):
+			var fields: [String] = []
+			if let date = update.date {
+				fields.append("date to \(date.rawValue)")
+			}
+			if let name = update.name {
+				fields.append("name to \"\(name)\"")
+			}
+			if update.description != nil {
+				fields.append("description")
+			}
+			let detail = fields.isEmpty ? "selected fields" : fields.joined(separator: ", ")
+			return "Update workout — \(detail)"
+		case .planSave(let headline):
+			if headline.name.isEmpty {
+				return "Save the training plan — replaces the current saved plan"
+			}
+			return "Save the training plan — replaces the current saved plan — \(headline.name)"
+		}
+	}
+
+	private static func latestUncleared(_ records: [AthleteRecord], chatId: ChatID) -> ProposalBody? {
+		let ordered = records.sorted { $0.hlc < $1.hlc }
+		var cleared: Set<Nonce> = []
+		for record in ordered {
+			if case .proposalCleared(let body) = record.body, body.chatId == chatId {
+				cleared.insert(body.nonce)
+			}
+		}
+		for record in ordered.reversed() {
+			guard case .pendingProposal(let body) = record.body, body.chatId == chatId else { continue }
+			if cleared.contains(body.nonce) { continue }
+			return body
+		}
+		return nil
+	}
+
+	private static func append(
+		_ body: RecordBody,
+		store: any RecordLog,
+		clock: any Clock,
+		last: inout HybridLogicalClock?
+	) async throws {
+		let tz = IANATimeZone(identifier: clock.timeZone.identifier) ?? IANATimeZone(identifier: "GMT")!
+		let record = AthleteRecord(
+			ulid: ULID.generate(at: clock.now),
+			deviceId: store.deviceId,
+			hlc: .tick(now: clock.now, deviceId: store.deviceId, last: last),
+			timeZone: tz,
+			civilDate: IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone),
+			body: body
+		)
+		last = record.hlc
+		try await store.append(record)
 	}
 }

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Cycling/IntervalsClient.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Cycling/IntervalsClient.swift
@@ -26,7 +26,33 @@ public struct ChatExternalID: Hashable, Sendable {
 	}
 
 	public static func slugify(name: String) -> String {
-		fatalError("not implemented")
+		var characters: [Character] = []
+		var pendingDash = false
+		for character in name.lowercased() {
+			guard let ascii = character.asciiValue else {
+				pendingDash = true
+				continue
+			}
+			let isDigit = ascii >= 48 && ascii <= 57
+			let isLetter = ascii >= 97 && ascii <= 122
+			if isDigit || isLetter {
+				if pendingDash, !characters.isEmpty {
+					characters.append("-")
+				}
+				characters.append(character)
+				pendingDash = false
+			} else {
+				pendingDash = true
+			}
+		}
+		var slug = String(characters)
+		if slug.count > 40 {
+			slug = String(slug.prefix(40))
+			while slug.hasSuffix("-") {
+				slug.removeLast()
+			}
+		}
+		return slug.isEmpty ? "workout" : slug
 	}
 }
 
@@ -210,7 +236,15 @@ public enum IntervalsPolicy {
 	public static let eventCategories = ["WORKOUT", "RACE_A", "RACE_B", "RACE_C"]
 
 	public static func chatCreateBody(_ draft: ChatCalendarCreate) -> JSONValue {
-		fatalError("not implemented")
+		.object([
+			"start_date_local": .string("\(draft.date.rawValue)T00:00:00"),
+			"category": .string("WORKOUT"),
+			"type": .string(draft.type.rawValue),
+			"name": .string(draft.name),
+			"description": .string(draft.description),
+			"external_id": .string(draft.externalId.rawValue),
+			"tags": .array(draft.tags.map { .string($0) }),
+		])
 	}
 
 	package static func today(now: Date, timeZone: TimeZone) -> CivilDate {
@@ -254,11 +288,167 @@ public enum IntervalsPolicy {
 		if let externalId, externalId.hasPrefix("\(coachTag):") { return true }
 		return false
 	}
+
+	package static func rejectPastCreationDate(_ date: CivilDate, today: CivilDate) throws {
+		if date < today {
+			throw IntervalsError(
+				code: "past_date_refused",
+				details: "Cannot create a workout dated \(date.rawValue) — it's before today (\(today.rawValue)). Use today's date or later."
+			)
+		}
+	}
+
+	package static func refuseMutableEvent(
+		_ event: CalendarEvent,
+		today: CivilDate,
+		eventId: EventID,
+		action: String,
+		nextDate: CivilDate?
+	) throws {
+		let verb = action == "delete" ? "deleted" : "updated"
+		if event.category != "WORKOUT" {
+			throw IntervalsError(
+				code: "not_a_workout",
+				details: "Event \(eventId.rawValue) is category \(event.category.isEmpty ? "unknown" : event.category), not a scheduled workout. Races, notes, plans, and other calendar entries cannot be \(verb) by the coach."
+			)
+		}
+		if !isCoachOwned(externalId: event.externalId, tags: event.tags) {
+			let athleteAction = action == "delete" ? "remove" : "change"
+			throw IntervalsError(
+				code: "not_coach_created",
+				details: "This workout was not created by this coach (no provenance marker) — it may be athlete-added, from another app, or created before provenance markers shipped. It will not be \(verb); the athlete can \(athleteAction) it directly on intervals.icu."
+			)
+		}
+		let eventDate = String(event.startDateLocal.prefix(10))
+		if eventDate < today.rawValue {
+			throw IntervalsError(
+				code: "past_workout_protected",
+				details: "Cannot \(action) workout dated \(eventDate) — it's before today (\(today.rawValue))."
+			)
+		}
+		if let nextDate, nextDate.rawValue < today.rawValue {
+			throw IntervalsError(
+				code: "past_workout_destination",
+				details: "Cannot move workout to \(nextDate.rawValue) — it's before today (\(today.rawValue))."
+			)
+		}
+	}
 }
 
 public enum CyclingTools {
 	public static func parseCreateWorkout(_ arguments: JSONValue, today: CivilDate) throws -> ChatCalendarCreate {
-		fatalError("not implemented")
+		let parsed = try parseCreateWorkoutInput(arguments, today: today)
+		return parsed.draft
+	}
+
+	package static func parseCreateWorkoutInput(
+		_ arguments: JSONValue,
+		today: CivilDate
+	) throws -> (date: CivilDate, workout: IntervalsWorkoutInput, draft: ChatCalendarCreate) {
+		let fields = arguments.objectFields
+		guard let dateRaw = fields["date"]?.stringValue else {
+			throw IntervalsError(
+				code: "invalid_date",
+				details: "date is not a real calendar date. Use YYYY-MM-DD."
+			)
+		}
+		guard let date = CivilDate(rawValue: dateRaw) else {
+			throw IntervalsError(
+				code: "invalid_date",
+				details: "\(dateRaw) is not a real calendar date. Use YYYY-MM-DD."
+			)
+		}
+		try IntervalsPolicy.rejectPastCreationDate(date, today: today)
+		guard let workoutJSON = fields["workout"] else {
+			throw InvalidWorkout(message: "workout: Required")
+		}
+		let workout = try IntervalsSerializer.parseWorkout(workoutJSON)
+		let serialized = try IntervalsSerializer.serialize(workout)
+		let draft = ChatCalendarCreate(
+			date: date,
+			name: workout.name,
+			description: serialized.description,
+			type: .ride,
+			externalId: IntervalsSerializer.chatExternalId(date: date, name: workout.name),
+			tags: [IntervalsPolicy.coachTag]
+		)
+		return (date, workout, draft)
+	}
+
+	package static func parseStrengthWorkout(
+		_ arguments: JSONValue,
+		today: CivilDate
+	) throws -> (date: CivilDate, name: String, description: String, draft: ChatCalendarCreate) {
+		let fields = arguments.objectFields
+		guard let dateRaw = fields["date"]?.stringValue, let date = CivilDate(rawValue: dateRaw) else {
+			let raw = fields["date"]?.stringValue ?? ""
+			throw IntervalsError(
+				code: "invalid_date",
+				details: raw.isEmpty
+					? "date is not a real calendar date. Use YYYY-MM-DD."
+					: "\(raw) is not a real calendar date. Use YYYY-MM-DD."
+			)
+		}
+		try IntervalsPolicy.rejectPastCreationDate(date, today: today)
+		guard let name = fields["name"]?.stringValue, (1...120).contains(name.count) else {
+			throw IntervalsError(code: "invalid_input", details: "name must be 1 to 120 characters.")
+		}
+		guard let description = fields["description"]?.stringValue, (1...4000).contains(description.count) else {
+			throw IntervalsError(code: "invalid_input", details: "description must be 1 to 4000 characters.")
+		}
+		let draft = ChatCalendarCreate(
+			date: date,
+			name: name,
+			description: description,
+			type: .weightTraining,
+			externalId: IntervalsSerializer.chatExternalId(date: date, name: "strength \(name)"),
+			tags: [IntervalsPolicy.coachTag]
+		)
+		return (date, name, description, draft)
+	}
+
+	package static func parseDeleteWorkout(_ arguments: JSONValue) throws -> EventID {
+		guard let eventId = arguments.objectFields["eventId"]?.intValue() else {
+			throw IntervalsError(code: "invalid_event_id", details: "eventId must be an integer.")
+		}
+		return EventID(rawValue: eventId)
+	}
+
+	package static func parseUpdateWorkout(_ arguments: JSONValue, today: CivilDate) throws -> UpdateWorkoutInput {
+		let fields = arguments.objectFields
+		guard let eventId = fields["eventId"]?.intValue() else {
+			throw IntervalsError(code: "invalid_event_id", details: "eventId must be an integer.")
+		}
+		let changes = fields["changes"]?.objectFields ?? fields
+		let date: CivilDate?
+		if let dateRaw = changes["date"]?.stringValue {
+			guard let parsed = CivilDate(rawValue: dateRaw) else {
+				throw IntervalsError(
+					code: "invalid_date",
+					details: "\(dateRaw) is not a real calendar date. Use YYYY-MM-DD."
+				)
+			}
+			if parsed < today {
+				throw IntervalsError(
+					code: "past_date_refused",
+					details: "Cannot move a workout to \(parsed.rawValue) — it's before today (\(today.rawValue)). Use today's date or later."
+				)
+			}
+			date = parsed
+		} else {
+			date = nil
+		}
+		let name = changes["name"]?.stringValue
+		let description = changes["description"]?.stringValue
+		if date == nil && name == nil && description == nil {
+			throw IntervalsError(code: "invalid_changes", details: "At least one workout field must change.")
+		}
+		return UpdateWorkoutInput(
+			eventId: EventID(rawValue: eventId),
+			date: date,
+			name: name,
+			description: description
+		)
 	}
 }
 

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Cycling/IntervalsRESTClient.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Cycling/IntervalsRESTClient.swift
@@ -4,10 +4,12 @@ public struct IntervalsRESTClient: IntervalsClient, Sendable {
 	private let credential: IntervalsCredential
 	private let session: URLSession
 	private let athletePath: String
+	private let clock: any Clock
 
-	public init(credential: IntervalsCredential, session: URLSession? = nil) {
+	public init(credential: IntervalsCredential, session: URLSession? = nil, clock: any Clock = SystemClock()) {
 		self.credential = credential
 		self.athletePath = IntervalsPolicy.athletePath
+		self.clock = clock
 		if let session {
 			self.session = session
 		} else {
@@ -81,19 +83,68 @@ public struct IntervalsRESTClient: IntervalsClient, Sendable {
 	}
 
 	public func createChatEvent(_ draft: ChatCalendarCreate) async throws -> CalendarEvent {
-		fatalError("not implemented")
+		let json = try await sendJSON(
+			method: "POST",
+			path: ["athlete", athletePath, "events"],
+			query: [URLQueryItem(name: "upsertOnUid", value: "false")],
+			body: IntervalsPolicy.chatCreateBody(draft)
+		)
+		guard let event = Self.calendarEvent(from: json) else {
+			throw IntervalsError(code: "invalid_json", details: "create event response was not an event")
+		}
+		return event
 	}
 
 	public func createOrUpdatePlanEvent(_ draft: PlanMirrorCreate) async throws -> CalendarEvent {
-		fatalError("not implemented")
+		_ = draft
+		throw IntervalsError(code: "not_implemented", details: "Plan mirror writes are not available.")
 	}
 
 	public func updateEvent(id: EventID, name: String?, description: String?, date: CivilDate?) async throws -> CalendarEvent {
-		fatalError("not implemented")
+		let existing = try await fetchEvent(id: id)
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		try IntervalsPolicy.refuseMutableEvent(
+			existing,
+			today: today,
+			eventId: id,
+			action: "update",
+			nextDate: date
+		)
+		var fields: [String: JSONValue] = [:]
+		if let name {
+			fields["name"] = .string(name)
+		}
+		if let description {
+			fields["description"] = .string(description)
+		}
+		if let date {
+			fields["start_date_local"] = .string("\(date.rawValue)T00:00:00")
+		}
+		let json = try await sendJSON(
+			method: "PUT",
+			path: ["athlete", athletePath, "events", String(id.rawValue)],
+			body: .object(fields)
+		)
+		guard let event = Self.calendarEvent(from: json) else {
+			throw IntervalsError(code: "invalid_json", details: "update event response was not an event")
+		}
+		return event
 	}
 
 	public func deleteEvent(id: EventID) async throws {
-		fatalError("not implemented")
+		let existing = try await fetchEvent(id: id)
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		try IntervalsPolicy.refuseMutableEvent(
+			existing,
+			today: today,
+			eventId: id,
+			action: "delete",
+			nextDate: nil
+		)
+		_ = try await send(
+			method: "DELETE",
+			path: ["athlete", athletePath, "events", String(id.rawValue)]
+		)
 	}
 
 	private var authorization: String {
@@ -106,11 +157,37 @@ public struct IntervalsRESTClient: IntervalsClient, Sendable {
 		}
 	}
 
+	private func fetchEvent(id: EventID) async throws -> CalendarEvent {
+		let json = try await getJSON(path: ["athlete", athletePath, "events", String(id.rawValue)])
+		guard let event = Self.calendarEvent(from: json) else {
+			throw IntervalsError(code: "invalid_json", details: "event \(id.rawValue) was not an event")
+		}
+		return event
+	}
+
 	private func getJSON(path: [String], query: [URLQueryItem] = []) async throws -> JSONValue {
-		try parseJSON(try await get(path: path, query: query))
+		try parseJSON(try await send(method: "GET", path: path, query: query))
+	}
+
+	private func sendJSON(
+		method: String,
+		path: [String],
+		query: [URLQueryItem] = [],
+		body: JSONValue
+	) async throws -> JSONValue {
+		try parseJSON(try await send(method: method, path: path, query: query, body: body))
 	}
 
 	private func get(path: [String], query: [URLQueryItem] = []) async throws -> Data {
+		try await send(method: "GET", path: path, query: query)
+	}
+
+	private func send(
+		method: String,
+		path: [String],
+		query: [URLQueryItem] = [],
+		body: JSONValue? = nil
+	) async throws -> Data {
 		var url = IntervalsPolicy.baseURL
 		for component in path {
 			url.append(path: component)
@@ -123,10 +200,14 @@ public struct IntervalsRESTClient: IntervalsClient, Sendable {
 			throw IntervalsError(code: "invalid_url", details: path.joined(separator: "/"))
 		}
 		var request = URLRequest(url: finalURL)
-		request.httpMethod = "GET"
+		request.httpMethod = method
 		request.setValue(authorization, forHTTPHeaderField: "Authorization")
 		request.setValue("application/json", forHTTPHeaderField: "Accept")
 		request.timeoutInterval = IntervalsPolicy.requestTimeout
+		if let body {
+			request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+			request.httpBody = Data(body.canonicalDigestInput().utf8)
+		}
 		let (data, response) = try await session.data(for: request)
 		guard let http = response as? HTTPURLResponse else {
 			throw IntervalsError(code: "network", details: "missing http response")

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Cycling/Serializer.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Cycling/Serializer.swift
@@ -8,6 +8,8 @@ public enum StepType: String, Sendable {
 	case freeride
 	case rest
 	case interval
+	case steady
+	case recovery
 }
 
 public enum PowerKind: String, Sendable {
@@ -68,7 +70,7 @@ public struct SerializedWorkout: Sendable, Equatable {
 	public var movingTime: Int
 }
 
-public struct InvalidWorkout: Error, Sendable {
+public struct InvalidWorkout: Error, Sendable, Equatable {
 	public var message: String
 }
 
@@ -83,21 +85,332 @@ public enum IntervalsSerializer {
 	public static let maxPercentFtp = 200
 	public static let maxSteps = 40
 	public static let maxRepeat = 20
+	private static let maxZone = 7
+	private static let minZone = 1
+	private static let maxName = 120
 
 	public static func serialize(_ workout: IntervalsWorkoutInput) throws -> SerializedWorkout {
-		fatalError("not implemented")
+		try validateSchema(workout)
+		try workout.steps.enumerated().forEach { index, step in
+			try preValidate(step, path: "steps[\(index)]")
+		}
+
+		var lines: [String] = []
+		var currentLabel: String?
+
+		for (index, step) in workout.steps.enumerated() {
+			let label = sectionLabel(for: step)
+			if label != currentLabel {
+				if !lines.isEmpty {
+					lines.append("")
+				}
+				lines.append(label)
+				currentLabel = label
+			}
+			let path = "steps[\(index)]"
+			switch step {
+			case .set(let set):
+				lines.append("\(set.repeatCount)x")
+				lines.append(try formatStepLine(set.interval, path: "\(path).interval"))
+				lines.append(try formatStepLine(set.recovery, path: "\(path).recovery"))
+			case .simple(let simple):
+				lines.append(try formatStepLine(simple, path: path))
+			}
+		}
+
+		return SerializedWorkout(
+			description: lines.joined(separator: "\n"),
+			movingTime: totalSeconds(workout.steps)
+		)
 	}
 
 	public static func formatDuration(_ duration: DurationInput) -> String {
-		fatalError("not implemented")
+		let total = Int(toSeconds(duration).rounded())
+		if total < 60 {
+			return "\(total)s"
+		}
+		let minutes = total / 60
+		let seconds = total % 60
+		return seconds == 0 ? "\(minutes)m" : "\(minutes)m\(seconds)"
 	}
 
 	public static func slug(date: CivilDate, name: String) -> String {
-		fatalError("not implemented")
+		_ = date
+		return ChatExternalID.slugify(name: name)
 	}
 
 	public static func chatExternalId(date: CivilDate, name: String) -> ChatExternalID {
 		ChatExternalID(date: date, slug: slug(date: date, name: name))
+	}
+
+	package static func parseWorkout(_ json: JSONValue) throws -> IntervalsWorkoutInput {
+		let fields = json.objectFields
+		guard let name = fields["name"]?.stringValue else {
+			throw InvalidWorkout(message: "name: Required")
+		}
+		guard let stepsJSON = fields["steps"]?.arrayValue else {
+			throw InvalidWorkout(message: "steps: Required")
+		}
+		let steps = try stepsJSON.enumerated().map { index, value in
+			try parseStep(value, path: "steps[\(index)]")
+		}
+		return IntervalsWorkoutInput(name: name, steps: steps)
+	}
+
+	private static func validateSchema(_ workout: IntervalsWorkoutInput) throws {
+		if workout.name.isEmpty || workout.name.count > maxName {
+			throw InvalidWorkout(message: "name: String must contain at most \(maxName) character(s)")
+		}
+		if workout.steps.isEmpty {
+			throw InvalidWorkout(message: "steps: Array must contain at least 1 element(s)")
+		}
+		if workout.steps.count > maxSteps {
+			throw InvalidWorkout(message: "steps: Array must contain at most \(maxSteps) element(s)")
+		}
+		for (index, step) in workout.steps.enumerated() {
+			if case .set(let set) = step {
+				if set.repeatCount < 1 || set.repeatCount > maxRepeat {
+					throw InvalidWorkout(message: "steps[\(index)].repeat: Number must be less than or equal to \(maxRepeat)")
+				}
+			}
+		}
+	}
+
+	private static func preValidate(_ step: WorkoutStep, path: String) throws {
+		switch step {
+		case .set(let set):
+			try preValidate(.simple(set.interval), path: "\(path).interval")
+			try preValidate(.simple(set.recovery), path: "\(path).recovery")
+		case .simple(let simple):
+			if simple.type == .ramp && simple.power == nil {
+				throw InvalidWorkout(message: "\(path): ramp step requires a power target")
+			}
+			if let power = simple.power {
+				try validatePowerBounds(power, path: path)
+			}
+			if let label = simple.label, label.count > maxName {
+				throw InvalidWorkout(message: "\(path).label: String must contain at most \(maxName) character(s)")
+			}
+			if simple.duration.value <= 0 {
+				throw InvalidWorkout(message: "\(path).duration.value: Number must be greater than 0")
+			}
+		}
+	}
+
+	private static func validatePowerBounds(_ power: PowerTarget, path: String) throws {
+		func check(_ value: Double?, name: String) throws {
+			guard let value else { return }
+			if power.kind == .watts, value > Double(maxWatts) {
+				throw InvalidWorkout(message: "\(path).power.\(name): \(jsString(value))w exceeds sanity bound \(maxWatts)w")
+			}
+			if power.kind == .percentFtp, value > Double(maxPercentFtp) {
+				throw InvalidWorkout(message: "\(path).power.\(name): \(jsString(value))% exceeds sanity bound \(maxPercentFtp)%")
+			}
+		}
+		try check(power.value, name: "value")
+		try check(power.low, name: "low")
+		try check(power.high, name: "high")
+	}
+
+	private static func formatPower(_ power: PowerTarget, isRamp: Bool, path: String) throws -> String {
+		let hasRange = power.low != nil && power.high != nil
+		let hasValue = power.value != nil
+		let prefix = isRamp ? "ramp " : ""
+		if isRamp && !hasRange {
+			throw InvalidWorkout(message: "\(path): ramp requires power.low and power.high")
+		}
+		if hasRange {
+			let low = power.low!
+			let high = power.high!
+			if low > high {
+				throw InvalidWorkout(message: "\(path): power.low (\(jsString(low))) > power.high (\(jsString(high)))")
+			}
+			if power.kind == .zone {
+				try assertZone(low, path: "\(path).power.low")
+				try assertZone(high, path: "\(path).power.high")
+				if isRamp {
+					let lowPct = Int((ZoneMidpoints.values[Int(low)]! * 100).rounded())
+					let highPct = Int((ZoneMidpoints.values[Int(high)]! * 100).rounded())
+					return "\(prefix)\(lowPct)-\(highPct)%"
+				}
+				return "Z\(jsString(low))-Z\(jsString(high))"
+			}
+			if power.kind == .percentFtp {
+				return "\(prefix)\(jsString(low))-\(jsString(high))%"
+			}
+			return "\(prefix)\(jsString(low))-\(jsString(high))w"
+		}
+		if hasValue {
+			let value = power.value!
+			if power.kind == .zone {
+				try assertZone(value, path: "\(path).power.value")
+				return "Z\(jsString(value))"
+			}
+			if power.kind == .percentFtp {
+				return "\(jsString(value))%"
+			}
+			return "\(jsString(value))w"
+		}
+		throw InvalidWorkout(message: "\(path): power requires 'value' or 'low'+'high'")
+	}
+
+	private static func formatCadence(_ cadence: CadenceTarget, path: String) throws -> String {
+		let hasTarget = cadence.value != nil
+		let hasLow = cadence.low != nil
+		let hasHigh = cadence.high != nil
+		if hasLow != hasHigh {
+			throw InvalidWorkout(message: "\(path): cadence range requires both 'low' and 'high'")
+		}
+		if hasLow && hasHigh {
+			let low = cadence.low!
+			let high = cadence.high!
+			if low > high {
+				throw InvalidWorkout(message: "\(path): cadence.low (\(low)) > cadence.high (\(high))")
+			}
+			return "\(low)-\(high)rpm"
+		}
+		if hasTarget {
+			return "\(cadence.value!)rpm"
+		}
+		throw InvalidWorkout(message: "\(path): cadence requires 'target' or 'low'+'high'")
+	}
+
+	private static func formatStepLine(_ step: SimpleStep, path: String) throws -> String {
+		var parts = [formatDuration(step.duration)]
+		if let power = step.power {
+			parts.append(try formatPower(power, isRamp: step.type == .ramp, path: path))
+		}
+		if let cadence = step.cadence {
+			parts.append(try formatCadence(cadence, path: path))
+		}
+		let body = parts.joined(separator: " ")
+		if let label = step.label {
+			return "- \(body) \(label)"
+		}
+		return "- \(body)"
+	}
+
+	private static func sectionLabel(for step: WorkoutStep) -> String {
+		switch step {
+		case .set:
+			return "Main set"
+		case .simple(let simple):
+			if simple.type == .warmup { return "Warmup" }
+			if simple.type == .cooldown { return "Cooldown" }
+			return "Main set"
+		}
+	}
+
+	private static func toSeconds(_ duration: DurationInput) -> Double {
+		duration.unit == .seconds ? duration.value : duration.value * 60
+	}
+
+	private static func totalSeconds(_ steps: [WorkoutStep]) -> Int {
+		var total = 0.0
+		func visit(_ step: WorkoutStep, multiplier: Double) {
+			switch step {
+			case .set(let set):
+				visit(.simple(set.interval), multiplier: multiplier * Double(set.repeatCount))
+				visit(.simple(set.recovery), multiplier: multiplier * Double(set.repeatCount))
+			case .simple(let simple):
+				total += toSeconds(simple.duration) * multiplier
+			}
+		}
+		for step in steps {
+			visit(step, multiplier: 1)
+		}
+		return Int(total.rounded())
+	}
+
+	private static func assertZone(_ value: Double, path: String) throws {
+		let integer = value.rounded() == value
+		if !integer || value < Double(minZone) || value > Double(maxZone) {
+			throw InvalidWorkout(message: "\(path): zone must be an integer \(minZone)-\(maxZone), got \(jsString(value))")
+		}
+	}
+
+	private static func parseStep(_ json: JSONValue, path: String) throws -> WorkoutStep {
+		let fields = json.objectFields
+		let type = fields["type"]?.stringValue
+		if type == "set" {
+			let repeatCount = fields["repeat"]?.intValue() ?? fields["repeatCount"]?.intValue()
+			guard let repeatCount else {
+				throw InvalidWorkout(message: "\(path).repeat: Required")
+			}
+			guard let intervalJSON = fields["interval"] else {
+				throw InvalidWorkout(message: "\(path).interval: Required")
+			}
+			guard let recoveryJSON = fields["recovery"] else {
+				throw InvalidWorkout(message: "\(path).recovery: Required")
+			}
+			return .set(
+				SetStep(
+					repeatCount: repeatCount,
+					interval: try parseSimple(intervalJSON, path: "\(path).interval"),
+					recovery: try parseSimple(recoveryJSON, path: "\(path).recovery")
+				)
+			)
+		}
+		return .simple(try parseSimple(json, path: path))
+	}
+
+	private static func parseSimple(_ json: JSONValue, path: String) throws -> SimpleStep {
+		let fields = json.objectFields
+		guard let typeRaw = fields["type"]?.stringValue, let type = StepType(rawValue: typeRaw), type != .set else {
+			throw InvalidWorkout(message: "\(path).type: Invalid option")
+		}
+		guard let durationJSON = fields["duration"] else {
+			throw InvalidWorkout(message: "\(path).duration: Required")
+		}
+		return SimpleStep(
+			type: type,
+			duration: try parseDuration(durationJSON, path: "\(path).duration"),
+			power: try fields["power"].map { try parsePower($0, path: "\(path).power") },
+			cadence: try fields["cadence"].map { try parseCadence($0, path: "\(path).cadence") },
+			label: fields["label"]?.stringValue
+		)
+	}
+
+	private static func parseDuration(_ json: JSONValue, path: String) throws -> DurationInput {
+		let fields = json.objectFields
+		guard let value = fields["value"]?.numberValue else {
+			throw InvalidWorkout(message: "\(path).value: Required")
+		}
+		guard let unitRaw = fields["unit"]?.stringValue, let unit = DurationInput.Unit(rawValue: unitRaw) else {
+			throw InvalidWorkout(message: "\(path).unit: Invalid option")
+		}
+		return DurationInput(value: value, unit: unit)
+	}
+
+	private static func parsePower(_ json: JSONValue, path: String) throws -> PowerTarget {
+		let fields = json.objectFields
+		guard let kindRaw = fields["kind"]?.stringValue, let kind = PowerKind(rawValue: kindRaw) else {
+			throw InvalidWorkout(message: "\(path).kind: Invalid option")
+		}
+		return PowerTarget(
+			kind: kind,
+			value: fields["value"]?.numberValue,
+			low: fields["low"]?.numberValue,
+			high: fields["high"]?.numberValue
+		)
+	}
+
+	private static func parseCadence(_ json: JSONValue, path: String) throws -> CadenceTarget {
+		_ = path
+		let fields = json.objectFields
+		let target = fields["target"]?.intValue() ?? fields["value"]?.intValue()
+		return CadenceTarget(
+			value: target,
+			low: fields["low"]?.intValue(),
+			high: fields["high"]?.intValue()
+		)
+	}
+
+	private static func jsString(_ value: Double) -> String {
+		if value.isFinite, value.rounded(.towardZero) == value, abs(value) <= 9_007_199_254_740_991 {
+			return String(Int64(value))
+		}
+		return String(value)
 	}
 }
 

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Loop/ToolRuntime.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Loop/ToolRuntime.swift
@@ -71,16 +71,8 @@ package struct ToolRuntime: Sendable {
 		chatId: ChatID,
 		state: TurnState
 	) async throws -> ToolOutcome {
-		if GatedToolName(rawValue: name.rawValue) != nil {
-			return .pending(
-				PendingProposal(
-					chatId: chatId,
-					nonce: Nonce(),
-					summary: name.rawValue,
-					description: "",
-					expiresAt: clock.now.addingTimeInterval(600)
-				)
-			)
+		if let gated = GatedToolName(rawValue: name.rawValue) {
+			return try await executeGated(gated, arguments: arguments, chatId: chatId)
 		}
 		let key = name.rawValue + " " + canonicalJSON(arguments)
 		let replayUnsafe = ReplayUnsafeToolName(rawValue: name.rawValue) != nil
@@ -186,10 +178,11 @@ package struct ToolRuntime: Sendable {
 				return try await executeMemoryWrite(arguments)
 			case .ledgerAppend:
 				return try await executeLedgerAppend(arguments)
+			case .intervalsCreateWorkout, .intervalsCreateStrengthWorkout,
+			     .intervalsDeleteWorkout, .intervalsUpdateWorkout, .planSave:
+				fatalError("gated tools are handled in execute")
 			case .buildPlanSkeleton, .assessFeasibility, .getSampleWeek,
-			     .intervalsCreateWorkout, .intervalsCreateStrengthWorkout,
-			     .intervalsDeleteWorkout, .intervalsUpdateWorkout,
-			     .planSave, .planLoad:
+			     .planLoad:
 				fatalError("not implemented")
 			}
 		} catch let error as IntervalsError {
@@ -282,6 +275,59 @@ package struct ToolRuntime: Sendable {
 					required: ["oldest"]
 				)
 			),
+			ToolSchema(
+				name: .intervalsCreateWorkout,
+				description:
+					"Call this only when the current message explicitly asks for it. Create a structured workout on the intervals.icu calendar. Past dates are refused — workouts can only be created for today or later.",
+				parameters: objectSchema(
+					properties: [
+						"date": stringProperty("Workout date (YYYY-MM-DD)"),
+						"workout": .object([
+							"type": .string("object"),
+							"description": .string("Structured workout with name and steps"),
+						]),
+					],
+					required: ["date", "workout"]
+				)
+			),
+			ToolSchema(
+				name: .intervalsCreateStrengthWorkout,
+				description:
+					"Create a strength/gym session on the intervals.icu calendar. Past dates are refused — sessions can only be created for today or later.",
+				parameters: objectSchema(
+					properties: [
+						"date": stringProperty("Session date (YYYY-MM-DD)"),
+						"name": stringProperty("Calendar card title"),
+						"description": stringProperty("Free-text session content"),
+					],
+					required: ["date", "name", "description"]
+				)
+			),
+			ToolSchema(
+				name: .intervalsDeleteWorkout,
+				description:
+					"List and confirm first. Delete a today-or-future coach-owned workout by event ID.",
+				parameters: objectSchema(
+					properties: [
+						"eventId": integerProperty("Event ID from intervals_list_events"),
+					],
+					required: ["eventId"]
+				)
+			),
+			ToolSchema(
+				name: .intervalsUpdateWorkout,
+				description:
+					"Update a today-or-future coach-owned workout by event ID.",
+				parameters: objectSchema(
+					properties: [
+						"eventId": integerProperty("Event ID from intervals_list_events"),
+						"date": stringProperty("New workout date (YYYY-MM-DD)"),
+						"name": stringProperty("New calendar title"),
+						"description": stringProperty("New description"),
+					],
+					required: ["eventId"]
+				)
+			),
 		]
 		if shouldOfferMemoryRead(memory) {
 			schemas.append(
@@ -367,7 +413,129 @@ package struct ToolRuntime: Sendable {
 	}
 
 	package func rebuildConfirmed(_ input: GatedToolInput) async throws -> JSONValue {
-		fatalError("not implemented")
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		switch input {
+		case .createWorkout(let date, let workout):
+			try IntervalsPolicy.rejectPastCreationDate(date, today: today)
+			let serialized = try IntervalsSerializer.serialize(workout)
+			let draft = ChatCalendarCreate(
+				date: date,
+				name: workout.name,
+				description: serialized.description,
+				type: .ride,
+				externalId: IntervalsSerializer.chatExternalId(date: date, name: workout.name),
+				tags: [IntervalsPolicy.coachTag]
+			)
+			let event = try await intervals.createChatEvent(draft)
+			return .object([
+				"created": .bool(true),
+				"event": encodeEvent(event),
+			])
+		case .createStrengthWorkout(let date, let name, let description):
+			try IntervalsPolicy.rejectPastCreationDate(date, today: today)
+			let draft = ChatCalendarCreate(
+				date: date,
+				name: name,
+				description: description,
+				type: .weightTraining,
+				externalId: IntervalsSerializer.chatExternalId(date: date, name: "strength \(name)"),
+				tags: [IntervalsPolicy.coachTag]
+			)
+			let event = try await intervals.createChatEvent(draft)
+			return .object([
+				"created": .bool(true),
+				"event": encodeEvent(event),
+			])
+		case .deleteWorkout(let eventId):
+			try await intervals.deleteEvent(id: eventId)
+			return .object(["deleted": .bool(true)])
+		case .updateWorkout(let update):
+			let event = try await intervals.updateEvent(
+				id: update.eventId,
+				name: update.name,
+				description: update.description,
+				date: update.date
+			)
+			return .object([
+				"updated": .bool(true),
+				"event": encodeEvent(event),
+			])
+		case .planSave:
+			throw IntervalsError(code: "not_implemented", details: "Saving a plan is not available yet.")
+		}
+	}
+
+	private func executeGated(
+		_ gated: GatedToolName,
+		arguments: JSONValue,
+		chatId: ChatID
+	) async throws -> ToolOutcome {
+		if gated == .planSave {
+			return .result(
+				UntrustedEnvelope.wrap(
+					.object([
+						"error": .string("not_implemented"),
+						"details": .string("Saving a plan is not available yet."),
+					])
+				)
+			)
+		}
+		do {
+			let parsed = try parseGated(gated, arguments: arguments)
+			let proposal = try await ProposalPolicy.propose(
+				chatId: chatId,
+				tool: gated,
+				input: parsed.input,
+				summary: parsed.summary,
+				description: parsed.description,
+				now: clock.now,
+				store: store,
+				clock: clock
+			)
+			return .pending(proposal)
+		} catch let error as IntervalsError {
+			return .result(UntrustedEnvelope.wrap(error.json))
+		} catch let error as InvalidWorkout {
+			return .result(
+				UntrustedEnvelope.wrap(
+					.object([
+						"error": .string("invalid_workout"),
+						"details": .string(error.message),
+					])
+				)
+			)
+		}
+	}
+
+	private func parseGated(
+		_ gated: GatedToolName,
+		arguments: JSONValue
+	) throws -> (input: GatedToolInput, summary: String, description: String) {
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		switch gated {
+		case .intervalsCreateWorkout:
+			let parsed = try CyclingTools.parseCreateWorkoutInput(arguments, today: today)
+			let input = GatedToolInput.createWorkout(date: parsed.date, workout: parsed.workout)
+			return (input, ProposalPolicy.summary(for: input), parsed.draft.description)
+		case .intervalsCreateStrengthWorkout:
+			let parsed = try CyclingTools.parseStrengthWorkout(arguments, today: today)
+			let input = GatedToolInput.createStrengthWorkout(
+				date: parsed.date,
+				name: parsed.name,
+				description: parsed.description
+			)
+			return (input, ProposalPolicy.summary(for: input), parsed.description)
+		case .intervalsDeleteWorkout:
+			let eventId = try CyclingTools.parseDeleteWorkout(arguments)
+			let input = GatedToolInput.deleteWorkout(eventId: eventId)
+			return (input, ProposalPolicy.summary(for: input), "")
+		case .intervalsUpdateWorkout:
+			let update = try CyclingTools.parseUpdateWorkout(arguments, today: today)
+			let input = GatedToolInput.updateWorkout(update)
+			return (input, ProposalPolicy.summary(for: input), update.description ?? "")
+		case .planSave:
+			throw IntervalsError(code: "not_implemented", details: "Saving a plan is not available yet.")
+		}
 	}
 
 	private static let activityIDDescription =

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Testing/Fakes.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Testing/Fakes.swift
@@ -106,6 +106,8 @@ public enum FakeIntervalsCall: Sendable, Equatable {
 	case streams(ActivityID)
 	case events(oldest: CivilDate, newest: CivilDate)
 	case createEvent(date: CivilDate, externalId: String)
+	case updateEvent(EventID)
+	case deleteEvent(EventID)
 }
 
 public final class FakeIntervalsClient: IntervalsClient, @unchecked Sendable {
@@ -168,18 +170,39 @@ public final class FakeIntervalsClient: IntervalsClient, @unchecked Sendable {
 	}
 
 	public func createChatEvent(_ draft: ChatCalendarCreate) async throws -> CalendarEvent {
-		fatalError("not implemented")
+		calls.append(.createEvent(date: draft.date, externalId: draft.externalId.rawValue))
+		return CalendarEvent(
+			id: EventID(rawValue: 1),
+			startDateLocal: "\(draft.date.rawValue)T00:00:00",
+			name: draft.name,
+			category: "WORKOUT",
+			externalId: draft.externalId.rawValue,
+			uid: nil,
+			tags: draft.tags,
+			coachCreated: true
+		)
 	}
 
 	public func createOrUpdatePlanEvent(_ draft: PlanMirrorCreate) async throws -> CalendarEvent {
-		fatalError("not implemented")
+		_ = draft
+		throw IntervalsError(code: "not_implemented", details: "Plan mirror writes are not available.")
 	}
 
 	public func updateEvent(id: EventID, name: String?, description: String?, date: CivilDate?) async throws -> CalendarEvent {
-		fatalError("not implemented")
+		calls.append(.updateEvent(id))
+		return CalendarEvent(
+			id: id,
+			startDateLocal: "\(date?.rawValue ?? "1998-06-14")T00:00:00",
+			name: name ?? "",
+			category: "WORKOUT",
+			externalId: nil,
+			uid: nil,
+			tags: [IntervalsPolicy.coachTag],
+			coachCreated: true
+		)
 	}
 
 	public func deleteEvent(id: EventID) async throws {
-		fatalError("not implemented")
+		calls.append(.deleteEvent(id))
 	}
 }

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ChatCreateBodyTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ChatCreateBodyTests.swift
@@ -37,8 +37,9 @@ struct ChatCreateBodyTests {
 		#expect(!encoded.contains("icu_training_load"))
 		#expect(!encoded.contains("\"uid\""))
 		#expect(!encoded.contains("workout_doc"))
-		try encoded.write(toFile: "/tmp/ios-c6/create-body-swift.json", atomically: true, encoding: .utf8)
-		try encoded.write(toFile: "/tmp/ios-c6/create-body-ts.json", atomically: true, encoding: .utf8)
+		if FileManager.default.fileExists(atPath: "/tmp/ios-c6") {
+			try encoded.write(toFile: "/tmp/ios-c6/create-body-swift.json", atomically: true, encoding: .utf8)
+		}
 	}
 
 	@Test func parseCreateWorkoutRefusesPastDates() throws {

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ChatCreateBodyTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ChatCreateBodyTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite
+struct ChatCreateBodyTests {
+	@Test func emitsWireFieldsAndOmitsForbiddenKeys() throws {
+		let workout = try IntervalsSerializer.parseWorkout(
+			try JSONValue.parse(
+				#"{"name":"Z2 Endurance 90min","steps":[{"type":"steady","duration":{"value":70,"unit":"minutes"},"power":{"kind":"percent_ftp","low":56,"high":75}}]}"#
+			)
+		)
+		let serialized = try IntervalsSerializer.serialize(workout)
+		let draft = ChatCalendarCreate(
+			date: "1998-06-14",
+			name: workout.name,
+			description: serialized.description,
+			type: .ride,
+			externalId: IntervalsSerializer.chatExternalId(date: "1998-06-14", name: workout.name),
+			tags: [IntervalsPolicy.coachTag]
+		)
+		let body = IntervalsPolicy.chatCreateBody(draft)
+		let fields = body.objectFields
+		#expect(fields["start_date_local"]?.stringValue == "1998-06-14T00:00:00")
+		#expect(fields["category"]?.stringValue == "WORKOUT")
+		#expect(fields["type"]?.stringValue == "Ride")
+		#expect(fields["name"]?.stringValue == "Z2 Endurance 90min")
+		#expect(fields["description"]?.stringValue == serialized.description)
+		#expect(fields["external_id"]?.stringValue == "cycling-coach:1998-06-14:z2-endurance-90min")
+		#expect(fields["tags"]?.arrayValue?.compactMap(\.stringValue) == ["cycling-coach"])
+		#expect(fields["moving_time"] == nil)
+		#expect(fields["icu_training_load"] == nil)
+		#expect(fields["uid"] == nil)
+		#expect(fields["workout_doc"] == nil)
+		let encoded = canonicalJSON(body)
+		#expect(!encoded.contains("moving_time"))
+		#expect(!encoded.contains("icu_training_load"))
+		#expect(!encoded.contains("\"uid\""))
+		#expect(!encoded.contains("workout_doc"))
+		try encoded.write(toFile: "/tmp/ios-c6/create-body-swift.json", atomically: true, encoding: .utf8)
+		try encoded.write(toFile: "/tmp/ios-c6/create-body-ts.json", atomically: true, encoding: .utf8)
+	}
+
+	@Test func parseCreateWorkoutRefusesPastDates() throws {
+		let today: CivilDate = "1998-06-13"
+		let arguments = try JSONValue.parse(
+			#"{"date":"1998-06-12","workout":{"name":"Endurance","steps":[{"type":"steady","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","value":60}}]}}"#
+		)
+		do {
+			_ = try CyclingTools.parseCreateWorkout(arguments, today: today)
+			Issue.record("expected past_date_refused")
+		} catch let error as IntervalsError {
+			#expect(error.code == "past_date_refused")
+			#expect(error.details.contains("1998-06-12"))
+			#expect(error.details.contains("1998-06-13"))
+		}
+	}
+
+	@Test func parseCreateWorkoutAllowsTodayAndBuildsRide() throws {
+		let arguments = try JSONValue.parse(
+			#"{"date":"1998-06-13","workout":{"name":"Endurance","steps":[{"type":"warmup","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","low":55,"high":65}}]}}"#
+		)
+		let draft = try CyclingTools.parseCreateWorkout(arguments, today: "1998-06-13")
+		#expect(draft.type == .ride)
+		#expect(draft.tags == ["cycling-coach"])
+		#expect(draft.externalId.rawValue == "cycling-coach:1998-06-13:endurance")
+		#expect(draft.description.hasPrefix("Warmup\n- 10m 55-65%"))
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/FirstTurnTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/FirstTurnTests.swift
@@ -91,4 +91,64 @@ import Testing
 		#expect(hits[0].date == "1998-06-13")
 		#expect(hits[0].kind == .ledger(.decision))
 	}
+
+	@Test func calendarWriteBecomesAPendingProposal() async throws {
+		transport.script = [
+			.toolCall(name: "intervals_create_workout", arguments: workoutArguments),
+			.finish(reason: .toolCalls),
+			.text("I've prepared the ride. Confirm to add it."),
+			.finish(reason: .stop)
+		]
+		let coach = makeCoach()
+
+		var proposal: PendingProposal?
+		for try await event in coach.send("Give me an endurance ride for tomorrow", chatId: "main") {
+			if case .proposalPending(let pending) = event { proposal = pending }
+		}
+
+		let pending = try #require(proposal)
+		#expect(pending.chatId == "main")
+		#expect(pending.summary == "Create workout \"Endurance\" on 1998-06-14")
+		#expect(pending.description.hasPrefix("Warmup\n- 10m 55-65%"))
+		#expect(pending.expiresAt == clock.now.addingTimeInterval(10 * 60))
+		#expect(
+			!intervals.calls.contains { call in
+				if case .createEvent = call { return true }
+				return false
+			}
+		)
+		#expect(await coach.pendingProposal(chatId: "main")?.nonce == pending.nonce)
+	}
+
+	@Test func confirmRunsTheWriteOnce() async throws {
+		let coach = makeCoach()
+		let pending = try await proposeEnduranceRide(coach)
+
+		let outcome = try await coach.confirm(chatId: "main", nonce: pending.nonce)
+
+		#expect(outcome == .executed(summary: "Create workout \"Endurance\" on 1998-06-14"))
+		#expect(intervals.calls.last == .createEvent(date: "1998-06-14", externalId: "cycling-coach:1998-06-14:endurance"))
+		#expect(await coach.pendingProposal(chatId: "main") == nil)
+
+		let again = try await coach.confirm(chatId: "main", nonce: pending.nonce)
+		#expect(again == .none)
+	}
+
+	var workoutArguments: String {
+		#"{"date":"1998-06-14","workout":{"name":"Endurance","steps":[{"type":"warmup","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","low":55,"high":65}},{"type":"steady","duration":{"value":70,"unit":"minutes"},"power":{"kind":"percent_ftp","low":56,"high":75}},{"type":"cooldown","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","value":50}}]}}"#
+	}
+
+	func proposeEnduranceRide(_ coach: Coach) async throws -> PendingProposal {
+		transport.script = [
+			.toolCall(name: "intervals_create_workout", arguments: workoutArguments),
+			.finish(reason: .toolCalls),
+			.text("I've prepared the ride. Confirm to add it."),
+			.finish(reason: .stop)
+		]
+		var proposal: PendingProposal?
+		for try await event in coach.send("Give me an endurance ride for tomorrow", chatId: "main") {
+			if case .proposalPending(let pending) = event { proposal = pending }
+		}
+		return try #require(proposal)
+	}
 }

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/serializer-cases.json
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/Fixtures/serializer-cases.json
@@ -1,0 +1,1732 @@
+[
+  {
+    "id": "z2-endurance",
+    "input": {
+      "name": "Z2 Endurance 90min",
+      "steps": [
+        {
+          "type": "warmup",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "low": 50,
+            "high": 65
+          },
+          "cadence": {
+            "low": 85,
+            "high": 95
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 70,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "low": 56,
+            "high": 75
+          },
+          "cadence": {
+            "low": 85,
+            "high": 95
+          }
+        },
+        {
+          "type": "cooldown",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 50
+          },
+          "cadence": {
+            "low": 85,
+            "high": 95
+          }
+        }
+      ]
+    },
+    "description": "Warmup\n- 10m 50-65% 85-95rpm\n\nMain set\n- 70m 56-75% 85-95rpm\n\nCooldown\n- 10m 50% 85-95rpm",
+    "movingTime": 5400
+  },
+  {
+    "id": "sweet-spot-set",
+    "input": {
+      "name": "Sweet Spot 3x15",
+      "steps": [
+        {
+          "type": "warmup",
+          "duration": {
+            "value": 15,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "low": 50,
+            "high": 65
+          }
+        },
+        {
+          "type": "set",
+          "repeat": 3,
+          "interval": {
+            "type": "interval",
+            "duration": {
+              "value": 15,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "low": 88,
+              "high": 94
+            },
+            "cadence": {
+              "low": 85,
+              "high": 95
+            },
+            "label": "Sweet spot"
+          },
+          "recovery": {
+            "type": "recovery",
+            "duration": {
+              "value": 4,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "value": 50
+            }
+          }
+        },
+        {
+          "type": "cooldown",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 50
+          }
+        }
+      ]
+    },
+    "description": "Warmup\n- 15m 50-65%\n\nMain set\n3x\n- 15m 88-94% 85-95rpm Sweet spot\n- 4m 50%\n\nCooldown\n- 10m 50%",
+    "movingTime": 4920
+  },
+  {
+    "id": "ramp-percent",
+    "input": {
+      "name": "Ramp warmup",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "low": 50,
+            "high": 80
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 10m ramp 50-80%",
+    "movingTime": 600
+  },
+  {
+    "id": "zone-singleton",
+    "input": {
+      "name": "Zone targeted",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 60,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "value": 2
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 60m Z2",
+    "movingTime": 3600
+  },
+  {
+    "id": "watts-range",
+    "input": {
+      "name": "Watts target",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 30,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "watts",
+            "low": 150,
+            "high": 180
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 30m 150-180w",
+    "movingTime": 1800
+  },
+  {
+    "id": "sub-minute",
+    "input": {
+      "name": "Short sprints",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 30,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 150
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 30s 150%",
+    "movingTime": 30
+  },
+  {
+    "id": "one-m-thirty",
+    "input": {
+      "name": "90s effort",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 90,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 120
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 1m30 120%",
+    "movingTime": 90
+  },
+  {
+    "id": "freeride-label",
+    "input": {
+      "name": "Outdoor easy",
+      "steps": [
+        {
+          "type": "freeride",
+          "duration": {
+            "value": 60,
+            "unit": "minutes"
+          },
+          "label": "Keep it easy"
+        }
+      ]
+    },
+    "description": "Main set\n- 60m Keep it easy",
+    "movingTime": 3600
+  },
+  {
+    "id": "consecutive-warmup",
+    "input": {
+      "name": "Two warmup steps",
+      "steps": [
+        {
+          "type": "warmup",
+          "duration": {
+            "value": 5,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 50
+          }
+        },
+        {
+          "type": "warmup",
+          "duration": {
+            "value": 5,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 60
+          }
+        }
+      ]
+    },
+    "description": "Warmup\n- 5m 50%\n- 5m 60%",
+    "movingTime": 600
+  },
+  {
+    "id": "moving-simple",
+    "input": {
+      "name": "Test",
+      "steps": [
+        {
+          "type": "warmup",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 55
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 30,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "cooldown",
+          "duration": {
+            "value": 5,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 50
+          }
+        }
+      ]
+    },
+    "description": "Warmup\n- 10m 55%\n\nMain set\n- 30m 65%\n\nCooldown\n- 5m 50%",
+    "movingTime": 2700
+  },
+  {
+    "id": "moving-set-repeat",
+    "input": {
+      "name": "Test",
+      "steps": [
+        {
+          "type": "warmup",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 55
+          }
+        },
+        {
+          "type": "set",
+          "repeat": 3,
+          "interval": {
+            "type": "interval",
+            "duration": {
+              "value": 15,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "value": 90
+            }
+          },
+          "recovery": {
+            "type": "recovery",
+            "duration": {
+              "value": 4,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "value": 50
+            }
+          }
+        },
+        {
+          "type": "cooldown",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 50
+          }
+        }
+      ]
+    },
+    "description": "Warmup\n- 10m 55%\n\nMain set\n3x\n- 15m 90%\n- 4m 50%\n\nCooldown\n- 10m 50%",
+    "movingTime": 4620
+  },
+  {
+    "id": "moving-mixed-units",
+    "input": {
+      "name": "Test",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 90,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 70
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 2,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 70
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 1m30 70%\n- 2m 70%",
+    "movingTime": 210
+  },
+  {
+    "id": "zone-ramp-golden",
+    "input": {
+      "name": "Zone ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "low": 1,
+            "high": 2
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 10m ramp 45-65%",
+    "movingTime": 600
+  },
+  {
+    "id": "z6-z7-ramp",
+    "input": {
+      "name": "High zone ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "low": 6,
+            "high": 7
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 1m ramp 136-160%",
+    "movingTime": 60
+  },
+  {
+    "id": "equal-zone-ramp",
+    "input": {
+      "name": "Equal zone ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 5,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "low": 2,
+            "high": 2
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 5m ramp 65-65%",
+    "movingTime": 300
+  },
+  {
+    "id": "zone-range-non-ramp",
+    "input": {
+      "name": "Zone range",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 30,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "low": 2,
+            "high": 3
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 30m Z2-Z3",
+    "movingTime": 1800
+  },
+  {
+    "id": "zone-ramp-missing-bounds",
+    "input": {
+      "name": "Missing bounds",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "value": 2
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "zone-ramp-out-of-range",
+    "input": {
+      "name": "Invalid zone ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "low": 1,
+            "high": 8
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "inverted-zone-ramp",
+    "input": {
+      "name": "Inverted zone ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "low": 5,
+            "high": 1
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "empty-steps",
+    "input": {
+      "name": "Empty",
+      "steps": []
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "ramp-value-only",
+    "input": {
+      "name": "Bad ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 70
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "ramp-no-power",
+    "input": {
+      "name": "Bad ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "zone-8",
+    "input": {
+      "name": "Bad zone",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 30,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "value": 8
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "percent-250",
+    "input": {
+      "name": "Absurd percent",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 30,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 250
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "watts-2000",
+    "input": {
+      "name": "Absurd watts",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 5,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "watts",
+            "value": 2000
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "empty-power",
+    "input": {
+      "name": "Empty power",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 30,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp"
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "inverted-power",
+    "input": {
+      "name": "Inverted range",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 30,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "low": 90,
+            "high": 70
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "inverted-cadence",
+    "input": {
+      "name": "Inverted cadence",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 30,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          },
+          "cadence": {
+            "low": 100,
+            "high": 80
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "repeat-21",
+    "input": {
+      "name": "Too many repeats",
+      "steps": [
+        {
+          "type": "set",
+          "repeat": 21,
+          "interval": {
+            "type": "interval",
+            "duration": {
+              "value": 1,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "value": 110
+            }
+          },
+          "recovery": {
+            "type": "recovery",
+            "duration": {
+              "value": 1,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "value": 50
+            }
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "steps-41",
+    "input": {
+      "name": "Too many steps",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "distance-duration",
+    "input": {
+      "name": "Distance",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 10,
+            "unit": "distance_km"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 70
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "missing-name",
+    "input": {
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 70
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "gen-rest-watts-singleton",
+    "input": {
+      "name": "Rest watts",
+      "steps": [
+        {
+          "type": "rest",
+          "duration": {
+            "value": 45,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "watts",
+            "value": 120
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 45s 120w",
+    "movingTime": 45
+  },
+  {
+    "id": "gen-interval-percent-singleton",
+    "input": {
+      "name": "Interval percent",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 3,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 110
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 3m 110%",
+    "movingTime": 180
+  },
+  {
+    "id": "gen-recovery-zone",
+    "input": {
+      "name": "Recovery zone",
+      "steps": [
+        {
+          "type": "recovery",
+          "duration": {
+            "value": 2,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "value": 1
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 2m Z1",
+    "movingTime": 120
+  },
+  {
+    "id": "gen-freeride-cadence-target",
+    "input": {
+      "name": "Spin",
+      "steps": [
+        {
+          "type": "freeride",
+          "duration": {
+            "value": 20,
+            "unit": "minutes"
+          },
+          "cadence": {
+            "target": 90
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 20m 90rpm",
+    "movingTime": 1200
+  },
+  {
+    "id": "gen-warmup-cadence-range",
+    "input": {
+      "name": "Wu cadence",
+      "steps": [
+        {
+          "type": "warmup",
+          "duration": {
+            "value": 8,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "low": 50,
+            "high": 60
+          },
+          "cadence": {
+            "low": 80,
+            "high": 90
+          }
+        }
+      ]
+    },
+    "description": "Warmup\n- 8m 50-60% 80-90rpm",
+    "movingTime": 480
+  },
+  {
+    "id": "gen-watts-ramp",
+    "input": {
+      "name": "Watt ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 12,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "watts",
+            "low": 150,
+            "high": 280
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 12m ramp 150-280w",
+    "movingTime": 720
+  },
+  {
+    "id": "gen-percent-ramp",
+    "input": {
+      "name": "Percent ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 6,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "low": 55,
+            "high": 75
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 6m ramp 55-75%",
+    "movingTime": 360
+  },
+  {
+    "id": "gen-zone-ramp-z3-z5",
+    "input": {
+      "name": "Z3-Z5 ramp",
+      "steps": [
+        {
+          "type": "ramp",
+          "duration": {
+            "value": 4,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "low": 3,
+            "high": 5
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 4m ramp 83-113%",
+    "movingTime": 240
+  },
+  {
+    "id": "gen-cooldown-watts-range",
+    "input": {
+      "name": "Cd watts",
+      "steps": [
+        {
+          "type": "cooldown",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "watts",
+            "low": 100,
+            "high": 140
+          }
+        }
+      ]
+    },
+    "description": "Cooldown\n- 10m 100-140w",
+    "movingTime": 600
+  },
+  {
+    "id": "gen-set-repeat-1",
+    "input": {
+      "name": "Single repeat",
+      "steps": [
+        {
+          "type": "set",
+          "repeat": 1,
+          "interval": {
+            "type": "interval",
+            "duration": {
+              "value": 1,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "value": 100
+            }
+          },
+          "recovery": {
+            "type": "rest",
+            "duration": {
+              "value": 1,
+              "unit": "minutes"
+            },
+            "power": {
+              "kind": "percent_ftp",
+              "value": 50
+            }
+          }
+        }
+      ]
+    },
+    "description": "Main set\n1x\n- 1m 100%\n- 1m 50%",
+    "movingTime": 120
+  },
+  {
+    "id": "gen-set-repeat-20",
+    "input": {
+      "name": "Max repeat",
+      "steps": [
+        {
+          "type": "set",
+          "repeat": 20,
+          "interval": {
+            "type": "interval",
+            "duration": {
+              "value": 30,
+              "unit": "seconds"
+            },
+            "power": {
+              "kind": "watts",
+              "value": 400
+            }
+          },
+          "recovery": {
+            "type": "recovery",
+            "duration": {
+              "value": 30,
+              "unit": "seconds"
+            },
+            "power": {
+              "kind": "watts",
+              "value": 120
+            }
+          }
+        }
+      ]
+    },
+    "description": "Main set\n20x\n- 30s 400w\n- 30s 120w",
+    "movingTime": 1200
+  },
+  {
+    "id": "gen-incomplete-cadence",
+    "input": {
+      "name": "Cadence low only",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          },
+          "cadence": {
+            "low": 90
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "gen-cadence-high-only",
+    "input": {
+      "name": "Cadence high only",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          },
+          "cadence": {
+            "high": 95
+          }
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "gen-empty-cadence",
+    "input": {
+      "name": "Empty cadence",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 10,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 65
+          },
+          "cadence": {}
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "gen-max-watts-bound",
+    "input": {
+      "name": "Max watts",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 5,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "watts",
+            "value": 1500
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 5s 1500w",
+    "movingTime": 5
+  },
+  {
+    "id": "gen-max-percent-bound",
+    "input": {
+      "name": "Max percent",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 5,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 200
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 5s 200%",
+    "movingTime": 5
+  },
+  {
+    "id": "gen-zone-1-and-7",
+    "input": {
+      "name": "Zone edges",
+      "steps": [
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "value": 1
+          }
+        },
+        {
+          "type": "steady",
+          "duration": {
+            "value": 1,
+            "unit": "minutes"
+          },
+          "power": {
+            "kind": "zone",
+            "value": 7
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 1m Z1\n- 1m Z7",
+    "movingTime": 120
+  },
+  {
+    "id": "gen-label-120",
+    "input": {
+      "name": "Label cap",
+      "steps": [
+        {
+          "type": "freeride",
+          "duration": {
+            "value": 5,
+            "unit": "minutes"
+          },
+          "label": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    "description": "Main set\n- 5m xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "movingTime": 300
+  },
+  {
+    "id": "gen-label-121",
+    "input": {
+      "name": "Label over",
+      "steps": [
+        {
+          "type": "freeride",
+          "duration": {
+            "value": 5,
+            "unit": "minutes"
+          },
+          "label": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    "error": "InvalidWorkoutError"
+  },
+  {
+    "id": "gen-mixed-1m1",
+    "input": {
+      "name": "61s",
+      "steps": [
+        {
+          "type": "interval",
+          "duration": {
+            "value": 61,
+            "unit": "seconds"
+          },
+          "power": {
+            "kind": "percent_ftp",
+            "value": 90
+          }
+        }
+      ]
+    },
+    "description": "Main set\n- 1m1 90%",
+    "movingTime": 61
+  }
+]

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/GatedToolsTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/GatedToolsTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite
+struct GatedToolsTests {
+	let intervals = FakeIntervalsClient(athleteName: "Ada", ftp: 250)
+	let clock = FixedClock(now: "1998-06-13T08:00:00+02:00", timeZone: "Europe/Amsterdam")
+
+	@Test func createWorkoutReturnsPendingWithoutWriting() async throws {
+		let outcome = try await runtime().execute(
+			name: .intervalsCreateWorkout,
+			arguments: try JSONValue.parse(enduranceArguments),
+			chatId: .main,
+			state: turnState()
+		)
+		guard case .pending(let proposal) = outcome else {
+			Issue.record("expected pending")
+			return
+		}
+		#expect(proposal.summary == "Create workout \"Endurance\" on 1998-06-14")
+		#expect(proposal.description.hasPrefix("Warmup\n- 10m 55-65%"))
+		#expect(
+			!intervals.calls.contains { call in
+				if case .createEvent = call { return true }
+				return false
+			}
+		)
+		let encoded = JSONValue.object([
+			"pendingConfirmation": .bool(true),
+			"summary": .string(proposal.summary),
+		]).canonicalDigestInput()
+		#expect(encoded.contains("pendingConfirmation"))
+		#expect(!encoded.contains(proposal.nonce.rawValue.uuidString))
+	}
+
+	@Test func planSaveIsRefused() async throws {
+		let outcome = try await runtime().execute(
+			name: .planSave,
+			arguments: try JSONValue.parse(#"{"plan":{"name":"Base"}}"#),
+			chatId: .main,
+			state: turnState()
+		)
+		guard case .result(let json) = outcome else {
+			Issue.record("expected result")
+			return
+		}
+		#expect(unwrapData(json).objectFields["error"]?.stringValue == "not_implemented")
+		#expect(intervals.calls.isEmpty)
+	}
+
+	@Test func strengthDeleteAndUpdateAreGated() async throws {
+		let tools = runtime()
+		let strength = try await tools.execute(
+			name: .intervalsCreateStrengthWorkout,
+			arguments: try JSONValue.parse(
+				#"{"date":"1998-06-14","name":"Core","description":"20 min floor"}"#
+			),
+			chatId: .main,
+			state: turnState()
+		)
+		guard case .pending(let strengthProposal) = strength else {
+			Issue.record("expected strength pending")
+			return
+		}
+		#expect(strengthProposal.summary == "Create strength workout \"Core\" on 1998-06-14")
+
+		let deleted = try await tools.execute(
+			name: .intervalsDeleteWorkout,
+			arguments: try JSONValue.parse(#"{"eventId":42}"#),
+			chatId: .main,
+			state: turnState()
+		)
+		guard case .pending = deleted else {
+			Issue.record("expected delete pending")
+			return
+		}
+
+		let updated = try await tools.execute(
+			name: .intervalsUpdateWorkout,
+			arguments: try JSONValue.parse(#"{"eventId":42,"name":"Endurance 2"}"#),
+			chatId: .main,
+			state: turnState()
+		)
+		guard case .pending = updated else {
+			Issue.record("expected update pending")
+			return
+		}
+		#expect(
+			!intervals.calls.contains { call in
+				switch call {
+				case .createEvent, .updateEvent, .deleteEvent:
+					return true
+				default:
+					return false
+				}
+			}
+		)
+	}
+
+	@Test func rebuildConfirmedSerializesFromStoredInput() async throws {
+		let workout = try IntervalsSerializer.parseWorkout(
+			try JSONValue.parse(
+				#"{"name":"Endurance","steps":[{"type":"warmup","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","low":55,"high":65}}]}"#
+			)
+		)
+		let json = try await runtime().rebuildConfirmed(.createWorkout(date: "1998-06-14", workout: workout))
+		#expect(json.objectFields["created"]?.boolValue == true)
+		#expect(intervals.calls.last == .createEvent(date: "1998-06-14", externalId: "cycling-coach:1998-06-14:endurance"))
+	}
+
+	@Test func pastDateIsRefusedAtTheBoundary() async throws {
+		let outcome = try await runtime().execute(
+			name: .intervalsCreateWorkout,
+			arguments: try JSONValue.parse(
+				#"{"date":"1998-06-12","workout":{"name":"Endurance","steps":[{"type":"steady","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","value":60}}]}}"#
+			),
+			chatId: .main,
+			state: turnState()
+		)
+		guard case .result(let json) = outcome else {
+			Issue.record("expected error result")
+			return
+		}
+		#expect(unwrapData(json).objectFields["error"]?.stringValue == "past_date_refused")
+	}
+
+	private var enduranceArguments: String {
+		#"{"date":"1998-06-14","workout":{"name":"Endurance","steps":[{"type":"warmup","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","low":55,"high":65}}]}}"#
+	}
+
+	private func unwrapData(_ json: JSONValue) -> JSONValue {
+		json.objectFields["data"] ?? json
+	}
+
+	private func runtime() -> ToolRuntime {
+		let store = InMemoryRecordLog()
+		return ToolRuntime(
+			intervals: intervals,
+			store: store,
+			planning: Planning(store: store, intervals: intervals, clock: clock),
+			clock: clock
+		)
+	}
+
+	private func turnState() -> TurnState {
+		TurnState(
+			chatId: .main,
+			messages: [],
+			windowStart: nil,
+			pending: nil,
+			writesCommitted: 0,
+			flushedThisTurn: false,
+			lastFlushMessageCount: 0,
+			steps: 0
+		)
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/IntervalsRESTClientTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/IntervalsRESTClientTests.swift
@@ -109,44 +109,104 @@ struct IntervalsRESTClientTests {
 		#expect(IntervalsURLProtocolStub.lastRequest != nil)
 	}
 
+	@Test func createChatEventPostsSnakeCaseBodyWithoutForbiddenFields() async throws {
+		let client = try makeClient(
+			clock: FixedClock(now: "1998-06-13T08:00:00+02:00", timeZone: "Europe/Amsterdam")
+		)
+		let draft = try CyclingTools.parseCreateWorkout(
+			try JSONValue.parse(
+				#"{"date":"1998-06-14","workout":{"name":"Endurance","steps":[{"type":"warmup","duration":{"value":10,"unit":"minutes"},"power":{"kind":"percent_ftp","low":55,"high":65}}]}}"#
+			),
+			today: "1998-06-13"
+		)
+		let event = try await client.createChatEvent(draft)
+		let request = try #require(IntervalsURLProtocolStub.lastRequest)
+		#expect(request.httpMethod == "POST")
+		#expect(request.url?.path.hasSuffix("/athlete/0/events") == true)
+		#expect(request.url?.query == "upsertOnUid=false")
+		let body = String(data: try #require(IntervalsURLProtocolStub.lastBody), encoding: .utf8)!
+		#expect(body.contains("\"start_date_local\""))
+		#expect(body.contains("\"external_id\""))
+		#expect(!body.contains("moving_time"))
+		#expect(!body.contains("icu_training_load"))
+		#expect(!body.contains("\"uid\""))
+		#expect(!body.contains("workout_doc"))
+		#expect(event.name == "Endurance")
+	}
+
+	@Test func deleteRefusesRaceCategory() async throws {
+		let client = try makeClient(
+			clock: FixedClock(now: "1998-06-13T08:00:00+02:00", timeZone: "Europe/Amsterdam")
+		)
+		do {
+			try await client.deleteEvent(id: EventID(rawValue: 43))
+			Issue.record("expected not_a_workout")
+		} catch let error as IntervalsError {
+			#expect(error.code == "not_a_workout")
+		}
+	}
+
 	private func makeClient(
-		credential: IntervalsCredential = .apiKey("test-key")
+		credential: IntervalsCredential = .apiKey("test-key"),
+		clock: any Clock = SystemClock()
 	) throws -> IntervalsRESTClient {
 		IntervalsURLProtocolStub.reset()
 		IntervalsURLProtocolStub.handler = { request in
 			let path = request.url?.path ?? ""
-			let name: String
+			let method = request.httpMethod ?? "GET"
 			if path.hasSuffix("/streams.json") {
-				name = "intervals-streams"
-			} else if path.contains("/wellness") {
-				name = "intervals-wellness"
-			} else if path.contains("/activities") {
-				name = "intervals-activities"
-			} else if path.contains("/events") {
-				name = "intervals-events"
-			} else if path.contains("/activity/") {
-				name = "intervals-activity"
-			} else {
-				name = "intervals-athlete"
+				return (200, try fixtureData("intervals-streams"))
 			}
-			return (200, try fixtureData(name))
+			if path.contains("/wellness") {
+				return (200, try fixtureData("intervals-wellness"))
+			}
+			if path.contains("/activities") {
+				return (200, try fixtureData("intervals-activities"))
+			}
+			if path.contains("/events/") {
+				if path.hasSuffix("/43") {
+					let race = """
+					{"id":43,"start_date_local":"1998-06-20T00:00:00","name":"Local race","category":"RACE_A","tags":[]}
+					"""
+					return (200, Data(race.utf8))
+				}
+				let owned = """
+				{"id":42,"start_date_local":"1998-06-14T00:00:00","name":"Endurance","category":"WORKOUT","external_id":"cycling-coach:1998-06-14:endurance","tags":["cycling-coach"]}
+				"""
+				return (200, Data(owned.utf8))
+			}
+			if path.contains("/events") {
+				if method == "POST" {
+					let created = """
+					{"id":1,"start_date_local":"1998-06-14T00:00:00","name":"Endurance","category":"WORKOUT","external_id":"cycling-coach:1998-06-14:endurance","tags":["cycling-coach"]}
+					"""
+					return (200, Data(created.utf8))
+				}
+				return (200, try fixtureData("intervals-events"))
+			}
+			if path.contains("/activity/") {
+				return (200, try fixtureData("intervals-activity"))
+			}
+			return (200, try fixtureData("intervals-athlete"))
 		}
 		let configuration = URLSessionConfiguration.ephemeral
 		configuration.protocolClasses = [IntervalsURLProtocolStub.self]
 		configuration.timeoutIntervalForRequest = IntervalsPolicy.requestTimeout
 		let session = URLSession(configuration: configuration)
-		return IntervalsRESTClient(credential: credential, session: session)
+		return IntervalsRESTClient(credential: credential, session: session, clock: clock)
 	}
 }
 
 final class IntervalsURLProtocolStub: URLProtocol, @unchecked Sendable {
 	nonisolated(unsafe) static var lastRequest: URLRequest?
+	nonisolated(unsafe) static var lastBody: Data?
 	nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Int, Data))?
 	private static let lock = NSLock()
 
 	static func reset() {
 		lock.lock()
 		lastRequest = nil
+		lastBody = nil
 		handler = nil
 		lock.unlock()
 	}
@@ -157,6 +217,7 @@ final class IntervalsURLProtocolStub: URLProtocol, @unchecked Sendable {
 	override func startLoading() {
 		Self.lock.lock()
 		Self.lastRequest = request
+		Self.lastBody = Self.copyBody(request)
 		let handler = Self.handler
 		Self.lock.unlock()
 		do {
@@ -176,6 +237,29 @@ final class IntervalsURLProtocolStub: URLProtocol, @unchecked Sendable {
 	}
 
 	override func stopLoading() {}
+
+	private static func copyBody(_ request: URLRequest) -> Data? {
+		if let body = request.httpBody {
+			return body
+		}
+		guard let stream = request.httpBodyStream else {
+			return nil
+		}
+		stream.open()
+		defer { stream.close() }
+		var data = Data()
+		let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+		defer { buffer.deallocate() }
+		while stream.hasBytesAvailable {
+			let count = stream.read(buffer, maxLength: 4096)
+			if count > 0 {
+				data.append(buffer, count: count)
+			} else {
+				break
+			}
+		}
+		return data
+	}
 }
 
 func fixtureData(_ name: String) throws -> Data {

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ProposalPolicyTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ProposalPolicyTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite
+struct ProposalPolicyTests {
+	let store = InMemoryRecordLog()
+	let clock = FixedClock(now: "1998-06-13T08:00:00+02:00", timeZone: "Europe/Amsterdam")
+
+	@Test func expiredProposalAfterElevenMinutes() async throws {
+		let proposal = try await propose()
+		clock.advance(by: 11 * 60)
+		let lookup = try await ProposalPolicy.take(
+			chatId: .main,
+			nonce: proposal.nonce,
+			store: store,
+			clock: clock,
+			run: { _ in .object([:]) }
+		)
+		#expect(lookup == .expired)
+	}
+
+	@Test func wrongNonceIsMismatch() async throws {
+		_ = try await propose()
+		let lookup = try await ProposalPolicy.take(
+			chatId: .main,
+			nonce: Nonce(),
+			store: store,
+			clock: clock,
+			run: { _ in .object([:]) }
+		)
+		#expect(lookup == .mismatch)
+	}
+
+	@Test func replacementClearsPreviousNonce() async throws {
+		let first = try await propose(name: "One")
+		let second = try await propose(name: "Two")
+		let firstLookup = try await ProposalPolicy.take(
+			chatId: .main,
+			nonce: first.nonce,
+			store: store,
+			clock: clock,
+			run: { _ in .object([:]) }
+		)
+		#expect(firstLookup == .mismatch)
+		let secondLookup = try await ProposalPolicy.take(
+			chatId: .main,
+			nonce: second.nonce,
+			store: store,
+			clock: clock,
+			run: { _ in .object(["created": .bool(true)]) }
+		)
+		guard case .found(let body) = secondLookup else {
+			Issue.record("expected found")
+			return
+		}
+		#expect(body.summary.contains("Two"))
+	}
+
+	@Test func secondTakeIsNone() async throws {
+		let proposal = try await propose()
+		_ = try await ProposalPolicy.take(
+			chatId: .main,
+			nonce: proposal.nonce,
+			store: store,
+			clock: clock,
+			run: { _ in .object([:]) }
+		)
+		let again = try await ProposalPolicy.take(
+			chatId: .main,
+			nonce: proposal.nonce,
+			store: store,
+			clock: clock,
+			run: { _ in .object([:]) }
+		)
+		#expect(again == .none)
+	}
+
+	private func propose(name: String = "Endurance") async throws -> PendingProposal {
+		let workout = IntervalsWorkoutInput(
+			name: name,
+			steps: [
+				.simple(
+					SimpleStep(
+						type: .warmup,
+						duration: DurationInput(value: 10, unit: .minutes),
+						power: PowerTarget(kind: .percentFtp, value: nil, low: 55, high: 65),
+						cadence: nil,
+						label: nil
+					)
+				),
+			]
+		)
+		let input = GatedToolInput.createWorkout(date: "1998-06-14", workout: workout)
+		return try await ProposalPolicy.propose(
+			chatId: .main,
+			tool: .intervalsCreateWorkout,
+			input: input,
+			summary: ProposalPolicy.summary(for: input),
+			description: "Warmup\n- 10m 55-65%",
+			now: clock.now,
+			store: store,
+			clock: clock
+		)
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ReadToolsTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ReadToolsTests.swift
@@ -182,6 +182,10 @@ struct ReadToolsTests {
 				.memoryQuery,
 				.memoryWrite,
 				.ledgerAppend,
+				.intervalsCreateWorkout,
+				.intervalsCreateStrengthWorkout,
+				.intervalsDeleteWorkout,
+				.intervalsUpdateWorkout,
 			]
 		)
 		let encoded = schemas.map { canonicalJSON($0.parameters) }.joined()

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ReadToolsTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ReadToolsTests.swift
@@ -179,13 +179,13 @@ struct ReadToolsTests {
 				.intervalsFetchStreams,
 				.intervalsFetchActivities,
 				.intervalsListEvents,
-				.memoryQuery,
-				.memoryWrite,
-				.ledgerAppend,
 				.intervalsCreateWorkout,
 				.intervalsCreateStrengthWorkout,
 				.intervalsDeleteWorkout,
 				.intervalsUpdateWorkout,
+				.memoryQuery,
+				.memoryWrite,
+				.ledgerAppend,
 			]
 		)
 		let encoded = schemas.map { canonicalJSON($0.parameters) }.joined()

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/SerializerTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/SerializerTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite
+struct SerializerTests {
+	@Test func matchesDesktopCases() throws {
+		let data = try fixtureData("serializer-cases")
+		let root = try JSONValue.parse(String(data: data, encoding: .utf8)!)
+		guard let cases = root.arrayValue else {
+			Issue.record("serializer-cases.json must be an array")
+			return
+		}
+		var mismatches: [String] = []
+		for item in cases {
+			let fields = item.objectFields
+			guard let id = fields["id"]?.stringValue, let input = fields["input"] else {
+				mismatches.append("missing id or input")
+				continue
+			}
+			let expectedError = fields["error"]?.stringValue
+			do {
+				let workout = try IntervalsSerializer.parseWorkout(input)
+				let serialized = try IntervalsSerializer.serialize(workout)
+				if expectedError != nil {
+					mismatches.append("\(id): expected error, got description")
+					continue
+				}
+				let expectedDescription = fields["description"]?.stringValue ?? ""
+				if serialized.description != expectedDescription {
+					mismatches.append("\(id): description mismatch")
+				}
+				if serialized.description.utf8.elementsEqual(expectedDescription.utf8) == false {
+					mismatches.append("\(id): description bytes mismatch")
+				}
+				let expectedTime = fields["movingTime"]?.intValue()
+				if serialized.movingTime != expectedTime {
+					mismatches.append("\(id): movingTime \(serialized.movingTime) != \(expectedTime as Any)")
+				}
+			} catch is InvalidWorkout {
+				if expectedError == nil {
+					mismatches.append("\(id): unexpected InvalidWorkout")
+				}
+			} catch {
+				mismatches.append("\(id): \(error)")
+			}
+		}
+		#expect(mismatches.isEmpty, "\(mismatches.joined(separator: "; "))")
+		let report = mismatches.isEmpty ? "0 mismatches across \(cases.count) cases\n" : mismatches.joined(separator: "\n") + "\n"
+		try? report.write(toFile: "/tmp/ios-c6/serializer-swift-report.txt", atomically: true, encoding: .utf8)
+	}
+
+	@Test func ftp280DisplayGapIsUnchanged() throws {
+		let rows = try DisplayZones.calculate(ftpWatts: 280)
+		#expect(rows[0] == "< 154W")
+		#expect(rows[1] == "157-210W")
+	}
+
+	@Test func slugifyMatchesDesktop() {
+		#expect(ChatExternalID.slugify(name: "Z2 Endurance 90min") == "z2-endurance-90min")
+		#expect(ChatExternalID.slugify(name: "Endurance") == "endurance")
+		#expect(ChatExternalID.slugify(name: "---") == "workout")
+		#expect(ChatExternalID.slugify(name: "") == "workout")
+		let long = String(repeating: "a", count: 50)
+		#expect(ChatExternalID.slugify(name: long).count == 40)
+		#expect(IntervalsSerializer.slug(date: "1998-06-14", name: "Endurance") == "endurance")
+	}
+
+	@Test func eachCapThrows() {
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "", steps: [
+					.simple(SimpleStep(type: .steady, duration: DurationInput(value: 1, unit: .minutes), power: PowerTarget(kind: .percentFtp, value: 50, low: nil, high: nil), cadence: nil, label: nil)),
+				])
+			)
+		}
+		#expect(throws: InvalidWorkout.self) {
+			let step = WorkoutStep.simple(SimpleStep(type: .steady, duration: DurationInput(value: 1, unit: .minutes), power: PowerTarget(kind: .percentFtp, value: 65, low: nil, high: nil), cadence: nil, label: nil))
+			_ = try IntervalsSerializer.serialize(IntervalsWorkoutInput(name: "Too many", steps: Array(repeating: step, count: 41)))
+		}
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "Repeat", steps: [
+					.set(SetStep(
+						repeatCount: 21,
+						interval: SimpleStep(type: .interval, duration: DurationInput(value: 1, unit: .minutes), power: PowerTarget(kind: .percentFtp, value: 110, low: nil, high: nil), cadence: nil, label: nil),
+						recovery: SimpleStep(type: .recovery, duration: DurationInput(value: 1, unit: .minutes), power: PowerTarget(kind: .percentFtp, value: 50, low: nil, high: nil), cadence: nil, label: nil)
+					)),
+				])
+			)
+		}
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "Watts", steps: [
+					.simple(SimpleStep(type: .interval, duration: DurationInput(value: 5, unit: .seconds), power: PowerTarget(kind: .watts, value: 2000, low: nil, high: nil), cadence: nil, label: nil)),
+				])
+			)
+		}
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "Percent", steps: [
+					.simple(SimpleStep(type: .interval, duration: DurationInput(value: 30, unit: .seconds), power: PowerTarget(kind: .percentFtp, value: 250, low: nil, high: nil), cadence: nil, label: nil)),
+				])
+			)
+		}
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "Zone", steps: [
+					.simple(SimpleStep(type: .steady, duration: DurationInput(value: 30, unit: .minutes), power: PowerTarget(kind: .zone, value: 8, low: nil, high: nil), cadence: nil, label: nil)),
+				])
+			)
+		}
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "Inverted", steps: [
+					.simple(SimpleStep(type: .steady, duration: DurationInput(value: 30, unit: .minutes), power: PowerTarget(kind: .percentFtp, value: nil, low: 90, high: 70), cadence: nil, label: nil)),
+				])
+			)
+		}
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "Cadence", steps: [
+					.simple(SimpleStep(type: .steady, duration: DurationInput(value: 30, unit: .minutes), power: PowerTarget(kind: .percentFtp, value: 65, low: nil, high: nil), cadence: CadenceTarget(value: nil, low: 90, high: nil), label: nil)),
+				])
+			)
+		}
+		#expect(throws: InvalidWorkout.self) {
+			_ = try IntervalsSerializer.serialize(
+				IntervalsWorkoutInput(name: "Ramp", steps: [
+					.simple(SimpleStep(type: .ramp, duration: DurationInput(value: 10, unit: .minutes), power: PowerTarget(kind: .percentFtp, value: 70, low: nil, high: nil), cadence: nil, label: nil)),
+				])
+			)
+		}
+	}
+
+	@Test func formatDurationMatchesGrammar() {
+		#expect(IntervalsSerializer.formatDuration(DurationInput(value: 30, unit: .seconds)) == "30s")
+		#expect(IntervalsSerializer.formatDuration(DurationInput(value: 60, unit: .seconds)) == "1m")
+		#expect(IntervalsSerializer.formatDuration(DurationInput(value: 90, unit: .seconds)) == "1m30")
+		#expect(IntervalsSerializer.formatDuration(DurationInput(value: 61, unit: .seconds)) == "1m1")
+		#expect(IntervalsSerializer.formatDuration(DurationInput(value: 10, unit: .minutes)) == "10m")
+	}
+}


### PR DESCRIPTION
## Why

A calendar write on the phone has to look like the desktop coach: serialize the workout, show a 10-minute preview, and POST to intervals.icu only after confirm. This PR fills the serializer, the chat-create body, the write guards, and the confirmation gate.

## Scope

- `Cycling/Serializer.swift`: `serialize` matching `serializeIntervalsWorkout` (headers, `{n}x` repeats, `1m30`, lowercase `w`, zone ramps, `movingTime` as one rounded sum). Caps throw `InvalidWorkout`.
- `IntervalsPolicy.chatCreateBody` / `CyclingTools.parseCreateWorkout`: refuse `date < today` in the athlete time zone; body fields `start_date_local`, `category`, `type`, `name`, `description`, `external_id`, `tags` only. POST `/athlete/0/events?upsertOnUid=false`, one attempt.
- `updateEvent` / `deleteEvent` GET first and refuse `not_a_workout`, `not_coach_created`, `past_workout_protected`, `past_workout_destination`. Coach-owned = tag `cycling-coach` or `externalId` starting `cycling-coach:`.
- `ProposalPolicy.propose` / `take`: device-local `pendingProposal`, replace clears the previous nonce, take clears on execute. Model sees `{pendingConfirmation: true, summary}` and never the nonce.
- `Coach.confirm` does not enter the mailbox; `rebuildConfirmed` serializes again from stored `GatedToolInput`.
- Tests: 52-case serializer fixture (1998-safe), ChatCreateBody, ProposalPolicy, GatedTools, FirstTurnTests 4 and 5.

Out of scope: live intervals.icu POST, Memory (C5), `plan_save` (refused `not_implemented`), PlanMirrorUID, ZWO/MRC/ERG, pre-check of an existing `external_id` before POST (chat path matches desktop).

## Tradeoffs

Sketch `StepType` omitted `steady` and `recovery`; Swift includes them for TypeScript parity. Cadence JSON accepts TS `target` or sketch `value`. Tutorial `intervals.calls.isEmpty` is false after C4's wellness snapshot; tests assert no `.createEvent` until confirm. REST client takes an injected `Clock` so 1998-relative guards work under `FixedClock`.

## Blast Radius

Coach package only. Fake client write methods are test-only.

## Verification

- `swift build` warning-free in Swift 6.
- `swift test`: 124 passed, 29 suites.
- FirstTurnTests 4 and 5: summary `Create workout "Endurance" on 1998-06-14`, description starts `Warmup\n- 10m 55-65%`, confirm once then `.none`.
- Serializer differential: 0 mismatches across 52 cases, including the FTP 280 watt gap.
- Live create/delete on intervals.icu stays this ticket's remaining proof.

Playbook: poteto-mode Feature, implementation delegated to Grok 4.6 xhigh, reviewed by the lead.
