### PR TITLE
feat(ios): on-device coach memory, query, and flush

### DIFF
--- a/.changeset/ios-memory.md
+++ b/.changeset/ios-memory.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add on-device coach memory (sections, daily notes, event ledger, dated query, and post-reply flush) to the Enduragent iOS coach package. No npm or desktop release target yet.

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Chat/ChatMailbox.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Chat/ChatMailbox.swift
@@ -6,8 +6,10 @@ package actor ChatMailbox {
 	private let memory: Memory
 	private let store: any RecordLog
 	private let clock: any Clock
+	private let transport: any ModelTransport
 	private var tail: Task<Void, Never>
 	private var current: Task<Void, Never>?
+	private var flushTask: Task<Void, Never>?
 	package private(set) var busy = false
 
 	package init(
@@ -15,13 +17,15 @@ package actor ChatMailbox {
 		runner: TurnRunner,
 		memory: Memory,
 		store: any RecordLog,
-		clock: any Clock
+		clock: any Clock,
+		transport: any ModelTransport
 	) {
 		self.chatId = chatId
 		self.runner = runner
 		self.memory = memory
 		self.store = store
 		self.clock = clock
+		self.transport = transport
 		self.tail = Task {}
 	}
 
@@ -79,8 +83,26 @@ package actor ChatMailbox {
 	}
 
 	package func runQueuedFlush() async {
-		await enqueue {
-			try? await self.memory.flush(trigger: .softThreshold, chatId: self.chatId, transport: FlushNoopTransport())
+		if let inFlight = flushTask {
+			await inFlight.value
+			return
+		}
+		let previous = tail
+		let next = Task {
+			await previous.value
+			guard !Task.isCancelled else { return }
+			try? await self.memory.flush(
+				trigger: .softThreshold,
+				chatId: self.chatId,
+				transport: self.transport
+			)
+		}
+		tail = next
+		current = next
+		flushTask = next
+		await next.value
+		if flushTask != nil {
+			flushTask = nil
 		}
 	}
 
@@ -94,15 +116,6 @@ package actor ChatMailbox {
 		tail = next
 		current = next
 		await next.value
-	}
-}
-
-private struct FlushNoopTransport: ModelTransport {
-	func stream(_ request: CompletionRequest) -> AsyncThrowingStream<TransportEvent, Error> {
-		AsyncThrowingStream { continuation in
-			_ = request
-			continuation.finish()
-		}
 	}
 }
 

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Coach.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Coach.swift
@@ -123,7 +123,9 @@ public actor Coach {
 	}
 
 	public func waitForMemoryFlush() async {
-		await mailbox(for: .main).runQueuedFlush()
+		for box in mailboxes.values {
+			await box.runQueuedFlush()
+		}
 	}
 
 	public func stop(chatId: ChatID) async {
@@ -167,7 +169,8 @@ public actor Coach {
 			runner: runner,
 			memory: memory,
 			store: store,
-			clock: clock
+			clock: clock,
+			transport: transport
 		)
 		mailboxes[chatId] = created
 		return created

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Loop/ToolRuntime.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Loop/ToolRuntime.swift
@@ -83,10 +83,11 @@ package struct ToolRuntime: Sendable {
 			)
 		}
 		let key = name.rawValue + " " + canonicalJSON(arguments)
-		if let cached = await memo.cached(key) {
+		let replayUnsafe = ReplayUnsafeToolName(rawValue: name.rawValue) != nil
+		if !replayUnsafe, let cached = await memo.cached(key) {
 			return .result(cached)
 		}
-		if let existing = await memo.task(for: key) {
+		if !replayUnsafe, let existing = await memo.task(for: key) {
 			return try await existing.value
 		}
 		let task = Task {
@@ -94,7 +95,11 @@ package struct ToolRuntime: Sendable {
 		}
 		await memo.store(task: task, for: key)
 		do {
-			return try await task.value
+			let outcome = try await task.value
+			if replayUnsafe {
+				await memo.clearTask(key)
+			}
+			return outcome
 		} catch {
 			await memo.clearTask(key)
 			throw error
@@ -123,7 +128,9 @@ package struct ToolRuntime: Sendable {
 				)
 			} else {
 				outcome = .result(enveloped)
-				await memo.store(value: enveloped, for: key)
+				if ReplayUnsafeToolName(rawValue: name.rawValue) == nil {
+					await memo.store(value: enveloped, for: key)
+				}
 			}
 		case .pending, .truncated:
 			outcome = raw
@@ -171,10 +178,17 @@ package struct ToolRuntime: Sendable {
 					events = events.filter(\.coachCreated)
 				}
 				return .result(.array(events.map(encodeEvent)))
+			case .memoryRead:
+				return try await executeMemoryRead()
+			case .memoryQuery:
+				return try await executeMemoryQuery(arguments)
+			case .memoryWrite:
+				return try await executeMemoryWrite(arguments)
+			case .ledgerAppend:
+				return try await executeLedgerAppend(arguments)
 			case .buildPlanSkeleton, .assessFeasibility, .getSampleWeek,
 			     .intervalsCreateWorkout, .intervalsCreateStrengthWorkout,
 			     .intervalsDeleteWorkout, .intervalsUpdateWorkout,
-			     .memoryRead, .memoryQuery, .memoryWrite, .ledgerAppend,
 			     .planSave, .planLoad:
 				fatalError("not implemented")
 			}
@@ -185,8 +199,7 @@ package struct ToolRuntime: Sendable {
 
 	package func toolsForTurn(chatId: ChatID, memory: MemoryView) -> [ToolSchema] {
 		_ = chatId
-		_ = memory
-		return [
+		var schemas = [
 			ToolSchema(
 				name: .calculateZones,
 				description: "Calculate power-zone watt ranges from FTP watts (7-zone numbering)",
@@ -270,6 +283,87 @@ package struct ToolRuntime: Sendable {
 				)
 			),
 		]
+		if shouldOfferMemoryRead(memory) {
+			schemas.append(
+				ToolSchema(
+					name: .memoryRead,
+					description:
+						"Read only stored sections that Athlete Context does not show, plus today's notes and plan state.",
+					parameters: objectSchema(properties: [:], required: [])
+				)
+			)
+		}
+		let sectionNames = SectionName.cyclingEffective.map(\.rawValue) + memory.orphanNames
+		let uniqueSections = uniqueStrings(sectionNames)
+		let sectionList = uniqueSections.map { name in
+			let hint = SectionName(rawValue: name).hint
+			return "\(name) (\(hint))"
+		}.joined(separator: "; ")
+		schemas.append(
+			ToolSchema(
+				name: .memoryQuery,
+				description:
+					"Query dated athlete memory: daily notes, the event ledger, and section history over a date range. "
+					+ "Use this for any question about past notes, decisions, overrides, illness, or "
+					+ "experiments. Returns matching notes, events, and history grouped by date.",
+				parameters: objectSchema(
+					properties: [
+						"from": stringProperty("Start date (inclusive), YYYY-MM-DD"),
+						"to": stringProperty("End date (inclusive), YYYY-MM-DD"),
+						"query": stringProperty(
+							"Case-insensitive substring filter. Omit to return everything in the range."
+						),
+					],
+					required: ["from", "to"]
+				)
+			)
+		)
+		schemas.append(
+			ToolSchema(
+				name: .memoryWrite,
+				description:
+					"Write to long-term memory (replaces section content) or daily notes. "
+					+ "Sections: \(sectionList).",
+				parameters: objectSchema(
+					properties: [
+						"type": .object([
+							"type": .string("string"),
+							"enum": .array([.string("memory"), .string("daily")]),
+							"description": .string("'memory' for long-term facts, 'daily' for today's notes"),
+						]),
+						"section": .object([
+							"type": .string("string"),
+							"enum": .array(uniqueSections.map { .string($0) }),
+							"description": .string(
+								"Memory section to write to. REQUIRED when type='memory' — the write replaces the section content."
+							),
+						]),
+						"content": stringProperty("The information to save"),
+					],
+					required: ["type", "content"]
+				)
+			)
+		)
+		schemas.append(
+			ToolSchema(
+				name: .ledgerAppend,
+				description:
+					"Record a dated event the athlete just stated: decision, override, illness, experiment, outcome. Skip routine training data and anything already in Athlete Context.",
+				parameters: objectSchema(
+					properties: [
+						"date": stringProperty("Event date, YYYY-MM-DD, athlete-local"),
+						"kind": .object([
+							"type": .string("string"),
+							"enum": .array(LedgerKind.allCases.map { .string($0.rawValue) }),
+							"description": .string("Event category"),
+						]),
+						"text": stringProperty("One or two sentences, with rationale or outcome when stated"),
+					],
+					required: ["date", "kind", "text"]
+				)
+			)
+		)
+		return schemas
 	}
 
 	package func rebuildConfirmed(_ input: GatedToolInput) async throws -> JSONValue {
@@ -278,6 +372,96 @@ package struct ToolRuntime: Sendable {
 
 	private static let activityIDDescription =
 		"Activity ID from intervals_fetch_activities — a positive integer or digit string, optionally i-prefixed for intervals-native activities, or a lowercase 64-hex canonical ID. Pass exactly as listed."
+
+	private func memory() -> Memory {
+		Memory(store: store, clock: clock)
+	}
+
+	private func executeMemoryRead() async throws -> ToolOutcome {
+		let text = try await memory().complementContext()
+		if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+			return .result(.string("Every stored section is already in your Athlete Context."))
+		}
+		return .result(.string(text))
+	}
+
+	private func executeMemoryQuery(_ arguments: JSONValue) async throws -> ToolOutcome {
+		let fields = arguments.objectFields
+		let fromRaw = fields["from"]?.stringValue ?? ""
+		let toRaw = fields["to"]?.stringValue ?? ""
+		let query = fields["query"]?.stringValue
+		guard let from = CivilDate(rawValue: fromRaw), let to = CivilDate(rawValue: toRaw) else {
+			return .result(
+				.string("Error: \(fromRaw)..\(toRaw) contains an invalid calendar date. Use real YYYY-MM-DD dates.")
+			)
+		}
+		do {
+			let hits = try await memory().query(from: from, to: to, contains: query)
+			return .result(.string(MemoryQuery.render(hits, from: from, to: to, query: query)))
+		} catch let failure as MemoryQueryFailure {
+			return .result(.string(failure.message))
+		}
+	}
+
+	private func executeMemoryWrite(_ arguments: JSONValue) async throws -> ToolOutcome {
+		let fields = arguments.objectFields
+		let type = fields["type"]?.stringValue
+		let content = fields["content"]?.stringValue ?? ""
+		if type == "memory" {
+			guard let section = fields["section"]?.stringValue else {
+				return .result(
+					.object([
+						"details": .string(
+							"type='memory' requires a section. Pick one of the listed sections, or use type='daily' for free-form notes."
+						),
+						"error": .string("section_required"),
+					])
+				)
+			}
+			let allowed = Set(SectionName.cyclingEffective.map(\.rawValue) + ((try? await memory().view())?.orphanNames ?? []))
+			if !allowed.contains(section) {
+				return .result(
+					.object([
+						"details": .string("Unknown memory section."),
+						"error": .string("unknown_section"),
+					])
+				)
+			}
+			try await memory().writeSection(SectionName(rawValue: section), content: content, source: .chat)
+			return .result(.object(["saved": .bool(true)]))
+		}
+		try await memory().appendDailyNote(content)
+		return .result(.object(["saved": .bool(true)]))
+	}
+
+	private func executeLedgerAppend(_ arguments: JSONValue) async throws -> ToolOutcome {
+		let fields = arguments.objectFields
+		guard
+			let dateRaw = fields["date"]?.stringValue,
+			let date = CivilDate(rawValue: dateRaw),
+			let kindRaw = fields["kind"]?.stringValue,
+			let kind = LedgerKind(rawValue: kindRaw),
+			let text = fields["text"]?.stringValue,
+			!text.isEmpty
+		else {
+			let dateRaw = fields["date"]?.stringValue ?? ""
+			return .result(.string("Error: \(dateRaw) is not a real calendar date. Use YYYY-MM-DD."))
+		}
+		let recorded = try await memory().appendEvent(date: date, kind: kind, text: text, source: .chat)
+		if recorded {
+			return .result(.object(["recorded": .bool(true)]))
+		}
+		return .result(.object(["duplicate": .bool(true), "recorded": .bool(false)]))
+	}
+
+	private func shouldOfferMemoryRead(_ view: MemoryView) -> Bool {
+		for name in SectionName.cyclingEffective where !name.inject {
+			if let content = view.sections[name.rawValue], memorySectionHasLogicalContent(content) {
+				return true
+			}
+		}
+		return false
+	}
 
 	private func executeCalculateZones(_ arguments: JSONValue) throws -> ToolOutcome {
 		guard let ftp = arguments.objectFields["ftpWatts"]?.intValue() else {
@@ -412,6 +596,22 @@ package struct ToolRuntime: Sendable {
 			"type": .string("string"),
 			"description": .string(description),
 		])
+	}
+
+	private func uniqueStrings(_ values: [String]) -> [String] {
+		var seen: Set<String> = []
+		var unique: [String] = []
+		for value in values where seen.insert(value).inserted {
+			unique.append(value)
+		}
+		return unique
+	}
+
+	private func memorySectionHasLogicalContent(_ stamped: String) -> Bool {
+		guard let newline = stamped.firstIndex(of: "\n") else { return false }
+		return !stamped[stamped.index(after: newline)...]
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+			.isEmpty
 	}
 
 	private func integerProperty(_ description: String, minimum: Int? = nil, maximum: Int? = nil) -> JSONValue {

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Memory/Memory.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Memory/Memory.swift
@@ -1,20 +1,28 @@
 import Foundation
 
-public enum SectionName: String, Sendable {
-	case person
-	case schedule
-	case goals
-	case preferences
-	case notes
-	case medicalHistory = "medical-history"
-	case cyclingProfile = "cycling-profile"
-	case cyclingEquipment = "cycling-equipment"
-	case cyclingHistory = "cycling-history"
+public struct SectionName: RawRepresentable, Hashable, Sendable {
+	public let rawValue: String
+
+	public init(rawValue: String) {
+		self.rawValue = rawValue
+	}
+
+	public static let person = SectionName(rawValue: "person")
+	public static let schedule = SectionName(rawValue: "schedule")
+	public static let goals = SectionName(rawValue: "goals")
+	public static let preferences = SectionName(rawValue: "preferences")
+	public static let notes = SectionName(rawValue: "notes")
+	public static let medicalHistory = SectionName(rawValue: "medical-history")
+	public static let cyclingProfile = SectionName(rawValue: "cycling-profile")
+	public static let cyclingEquipment = SectionName(rawValue: "cycling-equipment")
+	public static let cyclingHistory = SectionName(rawValue: "cycling-history")
 
 	public var inject: Bool {
-		switch self {
-		case .notes, .cyclingEquipment, .cyclingHistory: return false
-		case .person, .schedule, .goals, .preferences, .medicalHistory, .cyclingProfile: return true
+		switch rawValue {
+		case SectionName.notes.rawValue, SectionName.cyclingEquipment.rawValue, SectionName.cyclingHistory.rawValue:
+			return false
+		default:
+			return true
 		}
 	}
 
@@ -22,6 +30,69 @@ public enum SectionName: String, Sendable {
 		.person, .schedule, .goals, .preferences, .notes, .medicalHistory,
 		.cyclingProfile, .cyclingEquipment, .cyclingHistory,
 	]
+
+	public static var declaredNames: Set<String> {
+		Set(cyclingEffective.map(\.rawValue))
+	}
+
+	public var hint: String {
+		switch rawValue {
+		case SectionName.person.rawValue:
+			return "name, weight, age, available training days"
+		case SectionName.schedule.rawValue:
+			return "weekly availability, time windows, blackout days"
+		case SectionName.goals.rawValue:
+			return "target events, race dates, fitness targets"
+		case SectionName.preferences.rawValue:
+			return "coaching style, communication preferences"
+		case SectionName.notes.rawValue:
+			return "anything not covered by other sections"
+		case SectionName.medicalHistory.rawValue:
+			return "chronic conditions, medications, long-term injuries"
+		case SectionName.cyclingProfile.rawValue:
+			return "FTP, max/resting HR, W/kg, experience level"
+		case SectionName.cyclingEquipment.rawValue:
+			return "bikes, trainer, power meter, sensors"
+		case SectionName.cyclingHistory.rawValue:
+			return "cycling injuries, FTP test history, ride recovery patterns"
+		default:
+			return rawValue
+		}
+	}
+
+	public var sectionDescription: String {
+		switch rawValue {
+		case SectionName.person.rawValue:
+			return
+				"Name, weight (kg), age, available training days per week. "
+				+ "Sport-specific physiology (FTP, VDOT, max HR) goes to the sport-prefixed profile section."
+		case SectionName.schedule.rawValue:
+			return "Weekly training availability, time windows, blackout days"
+		case SectionName.goals.rawValue:
+			return
+				"Target events, race dates, fitness targets, milestones "
+				+ "(e.g., 'sub-3:30 century in October', 'reach 280W FTP by Q3')"
+		case SectionName.preferences.rawValue:
+			return "Coaching style, training environment, communication preferences"
+		case SectionName.notes.rawValue:
+			return "Anything else important not covered by other sections"
+		case SectionName.medicalHistory.rawValue:
+			return "Chronic conditions, medications, long-term injuries — facts that persist across sports"
+		case SectionName.cyclingProfile.rawValue:
+			return
+				"FTP (watts), max HR, resting HR, W/kg ratio, experience level. "
+				+ "Body data lives in `person`; this is cycling-specific physiology."
+		case SectionName.cyclingEquipment.rawValue:
+			return "Bikes, trainer, power meter, head unit, indoor setup"
+		case SectionName.cyclingHistory.rawValue:
+			return
+				"Cycling-specific injuries (knee, lower back, fit issues), FTP test history, "
+				+ "recovery patterns from rides, ride-related sleep/HRV trends. "
+				+ "Chronic conditions belong in `medical-history`, not here."
+		default:
+			return rawValue
+		}
+	}
 }
 
 public enum LedgerKind: String, Sendable {
@@ -57,6 +128,12 @@ public struct MemoryHit: Sendable, Equatable {
 	public var kind: Kind
 	public var text: String
 
+	public init(date: CivilDate, kind: Kind, text: String) {
+		self.date = date
+		self.kind = kind
+		self.text = text
+	}
+
 	public enum Kind: Sendable, Equatable {
 		case dailyNote
 		case ledger(LedgerKind)
@@ -69,6 +146,13 @@ public struct MemoryView: Sendable, Equatable {
 	public var todayNotes: String?
 	public var planHeadline: PlanHeadline?
 	public var orphanNames: [String]
+
+	public init(sections: [String: String], todayNotes: String?, planHeadline: PlanHeadline?, orphanNames: [String]) {
+		self.sections = sections
+		self.todayNotes = todayNotes
+		self.planHeadline = planHeadline
+		self.orphanNames = orphanNames
+	}
 }
 
 public struct PlanHeadline: Sendable, Equatable {
@@ -76,6 +160,36 @@ public struct PlanHeadline: Sendable, Equatable {
 	public var primaryGoal: String?
 	public var totalWeeks: Int?
 	public var status: PlanStatus?
+
+	public init(name: String, primaryGoal: String?, totalWeeks: Int?, status: PlanStatus?) {
+		self.name = name
+		self.primaryGoal = primaryGoal
+		self.totalWeeks = totalWeeks
+		self.status = status
+	}
+}
+
+public struct MemoryQueryFailure: Error, Equatable, Sendable {
+	public var message: String
+
+	public init(message: String) {
+		self.message = message
+	}
+}
+
+public enum MemoryFlushPolicy {
+	public static let maxSteps = 5
+	public static let maxAttempts = 2
+	public static let sectionSoftWarnChars = 4000
+	public static let flushShrinkMinChars = 200
+	public static let flushShrinkRatio = 0.7
+	public static let flushZeroWriteMinMessages = 4
+	public static let memorySectionBudgetChars = 1500
+	public static let compactionStart = "### Compaction summary"
+	public static let compactionEnd = "### End of compaction summary"
+	public static let stampPrefix = "_updated: "
+	public static let consumedFlushKeyPrefix = "flush-consumed:"
+	public static let historyPreviewChars = 200
 }
 
 public struct Memory: Sendable {
@@ -88,49 +202,858 @@ public struct Memory: Sendable {
 	}
 
 	public func query(from: CivilDate, to: CivilDate, contains: String?) async throws -> [MemoryHit] {
-		_ = store
-		_ = from
-		_ = to
-		_ = contains
-		return []
+		if from > to {
+			throw MemoryQueryFailure(
+				message: "Error: 'from' (\(from.rawValue)) is after 'to' (\(to.rawValue)). Swap the bounds."
+			)
+		}
+		let days = IntervalsPolicy.inclusiveDayCount(from: from, to: to)
+		if days > MemoryQuery.maxRangeDays {
+			throw MemoryQueryFailure(
+				message:
+					"Error: range is \(days) days; the maximum is \(MemoryQuery.maxRangeDays). Query a narrower range."
+			)
+		}
+		let snapshot = try await loadSnapshot()
+		let needle = contains?.lowercased()
+		var collected: [(hit: MemoryHit, order: Int)] = []
+		var order = 0
+
+		for date in eachDate(from: from, to: to) {
+			let text = snapshot.dailyText(on: date)
+			if text.isEmpty { continue }
+			if let needle {
+				let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+					.filter { $0.lowercased().contains(needle) }
+					.map(String.init)
+				if lines.isEmpty { continue }
+				collected.append(
+					(MemoryHit(date: date, kind: .dailyNote, text: lines.joined(separator: "\n")), order)
+				)
+			} else {
+				collected.append((MemoryHit(date: date, kind: .dailyNote, text: text), order))
+			}
+			order += 1
+		}
+
+		for record in snapshot.ledgerRecords {
+			guard record.civilDate >= from, record.civilDate <= to else { continue }
+			guard case .ledgerEvent(let body) = record.body else { continue }
+			let line = serializeLedger(record, body: body)
+			if let needle, !line.lowercased().contains(needle) { continue }
+			collected.append(
+				(MemoryHit(date: record.civilDate, kind: .ledger(body.kind), text: line), order)
+			)
+			order += 1
+		}
+
+		for record in snapshot.journalRecords {
+			guard record.civilDate >= from, record.civilDate <= to else { continue }
+			guard case .journal(let body) = record.body else { continue }
+			let parsed = parseJournalPreview(body.preview)
+			let section = parsed.section
+			let oldBody = parsed.oldBody
+			let newBody = parsed.newBody ?? body.preview
+			if let needle {
+				let haystacks = [section, oldBody, newBody]
+				if !haystacks.contains(where: { $0?.lowercased().contains(needle) == true }) {
+					continue
+				}
+			}
+			let summary = historyBodySummary(section ?? body.op.rawValue, query: needle)
+			let was = historyBodySummary(oldBody, query: needle)
+			let now = historyBodySummary(newBody, query: needle)
+			collected.append(
+				(
+					MemoryHit(
+						date: record.civilDate,
+						kind: .journal,
+						text: "\(summary) — was: \(was) / now: \(now)"
+					),
+					order
+				)
+			)
+			order += 1
+		}
+
+		return collected.sorted { lhs, rhs in
+			if lhs.hit.date != rhs.hit.date {
+				return lhs.hit.date > rhs.hit.date
+			}
+			let leftKind = kindOrder(lhs.hit.kind)
+			let rightKind = kindOrder(rhs.hit.kind)
+			if leftKind != rightKind {
+				return leftKind < rightKind
+			}
+			return lhs.order < rhs.order
+		}.map(\.hit)
 	}
 
 	public func context() async throws -> String {
-		_ = store
-		return ""
+		try await renderContext(excluding: SectionName.cyclingEffective.filter { !$0.inject }.map(\.rawValue))
+	}
+
+	package func fullContext() async throws -> String {
+		try await renderContext(excluding: [])
+	}
+
+	package func complementContext() async throws -> String {
+		let injected = SectionName.cyclingEffective.filter(\.inject).map(\.rawValue)
+		return try await renderContext(excluding: injected)
 	}
 
 	public func writeSection(_ name: SectionName, content: String, source: LedgerSource) async throws {
-		fatalError("not implemented")
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		let snapshot = try await loadSnapshot()
+		let previous = UnionMerge.sectionText(snapshot.sections, name: name)
+		let stamped = stampUpdated(demoteEmbeddedH2(content), date: today)
+		_ = MemoryFlushPolicy.sectionSoftWarnChars
+		let digestBody = trimEnd(stamped)
+		let logical = hasLogicalSectionContent(stamped)
+		let provenance = ProvenanceBody(
+			key: "memory:\(name.rawValue)",
+			garmin: false,
+			nonGarmin: false,
+			unknown: logical,
+			contentSha256: sha256Hex(digestBody)
+		)
+		try await append(.provenance(provenance), civilDate: today)
+		let preview = JSONValue.object([
+			"newBody": .string(stamped),
+			"oldBody": previous.map(JSONValue.string) ?? .null,
+			"section": .string(name.rawValue),
+			"source": .string(source.rawValue),
+		]).canonicalDigestInput()
+		do {
+			try await append(.journal(JournalBody(op: .writeSection, preview: preview)), civilDate: today)
+		} catch {
+			_ = error
+		}
+		try await append(.memorySection(MemorySectionBody(name: name, content: stamped)), civilDate: today)
 	}
 
 	public func appendDailyNote(_ note: String) async throws {
-		fatalError("not implemented")
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		let snapshot = try await loadSnapshot()
+		let existing = snapshot.dailyNotesOnly(on: today)
+		if !existing.isEmpty, "\n\(existing)\n".contains("\n\(note)\n") {
+			return
+		}
+		try await append(.dailyNote(DailyNoteBody(note: note)), civilDate: today)
 	}
 
 	public func appendEvent(date: CivilDate, kind: LedgerKind, text: String, source: LedgerSource) async throws -> Bool {
-		fatalError("not implemented")
+		let snapshot = try await loadSnapshot()
+		let digest = UnionMerge.ledgerDigest(date: date, kind: kind, text: text)
+		for record in snapshot.ledgerRecords {
+			guard case .ledgerEvent(let body) = record.body else { continue }
+			if UnionMerge.ledgerDigest(date: record.civilDate, kind: body.kind, text: body.text) == digest {
+				return false
+			}
+		}
+		let body = LedgerEventBody(kind: kind, text: text, source: source)
+		let line = serializeLedgerLine(date: date, kind: kind, text: text, source: source, wallMs: wallMs(clock.now))
+		try await append(
+			.provenance(
+				ProvenanceBody(
+					key: "ledger:\(sha256Hex(line))",
+					garmin: false,
+					nonGarmin: false,
+					unknown: true,
+					contentSha256: sha256Hex(line)
+				)
+			),
+			civilDate: date
+		)
+		try await append(.ledgerEvent(body), civilDate: date)
+		return true
 	}
 
 	public func flush(trigger: FlushTrigger, chatId: ChatID, transport: any ModelTransport) async throws {
-		_ = store
-		_ = trigger
-		_ = chatId
-		_ = transport
-		_ = clock
+		let pending = try await oldestUnconsumedFlush(chatId: chatId)
+		let effectiveTrigger: FlushTrigger = {
+			if let pending, case .flushPending(let body) = pending.body {
+				return body.trigger
+			}
+			return trigger
+		}()
+		let conversation = try await loadFlushMessages(trigger: effectiveTrigger, chatId: chatId, pending: pending)
+		if conversation.isEmpty, pending == nil {
+			return
+		}
+		var attempt = 0
+		var lastWrites = 0
+		var lastLedger = 0
+		while attempt < MemoryFlushPolicy.maxAttempts {
+			attempt += 1
+			let outcome = try await runFlushGenerate(conversation: conversation, transport: transport)
+			lastWrites = outcome.writes
+			lastLedger = outcome.ledgerAppends
+			let zeroWrite =
+				outcome.writes == 0
+				&& outcome.ledgerAppends == 0
+				&& conversation.count >= MemoryFlushPolicy.flushZeroWriteMinMessages
+			if effectiveTrigger == .staleReset, zeroWrite, attempt < MemoryFlushPolicy.maxAttempts {
+				continue
+			}
+			break
+		}
+		_ = lastWrites
+		_ = lastLedger
+		if let pending {
+			try await markConsumed(pending)
+		}
 	}
 
 	public func view() async throws -> MemoryView {
-		_ = store
-		return MemoryView(sections: [:], todayNotes: nil, planHeadline: nil, orphanNames: [])
+		let snapshot = try await loadSnapshot()
+		var sections: [String: String] = [:]
+		for name in SectionName.cyclingEffective {
+			if let content = UnionMerge.sectionText(snapshot.sections, name: name) {
+				sections[name.rawValue] = content
+			}
+		}
+		for orphan in snapshot.orphanNames {
+			if let content = UnionMerge.sectionText(snapshot.sections, name: SectionName(rawValue: orphan)) {
+				sections[orphan] = content
+			}
+		}
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		let notes = injectableDailyLines(snapshot.dailyText(on: today)).joined(separator: "\n")
+		let trimmed = trimEnd(notes)
+		return MemoryView(
+			sections: sections,
+			todayNotes: trimmed.isEmpty ? nil : trimmed,
+			planHeadline: nil,
+			orphanNames: snapshot.orphanNames
+		)
+	}
+
+	package func hiddenSectionsHaveLogicalContent() async throws -> Bool {
+		let snapshot = try await loadSnapshot()
+		for name in SectionName.cyclingEffective where !name.inject {
+			if let content = UnionMerge.sectionText(snapshot.sections, name: name), hasLogicalSectionContent(content) {
+				return true
+			}
+		}
+		return false
+	}
+
+	private func renderContext(excluding: [String]) async throws -> String {
+		let snapshot = try await loadSnapshot()
+		let exclude = Set(excluding)
+		var parts: [String] = []
+		var blocks: [String] = []
+		for name in SectionName.cyclingEffective where name.inject && !exclude.contains(name.rawValue) {
+			if let content = UnionMerge.sectionText(snapshot.sections, name: name), !content.isEmpty {
+				blocks.append("## \(name.rawValue)\n\(content)")
+			}
+		}
+		for orphan in snapshot.orphanNames where !exclude.contains(orphan) {
+			if let content = UnionMerge.sectionText(snapshot.sections, name: SectionName(rawValue: orphan)),
+			   !content.isEmpty
+			{
+				blocks.append("## \(orphan)\n\(content)")
+			}
+		}
+		if !blocks.isEmpty {
+			parts.append("## Athlete Memory\n" + blocks.joined(separator: "\n\n") + "\n")
+		}
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		let daily = injectableDailyLines(snapshot.dailyText(on: today)).joined(separator: "\n")
+		if !trimEnd(daily).isEmpty {
+			parts.append("## Today's Notes\n" + daily)
+		}
+		if let headline = snapshot.planHeadline {
+			var lines: [String] = []
+			lines.append("- Name: \(headline.name)")
+			if let goal = headline.primaryGoal {
+				lines.append("- Goal: \(goal)")
+			}
+			if let weeks = headline.totalWeeks {
+				lines.append("- Duration: \(weeks) weeks")
+			}
+			if let status = headline.status {
+				lines.append("- Status: \(status.rawValue)")
+			}
+			if !lines.isEmpty {
+				parts.append("## Current Plan\n" + lines.joined(separator: "\n"))
+			}
+		}
+		return parts.joined(separator: "\n\n")
+	}
+
+	private func runFlushGenerate(
+		conversation: [ChatMessage],
+		transport: any ModelTransport
+	) async throws -> (writes: Int, ledgerAppends: Int) {
+		let current = (try? await fullContext()) ?? ""
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		let fenced = PromptAssembly.wrapAthleteContext(current.isEmpty ? "No athlete data stored yet." : current)
+		var messages: [WireMessage] = [
+			WireMessage(role: .system, content: MemoryFlushPrompt.system, toolCalls: [], toolCallId: nil),
+		]
+		messages.append(contentsOf: conversation.map(wireMessage(from:)))
+		messages.append(
+			WireMessage(
+				role: .user,
+				content: MemoryFlushPrompt.userPrompt(
+					sections: SectionName.cyclingEffective,
+					currentMemory: fenced,
+					today: today.rawValue
+				),
+				toolCalls: [],
+				toolCallId: nil
+			)
+		)
+		let schemas = MemoryFlushPrompt.toolSchemas()
+		var writes = 0
+		var ledgerAppends = 0
+		var steps = 0
+		while steps < MemoryFlushPolicy.maxSteps {
+			steps += 1
+			let request = CompletionRequest.openRouter(
+				messages: messages,
+				tools: schemas,
+				deadline: TurnPolicy.chatCallDeadline
+			)
+			let step = try await collectFlush(transport: transport, request: request)
+			if step.calls.isEmpty {
+				break
+			}
+			messages.append(
+				WireMessage(role: .assistant, content: step.text, toolCalls: step.calls, toolCallId: nil)
+			)
+			for call in step.calls {
+				let (payload, wroteSection, wroteLedger) = try await executeFlushTool(call)
+				if wroteSection { writes += 1 }
+				if wroteLedger { ledgerAppends += 1 }
+				messages.append(
+					WireMessage(role: .tool, content: payload, toolCalls: [], toolCallId: call.id)
+				)
+			}
+		}
+		return (writes, ledgerAppends)
+	}
+
+	private func collectFlush(
+		transport: any ModelTransport,
+		request: CompletionRequest
+	) async throws -> (text: String, calls: [WireToolCall], reason: FinishReason) {
+		var text = ""
+		var calls: [WireToolCall] = []
+		var reason: FinishReason = .stop
+		for try await event in transport.stream(request) {
+			switch event {
+			case .textDelta(let delta):
+				text += delta
+			case .toolCall(let call):
+				calls.append(call)
+			case .heartbeat:
+				break
+			case .finished(let finishReason, _):
+				reason = finishReason
+			}
+		}
+		_ = reason
+		return (text, calls, reason)
+	}
+
+	private func executeFlushTool(_ call: WireToolCall) async throws -> (String, Bool, Bool) {
+		let arguments = (try? JSONValue.parse(call.arguments)) ?? .object([:])
+		switch call.name {
+		case .memoryWrite:
+			let fields = arguments.objectFields
+			guard let section = fields["section"]?.stringValue, let content = fields["content"]?.stringValue else {
+				return (JSONValue.object(["error": .string("section_required")]).canonicalDigestInput(), false, false)
+			}
+			try await writeSection(SectionName(rawValue: section), content: content, source: .flush)
+			return (JSONValue.object(["saved": .bool(true)]).canonicalDigestInput(), true, false)
+		case .ledgerAppend:
+			let fields = arguments.objectFields
+			guard
+				let dateRaw = fields["date"]?.stringValue,
+				let date = CivilDate(rawValue: dateRaw),
+				let kindRaw = fields["kind"]?.stringValue,
+				let kind = LedgerKind(rawValue: kindRaw),
+				let text = fields["text"]?.stringValue,
+				!text.isEmpty
+			else {
+				return (
+					JSONValue.object(["error": .string("invalid_event")]).canonicalDigestInput(),
+					false,
+					false
+				)
+			}
+			let recorded = try await appendEvent(date: date, kind: kind, text: text, source: .flush)
+			if recorded {
+				return (JSONValue.object(["recorded": .bool(true)]).canonicalDigestInput(), false, true)
+			}
+			return (
+				JSONValue.object(["duplicate": .bool(true), "recorded": .bool(false)]).canonicalDigestInput(),
+				false,
+				false
+			)
+		default:
+			return (JSONValue.object(["error": .string("unsupported")]).canonicalDigestInput(), false, false)
+		}
+	}
+
+	private func oldestUnconsumedFlush(chatId: ChatID) async throws -> AthleteRecord? {
+		let pending = try await store.fetch(
+			RecordQuery(kinds: [.flushPending], chatId: chatId, deviceLocalOnly: true)
+		).sorted { $0.hlc < $1.hlc }
+		let consumed = try await consumedFlushIDs()
+		return pending.first { record in
+			!consumed.contains(record.ulid.rawValue)
+		}
+	}
+
+	private func consumedFlushIDs() async throws -> Set<String> {
+		let records = try await store.fetch(RecordQuery(kinds: [.provenance]))
+		var ids: Set<String> = []
+		for record in records {
+			guard case .provenance(let body) = record.body else { continue }
+			if body.key.hasPrefix(MemoryFlushPolicy.consumedFlushKeyPrefix) {
+				ids.insert(String(body.key.dropFirst(MemoryFlushPolicy.consumedFlushKeyPrefix.count)))
+			}
+		}
+		return ids
+	}
+
+	private func markConsumed(_ pending: AthleteRecord) async throws {
+		let today = IntervalsPolicy.today(now: clock.now, timeZone: clock.timeZone)
+		try await append(
+			.provenance(
+				ProvenanceBody(
+					key: MemoryFlushPolicy.consumedFlushKeyPrefix + pending.ulid.rawValue,
+					garmin: false,
+					nonGarmin: false,
+					unknown: false,
+					contentSha256: sha256Hex(pending.ulid.rawValue)
+				)
+			),
+			civilDate: today
+		)
+	}
+
+	private func loadFlushMessages(
+		trigger: FlushTrigger,
+		chatId: ChatID,
+		pending: AthleteRecord?
+	) async throws -> [ChatMessage] {
+		let records = try await store.fetch(
+			RecordQuery(kinds: [.userMessage, .assistantMessage, .windowStart], chatId: chatId)
+		)
+		let ignoreWindow =
+			trigger == .trim || trigger == .preCompaction || trigger == .overflow || trigger == .explicitReset
+		if let pending, case .flushPending(let body) = pending.body, !body.messageUlids.isEmpty {
+			let wanted = Set(body.messageUlids.map(\.rawValue))
+			let byUlid = Dictionary(uniqueKeysWithValues: records.map { ($0.ulid.rawValue, $0) })
+			var messages: [ChatMessage] = []
+			for ulid in body.messageUlids {
+				guard let record = byUlid[ulid.rawValue] ?? records.first(where: { $0.ulid.rawValue == ulid.rawValue })
+				else { continue }
+				_ = wanted
+				switch record.body {
+				case .userMessage(let message):
+					messages.append(ChatMessage(role: .user, text: message.athleteText, civilDate: record.civilDate))
+				case .assistantMessage(let message):
+					messages.append(ChatMessage(role: .assistant, text: message.text, civilDate: record.civilDate))
+				default:
+					break
+				}
+			}
+			let current = UnionMerge.conversation(records, chatId: chatId, deviceId: store.deviceId)
+			return mergeUnique(messages, current)
+		}
+		if ignoreWindow {
+			return records.sorted { $0.hlc < $1.hlc }.compactMap { record in
+				switch record.body {
+				case .userMessage(let body) where body.chatId == chatId:
+					return ChatMessage(role: .user, text: body.athleteText, civilDate: record.civilDate)
+				case .assistantMessage(let body) where body.chatId == chatId:
+					return ChatMessage(role: .assistant, text: body.text, civilDate: record.civilDate)
+				default:
+					return nil
+				}
+			}
+		}
+		return UnionMerge.conversation(records, chatId: chatId, deviceId: store.deviceId)
+	}
+
+	private func mergeUnique(_ first: [ChatMessage], _ second: [ChatMessage]) -> [ChatMessage] {
+		var seen: Set<String> = []
+		var out: [ChatMessage] = []
+		for message in first + second {
+			let key = message.role.rawValue + "\u{1e}" + message.text
+			if seen.insert(key).inserted {
+				out.append(message)
+			}
+		}
+		return out
+	}
+
+	private func loadSnapshot() async throws -> MemorySnapshot {
+		let sections = try await store.fetch(RecordQuery(kinds: [.memorySection]))
+		let daily = try await store.fetch(RecordQuery(kinds: [.dailyNote]))
+		let ledger = try await store.fetch(RecordQuery(kinds: [.ledgerEvent]))
+		let journal = try await store.fetch(RecordQuery(kinds: [.journal]))
+		let compaction = try await store.fetch(RecordQuery(kinds: [.compactionSummary]))
+		return MemorySnapshot(
+			sections: sections,
+			daily: daily,
+			ledgerRecords: ledger.sorted { $0.hlc < $1.hlc },
+			journalRecords: journal.sorted { $0.hlc < $1.hlc },
+			compaction: compaction,
+			orphanNames: orphanNames(in: sections)
+		)
+	}
+
+	private func orphanNames(in records: [AthleteRecord]) -> [String] {
+		let declared = SectionName.declaredNames
+		var seen: Set<String> = []
+		var names: [String] = []
+		for record in records.sorted(by: { $0.hlc < $1.hlc }) {
+			guard case .memorySection(let body) = record.body else { continue }
+			if declared.contains(body.name.rawValue) { continue }
+			if seen.insert(body.name.rawValue).inserted {
+				names.append(body.name.rawValue)
+			}
+		}
+		return names
+	}
+
+	private func append(_ body: RecordBody, civilDate: CivilDate) async throws {
+		let last = try await maxHLC()
+		let tz = IANATimeZone(identifier: clock.timeZone.identifier) ?? IANATimeZone(identifier: "GMT")!
+		let record = AthleteRecord(
+			ulid: ULID.generate(at: clock.now),
+			deviceId: store.deviceId,
+			hlc: .tick(now: clock.now, deviceId: store.deviceId, last: last),
+			timeZone: tz,
+			civilDate: civilDate,
+			body: body
+		)
+		try await store.append(record)
+	}
+
+	private func maxHLC() async throws -> HybridLogicalClock? {
+		let synced = RecordKind.allCases.filter { $0.locality == .synced }
+		let local = RecordKind.allCases.filter { $0.locality == .deviceLocal }
+		let first = try await store.fetch(RecordQuery(kinds: Set(synced)))
+		let second = try await store.fetch(RecordQuery(kinds: Set(local), deviceLocalOnly: true))
+		return (first + second).map(\.hlc).max()
 	}
 }
 
 public enum MemoryQuery {
 	public static let maxRangeDays = 366
 	public static let maxResultChars = 20_000
+	public static let truncationNotice = "[truncated — narrow the date range or add a query term]"
+	public static let emptySuffix = ": no daily notes, events, or history found."
 
-	public static func render(_ hits: [MemoryHit], from: CivilDate, to: CivilDate) -> String {
-		fatalError("not implemented")
+	public static func render(_ hits: [MemoryHit], from: CivilDate, to: CivilDate, query: String? = nil) -> String {
+		let header = "Memory query \(from.rawValue)..\(to.rawValue)" + (query.map { " matching \"\($0)\"" } ?? "")
+		if hits.isEmpty {
+			return header + emptySuffix
+		}
+		var grouped: [(CivilDate, [MemoryHit])] = []
+		for hit in hits {
+			if grouped.last?.0 == hit.date {
+				grouped[grouped.count - 1].1.append(hit)
+			} else {
+				grouped.append((hit.date, [hit]))
+			}
+		}
+		let sections = grouped.map { date, rows in
+			let lines = rows.map(renderLine)
+			return "## \(date.rawValue)\n" + lines.joined(separator: "\n")
+		}
+		let result = ([header] + sections).joined(separator: "\n\n")
+		if result.utf16.count > maxResultChars {
+			return truncateUtf16Safe(result, maxChars: maxResultChars) + "\n" + truncationNotice
+		}
+		return result
 	}
+}
+
+private struct MemorySnapshot {
+	var sections: [AthleteRecord]
+	var daily: [AthleteRecord]
+	var ledgerRecords: [AthleteRecord]
+	var journalRecords: [AthleteRecord]
+	var compaction: [AthleteRecord]
+	var orphanNames: [String]
+	var planHeadline: PlanHeadline? { nil }
+
+	func dailyNotesOnly(on date: CivilDate) -> String {
+		daily.sorted { $0.hlc < $1.hlc }.compactMap { record -> String? in
+			guard record.civilDate == date, case .dailyNote(let body) = record.body else { return nil }
+			return body.note
+		}.joined(separator: "\n")
+	}
+
+	func dailyText(on date: CivilDate) -> String {
+		var notes = dailyNotesOnly(on: date)
+		if notes.contains(MemoryFlushPolicy.compactionStart) {
+			return notes
+		}
+		let extras = compaction.sorted { $0.hlc < $1.hlc }.compactMap { record -> String? in
+			guard record.civilDate == date, case .compactionSummary(let body) = record.body else { return nil }
+			return formatCompactionNote(body.markdown)
+		}
+		for extra in extras {
+			notes = notes.isEmpty ? extra : notes + "\n" + extra
+		}
+		return notes
+	}
+}
+
+private struct JournalPreview {
+	var section: String?
+	var oldBody: String?
+	var newBody: String?
+}
+
+private func parseJournalPreview(_ preview: String) -> JournalPreview {
+	guard let parsed = try? JSONValue.parse(preview) else {
+		return JournalPreview(section: nil, oldBody: nil, newBody: preview)
+	}
+	let fields = parsed.objectFields
+	return JournalPreview(
+		section: fields["section"]?.stringValue,
+		oldBody: fields["oldBody"]?.stringValue,
+		newBody: fields["newBody"]?.stringValue
+	)
+}
+
+private func demoteEmbeddedH2(_ content: String) -> String {
+	content.split(separator: "\n", omittingEmptySubsequences: false).map { line in
+		let text = String(line)
+		if text.hasPrefix("## ") {
+			return "### " + text.dropFirst(3)
+		}
+		return text
+	}.joined(separator: "\n")
+}
+
+private func stampUpdated(_ content: String, date: CivilDate) -> String {
+	var body = content
+	if body.hasPrefix(MemoryFlushPolicy.stampPrefix) {
+		if let newline = body.firstIndex(of: "\n") {
+			body = String(body[body.index(after: newline)...])
+		} else {
+			body = ""
+		}
+	}
+	if body.isEmpty {
+		return MemoryFlushPolicy.stampPrefix + date.rawValue
+	}
+	return MemoryFlushPolicy.stampPrefix + date.rawValue + "\n" + body
+}
+
+private func hasLogicalSectionContent(_ stamped: String) -> Bool {
+	guard let newline = stamped.firstIndex(of: "\n") else { return false }
+	return !stamped[stamped.index(after: newline)...]
+		.trimmingCharacters(in: .whitespacesAndNewlines)
+		.isEmpty
+}
+
+package func injectableDailyLines(_ daily: String) -> [String] {
+	var inSummary = false
+	var lines: [String] = []
+	for raw in daily.split(separator: "\n", omittingEmptySubsequences: false) {
+		let line = String(raw)
+		let trimmed = trimEnd(line)
+		if trimmed == MemoryFlushPolicy.compactionStart {
+			inSummary = true
+			continue
+		}
+		if trimmed == MemoryFlushPolicy.compactionEnd {
+			inSummary = false
+			continue
+		}
+		if inSummary, isAtMostH3(line) {
+			inSummary = false
+			lines.append(line)
+			continue
+		}
+		if inSummary {
+			continue
+		}
+		lines.append(line)
+	}
+	return lines
+}
+
+private func isAtMostH3(_ line: String) -> Bool {
+	line.hasPrefix("# ") || line.hasPrefix("## ") || line.hasPrefix("### ")
+}
+
+private func formatCompactionNote(_ summary: String) -> String {
+	let demoted = summary.split(separator: "\n", omittingEmptySubsequences: false).map { line -> String in
+		let text = String(line)
+		if text.hasPrefix("## "), !text.hasPrefix("### ") {
+			return "#### " + text.dropFirst(3)
+		}
+		return text
+	}.joined(separator: "\n")
+	return
+		MemoryFlushPolicy.compactionStart
+		+ "\n\n"
+		+ demoted
+		+ "\n"
+		+ MemoryFlushPolicy.compactionEnd
+}
+
+private func eachDate(from: CivilDate, to: CivilDate) -> [CivilDate] {
+	var dates: [CivilDate] = []
+	var cursor = from
+	while cursor <= to {
+		dates.append(cursor)
+		if cursor == to { break }
+		cursor = cursor.adding(days: 1)
+	}
+	return dates
+}
+
+private func kindOrder(_ kind: MemoryHit.Kind) -> Int {
+	switch kind {
+	case .dailyNote: return 0
+	case .ledger: return 1
+	case .journal: return 2
+	}
+}
+
+private func renderLine(_ hit: MemoryHit) -> String {
+	switch hit.kind {
+	case .dailyNote:
+		return hit.text
+	case .ledger:
+		return "event: \(hit.text)"
+	case .journal:
+		return "history: \(hit.text)"
+	}
+}
+
+private func serializeLedger(_ record: AthleteRecord, body: LedgerEventBody) -> String {
+	serializeLedgerLine(
+		date: record.civilDate,
+		kind: body.kind,
+		text: body.text,
+		source: body.source,
+		wallMs: record.hlc.wallMs
+	)
+}
+
+private func serializeLedgerLine(
+	date: CivilDate,
+	kind: LedgerKind,
+	text: String,
+	source: LedgerSource,
+	wallMs: Int64
+) -> String {
+	let ts = isoFromWallMs(wallMs)
+	return
+		"{\"ts\":\(JSONValue.string(ts).canonicalDigestInput()),"
+		+ "\"date\":\(JSONValue.string(date.rawValue).canonicalDigestInput()),"
+		+ "\"kind\":\(JSONValue.string(kind.rawValue).canonicalDigestInput()),"
+		+ "\"text\":\(JSONValue.string(text).canonicalDigestInput()),"
+		+ "\"source\":\(JSONValue.string(source.rawValue).canonicalDigestInput())}"
+}
+
+private func isoFromWallMs(_ wallMs: Int64) -> String {
+	let date = Date(timeIntervalSince1970: TimeInterval(wallMs) / 1000)
+	var calendar = Calendar(identifier: .gregorian)
+	calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+	let parts = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+	let millis = wallMs % 1000
+	return String(
+		format: "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
+		parts.year!,
+		parts.month!,
+		parts.day!,
+		parts.hour!,
+		parts.minute!,
+		parts.second!,
+		millis
+	)
+}
+
+private func wallMs(_ date: Date) -> Int64 {
+	Int64((date.timeIntervalSince1970 * 1000).rounded(.down))
+}
+
+private func historyBodySummary(_ body: String?, query: String?) -> String {
+	let text = (body ?? "").trimmingCharacters(in: .whitespacesAndNewlines).replacing(/\s+/, with: " ")
+	if text.utf16.count <= MemoryFlushPolicy.historyPreviewChars {
+		return text
+	}
+	let lowered = text.lowercased()
+	let match = query.flatMap { lowered.range(of: $0)?.lowerBound }
+	if query == nil || match == nil {
+		return truncateUtf16Safe(text, maxChars: MemoryFlushPolicy.historyPreviewChars)
+	}
+	let utf16 = Array(text.utf16)
+	let queryUnits = Array((query ?? "").utf16)
+	let matchIndex = lowered.utf16.distance(from: lowered.utf16.startIndex, to: match!)
+	var start = max(
+		0,
+		min(
+			matchIndex + queryUnits.count / 2 - MemoryFlushPolicy.historyPreviewChars / 2,
+			utf16.count - MemoryFlushPolicy.historyPreviewChars
+		)
+	)
+	if start < utf16.count {
+		let unit = utf16[start]
+		if (0xDC00...0xDFFF).contains(unit), start > 0 {
+			start -= 1
+		}
+	}
+	let window = truncateUtf16Safe(
+		String(utf16CodeUnits: Array(utf16.suffix(from: start)), count: utf16.count - start),
+		maxChars: MemoryFlushPolicy.historyPreviewChars
+	)
+	let leading = start > 0 ? "…" : ""
+	let trailing = start + window.utf16.count < utf16.count ? "…" : ""
+	return "\(leading)\(window)\(trailing)"
+}
+
+private func wireMessage(from message: ChatMessage) -> WireMessage {
+	WireMessage(
+		role: message.role == .user ? .user : .assistant,
+		content: message.text,
+		toolCalls: [],
+		toolCallId: nil
+	)
+}
+
+private func truncateUtf16Safe(_ text: String, maxChars: Int) -> String {
+	if maxChars <= 0 {
+		return ""
+	}
+	let units = Array(text.utf16)
+	if units.count <= maxChars {
+		return text
+	}
+	var cut = maxChars
+	let prev = units[maxChars - 1]
+	if (0xD800...0xDBFF).contains(prev), maxChars > 1 {
+		cut = maxChars - 1
+	}
+	return String(utf16CodeUnits: Array(units.prefix(cut)), count: cut)
+}
+
+private func trimEnd(_ text: String) -> String {
+	var end = text.endIndex
+	while end > text.startIndex {
+		let prev = text.index(before: end)
+		if text[prev].isWhitespace {
+			end = prev
+		} else {
+			break
+		}
+	}
+	return String(text[..<end])
 }

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Memory/MemoryFlushPrompt.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Memory/MemoryFlushPrompt.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+package enum MemoryFlushPrompt {
+	package static let system = """
+		You are reviewing a conversation to extract and save important athlete
+		information before it is summarized. Use the memory_write tool to save
+		details into the appropriate section. Each section is fully replaced on
+		write, so include ALL current facts for that section, not just new ones.
+		Use the ledger_append tool to record dated events (decisions, overrides,
+		illness, experiment outcomes); ledger entries are appended, never replaced.
+		"""
+
+	package static func userPrompt(sections: [SectionName], currentMemory: String, today: String) -> String {
+		let sectionList = sections.map { "- \"\($0.rawValue)\": \($0.sectionDescription)" }.joined(separator: "\n")
+		return """
+			Review the new conversation messages above and save athlete details to
+			structured memory sections. The current memory is shown below; write each
+			section that has new or updated information.
+
+			Write to these sections using memory_write:
+			\(sectionList)
+
+			For each section you write, include ALL current facts for that section
+			(both from memory and from the conversation). This fully replaces the
+			section content — omitted facts will be lost.
+
+			Dating discipline for durable facts:
+			- Append "(<source>, <YYYY-MM-DD>)" to each material fact — who stated it
+			  (athlete, coach, intervals.icu) and the date it was last confirmed.
+			  Example: "- FTP 252W (athlete, 1998-06-08)".
+			- When carrying an unchanged fact forward, keep its existing source and date;
+			  re-date a fact only when this conversation re-confirmed it.
+			- If a fact's date is more than 6 months before today, keep the fact and
+			  append "(re-confirm)" so it can be verified with the athlete.
+			- Never write "_updated:" lines yourself; the system stamps each section's
+			  update date automatically.
+
+			Keep each section under ~\(MemoryFlushPolicy.memorySectionBudgetChars) characters. When a
+			section would grow past that, do NOT let it balloon: move the dated or episodic
+			detail (specific workouts, day-by-day observations, one-off events) out to the
+			event ledger (ledger_append), and keep only the current durable facts in the
+			section itself. Nothing is dropped — ledger entries stay reachable through
+			memory_query.
+
+			Today is \(today).
+
+			Also record dated events in the permanent event ledger using ledger_append:
+			- decisions made with the athlete, with the rationale
+			- times the athlete overrode, declined, or changed a recommendation
+			- illness, injury, or pain mentions (acute ones count — they need no memory section)
+			- experiment outcomes (what was tried, what happened)
+			Date each event (YYYY-MM-DD) with the day it happened, which may be earlier
+			than today. Record only events from this conversation; never re-record
+			events that earlier reviews already saved.
+
+			Only write sections that have new or changed information.
+
+			Current memory:
+
+			\(currentMemory)
+			"""
+	}
+
+	package static func toolSchemas() -> [ToolSchema] {
+		let names = SectionName.cyclingEffective.map(\.rawValue)
+		return [
+			ToolSchema(
+				name: .memoryWrite,
+				description: "Write to a memory section (replaces entire section content)",
+				parameters: .object([
+					"type": .string("object"),
+					"properties": .object([
+						"section": .object([
+							"type": .string("string"),
+							"enum": .array(names.map { .string($0) }),
+							"description": .string("Which section to write"),
+						]),
+						"content": .object([
+							"type": .string("string"),
+							"description": .string("Complete section content — include ALL facts for this section"),
+						]),
+					]),
+					"required": .array([.string("section"), .string("content")]),
+				])
+			),
+			ToolSchema(
+				name: .ledgerAppend,
+				description:
+					"Record a dated athlete event (decision, override, illness, experiment, outcome) in the permanent event ledger. Entries are appended, never replaced.",
+				parameters: .object([
+					"type": .string("object"),
+					"properties": .object([
+						"date": .object([
+							"type": .string("string"),
+							"description": .string("Event date, YYYY-MM-DD, athlete-local"),
+						]),
+						"kind": .object([
+							"type": .string("string"),
+							"enum": .array(LedgerKind.allCases.map { .string($0.rawValue) }),
+							"description": .string("Event category"),
+						]),
+						"text": .object([
+							"type": .string("string"),
+							"description": .string("One or two sentences, with rationale or outcome when stated"),
+						]),
+					]),
+					"required": .array([.string("date"), .string("kind"), .string("text")]),
+				])
+			),
+		]
+	}
+}
+
+extension LedgerKind: CaseIterable {
+	public static var allCases: [LedgerKind] {
+		[.decision, .override, .illness, .experiment, .outcome]
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/RecordLog.swift
+++ b/apps/ios/Packages/EnduragentCoach/Sources/EnduragentCoach/Records/RecordLog.swift
@@ -630,10 +630,9 @@ extension BodyEnvelope {
 				CompactionSummaryBody(chatId: try decodeChatID(payload.chatId), markdown: payload.markdown)
 			)
 		case .memorySection(let payload):
-			guard let name = SectionName(rawValue: payload.name) else {
-				throw RecordDecodeFailure(reason: "section")
-			}
-			return .memorySection(MemorySectionBody(name: name, content: payload.content))
+			return .memorySection(
+				MemorySectionBody(name: SectionName(rawValue: payload.name), content: payload.content)
+			)
 		case .dailyNote(let payload):
 			return .dailyNote(DailyNoteBody(note: payload.note))
 		case .ledgerEvent(let payload):

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/FirstTurnTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/FirstTurnTests.swift
@@ -75,4 +75,20 @@ import Testing
 			]
 		)
 	}
+
+	@Test func memoryIsWrittenAfterTheReplyAndQueryable() async throws {
+		transport.script = [
+			.text("Noted: group ride on Saturdays."), .finish(reason: .stop),
+			.toolCall(name: "ledger_append", arguments: #"{"kind":"decision","date":"1998-06-13","text":"Rides with a group on Saturdays"}"#),
+			.finish(reason: .toolCalls), .finish(reason: .stop)
+		]
+		let coach = makeCoach()
+		for try await _ in coach.send("Remember that I ride with a group on Saturdays", chatId: "main") {}
+		await coach.waitForMemoryFlush()
+
+		let hits = try await coach.memory.query(from: "1998-06-01", to: "1998-06-30", contains: "Saturdays")
+		#expect(hits.count == 1)
+		#expect(hits[0].date == "1998-06-13")
+		#expect(hits[0].kind == .ledger(.decision))
+	}
 }

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryDifferentialTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryDifferentialTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct MemoryDifferentialTests {
+	let clock = FixedClock(now: "1998-06-13T12:00:00+00:00", timeZone: "Europe/Amsterdam")
+
+	@Test func copiedQueryStringsMatchDesktop() {
+		#expect(
+			MemoryQuery.render([], from: "1998-06-01", to: "1998-06-30")
+				== "Memory query 1998-06-01..1998-06-30: no daily notes, events, or history found."
+		)
+		#expect(MemoryQuery.truncationNotice == "[truncated — narrow the date range or add a query term]")
+		#expect(MemoryQuery.emptySuffix == ": no daily notes, events, or history found.")
+	}
+
+	@Test func dumpsContextAndQueryAgainstDesktop() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await seedAda(memory)
+		let context = try await memory.context()
+		let hits = try await memory.query(from: "1998-06-01", to: "1998-06-30", contains: nil)
+		let query = MemoryQuery.render(hits, from: "1998-06-01", to: "1998-06-30")
+		let skip = injectableDailyLines(MemoryDifferentialFixture.dailyWithSkip).joined(separator: "\n")
+		try writeDump("context-swift.txt", context)
+		try writeDump("query-swift.txt", query)
+		try writeDump("empty-swift.txt", MemoryQuery.render([], from: "1998-01-01", to: "1998-01-02"))
+		try writeDump("truncation-suffix-swift.txt", MemoryQuery.truncationNotice)
+		try writeDump("injectable-swift.txt", skip)
+		try compareIfPresent("empty-ts.txt", MemoryQuery.render([], from: "1998-01-01", to: "1998-01-02"))
+		try compareIfPresent("truncation-suffix-ts.txt", MemoryQuery.truncationNotice)
+		try compareIfPresent("injectable-ts.txt", skip)
+		try compareIfPresent("context-ts.txt", context)
+		try compareIfPresent("query-ts.txt", query)
+	}
+
+	private func seedAda(_ memory: Memory) async throws {
+		try await memory.writeSection(.person, content: "- Name: Ada Kovač", source: .chat)
+		try await memory.writeSection(.schedule, content: "- Saturdays group ride", source: .chat)
+		try await memory.writeSection(.cyclingProfile, content: "- FTP 250W", source: .chat)
+		try await memory.writeSection(
+			SectionName(rawValue: "random-legacy"),
+			content: "stale orphan body",
+			source: .chat
+		)
+		try await memory.appendDailyNote("Felt fresh on the morning spin.")
+		try await memory.appendDailyNote(MemoryDifferentialFixture.compactionNote)
+		try await memory.appendDailyNote("Knee felt fine on the evening spin.")
+		_ = try await memory.appendEvent(
+			date: "1998-06-01",
+			kind: .illness,
+			text: "Easy week after a cold",
+			source: .flush
+		)
+		_ = try await memory.appendEvent(
+			date: "1998-06-13",
+			kind: .decision,
+			text: "Hold volume this week",
+			source: .flush
+		)
+		_ = try await memory.appendEvent(
+			date: "1998-06-13",
+			kind: .decision,
+			text: "Hold volume this week",
+			source: .flush
+		)
+		_ = try await memory.appendEvent(
+			date: "1998-06-30",
+			kind: .outcome,
+			text: "Group ride felt strong",
+			source: .flush
+		)
+	}
+
+	private func writeDump(_ name: String, _ text: String) throws {
+		let dir = URL(fileURLWithPath: "/tmp/ios-c5", isDirectory: true)
+		try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+		try Data(text.utf8).write(to: dir.appendingPathComponent(name), options: .atomic)
+	}
+
+	private func compareIfPresent(_ name: String, _ actual: String) throws {
+		let url = URL(fileURLWithPath: "/tmp/ios-c5").appendingPathComponent(name)
+		guard FileManager.default.fileExists(atPath: url.path) else { return }
+		let expected = String(decoding: try Data(contentsOf: url), as: UTF8.self)
+		#expect(actual == expected, "mismatch vs \(name)")
+	}
+}
+
+enum MemoryDifferentialFixture {
+	static let compactionNote = """
+		### Compaction summary
+
+		#### Athlete Profile
+		- FTP 240W
+		### End of compaction summary
+		"""
+
+	static let dailyWithSkip = """
+		Felt fresh on the morning spin.
+		### Compaction summary
+
+		#### Athlete Profile
+		- FTP 240W
+		### End of compaction summary
+		Knee felt fine on the evening spin.
+		### Compaction summary
+		hidden inside skip
+		## person
+		kept after H2 exit
+		"""
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryFlushTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryFlushTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct MemoryFlushTests {
+	let clock = FixedClock(now: "1998-06-13T12:00:00+02:00", timeZone: "Europe/Amsterdam")
+
+	@Test func flushUsesOnlyMemoryWriteAndLedgerAppend() async throws {
+		let transport = FakeModelTransport()
+		transport.script = [
+			.toolCall(
+				name: "ledger_append",
+				arguments: #"{"kind":"decision","date":"1998-06-13","text":"Rides with a group on Saturdays"}"#
+			),
+			.finish(reason: .toolCalls),
+			.finish(reason: .stop),
+		]
+		let store = InMemoryRecordLog()
+		try await store.append(
+			RecordLogSamples.record(
+				deviceId: store.deviceId,
+				now: clock.now,
+				body: .userMessage(
+					UserMessageBody(
+						chatId: .main,
+						athleteText: "Remember that I ride with a group on Saturdays",
+						timedText: "Remember that I ride with a group on Saturdays",
+						slash: nil
+					)
+				)
+			)
+		)
+		let memory = Memory(store: store, clock: clock)
+		try await memory.flush(trigger: .softThreshold, chatId: .main, transport: transport)
+		#expect(transport.requests.count >= 1)
+		#expect(transport.requests[0].tools.map(\.name) == [.memoryWrite, .ledgerAppend])
+		let hits = try await memory.query(from: "1998-06-13", to: "1998-06-13", contains: "Saturdays")
+		#expect(hits.count == 1)
+	}
+
+	@Test func softThresholdFlushIsQueuedAfterFinished() async throws {
+		let transport = FakeModelTransport()
+		transport.script = [
+			.text("Noted."),
+			.finish(reason: .stop),
+			.toolCall(
+				name: "ledger_append",
+				arguments: #"{"kind":"decision","date":"1998-06-13","text":"Keep Saturdays free"}"#
+			),
+			.finish(reason: .toolCalls),
+			.finish(reason: .stop),
+		]
+		let store = InMemoryRecordLog()
+		let coach = Coach(
+			sport: .cycling,
+			transport: transport,
+			intervals: FakeIntervalsClient(athleteName: "Ada", ftp: 250),
+			store: store,
+			clock: clock,
+			language: .init(ui: .en, coachReply: nil)
+		)
+		var finished = false
+		var sawLedgerBeforeFinish = false
+		for try await event in coach.send("Remember Saturdays", chatId: "main") {
+			if case .finished = event {
+				finished = true
+				let events = try await store.fetch(RecordQuery(kinds: [.ledgerEvent]))
+				sawLedgerBeforeFinish = !events.isEmpty
+			}
+		}
+		#expect(finished)
+		#expect(sawLedgerBeforeFinish == false)
+		await coach.waitForMemoryFlush()
+		let hits = try await coach.memory.query(from: "1998-06-13", to: "1998-06-13", contains: "Saturdays")
+		#expect(hits.count == 1)
+	}
+
+	@Test func staleResetFlushPendingConsumedOnce() async throws {
+		let transport = FakeModelTransport()
+		transport.script = [
+			.finish(reason: .stop),
+			.finish(reason: .stop),
+			.finish(reason: .stop),
+		]
+		let store = InMemoryRecordLog()
+		let tz = IANATimeZone(identifier: "Europe/Amsterdam")!
+		let first = AthleteRecord(
+			ulid: ULID.generate(at: clock.now),
+			deviceId: store.deviceId,
+			hlc: .tick(now: clock.now, deviceId: store.deviceId, last: nil),
+			timeZone: tz,
+			civilDate: "1998-06-13",
+			body: .flushPending(FlushPendingBody(chatId: .main, trigger: .staleReset, messageUlids: []))
+		)
+		let second = AthleteRecord(
+			ulid: ULID.generate(at: clock.now),
+			deviceId: store.deviceId,
+			hlc: .tick(now: clock.now, deviceId: store.deviceId, last: first.hlc),
+			timeZone: tz,
+			civilDate: "1998-06-13",
+			body: .flushPending(FlushPendingBody(chatId: .main, trigger: .staleReset, messageUlids: []))
+		)
+		try await store.append(first)
+		try await store.append(second)
+		let memory = Memory(store: store, clock: clock)
+		try await memory.flush(trigger: .staleReset, chatId: .main, transport: transport)
+		try await memory.flush(trigger: .staleReset, chatId: .main, transport: transport)
+		let consumed = try await store.fetch(RecordQuery(kinds: [.provenance])).compactMap { record -> String? in
+			guard case .provenance(let body) = record.body else { return nil }
+			return body.key
+		}
+		#expect(consumed.filter { $0.hasPrefix(MemoryFlushPolicy.consumedFlushKeyPrefix) }.count == 2)
+		#expect(consumed.contains(MemoryFlushPolicy.consumedFlushKeyPrefix + first.ulid.rawValue))
+		#expect(consumed.contains(MemoryFlushPolicy.consumedFlushKeyPrefix + second.ulid.rawValue))
+	}
+
+	@Test func flushCapsAtFiveSteps() async throws {
+		let transport = FakeModelTransport()
+		var script: [ScriptedEvent] = []
+		for _ in 0..<6 {
+			script.append(
+				.toolCall(
+					name: "ledger_append",
+					arguments: #"{"kind":"decision","date":"1998-06-13","text":"Hold volume"}"#
+				)
+			)
+			script.append(.finish(reason: .toolCalls))
+		}
+		script.append(.finish(reason: .stop))
+		transport.script = script
+		let store = InMemoryRecordLog()
+		try await store.append(
+			RecordLogSamples.record(
+				deviceId: store.deviceId,
+				now: clock.now,
+				body: .userMessage(
+					UserMessageBody(chatId: .main, athleteText: "note", timedText: "note", slash: nil)
+				)
+			)
+		)
+		let memory = Memory(store: store, clock: clock)
+		try await memory.flush(trigger: .trim, chatId: .main, transport: transport)
+		#expect(transport.requests.count == MemoryFlushPolicy.maxSteps)
+		#expect(transport.requests.allSatisfy { $0.tools.map(\.name) == [.memoryWrite, .ledgerAppend] })
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryQueryTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryQueryTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct MemoryQueryTests {
+	let clock = FixedClock(now: "1998-06-13T12:00:00+02:00", timeZone: "Europe/Amsterdam")
+
+	@Test func newestDateFirst() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		_ = try await memory.appendEvent(date: "1998-06-13", kind: .decision, text: "Hold volume this week", source: .flush)
+		_ = try await memory.appendEvent(date: "1998-06-01", kind: .illness, text: "Easy week after a cold", source: .chat)
+		_ = try await memory.appendEvent(date: "1998-06-30", kind: .outcome, text: "Group ride felt strong", source: .chat)
+		let hits = try await memory.query(from: "1998-06-01", to: "1998-06-30", contains: nil)
+		#expect(hits.map(\.date) == ["1998-06-30", "1998-06-13", "1998-06-01"])
+	}
+
+	@Test func renderEmptyRangeCopiesDesktopString() {
+		let rendered = MemoryQuery.render([], from: "1998-06-01", to: "1998-06-30")
+		#expect(rendered == "Memory query 1998-06-01..1998-06-30: no daily notes, events, or history found.")
+	}
+
+	@Test func renderRejectsInvertedRangeThroughQuery() async throws {
+		let memory = Memory(store: InMemoryRecordLog(), clock: clock)
+		do {
+			_ = try await memory.query(from: "1998-06-30", to: "1998-06-01", contains: nil)
+			Issue.record("expected failure")
+		} catch let failure as MemoryQueryFailure {
+			#expect(failure.message == "Error: 'from' (1998-06-30) is after 'to' (1998-06-01). Swap the bounds.")
+		}
+	}
+
+	@Test func renderTruncationCopiesDesktopString() {
+		let filler = String(repeating: "a", count: MemoryQuery.maxResultChars + 40)
+		let hits = [MemoryHit(date: "1998-06-13", kind: .dailyNote, text: filler)]
+		let rendered = MemoryQuery.render(hits, from: "1998-06-01", to: "1998-06-30")
+		#expect(rendered.hasSuffix("\n[truncated — narrow the date range or add a query term]"))
+		#expect(rendered.utf16.count > MemoryQuery.maxResultChars)
+	}
+
+	@Test func queryRendersDailyThenEventThenHistory() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await memory.appendDailyNote("Felt fresh on the morning spin.")
+		_ = try await memory.appendEvent(
+			date: "1998-06-13",
+			kind: .decision,
+			text: "Hold volume this week",
+			source: .flush
+		)
+		try await memory.writeSection(.person, content: "- Name: Ada Kovač", source: .chat)
+		let hits = try await memory.query(from: "1998-06-13", to: "1998-06-13", contains: nil)
+		#expect(hits.map(\.kind) == [.dailyNote, .ledger(.decision), .journal])
+		let rendered = MemoryQuery.render(hits, from: "1998-06-13", to: "1998-06-13")
+		#expect(rendered.contains("## 1998-06-13\nFelt fresh on the morning spin.\nevent: "))
+		#expect(rendered.contains("history: "))
+	}
+
+	@Test func overMaxRangeThrowsCopiedError() async throws {
+		let memory = Memory(store: InMemoryRecordLog(), clock: clock)
+		do {
+			_ = try await memory.query(from: "1998-01-01", to: "1999-01-03", contains: nil)
+			Issue.record("expected failure")
+		} catch let failure as MemoryQueryFailure {
+			#expect(
+				failure.message
+					== "Error: range is 368 days; the maximum is 366. Query a narrower range."
+			)
+		}
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct MemoryTests {
+	let clock = FixedClock(now: "1998-06-13T12:00:00+02:00", timeZone: "Europe/Amsterdam")
+
+	@Test func journalRecordPrecedesSectionRecord() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await memory.writeSection(.person, content: "## Ada Kovač\nRides on Saturdays.", source: .chat)
+		let records = try await store.fetch(RecordQuery(kinds: [.journal, .memorySection]))
+			.sorted { $0.hlc < $1.hlc }
+		#expect(records.count == 2)
+		guard case .journal(let journal) = records[0].body else {
+			Issue.record("expected journal first")
+			return
+		}
+		guard case .memorySection(let section) = records[1].body else {
+			Issue.record("expected section second")
+			return
+		}
+		#expect(journal.op == .writeSection)
+		#expect(records[0].hlc < records[1].hlc)
+		#expect(section.name == .person)
+		#expect(section.content.hasPrefix("_updated: 1998-06-13"))
+		#expect(!section.content.contains("\n## "))
+		#expect(section.content.contains("### Ada Kovač"))
+		#expect(section.content.contains("_updated: 1998-06-13\n"))
+		let stamps = section.content.split(separator: "\n").filter { $0.hasPrefix("_updated: ") }
+		#expect(stamps.count == 1)
+	}
+
+	@Test func appendDailyNoteSkipsWholeLineDuplicateWithoutJournal() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await memory.appendDailyNote("Felt fresh on the morning spin.")
+		try await memory.appendDailyNote("Felt fresh on the morning spin.")
+		try await memory.appendDailyNote("Knee felt fine on the evening spin.")
+		let notes = try await store.fetch(RecordQuery(kinds: [.dailyNote, .journal]))
+		#expect(notes.filter { if case .dailyNote = $0.body { true } else { false } }.count == 2)
+		#expect(notes.filter { if case .journal = $0.body { true } else { false } }.isEmpty)
+	}
+
+	@Test func appendEventReturnsFalseOnTwoDeviceDuplicate() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		let other = DeviceID(rawValue: "phone-b")
+		let now = clock.now
+		try await store.append(
+			AthleteRecord(
+				ulid: ULID.generate(at: now),
+				deviceId: other,
+				hlc: .tick(now: now, deviceId: other, last: nil),
+				timeZone: IANATimeZone(identifier: "Europe/Amsterdam")!,
+				civilDate: "1998-06-13",
+				body: .ledgerEvent(LedgerEventBody(kind: .decision, text: "Keep Saturdays free.", source: .chat))
+			)
+		)
+		let recorded = try await memory.appendEvent(
+			date: "1998-06-13",
+			kind: .decision,
+			text: "  Keep Saturdays   free.  ",
+			source: .flush
+		)
+		#expect(recorded == false)
+		let events = try await store.fetch(RecordQuery(kinds: [.ledgerEvent]))
+		#expect(events.count == 1)
+	}
+
+	@Test func contextInjectsOrphansAndStripsCompaction() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await memory.writeSection(.person, content: "- Name: Ada Kovač", source: .chat)
+		try await memory.writeSection(.notes, content: "- Prefers hill repeats", source: .chat)
+		try await memory.writeSection(
+			SectionName(rawValue: "random-legacy"),
+			content: "stale orphan body",
+			source: .chat
+		)
+		try await memory.appendDailyNote("Felt fresh on the morning spin.")
+		try await memory.appendDailyNote(
+			"""
+			### Compaction summary
+
+			#### Athlete Profile
+			- FTP 240W
+			### End of compaction summary
+			"""
+		)
+		try await memory.appendDailyNote("Knee felt fine on the evening spin.")
+		let context = try await memory.context()
+		#expect(context.contains("## Athlete Memory"))
+		#expect(context.contains("## person"))
+		#expect(context.contains("Ada Kovač"))
+		#expect(context.contains("## random-legacy"))
+		#expect(context.contains("stale orphan body"))
+		#expect(!context.contains("## notes"))
+		#expect(context.contains("## Today's Notes"))
+		#expect(context.contains("Felt fresh on the morning spin."))
+		#expect(context.contains("Knee felt fine on the evening spin."))
+		#expect(!context.contains("### Compaction summary"))
+		#expect(!context.contains("FTP 240W"))
+		#expect(!context.contains("## Current Plan"))
+		let view = try await memory.view()
+		#expect(view.orphanNames == ["random-legacy"])
+		#expect(view.planHeadline == nil)
+	}
+
+	@Test func injectableDailyLinesDropsMarkersAndExitsOnH3() {
+		let daily = [
+			"Felt fresh on the morning spin.",
+			"### Compaction summary",
+			"",
+			"#### Athlete Profile",
+			"- FTP 240W",
+			"### End of compaction summary",
+			"Knee felt fine on the evening spin.",
+			"### Compaction summary",
+			"hidden inside skip",
+			"## person",
+			"kept after H2 exit",
+		].joined(separator: "\n")
+		#expect(
+			injectableDailyLines(daily).joined(separator: "\n")
+				== [
+					"Felt fresh on the morning spin.",
+					"Knee felt fine on the evening spin.",
+					"## person",
+					"kept after H2 exit",
+				].joined(separator: "\n")
+		)
+	}
+
+	@Test func writeSectionReplacesLeadingStampRatherThanStacking() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await memory.writeSection(.person, content: "_updated: 1998-06-01\n- Name: Ada", source: .chat)
+		let records = try await store.fetch(RecordQuery(kinds: [.memorySection]))
+		guard case .memorySection(let body) = records.last?.body else {
+			Issue.record("expected section")
+			return
+		}
+		#expect(body.content == "_updated: 1998-06-13\n- Name: Ada")
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryToolsTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/MemoryToolsTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import EnduragentCoach
+
+@Suite struct MemoryToolsTests {
+	let intervals = FakeIntervalsClient(athleteName: "Ada Kovač", ftp: 250)
+	let clock = FixedClock(now: "1998-06-13T12:00:00+02:00", timeZone: "Europe/Amsterdam")
+
+	@Test func memoryReadOmittedWhenNotesAreStampOnly() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await memory.writeSection(.notes, content: "", source: .chat)
+		let view = try await memory.view()
+		let schemas = runtime(store: store).toolsForTurn(chatId: .main, memory: view)
+		#expect(!schemas.map(\.name).contains(.memoryRead))
+		try await memory.writeSection(.notes, content: "- Prefers hill repeats", source: .chat)
+		let withNotes = try await memory.view()
+		let offered = runtime(store: store).toolsForTurn(chatId: .main, memory: withNotes)
+		#expect(offered.map(\.name).contains(.memoryRead))
+	}
+
+	@Test func ledgerAppendReturnsDuplicateFlag() async throws {
+		let store = InMemoryRecordLog()
+		let tools = runtime(store: store)
+		let first = try await tools.execute(
+			name: .ledgerAppend,
+			arguments: try JSONValue.parse(
+				#"{"date":"1998-06-13","kind":"decision","text":"Rides with a group on Saturdays"}"#
+			),
+			chatId: .main,
+			state: turnState()
+		)
+		let second = try await tools.execute(
+			name: .ledgerAppend,
+			arguments: try JSONValue.parse(
+				#"{"date":"1998-06-13","kind":"decision","text":"Rides with a group on Saturdays"}"#
+			),
+			chatId: .main,
+			state: turnState()
+		)
+		#expect(unwrap(first).objectFields["recorded"]?.boolValue == true)
+		#expect(unwrap(second).objectFields["recorded"]?.boolValue == false)
+		#expect(unwrap(second).objectFields["duplicate"]?.boolValue == true)
+	}
+
+	@Test func memoryQueryInvalidRangeReturnsCopiedError() async throws {
+		let outcome = try await runtime().execute(
+			name: .memoryQuery,
+			arguments: try JSONValue.parse(#"{"from":"1998-06-30","to":"1998-06-01"}"#),
+			chatId: .main,
+			state: turnState()
+		)
+		#expect(
+			unwrapString(outcome)
+				== "Error: 'from' (1998-06-30) is after 'to' (1998-06-01). Swap the bounds."
+		)
+	}
+
+	@Test func memoryQueryInvalidDateReturnsCopiedError() async throws {
+		let outcome = try await runtime().execute(
+			name: .memoryQuery,
+			arguments: try JSONValue.parse(#"{"from":"1998-02-31","to":"1998-03-01"}"#),
+			chatId: .main,
+			state: turnState()
+		)
+		#expect(
+			unwrapString(outcome)
+				== "Error: 1998-02-31..1998-03-01 contains an invalid calendar date. Use real YYYY-MM-DD dates."
+		)
+	}
+
+	@Test func memoryWriteAcceptsOrphanName() async throws {
+		let store = InMemoryRecordLog()
+		let memory = Memory(store: store, clock: clock)
+		try await memory.writeSection(SectionName(rawValue: "random-legacy"), content: "stale orphan body", source: .chat)
+		let tools = runtime(store: store)
+		let view = try await memory.view()
+		let schema = tools.toolsForTurn(chatId: .main, memory: view).first { $0.name == .memoryWrite }
+		let encoded = canonicalJSON(schema?.parameters ?? .null)
+		#expect(encoded.contains("random-legacy"))
+		let result = try await tools.execute(
+			name: .memoryWrite,
+			arguments: try JSONValue.parse(
+				#"{"type":"memory","section":"random-legacy","content":"updated orphan"}"#
+			),
+			chatId: .main,
+			state: turnState()
+		)
+		#expect(unwrap(result).objectFields["saved"]?.boolValue == true)
+	}
+
+	@Test func memoryWriteDailyAppendsToday() async throws {
+		let store = InMemoryRecordLog()
+		let result = try await runtime(store: store).execute(
+			name: .memoryWrite,
+			arguments: try JSONValue.parse(#"{"type":"daily","content":"Group ride on Saturdays"}"#),
+			chatId: .main,
+			state: turnState()
+		)
+		#expect(unwrap(result).objectFields["saved"]?.boolValue == true)
+		let notes = try await store.fetch(RecordQuery(kinds: [.dailyNote]))
+		#expect(notes.count == 1)
+	}
+
+	private func unwrap(_ outcome: ToolOutcome) -> JSONValue {
+		guard case .result(let json) = outcome else { return .null }
+		return json.objectFields["data"] ?? json
+	}
+
+	private func unwrapString(_ outcome: ToolOutcome) -> String {
+		unwrap(outcome).stringValue ?? ""
+	}
+
+	private func runtime(store: InMemoryRecordLog = InMemoryRecordLog()) -> ToolRuntime {
+		ToolRuntime(
+			intervals: intervals,
+			store: store,
+			planning: Planning(store: store, intervals: intervals, clock: clock),
+			clock: clock
+		)
+	}
+
+	private func turnState() -> TurnState {
+		TurnState(
+			chatId: .main,
+			messages: [],
+			windowStart: nil,
+			pending: nil,
+			writesCommitted: 0,
+			flushedThisTurn: false,
+			lastFlushMessageCount: 0,
+			steps: 0
+		)
+	}
+}

--- a/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ReadToolsTests.swift
+++ b/apps/ios/Packages/EnduragentCoach/Tests/EnduragentCoachTests/ReadToolsTests.swift
@@ -179,6 +179,9 @@ struct ReadToolsTests {
 				.intervalsFetchStreams,
 				.intervalsFetchActivities,
 				.intervalsListEvents,
+				.memoryQuery,
+				.memoryWrite,
+				.ledgerAppend,
 			]
 		)
 		let encoded = schemas.map { canonicalJSON($0.parameters) }.joined()


### PR DESCRIPTION
## Why

The coach has to remember what the athlete said and look it up by date. This PR fills on-device memory: section writes, daily notes, the event ledger, dated query, and the post-reply flush.

## Scope

- `Memory.swift`: `writeSection` (journal then section, demote `## `, `_updated` stamp), `appendEvent` (digest-deduped), `appendDailyNote` (skip whole-line duplicates), `context` / `view` / `query`, `flush` (memory_write + ledger_append only, five steps, two attempts, `LedgerSource.flush`).
- `MemoryFlushPrompt.swift`: flush system prompt copied from desktop `memory-flush.ts` with a 1998 example date.
- `ToolRuntime`: `memory_read`, `memory_query`, `memory_write`, `ledger_append`. Duplicate ledger returns `{recorded: false, duplicate: true}`. `memory_read` omitted when every non-inject section is empty or stamp-only.
- `ChatMailbox.runQueuedFlush` runs `Memory.flush` on the real transport after the reply FIFO. `Coach.waitForMemoryFlush` awaits every mailbox.
- `SectionName` is a struct so orphan names persist. `RecordLog` decode no longer drops unknown section names.
- Tests: FirstTurnTests tutorial §6, Memory, MemoryQuery, MemoryFlush, MemoryTools, MemoryDifferential.

Out of scope: live OpenRouter flush, `plan_save` / PlanHeadline (still nil), gated calendar tools (C6), SwiftData.

## Tradeoffs

Journal storage is `{op, preview}` with canonical JSON in `preview`, not the desktop `{ts,section,op,oldBody,newBody,source}` line. `context()` has no exclude argument; `fullContext()` / `complementContext()` cover flush and `memory_read`. Post-reply flush is not auto-queued inside `send`; the host calls `waitForMemoryFlush`.

## Blast Radius

Coach package only. Shared files with C6: `Coach.swift` (`waitForMemoryFlush` only) and `ToolRuntime.swift` (memory tools only).

## Verification

- `swift build` warning-free in Swift 6.
- `swift test`: 128 passed, 30 suites, 3 skipped live.
- FirstTurnTests: flush after `.finished`, query `1998-06-01`…`1998-06-30` `Saturdays` → one `.ledger(.decision)` on `1998-06-13`.
- Differential under `/tmp/ios-c5/`: context, query, empty-range, truncation suffix, and daily-note skip matched TypeScript.
- Live OpenRouter flush stays this ticket's remaining proof.

Playbook: poteto-mode Feature, implementation delegated to Grok 4.6 xhigh, reviewed by the lead.
