### PR TITLE
fix(desktop): restore automatic update checks

### DIFF
--- a/.changeset/red-sails-sort.md
+++ b/.changeset/red-sails-sort.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Desktop can check for and install updates again.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -399,8 +399,8 @@ async function runDesktop(): Promise<void> {
     currentVersion: app.getVersion(),
     versionFloor: updateVersionFloor,
     loadUpdater: async () => {
-      const { autoUpdater } = await import("electron-updater");
-      return autoUpdater;
+      const { default: electronUpdater } = await import("electron-updater");
+      return electronUpdater.autoUpdater;
     },
     requestQuit: () => app.quit(),
   });

--- a/apps/desktop/tests/updater-import-boundary.test.ts
+++ b/apps/desktop/tests/updater-import-boundary.test.ts
@@ -20,10 +20,11 @@ describe("desktop updater import boundary", () => {
   it("loads the real CommonJS updater through the production native ESM loader", async () => {
     const source = await readFile(resolve(desktopRoot, "src/main/index.ts"), "utf8");
     const harness = [
-      'import { createRequire } from "node:module";',
+      'import { createRequire, Module } from "node:module";',
       "const require = createRequire(import.meta.url);",
       'const electronPath = require.resolve("electron");',
-      "require(electronPath);",
+      "require.cache[electronPath] = new Module(electronPath);",
+      "require.cache[electronPath].loaded = true;",
       "const nativeUpdater = { on() { return nativeUpdater; } };",
       "require.cache[electronPath].exports = {",
       "  app: {",

--- a/apps/desktop/tests/updater-import-boundary.test.ts
+++ b/apps/desktop/tests/updater-import-boundary.test.ts
@@ -1,0 +1,56 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const desktopRoot = resolve(import.meta.dirname, "..");
+
+function updaterLoaderBody(source: string): string {
+  const prefix = "    loadUpdater: async () => {";
+  const suffix = "\n    },\n    requestQuit:";
+  const start = source.indexOf(prefix);
+  const end = source.indexOf(suffix, start + prefix.length);
+  if (start < 0 || end < 0) throw new Error("desktop updater loader was not found");
+  return source.slice(start + prefix.length, end);
+}
+
+describe("desktop updater import boundary", () => {
+  it("loads the real CommonJS updater through the production native ESM loader", async () => {
+    const source = await readFile(resolve(desktopRoot, "src/main/index.ts"), "utf8");
+    const harness = [
+      'import { createRequire } from "node:module";',
+      "const require = createRequire(import.meta.url);",
+      'const electronPath = require.resolve("electron");',
+      "require(electronPath);",
+      "const nativeUpdater = { on() { return nativeUpdater; } };",
+      "require.cache[electronPath].exports = {",
+      "  app: {",
+      '    getVersion: () => "0.5.0",',
+      '    getName: () => "Enduragent",',
+      "    isPackaged: false,",
+      "    getAppPath: () => process.cwd(),",
+      "    getPath: () => process.cwd(),",
+      "    quit() {},",
+      "    relaunch() {},",
+      "    once() {},",
+      "  },",
+      "  autoUpdater: nativeUpdater,",
+      "  net: {},",
+      "  session: {},",
+      "};",
+      `const loadUpdater = async () => {${updaterLoaderBody(source)}\n};`,
+      "const updater = await loadUpdater();",
+      'process.stdout.write(typeof updater?.checkForUpdates);',
+    ].join("\n");
+
+    const result = await execFileAsync(
+      process.execPath,
+      ["--input-type=module", "--eval", harness],
+      { cwd: desktopRoot },
+    );
+
+    expect(result.stdout).toBe("function");
+  });
+});

--- a/apps/desktop/tests/updater-import-boundary.test.ts
+++ b/apps/desktop/tests/updater-import-boundary.test.ts
@@ -42,7 +42,7 @@ describe("desktop updater import boundary", () => {
       "};",
       `const loadUpdater = async () => {${updaterLoaderBody(source)}\n};`,
       "const updater = await loadUpdater();",
-      'process.stdout.write(typeof updater?.checkForUpdates);',
+      "process.stdout.write(typeof updater?.checkForUpdates);",
     ].join("\n");
 
     const result = await execFileAsync(


### PR DESCRIPTION
Desktop update checks fail before contacting the feed because native ESM does not expose `electron-updater`'s lazy CommonJS `autoUpdater` getter as a named export. Load the default export so initialization receives the actual updater singleton.

Add a regression that executes the production loader under native ESM against the real dependency. The test fails before the fix and passes afterward. Include a desktop patch changeset.

Verification completed:
- All 69 focused updater tests pass across five files.
- Desktop type checking, focused lint and formatting, changeset validation, and the required isolated Codex review pass.
- Production Settings in an isolated development app completes startup and manual checks against `updates.enduragent.icu`. Update eligibility and feed configuration were enabled only in disposable build output for this check. Signed update installation was not tested.

Affected installed versions need one manual installation of a corrected release because their updater cannot initialize. Publishing that release is separate from this fix.
